### PR TITLE
feat(vsock): expose host IPC routes across SDKs

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -44,6 +44,9 @@ jobs:
         with:
           components: clippy, rustfmt
 
+      # The Ruby extension is its own Cargo project and must keep an exact crates.io
+      # dependency for source-gem releases. Until the matching core crate is published,
+      # patch CI to the checkout so new Ruby bindings can be tested in the same PR.
       - name: Use checkout Rust SDK
         shell: bash
         run: |

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -44,6 +44,18 @@ jobs:
         with:
           components: clippy, rustfmt
 
+      - name: Use checkout Rust SDK
+        shell: bash
+        run: |
+          ruby_cargo_home="$RUNNER_TEMP/microsandbox-ruby-cargo"
+          standalone_lock="$RUNNER_TEMP/microsandbox-ruby-standalone.lock"
+          mkdir -p "$ruby_cargo_home"
+          printf '[patch.crates-io]\nmicrosandbox = { path = "%s/sdk/rust" }\n' "$GITHUB_WORKSPACE" > "$ruby_cargo_home/config.toml"
+          mv "$GITHUB_WORKSPACE/sdk/ruby/ext/microsandbox/Cargo.lock" "$standalone_lock"
+          cp "$GITHUB_WORKSPACE/Cargo.lock" "$GITHUB_WORKSPACE/sdk/ruby/ext/microsandbox/Cargo.lock"
+          echo "CARGO_HOME=$ruby_cargo_home" >> "$GITHUB_ENV"
+          echo "MICROSANDBOX_RUBY_STANDALONE_LOCK=$standalone_lock" >> "$GITHUB_ENV"
+
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           workspaces: sdk/ruby/ext/microsandbox
@@ -66,9 +78,16 @@ jobs:
         working-directory: sdk/ruby
         run: rake clean compile test
 
-      - name: Build and install source gem
+      # The temporary Cargo patch is outside the gem, so the artifact keeps its
+      # exact crates.io pin while this source-tree check uses the matching local API.
+      - name: Build and install source gem against checkout
         working-directory: sdk/ruby
         run: |
           gem build microsandbox.gemspec
           gem install --local microsandbox-*.gem --no-document
           ruby --disable-gems -e 'require "rubygems"; require "microsandbox"; abort unless Microsandbox.version == "0.6.8"'
+
+      - name: Restore standalone Ruby lockfile
+        if: always()
+        shell: bash
+        run: mv "$MICROSANDBOX_RUBY_STANDALONE_LOCK" "$GITHUB_WORKSPACE/sdk/ruby/ext/microsandbox/Cargo.lock"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4046,6 +4046,7 @@ dependencies = [
  "sea-orm",
  "serde",
  "serde_json",
+ "sha2 0.11.0",
  "tempfile",
  "thiserror 2.0.19",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4039,6 +4039,7 @@ dependencies = [
  "microsandbox-protocol",
  "microsandbox-types",
  "microsandbox-utils",
+ "microsandbox-vsock",
  "msb_krun",
  "nix 0.31.3",
  "rand 0.10.2",
@@ -4081,6 +4082,18 @@ dependencies = [
  "scopeguard",
  "tempfile",
  "ureq",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "microsandbox-vsock"
+version = "0.6.8"
+dependencies = [
+ "libc",
+ "msb_krun",
+ "nix 0.31.3",
+ "tempfile",
+ "tracing",
  "windows-sys 0.61.2",
 ]
 
@@ -4164,9 +4177,9 @@ dependencies = [
 
 [[package]]
 name = "msb_krun"
-version = "0.1.26"
+version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d8ee04c9ab5ac9849d288f9b38cb143dcde304b97fdf8b9fd027ef945a94a7c"
+checksum = "e26b10da8fe79dcf8fcc3e74f05c2fb73a39e287f31d31e0a8a20aa7895f378d"
 dependencies = [
  "crossbeam-channel",
  "kvm-bindings",
@@ -4184,9 +4197,9 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_arch"
-version = "0.1.26"
+version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfd265469aa37265b2de6d4e6ebcf536e2cc915bffd014a8bb0034fedd74d838"
+checksum = "7231acd5d0bb2bc05ac5234ed7a4e5033ff6bbbe7f4561cfdfa484dfaf6f9845"
 dependencies = [
  "kvm-bindings",
  "kvm-ioctls",
@@ -4199,15 +4212,15 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_arch_gen"
-version = "0.1.26"
+version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df8472690b285cf4ead92816b468662b5468fce99a0597f4f6f54696d313254e"
+checksum = "9fea61a85d430a45e6fa4585990630477a86b9c44a552acc95242b41869dbb05"
 
 [[package]]
 name = "msb_krun_cpuid"
-version = "0.1.26"
+version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1057ddf1b7a1c9ef8178986066b2c018a8dc54f0ffdc69356ce1b621e1088a9c"
+checksum = "619841e22639217ed1a9588657afc620e73d93824b7a861e4ebd755d98249d97"
 dependencies = [
  "kvm-bindings",
  "kvm-ioctls",
@@ -4216,9 +4229,9 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_devices"
-version = "0.1.26"
+version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f622af9b0ff353abddcc1c3fca9e1613b67f613be15776df1b4f246b52245b2f"
+checksum = "d43eacbce4a897a6fdb2e195a59c7b2b271e80aabf1eeea3286665bacf629d88"
 dependencies = [
  "bitflags 1.3.2",
  "capng",
@@ -4246,9 +4259,9 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_hvf"
-version = "0.1.26"
+version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca2025a231679bf342281c19e64eef7cfd120882e60ade8ef533c16b9fe246d1"
+checksum = "cc09b91b6207eaba888dcbe9b0653ff59f9e88a41fd9a82ce7b72445d4e31a3e"
 dependencies = [
  "crossbeam-channel",
  "libloading 0.8.9",
@@ -4258,9 +4271,9 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_kernel"
-version = "0.1.26"
+version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53c05990d373eb5c26c9179c5d9c87f4025721c4c30187d74e74a8d0d03c6e16"
+checksum = "0a4bd426bfcb2525c80a4a3d614105bc8375a747fe2134d90794a8a163a5821e"
 dependencies = [
  "msb_krun_utils",
  "vm-memory",
@@ -4268,9 +4281,9 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_polly"
-version = "0.1.26"
+version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02fcc828ea3d4aa1c5da02ed1433bc81ce3f1ede5c65dbb756a4b03271109aae"
+checksum = "0deda34342d57a300e7393566738443039116b02297000c15edbf8258bd33834"
 dependencies = [
  "libc",
  "msb_krun_utils",
@@ -4278,18 +4291,18 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_smbios"
-version = "0.1.26"
+version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd6d617b90458c041da4ee3a4cb8f548eb750eed8b50cc87ed8c0d6a9276070c"
+checksum = "4e6f7e3c203d9b78646e3432fffd1f8274ee22b95f8ffe106cbc0e8c03542cd3"
 dependencies = [
  "vm-memory",
 ]
 
 [[package]]
 name = "msb_krun_utils"
-version = "0.1.26"
+version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5f881a3a5ab9d960c829c77dfab765cffac2208e6bea52d456c6d2e7495f2b5"
+checksum = "da1b37d927c638b5335a6c3e584afe9f5d8c27c0f4489791314927749920673a"
 dependencies = [
  "bitflags 1.3.2",
  "crossbeam-channel",
@@ -4303,9 +4316,9 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_vmm"
-version = "0.1.26"
+version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "063bf27d7dbd535afd4f25071de0c0fc83023d574d58eea39d682c4c58cc7571"
+checksum = "36d4cf2c2ef62e61e7d8a0c517fc7939b58d6f1a4e1c990793a97278a6cbe0c4"
 dependencies = [
  "bzip2",
  "crossbeam-channel",
@@ -4497,6 +4510,7 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
+ "memoffset",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4177,9 +4177,9 @@ dependencies = [
 
 [[package]]
 name = "msb_krun"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e26b10da8fe79dcf8fcc3e74f05c2fb73a39e287f31d31e0a8a20aa7895f378d"
+checksum = "bf0dc8bd4d9f56f4a418e4a671b52c0939874cb3605b8c8defdaba46a393d811"
 dependencies = [
  "crossbeam-channel",
  "kvm-bindings",
@@ -4197,9 +4197,9 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_arch"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7231acd5d0bb2bc05ac5234ed7a4e5033ff6bbbe7f4561cfdfa484dfaf6f9845"
+checksum = "6a00354baae50de4380c7063310e0b4d717b4416de2996985686df8279bd1d11"
 dependencies = [
  "kvm-bindings",
  "kvm-ioctls",
@@ -4212,15 +4212,15 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_arch_gen"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fea61a85d430a45e6fa4585990630477a86b9c44a552acc95242b41869dbb05"
+checksum = "ce8e2f19da08eafa0ad8b2f71654c20f393b3682132a3254c0bbe4f045e88060"
 
 [[package]]
 name = "msb_krun_cpuid"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "619841e22639217ed1a9588657afc620e73d93824b7a861e4ebd755d98249d97"
+checksum = "695fd3ecdff794333d6081766279d258828e47dfa6d65d36118fba42a54fab4f"
 dependencies = [
  "kvm-bindings",
  "kvm-ioctls",
@@ -4229,9 +4229,9 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_devices"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d43eacbce4a897a6fdb2e195a59c7b2b271e80aabf1eeea3286665bacf629d88"
+checksum = "8a1a067fabeb7051f69c206c019779e330dcf9b83b94110e2c57f5882a45c058"
 dependencies = [
  "bitflags 1.3.2",
  "capng",
@@ -4259,9 +4259,9 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_hvf"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc09b91b6207eaba888dcbe9b0653ff59f9e88a41fd9a82ce7b72445d4e31a3e"
+checksum = "f38155b938d3cd83e5d8136b93399d2cadab9894945398265d4e2b89e7d763aa"
 dependencies = [
  "crossbeam-channel",
  "libloading 0.8.9",
@@ -4271,9 +4271,9 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_kernel"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a4bd426bfcb2525c80a4a3d614105bc8375a747fe2134d90794a8a163a5821e"
+checksum = "75f213e99af32073c1ac28f1230a8559b7c26a07ed51a702194944a35db2b889"
 dependencies = [
  "msb_krun_utils",
  "vm-memory",
@@ -4281,9 +4281,9 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_polly"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0deda34342d57a300e7393566738443039116b02297000c15edbf8258bd33834"
+checksum = "8afd50664467149435e242ea818390ac69815b65508c257ff40f67e7509909ae"
 dependencies = [
  "libc",
  "msb_krun_utils",
@@ -4291,18 +4291,18 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_smbios"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e6f7e3c203d9b78646e3432fffd1f8274ee22b95f8ffe106cbc0e8c03542cd3"
+checksum = "7ce4022d2bbfb8943ff35a9835ed184f83bce8b6d821a4f781b73421b4d11a02"
 dependencies = [
  "vm-memory",
 ]
 
 [[package]]
 name = "msb_krun_utils"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da1b37d927c638b5335a6c3e584afe9f5d8c27c0f4489791314927749920673a"
+checksum = "d32e4b71cd539d1ff7e212930e06fe3c005e59630df67f838ba9b33884ab3b49"
 dependencies = [
  "bitflags 1.3.2",
  "crossbeam-channel",
@@ -4316,9 +4316,9 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_vmm"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36d4cf2c2ef62e61e7d8a0c517fc7939b58d6f1a4e1c990793a97278a6cbe0c4"
+checksum = "fcb5cb4c2d8461ce3cf385fb30eccb3955df0162d05ea07785437da67740da62"
 dependencies = [
  "bzip2",
  "crossbeam-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,8 +79,8 @@ microsandbox-protocol = { version = "=0.6.8", path = "crates/protocol" }
 microsandbox-runtime = { version = "=0.6.8", path = "crates/runtime", default-features = false }
 microsandbox-utils = { version = "=0.6.8", path = "crates/utils" }
 microsandbox-vsock = { version = "=0.6.8", path = "crates/vsock" }
-msb_krun = "=0.1.27"
-msb_krun_utils = "=0.1.27"
+msb_krun = "=0.1.28"
+msb_krun_utils = "=0.1.28"
 test-macros = { path = "crates/test-macros" }
 test-utils = { path = "crates/test-utils" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ members = [
     "crates/test-macros",
     "crates/test-utils",
     "crates/utils",
+    "crates/vsock",
     "examples/rust/cloud-backend",
     "examples/rust/fs-read-stream",
     "examples/rust/init-handoff",
@@ -77,8 +78,9 @@ microsandbox-network = { version = "=0.6.8", path = "crates/network" }
 microsandbox-protocol = { version = "=0.6.8", path = "crates/protocol" }
 microsandbox-runtime = { version = "=0.6.8", path = "crates/runtime", default-features = false }
 microsandbox-utils = { version = "=0.6.8", path = "crates/utils" }
-msb_krun = "=0.1.26"
-msb_krun_utils = "=0.1.26"
+microsandbox-vsock = { version = "=0.6.8", path = "crates/vsock" }
+msb_krun = "=0.1.27"
+msb_krun_utils = "=0.1.27"
 test-macros = { path = "crates/test-macros" }
 test-utils = { path = "crates/test-utils" }
 

--- a/crates/cli/lib/commands/common.rs
+++ b/crates/cli/lib/commands/common.rs
@@ -9,7 +9,7 @@ use microsandbox::backend::{Backend, LocalBackend};
 use microsandbox::sandbox::{
     CpuPlacement, DeploymentProfile, DiskImageFormat, FlatClone, MountBuilder, Patch,
     RootDiskBuilder, Sandbox, SandboxBuilder, SandboxHandle, SecurityProfile,
-    TransparentHugePagePolicy,
+    TransparentHugePagePolicy, VsockSocketType,
 };
 
 use crate::ui;
@@ -254,6 +254,14 @@ pub struct SandboxOpts {
     /// Stop the sandbox after this period of inactivity (e.g. 30s, 5m, 1h).
     #[arg(long)]
     pub idle_timeout: Option<String>,
+
+    // --- Host communication ---
+    /// Expose a host local-IPC endpoint on a guest-to-host vsock port.
+    ///
+    /// Syntax: HOST_PATH:PORT, optionally followed by /stream or /dgram.
+    /// Stream is the default. Repeat the flag to expose multiple services.
+    #[arg(long, value_name = "HOST_PATH:PORT[/stream|/dgram]")]
+    pub vsock: Vec<String>,
 
     // --- Networking (requires "net" feature) ---
     /// Forward a host port to the sandbox (HOST:GUEST, BIND_ADDR:HOST:GUEST, and /udp variants).
@@ -529,7 +537,8 @@ impl SandboxOpts {
             || self.log_level.is_some()
             || self.max_duration.is_some()
             || self.idle_timeout.is_some()
-            || self.security.is_some();
+            || self.security.is_some()
+            || !self.vsock.is_empty();
 
         #[cfg(feature = "net")]
         let net = !self.port.is_empty()
@@ -737,6 +746,15 @@ pub fn apply_sandbox_opts(
         builder = builder.idle_timeout(parse_duration_secs(dur)?);
     }
 
+    // --- Host communication ---
+    for route in &opts.vsock {
+        let (host_socket, port, socket_type) = parse_vsock_route(route)?;
+        builder = match socket_type {
+            VsockSocketType::Stream => builder.vsock(host_socket, port),
+            VsockSocketType::Dgram => builder.vsock_dgram(host_socket, port),
+        };
+    }
+
     // --- Networking ---
     #[cfg(feature = "net")]
     {
@@ -744,6 +762,38 @@ pub fn apply_sandbox_opts(
     }
 
     Ok(builder)
+}
+
+/// Parse `HOST_PATH:PORT[/stream|/dgram]` without treating colons in the
+/// host path as separators. Stream is intentionally the compact default.
+fn parse_vsock_route(spec: &str) -> anyhow::Result<(PathBuf, u32, VsockSocketType)> {
+    let (host_socket, endpoint) = spec.rsplit_once(':').ok_or_else(|| {
+        anyhow::anyhow!("--vsock must use HOST_PATH:PORT[/stream|/dgram], got {spec:?}")
+    })?;
+    if host_socket.is_empty() {
+        anyhow::bail!("--vsock host path cannot be empty");
+    }
+
+    let (port, socket_type) = match endpoint.rsplit_once('/') {
+        None => (endpoint, VsockSocketType::Stream),
+        Some((port, "stream")) => (port, VsockSocketType::Stream),
+        Some((port, "dgram")) => (port, VsockSocketType::Dgram),
+        Some((_, kind)) => {
+            anyhow::bail!("--vsock socket type must be stream or dgram, got {kind:?}")
+        }
+    };
+    let port = port.parse::<u32>().map_err(|_| {
+        anyhow::anyhow!("--vsock port must be an unsigned 32-bit integer, got {port:?}")
+    })?;
+    let host_socket = PathBuf::from(host_socket);
+    if !host_socket.is_absolute() {
+        anyhow::bail!(
+            "--vsock host path must be absolute, got {}",
+            host_socket.display()
+        );
+    }
+
+    Ok((host_socket, port, socket_type))
 }
 
 /// Parsed `--root-disk` value, classified before it touches the builder.
@@ -2522,6 +2572,51 @@ mod tests {
     };
 
     use super::*;
+
+    #[cfg(unix)]
+    #[test]
+    fn parse_vsock_route_defaults_to_stream() {
+        let route = parse_vsock_route("/run/host-api.sock:5000").unwrap();
+        assert_eq!(route.0, PathBuf::from("/run/host-api.sock"));
+        assert_eq!(route.1, 5000);
+        assert_eq!(route.2, VsockSocketType::Stream);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn parse_vsock_route_accepts_explicit_socket_types() {
+        let stream = parse_vsock_route("/run/host-api.sock:5000/stream").unwrap();
+        let dgram = parse_vsock_route("/run/events.sock:5001/dgram").unwrap();
+
+        assert_eq!(stream.2, VsockSocketType::Stream);
+        assert_eq!(dgram.2, VsockSocketType::Dgram);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn parse_vsock_route_rejects_relative_paths_and_unknown_types() {
+        assert!(
+            parse_vsock_route("run/host-api.sock:5000")
+                .unwrap_err()
+                .to_string()
+                .contains("absolute")
+        );
+        assert!(
+            parse_vsock_route("/run/host-api.sock:5000/seqpacket")
+                .unwrap_err()
+                .to_string()
+                .contains("stream or dgram")
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn parse_vsock_route_accepts_named_pipe_with_default_stream() {
+        let route = parse_vsock_route(r"\\.\pipe\host-api:5000").unwrap();
+        assert_eq!(route.0, PathBuf::from(r"\\.\pipe\host-api"));
+        assert_eq!(route.1, 5000);
+        assert_eq!(route.2, VsockSocketType::Stream);
+    }
 
     #[test]
     fn parse_secret_returns_env_and_host_reference() {

--- a/crates/cli/lib/sandbox_cmd.rs
+++ b/crates/cli/lib/sandbox_cmd.rs
@@ -145,6 +145,7 @@ pub fn run(args: SandboxArgs) -> ! {
             std::process::exit(2);
         }
     };
+    let run_dir = launch_run_dir(&launch);
     // A user-supplied (disk-image) root disk carries an explicit format and
     // rides the typed UpperSpec; the managed ext4 fast path stays on
     // rootfs_upper. Exactly one of the two is populated.
@@ -225,6 +226,7 @@ pub fn run(args: SandboxArgs) -> ! {
         log_dir: launch.log_dir,
         runtime_dir: launch.runtime_dir,
         sandboxes_dir: launch.sandboxes_dir,
+        run_dir,
         cpu_lease_dir: launch.cpu_lease_dir,
         writeback_lease_dir: launch.writeback_lease_dir,
         block_writeback_pool_bytes: launch.block_writeback_pool_bytes,
@@ -249,6 +251,31 @@ pub fn run(args: SandboxArgs) -> ! {
     };
 
     microsandbox_runtime::vm::enter(config)
+}
+
+/// Resolve the runtime artifact root across launch-config generations.
+fn launch_run_dir(launch: &LaunchConfig) -> PathBuf {
+    if !launch.run_dir.as_os_str().is_empty() {
+        return launch.run_dir.clone();
+    }
+
+    // Older launchers bind `<run>/agent/<hash>.sock` and do not serialize a
+    // run root. Recover it from that stable legacy endpoint when possible.
+    if let Some(agent_dir) = launch.agent_sock.parent()
+        && agent_dir.file_name().is_some_and(|name| name == "agent")
+        && let Some(run_dir) = agent_dir.parent()
+    {
+        return run_dir.to_path_buf();
+    }
+
+    // The pre-hash deep-path fallback lives below the sandbox root, so it
+    // carries no run-root information. Existing homes colocate `run` beside
+    // `sandboxes`; this inference is only used for old launch payloads.
+    launch
+        .sandboxes_dir
+        .parent()
+        .map(|home| home.join(microsandbox_utils::RUN_SUBDIR))
+        .unwrap_or_default()
 }
 
 /// Load the JSON [`LaunchConfig`] for this sandbox from the inherited config
@@ -602,6 +629,39 @@ mod tests {
             loaded.writeback_lease_dir,
             PathBuf::from("/tmp/writeback-leases")
         );
+    }
+
+    #[test]
+    fn test_old_launch_config_without_run_dir_remains_readable() {
+        use std::io::Write;
+
+        let launch = LaunchConfig {
+            sandboxes_dir: PathBuf::from("/tmp/msb/sandboxes"),
+            agent_sock: PathBuf::from("/tmp/msb/run/agent/legacy.sock"),
+            ..Default::default()
+        };
+        let mut value = serde_json::to_value(&launch).unwrap();
+        value.as_object_mut().unwrap().remove("run_dir");
+        let mut file = tempfile::NamedTempFile::new().unwrap();
+        file.write_all(&serde_json::to_vec(&value).unwrap())
+            .unwrap();
+
+        let args = args_with(None, Some(file.path().to_path_buf()));
+        let loaded = load_launch_config(&args).unwrap();
+
+        assert!(loaded.run_dir.as_os_str().is_empty());
+        assert_eq!(launch_run_dir(&loaded), PathBuf::from("/tmp/msb/run"));
+    }
+
+    #[test]
+    fn test_old_fallback_launch_config_infers_run_dir_from_sandbox_root() {
+        let launch = LaunchConfig {
+            sandboxes_dir: PathBuf::from("/tmp/msb/sandboxes"),
+            agent_sock: PathBuf::from("/tmp/msb/sandboxes/demo/runtime/agent.sock"),
+            ..Default::default()
+        };
+
+        assert_eq!(launch_run_dir(&launch), PathBuf::from("/tmp/msb/run"));
     }
 
     #[test]

--- a/crates/cli/lib/sandbox_cmd.rs
+++ b/crates/cli/lib/sandbox_cmd.rs
@@ -233,6 +233,7 @@ pub fn run(args: SandboxArgs) -> ! {
         rootfs_disk_readonly: launch.rootfs.disk_readonly,
         mounts: launch.mounts,
         disks,
+        vsock: launch.vsock,
         #[cfg(unix)]
         backends: vec![],
         init_path: launch.init_path,

--- a/crates/cli/lib/sandbox_cmd.rs
+++ b/crates/cli/lib/sandbox_cmd.rs
@@ -55,6 +55,11 @@ pub struct SandboxArgs {
     #[arg(long = "startup-fd", hide = true)]
     pub startup_fd: Option<i32>,
 
+    /// Inherited descriptor owning this sandbox's lifecycle lock.
+    #[cfg(unix)]
+    #[arg(long = "lifecycle-lock-fd", hide = true)]
+    pub lifecycle_lock_fd: Option<i32>,
+
     /// Windows named pipe used to write startup JSON.
     #[cfg(windows)]
     #[arg(long = "startup-pipe", hide = true)]
@@ -137,6 +142,33 @@ pub fn run(args: SandboxArgs) -> ! {
             std::process::exit(2);
         }
     };
+    let run_dir = launch_run_dir(&launch);
+    #[cfg(unix)]
+    let lifecycle_guard = match args.lifecycle_lock_fd {
+        Some(fd) => match lifecycle_guard_from_fd(fd) {
+            Ok(guard) => guard,
+            Err(err) => {
+                eprintln!("{err}");
+                std::process::exit(2);
+            }
+        },
+        None => {
+            match microsandbox_runtime::ipc::acquire_lifecycle_guard(&run_dir, &args.sandbox_name) {
+                Ok(guard) => guard,
+                Err(err) => {
+                    eprintln!("failed to acquire sandbox lifecycle ownership: {err}");
+                    std::process::exit(2);
+                }
+            }
+        }
+    };
+    #[cfg(not(unix))]
+    let lifecycle_guard =
+        microsandbox_runtime::ipc::acquire_lifecycle_guard(&run_dir, &args.sandbox_name)
+            .unwrap_or_else(|err| {
+                eprintln!("failed to acquire sandbox lifecycle ownership: {err}");
+                std::process::exit(2);
+            });
     let is_vmdk = launch.rootfs.disk_format.as_deref() == Some("vmdk");
     let disks = match parse_disk_args(&launch.disks) {
         Ok(disks) => disks,
@@ -145,7 +177,6 @@ pub fn run(args: SandboxArgs) -> ! {
             std::process::exit(2);
         }
     };
-    let run_dir = launch_run_dir(&launch);
     // A user-supplied (disk-image) root disk carries an explicit format and
     // rides the typed UpperSpec; the managed ext4 fast path stays on
     // rootfs_upper. Exactly one of the two is populated.
@@ -227,6 +258,7 @@ pub fn run(args: SandboxArgs) -> ! {
         runtime_dir: launch.runtime_dir,
         sandboxes_dir: launch.sandboxes_dir,
         run_dir,
+        lifecycle_guard,
         cpu_lease_dir: launch.cpu_lease_dir,
         writeback_lease_dir: launch.writeback_lease_dir,
         block_writeback_pool_bytes: launch.block_writeback_pool_bytes,
@@ -337,7 +369,40 @@ fn startup_from_fd(fd: i32) -> Result<OwnedFd, String> {
 }
 
 #[cfg(unix)]
+fn lifecycle_guard_from_fd(
+    fd: i32,
+) -> Result<microsandbox_runtime::ipc::SandboxLifecycleGuard, String> {
+    validate_open_fd(
+        fd,
+        microsandbox_runtime::vm::LIFECYCLE_LOCK_FD,
+        "lifecycle-lock-fd",
+    )?;
+    let file = unsafe { File::from_raw_fd(fd) };
+    Ok(microsandbox_runtime::ipc::SandboxLifecycleGuard::from_inherited_file(file))
+}
+
+#[cfg(unix)]
 fn validate_pipe_fd(fd: i32, expected_fd: i32, arg_name: &str) -> Result<(), String> {
+    validate_open_fd(fd, expected_fd, arg_name)?;
+
+    let mut stat = MaybeUninit::<libc::stat>::uninit();
+    if unsafe { libc::fstat(fd, stat.as_mut_ptr()) } != 0 {
+        return Err(format!(
+            "invalid --{arg_name} {fd}: {}",
+            std::io::Error::last_os_error()
+        ));
+    }
+    let stat = unsafe { stat.assume_init() };
+    let file_type = stat.st_mode & libc::S_IFMT as libc::mode_t;
+    if file_type != libc::S_IFIFO as libc::mode_t {
+        return Err(format!("invalid --{arg_name} {fd}: fd is not a pipe"));
+    }
+
+    Ok(())
+}
+
+#[cfg(unix)]
+fn validate_open_fd(fd: i32, expected_fd: i32, arg_name: &str) -> Result<(), String> {
     if fd < 0 {
         return Err(format!(
             "invalid --{arg_name}: fd must be non-negative, got {fd}"
@@ -355,19 +420,6 @@ fn validate_pipe_fd(fd: i32, expected_fd: i32, arg_name: &str) -> Result<(), Str
             "invalid --{arg_name} {fd}: {}",
             std::io::Error::last_os_error()
         ));
-    }
-
-    let mut stat = MaybeUninit::<libc::stat>::uninit();
-    if unsafe { libc::fstat(fd, stat.as_mut_ptr()) } != 0 {
-        return Err(format!(
-            "invalid --{arg_name} {fd}: {}",
-            std::io::Error::last_os_error()
-        ));
-    }
-    let stat = unsafe { stat.assume_init() };
-    let file_type = stat.st_mode & libc::S_IFMT as libc::mode_t;
-    if file_type != libc::S_IFIFO as libc::mode_t {
-        return Err(format!("invalid --{arg_name} {fd}: fd is not a pipe"));
     }
 
     Ok(())
@@ -586,6 +638,8 @@ mod tests {
             parent_watch_fd: None,
             #[cfg(unix)]
             startup_fd: None,
+            #[cfg(unix)]
+            lifecycle_lock_fd: None,
             #[cfg(windows)]
             startup_pipe: None,
             forward_output: false,

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -30,6 +30,7 @@ microsandbox-network = { workspace = true, optional = true }
 microsandbox-protocol.workspace = true
 microsandbox-types.workspace = true
 microsandbox-utils.workspace = true
+microsandbox-vsock.workspace = true
 msb_krun = { workspace = true, features = ["blk"] }
 nix = { workspace = true, features = ["process", "signal"] }
 rand.workspace = true

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -37,6 +37,7 @@ rustls = { workspace = true }
 sea-orm.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+sha2.workspace = true
 tempfile.workspace = true
 thiserror.workspace = true
 tokio.workspace = true

--- a/crates/runtime/lib/control.rs
+++ b/crates/runtime/lib/control.rs
@@ -22,8 +22,8 @@ use serde::{Deserialize, Serialize};
 // Constants
 //--------------------------------------------------------------------------------------------------
 
-/// Extension of the per-sandbox control socket, derived from the agent
-/// socket path (`<sandbox>.sock` becomes `<sandbox>.control.sock`).
+/// Extension of legacy per-sandbox control sockets (`<sandbox>.sock` becomes
+/// `<sandbox>.control.sock`). Canonical sockets use sibling `control.sock`.
 pub const CONTROL_SOCKET_EXTENSION: &str = "control.sock";
 
 //--------------------------------------------------------------------------------------------------
@@ -216,7 +216,7 @@ impl std::fmt::Debug for SecretValue {
 
 /// The control socket path that belongs to the given agent socket path.
 pub fn control_socket_path_for(agent_sock: &std::path::Path) -> PathBuf {
-    agent_sock.with_extension(CONTROL_SOCKET_EXTENSION)
+    crate::ipc::control_socket_path_for(agent_sock)
 }
 
 /// Spawn the control listener thread. Non-fatal on failure by design: the

--- a/crates/runtime/lib/ipc.rs
+++ b/crates/runtime/lib/ipc.rs
@@ -1,6 +1,16 @@
 //! Host-side per-sandbox IPC endpoint paths and lifecycle cleanup.
 
-use std::fmt::Write as _;
+#[cfg(unix)]
+use std::ffi::{CStr, CString};
+use std::fmt::{self, Write as _};
+#[cfg(unix)]
+use std::fs::{DirBuilder, File, OpenOptions};
+#[cfg(unix)]
+use std::os::fd::{AsRawFd, FromRawFd, RawFd};
+#[cfg(unix)]
+use std::os::unix::ffi::OsStrExt;
+#[cfg(unix)]
+use std::os::unix::fs::{DirBuilderExt, OpenOptionsExt};
 use std::path::{Path, PathBuf};
 
 use sha2::{Digest, Sha256};
@@ -35,6 +45,23 @@ pub struct SandboxSocketPaths {
     pub legacy_control: PathBuf,
 }
 
+/// Cross-process ownership guard for one sandbox's runtime lifecycle.
+///
+/// On Unix the guard is an advisory `flock` held by the underlying open file
+/// description. Launchers may duplicate the descriptor into the sandbox
+/// process; closing the launcher's copy then preserves ownership in the child
+/// until it exits, including after `SIGKILL`.
+pub struct SandboxLifecycleGuard {
+    #[cfg(unix)]
+    file: File,
+}
+
+impl fmt::Debug for SandboxLifecycleGuard {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("SandboxLifecycleGuard")
+    }
+}
+
 //--------------------------------------------------------------------------------------------------
 // Functions
 //--------------------------------------------------------------------------------------------------
@@ -53,6 +80,67 @@ pub fn canonical_agent_endpoint(run_dir: &Path, name: &str) -> PathBuf {
             r"\\.\pipe\msb-agent-{}",
             socket_hash(name, LEGACY_SOCKET_HASH_BYTES)
         ))
+    }
+}
+
+/// Derive the stable lifecycle-lock path for one sandbox name.
+pub fn lifecycle_lock_path(run_dir: &Path, name: &str) -> PathBuf {
+    let digest = Sha256::digest(name.as_bytes());
+    let id = encode_hash(&digest, LEGACY_SOCKET_HASH_BYTES);
+    run_dir.join("locks").join(format!("{id}.lock"))
+}
+
+/// Acquire exclusive lifecycle ownership, waiting for a current owner to exit.
+pub fn acquire_lifecycle_guard(
+    run_dir: &Path,
+    name: &str,
+) -> std::io::Result<SandboxLifecycleGuard> {
+    #[cfg(unix)]
+    {
+        acquire_lifecycle_guard_unix(run_dir, name, false)?.ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::WouldBlock,
+                format!("sandbox {name:?} lifecycle is currently owned"),
+            )
+        })
+    }
+
+    #[cfg(not(unix))]
+    {
+        let _ = (run_dir, name);
+        Ok(SandboxLifecycleGuard {})
+    }
+}
+
+/// Try to acquire exclusive lifecycle ownership without blocking.
+pub fn try_acquire_lifecycle_guard(
+    run_dir: &Path,
+    name: &str,
+) -> std::io::Result<Option<SandboxLifecycleGuard>> {
+    #[cfg(unix)]
+    {
+        acquire_lifecycle_guard_unix(run_dir, name, true)
+    }
+
+    #[cfg(not(unix))]
+    {
+        let _ = (run_dir, name);
+        Ok(Some(SandboxLifecycleGuard {}))
+    }
+}
+
+#[cfg(unix)]
+impl SandboxLifecycleGuard {
+    /// Adopt a descriptor that already owns the sandbox lifecycle lock.
+    ///
+    /// This is used only for the descriptor inherited from the SDK launcher.
+    pub fn from_inherited_file(file: File) -> Self {
+        Self { file }
+    }
+
+    /// Return the descriptor to duplicate into a sandbox child process.
+    pub fn as_raw_fd(&self) -> RawFd {
+        self.file.as_raw_fd()
     }
 }
 
@@ -137,7 +225,9 @@ pub fn prepare_canonical_socket_dir(
         )
     })?;
     std::fs::create_dir_all(parent)?;
-    match std::fs::create_dir(&paths.canonical_dir) {
+    let mut builder = DirBuilder::new();
+    builder.mode(0o700);
+    match builder.create(&paths.canonical_dir) {
         Ok(()) => {}
         Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
             let metadata = std::fs::symlink_metadata(&paths.canonical_dir)?;
@@ -192,6 +282,13 @@ pub fn publish_legacy_control_link(
 pub fn remove_socket_pair(agent_sock: &Path) -> std::io::Result<()> {
     #[cfg(unix)]
     {
+        if is_canonical_agent_socket(agent_sock) {
+            return remove_canonical_socket_pair(agent_sock);
+        }
+        if is_legacy_agent_socket(agent_sock) {
+            return remove_legacy_socket_pair(agent_sock);
+        }
+
         let control_sock = control_socket_path_for(agent_sock);
         let control_result = remove_file_if_exists(&control_sock);
         let agent_result = remove_file_if_exists(agent_sock);
@@ -209,7 +306,7 @@ pub fn remove_socket_pair(agent_sock: &Path) -> std::io::Result<()> {
 pub fn remove_canonical_socket_artifacts(run_dir: &Path, name: &str) -> std::io::Result<()> {
     #[cfg(unix)]
     {
-        remove_canonical_socket_dir(&sandbox_socket_paths(run_dir, name))
+        remove_canonical_socket_dir(run_dir, &sandbox_socket_paths(run_dir, name))
     }
 
     #[cfg(windows)]
@@ -226,12 +323,8 @@ pub fn remove_sandbox_socket_artifacts(run_dir: &Path, name: &str) -> std::io::R
         let paths = sandbox_socket_paths(run_dir, name);
         let mut first_error = None;
 
-        for path in [&paths.legacy_control, &paths.legacy_agent] {
-            if let Err(error) = remove_file_if_exists(path)
-                && first_error.is_none()
-            {
-                first_error = Some(error);
-            }
+        if let Err(error) = remove_legacy_socket_artifacts(run_dir, &paths) {
+            first_error = Some(error);
         }
 
         if let Err(error) = remove_canonical_socket_artifacts(run_dir, name)
@@ -297,6 +390,38 @@ fn publish_compatibility_link(run_dir: &Path, link: &Path, target: &Path) -> std
 }
 
 #[cfg(unix)]
+fn acquire_lifecycle_guard_unix(
+    run_dir: &Path,
+    name: &str,
+    nonblocking: bool,
+) -> std::io::Result<Option<SandboxLifecycleGuard>> {
+    let path = lifecycle_lock_path(run_dir, name);
+    let parent = path.parent().ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!("lifecycle lock has no parent: {}", path.display()),
+        )
+    })?;
+    std::fs::create_dir_all(parent)?;
+    let file = OpenOptions::new()
+        .create(true)
+        .truncate(false)
+        .read(true)
+        .write(true)
+        .open(&path)?;
+    let operation = libc::LOCK_EX | if nonblocking { libc::LOCK_NB } else { 0 };
+    if unsafe { libc::flock(file.as_raw_fd(), operation) } == 0 {
+        return Ok(Some(SandboxLifecycleGuard { file }));
+    }
+
+    let error = std::io::Error::last_os_error();
+    if nonblocking && error.kind() == std::io::ErrorKind::WouldBlock {
+        return Ok(None);
+    }
+    Err(error)
+}
+
+#[cfg(unix)]
 fn validate_compatibility_path(path: &Path) -> std::io::Result<()> {
     if socket_path_fits(path) {
         Ok(())
@@ -349,6 +474,24 @@ fn is_canonical_agent_socket(path: &Path) -> bool {
 }
 
 #[cfg(unix)]
+fn is_legacy_agent_socket(path: &Path) -> bool {
+    let Some(stem) = path.file_stem().and_then(|stem| stem.to_str()) else {
+        return false;
+    };
+
+    path.parent()
+        .and_then(Path::file_name)
+        .is_some_and(|name| name == "agent")
+        && path
+            .extension()
+            .is_some_and(|extension| extension == "sock")
+        && stem.len() == LEGACY_SOCKET_HASH_BYTES * 2
+        && stem
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+}
+
+#[cfg(unix)]
 fn remove_file_if_exists(path: &Path) -> std::io::Result<()> {
     match std::fs::remove_file(path) {
         Ok(()) => Ok(()),
@@ -358,32 +501,217 @@ fn remove_file_if_exists(path: &Path) -> std::io::Result<()> {
 }
 
 #[cfg(unix)]
-fn remove_canonical_socket_dir(paths: &SandboxSocketPaths) -> std::io::Result<()> {
-    let metadata = match std::fs::symlink_metadata(&paths.canonical_dir) {
-        Ok(metadata) => metadata,
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+fn remove_canonical_socket_pair(agent_sock: &Path) -> std::io::Result<()> {
+    let canonical_path = agent_sock.parent().ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!(
+                "canonical socket has no directory: {}",
+                agent_sock.display()
+            ),
+        )
+    })?;
+    let run_dir = canonical_path
+        .parent()
+        .and_then(Path::parent)
+        .ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                format!(
+                    "canonical socket has no run directory: {}",
+                    agent_sock.display()
+                ),
+            )
+        })?;
+    let Some(run) = open_directory(run_dir)? else {
+        return Ok(());
+    };
+    let Some(sandboxes) = open_owned_child_directory(&run, c"sandboxes", run_dir)? else {
+        return Ok(());
+    };
+    let hash = c_path_name(canonical_path)?;
+    let Some(canonical) =
+        open_owned_child_directory(&sandboxes, &hash, &run_dir.join("sandboxes"))?
+    else {
+        return Ok(());
+    };
+
+    let control_result = unlinkat_if_exists(&canonical, c"control.sock", 0);
+    let agent_result = unlinkat_if_exists(&canonical, c"agent.sock", 0);
+    control_result.and(agent_result)
+}
+
+#[cfg(unix)]
+fn remove_legacy_socket_pair(agent_sock: &Path) -> std::io::Result<()> {
+    let agent_path = agent_sock.parent().ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!("legacy socket has no directory: {}", agent_sock.display()),
+        )
+    })?;
+    let run_dir = agent_path.parent().ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!(
+                "legacy socket has no run directory: {}",
+                agent_sock.display()
+            ),
+        )
+    })?;
+    let Some(run) = open_directory(run_dir)? else {
+        return Ok(());
+    };
+    let Some(agent) = open_owned_child_directory(&run, c"agent", run_dir)? else {
+        return Ok(());
+    };
+
+    let control = c_path_name(&control_socket_path_for(agent_sock))?;
+    let relay = c_path_name(agent_sock)?;
+    let control_result = unlinkat_if_exists(&agent, &control, 0);
+    let relay_result = unlinkat_if_exists(&agent, &relay, 0);
+    control_result.and(relay_result)
+}
+
+#[cfg(unix)]
+fn remove_legacy_socket_artifacts(
+    run_dir: &Path,
+    paths: &SandboxSocketPaths,
+) -> std::io::Result<()> {
+    let Some(run) = open_directory(run_dir)? else {
+        return Ok(());
+    };
+    let Some(agent) = open_owned_child_directory(&run, c"agent", run_dir)? else {
+        return Ok(());
+    };
+
+    let control = c_path_name(&paths.legacy_control)?;
+    let relay = c_path_name(&paths.legacy_agent)?;
+    let control_result = unlinkat_if_exists(&agent, &control, 0);
+    let relay_result = unlinkat_if_exists(&agent, &relay, 0);
+    control_result.and(relay_result)
+}
+
+#[cfg(unix)]
+fn remove_canonical_socket_dir(run_dir: &Path, paths: &SandboxSocketPaths) -> std::io::Result<()> {
+    let Some(run) = open_directory(run_dir)? else {
+        return Ok(());
+    };
+    let Some(sandboxes) = open_owned_child_directory(&run, c"sandboxes", run_dir)? else {
+        return Ok(());
+    };
+    let hash = c_path_name(&paths.canonical_dir)?;
+    let canonical = match open_child_directory(&sandboxes, &hash) {
+        Ok(Some(directory)) => directory,
+        Ok(None) => return Ok(()),
+        Err(error)
+            if matches!(
+                error.raw_os_error(),
+                Some(libc::ELOOP) | Some(libc::ENOTDIR)
+            ) =>
+        {
+            // The hash entry is not a directory. Remove that exact entry via
+            // the already-open parent without following a possible symlink.
+            return unlinkat_if_exists(&sandboxes, &hash, 0);
+        }
         Err(error) => return Err(error),
     };
 
-    if metadata.file_type().is_symlink() {
-        // Remove the unexpected namespace entry itself without following it
-        // to attacker-controlled socket names elsewhere on the host.
-        return std::fs::remove_file(&paths.canonical_dir);
+    let control_result = unlinkat_if_exists(&canonical, c"control.sock", 0);
+    let agent_result = unlinkat_if_exists(&canonical, c"agent.sock", 0);
+    control_result.and(agent_result)?;
+    unlinkat_if_exists(&sandboxes, &hash, libc::AT_REMOVEDIR)
+}
+
+#[cfg(unix)]
+fn open_directory(path: &Path) -> std::io::Result<Option<File>> {
+    let mut options = OpenOptions::new();
+    options
+        .read(true)
+        .custom_flags(libc::O_DIRECTORY | libc::O_CLOEXEC);
+    match options.open(path) {
+        Ok(directory) => Ok(Some(directory)),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(error),
     }
-    if !metadata.is_dir() {
-        return Err(std::io::Error::new(
-            std::io::ErrorKind::InvalidData,
-            format!(
-                "canonical socket path is not a directory: {}",
-                paths.canonical_dir.display()
-            ),
-        ));
+}
+
+#[cfg(unix)]
+fn open_owned_child_directory(
+    parent: &File,
+    name: &CStr,
+    run_dir: &Path,
+) -> std::io::Result<Option<File>> {
+    match open_child_directory(parent, name) {
+        Ok(directory) => Ok(directory),
+        Err(error)
+            if matches!(
+                error.raw_os_error(),
+                Some(libc::ELOOP) | Some(libc::ENOTDIR)
+            ) =>
+        {
+            Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!(
+                    "runtime IPC directory is not an owned directory: {}",
+                    run_dir
+                        .join(std::ffi::OsStr::from_bytes(name.to_bytes()))
+                        .display()
+                ),
+            ))
+        }
+        Err(error) => Err(error),
+    }
+}
+
+#[cfg(unix)]
+fn open_child_directory(parent: &File, name: &CStr) -> std::io::Result<Option<File>> {
+    let fd = unsafe {
+        libc::openat(
+            parent.as_raw_fd(),
+            name.as_ptr(),
+            libc::O_RDONLY | libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC,
+        )
+    };
+    if fd >= 0 {
+        return Ok(Some(unsafe { File::from_raw_fd(fd) }));
     }
 
-    let control_result = remove_file_if_exists(&paths.control);
-    let agent_result = remove_file_if_exists(&paths.agent);
-    control_result.and(agent_result)?;
-    std::fs::remove_dir(&paths.canonical_dir)
+    let error = std::io::Error::last_os_error();
+    if error.kind() == std::io::ErrorKind::NotFound {
+        Ok(None)
+    } else {
+        Err(error)
+    }
+}
+
+#[cfg(unix)]
+fn unlinkat_if_exists(parent: &File, name: &CStr, flags: i32) -> std::io::Result<()> {
+    if unsafe { libc::unlinkat(parent.as_raw_fd(), name.as_ptr(), flags) } == 0 {
+        return Ok(());
+    }
+
+    let error = std::io::Error::last_os_error();
+    if error.kind() == std::io::ErrorKind::NotFound {
+        Ok(())
+    } else {
+        Err(error)
+    }
+}
+
+#[cfg(unix)]
+fn c_path_name(path: &Path) -> std::io::Result<CString> {
+    let name = path.file_name().ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!("runtime IPC path has no file name: {}", path.display()),
+        )
+    })?;
+    CString::new(name.as_bytes()).map_err(|_| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!("runtime IPC file name contains NUL: {}", path.display()),
+        )
+    })
 }
 
 #[cfg(unix)]
@@ -447,6 +775,42 @@ mod tests {
         assert_eq!(
             paths.legacy_agent,
             Path::new("/tmp/msb/run/agent/bc62d1b6b936c78dbbd0bbe5572e32d0.sock")
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn lifecycle_guard_remains_owned_by_an_inherited_descriptor() {
+        use std::os::fd::FromRawFd;
+
+        let temp = tempfile::Builder::new()
+            .prefix("msb-lifecycle")
+            .tempdir_in("/tmp")
+            .unwrap();
+        let run_dir = temp.path().join("run");
+        let launcher = acquire_lifecycle_guard(&run_dir, "worker").unwrap();
+        let inherited_fd = unsafe { libc::dup(launcher.as_raw_fd()) };
+        assert!(inherited_fd >= 0);
+        let inherited =
+            SandboxLifecycleGuard::from_inherited_file(unsafe { File::from_raw_fd(inherited_fd) });
+
+        assert!(
+            try_acquire_lifecycle_guard(&run_dir, "worker")
+                .unwrap()
+                .is_none()
+        );
+        drop(launcher);
+        assert!(
+            try_acquire_lifecycle_guard(&run_dir, "worker")
+                .unwrap()
+                .is_none(),
+            "closing the launcher copy must not unlock the child copy"
+        );
+        drop(inherited);
+        assert!(
+            try_acquire_lifecycle_guard(&run_dir, "worker")
+                .unwrap()
+                .is_some()
         );
     }
 
@@ -616,5 +980,61 @@ mod tests {
 
         assert!(external.join("agent.sock").exists());
         assert!(std::fs::symlink_metadata(&paths.canonical_dir).is_err());
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn sandbox_cleanup_does_not_follow_owned_parent_symlinks() {
+        use std::os::unix::fs::symlink;
+
+        let temp = tempfile::Builder::new()
+            .prefix("msb-ipc")
+            .tempdir_in("/tmp")
+            .unwrap();
+        let run_dir = temp.path().join("run");
+        let paths = sandbox_socket_paths(&run_dir, "parent-symlinks");
+        let external_agent = temp.path().join("external-agent");
+        let external_sandboxes = temp.path().join("external-sandboxes");
+        let external_canonical = external_sandboxes.join(
+            paths
+                .canonical_dir
+                .file_name()
+                .expect("canonical directory has a hash name"),
+        );
+        std::fs::create_dir_all(&run_dir).unwrap();
+        std::fs::create_dir_all(&external_agent).unwrap();
+        std::fs::create_dir_all(&external_canonical).unwrap();
+        let legacy_agent = external_agent.join(paths.legacy_agent.file_name().unwrap());
+        let legacy_control = external_agent.join(paths.legacy_control.file_name().unwrap());
+        let canonical_agent = external_canonical.join("agent.sock");
+        let canonical_control = external_canonical.join("control.sock");
+        let _listeners = [
+            std::os::unix::net::UnixListener::bind(&legacy_agent).unwrap(),
+            std::os::unix::net::UnixListener::bind(&legacy_control).unwrap(),
+            std::os::unix::net::UnixListener::bind(&canonical_agent).unwrap(),
+            std::os::unix::net::UnixListener::bind(&canonical_control).unwrap(),
+        ];
+        symlink(&external_agent, run_dir.join("agent")).unwrap();
+        symlink(&external_sandboxes, run_dir.join("sandboxes")).unwrap();
+
+        assert_eq!(
+            remove_socket_pair(&paths.agent).unwrap_err().kind(),
+            std::io::ErrorKind::InvalidData
+        );
+        assert_eq!(
+            remove_socket_pair(&paths.legacy_agent).unwrap_err().kind(),
+            std::io::ErrorKind::InvalidData
+        );
+        let error = remove_sandbox_socket_artifacts(&run_dir, "parent-symlinks").unwrap_err();
+
+        assert_eq!(error.kind(), std::io::ErrorKind::InvalidData);
+        for endpoint in [
+            legacy_agent,
+            legacy_control,
+            canonical_agent,
+            canonical_control,
+        ] {
+            assert!(endpoint.exists(), "cleanup followed parent to {endpoint:?}");
+        }
     }
 }

--- a/crates/runtime/lib/ipc.rs
+++ b/crates/runtime/lib/ipc.rs
@@ -1,0 +1,620 @@
+//! Host-side per-sandbox IPC endpoint paths and lifecycle cleanup.
+
+use std::fmt::Write as _;
+use std::path::{Path, PathBuf};
+
+use sha2::{Digest, Sha256};
+
+//--------------------------------------------------------------------------------------------------
+// Constants
+//--------------------------------------------------------------------------------------------------
+
+/// Bytes of SHA-256 used by the canonical per-sandbox socket directory.
+pub const CANONICAL_SOCKET_HASH_BYTES: usize = 12;
+
+/// Bytes of SHA-256 used by the legacy flat agent socket names.
+pub const LEGACY_SOCKET_HASH_BYTES: usize = 16;
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// Canonical and compatibility Unix socket paths owned by one sandbox name.
+#[cfg(unix)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SandboxSocketPaths {
+    /// Canonical directory containing the sandbox's runtime sockets.
+    pub canonical_dir: PathBuf,
+    /// Canonical agent relay socket.
+    pub agent: PathBuf,
+    /// Canonical host-control socket.
+    pub control: PathBuf,
+    /// Legacy flat agent socket path used by older clients.
+    pub legacy_agent: PathBuf,
+    /// Legacy flat control socket path used by older clients.
+    pub legacy_control: PathBuf,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+/// Derive the canonical agent endpoint for a sandbox name.
+pub fn canonical_agent_endpoint(run_dir: &Path, name: &str) -> PathBuf {
+    #[cfg(unix)]
+    {
+        sandbox_socket_paths(run_dir, name).agent
+    }
+
+    #[cfg(windows)]
+    {
+        let _ = run_dir;
+        PathBuf::from(format!(
+            r"\\.\pipe\msb-agent-{}",
+            socket_hash(name, LEGACY_SOCKET_HASH_BYTES)
+        ))
+    }
+}
+
+/// Derive the control endpoint belonging to an agent endpoint.
+pub fn control_socket_path_for(agent_sock: &Path) -> PathBuf {
+    #[cfg(unix)]
+    if is_canonical_agent_socket(agent_sock) {
+        return agent_sock.with_file_name("control.sock");
+    }
+
+    agent_sock.with_extension(crate::control::CONTROL_SOCKET_EXTENSION)
+}
+
+/// Derive every canonical and compatibility Unix socket path for a sandbox.
+#[cfg(unix)]
+pub fn sandbox_socket_paths(run_dir: &Path, name: &str) -> SandboxSocketPaths {
+    let digest = Sha256::digest(name.as_bytes());
+    let canonical_id = encode_hash(&digest, CANONICAL_SOCKET_HASH_BYTES);
+    let legacy_id = encode_hash(&digest, LEGACY_SOCKET_HASH_BYTES);
+    let canonical_dir = run_dir.join("sandboxes").join(canonical_id);
+    let agent = canonical_dir.join("agent.sock");
+    let control = control_socket_path_for(&agent);
+    let legacy_agent = run_dir.join("agent").join(format!("{legacy_id}.sock"));
+    let legacy_control = control_socket_path_for(&legacy_agent);
+
+    SandboxSocketPaths {
+        canonical_dir,
+        agent,
+        control,
+        legacy_agent,
+        legacy_control,
+    }
+}
+
+/// Return whether a Unix socket path fits the platform `sockaddr_un` field.
+#[cfg(unix)]
+pub fn socket_path_fits(path: &Path) -> bool {
+    socket_path_len(path) < unix_socket_path_capacity()
+}
+
+/// Validate both endpoints in an agent/control socket pair.
+#[cfg(unix)]
+pub fn validate_socket_pair(agent_sock: &Path) -> std::io::Result<()> {
+    let control_sock = control_socket_path_for(agent_sock);
+    for path in [agent_sock, control_sock.as_path()] {
+        if !socket_path_fits(path) {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                format!(
+                    "Unix socket path is too long: {} bytes at {}; paths must be shorter than {} bytes",
+                    socket_path_len(path),
+                    path.display(),
+                    unix_socket_path_capacity()
+                ),
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// Prepare the canonical socket directory when `agent_sock` uses that layout.
+#[cfg(unix)]
+pub fn prepare_canonical_socket_dir(
+    run_dir: &Path,
+    name: &str,
+    agent_sock: &Path,
+) -> std::io::Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let paths = sandbox_socket_paths(run_dir, name);
+    if agent_sock != paths.agent {
+        return Ok(());
+    }
+
+    let parent = paths.canonical_dir.parent().ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!(
+                "canonical socket directory has no parent: {}",
+                paths.canonical_dir.display()
+            ),
+        )
+    })?;
+    std::fs::create_dir_all(parent)?;
+    match std::fs::create_dir(&paths.canonical_dir) {
+        Ok(()) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+            let metadata = std::fs::symlink_metadata(&paths.canonical_dir)?;
+            if !metadata.is_dir() || metadata.file_type().is_symlink() {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::AlreadyExists,
+                    format!(
+                        "canonical socket path is not a directory: {}",
+                        paths.canonical_dir.display()
+                    ),
+                ));
+            }
+        }
+        Err(error) => return Err(error),
+    }
+    std::fs::set_permissions(&paths.canonical_dir, std::fs::Permissions::from_mode(0o700))
+}
+
+/// Publish the legacy agent symlink for an already-bound runtime endpoint.
+#[cfg(unix)]
+pub fn publish_legacy_agent_link(
+    run_dir: &Path,
+    name: &str,
+    agent_sock: &Path,
+) -> std::io::Result<()> {
+    let paths = sandbox_socket_paths(run_dir, name);
+    if agent_sock == paths.legacy_agent {
+        // An older launcher asks the new runtime to bind the compatibility
+        // path directly. The endpoint already satisfies that client contract.
+        return Ok(());
+    }
+    validate_compatibility_path(&paths.legacy_agent)?;
+    publish_compatibility_link(run_dir, &paths.legacy_agent, agent_sock)
+}
+
+/// Publish the legacy control symlink for an already-bound runtime endpoint.
+#[cfg(unix)]
+pub fn publish_legacy_control_link(
+    run_dir: &Path,
+    name: &str,
+    control_sock: &Path,
+) -> std::io::Result<()> {
+    let paths = sandbox_socket_paths(run_dir, name);
+    if control_sock == paths.legacy_control {
+        return Ok(());
+    }
+    validate_compatibility_path(&paths.legacy_control)?;
+    publish_compatibility_link(run_dir, &paths.legacy_control, control_sock)
+}
+
+/// Remove one agent/control socket pair, treating missing files as success.
+pub fn remove_socket_pair(agent_sock: &Path) -> std::io::Result<()> {
+    #[cfg(unix)]
+    {
+        let control_sock = control_socket_path_for(agent_sock);
+        let control_result = remove_file_if_exists(&control_sock);
+        let agent_result = remove_file_if_exists(agent_sock);
+        control_result.and(agent_result)
+    }
+
+    #[cfg(windows)]
+    {
+        let _ = agent_sock;
+        Ok(())
+    }
+}
+
+/// Remove only the canonical socket namespace for one sandbox name.
+pub fn remove_canonical_socket_artifacts(run_dir: &Path, name: &str) -> std::io::Result<()> {
+    #[cfg(unix)]
+    {
+        remove_canonical_socket_dir(&sandbox_socket_paths(run_dir, name))
+    }
+
+    #[cfg(windows)]
+    {
+        let _ = (run_dir, name);
+        Ok(())
+    }
+}
+
+/// Remove canonical and compatibility socket artifacts for one sandbox name.
+pub fn remove_sandbox_socket_artifacts(run_dir: &Path, name: &str) -> std::io::Result<()> {
+    #[cfg(unix)]
+    {
+        let paths = sandbox_socket_paths(run_dir, name);
+        let mut first_error = None;
+
+        for path in [&paths.legacy_control, &paths.legacy_agent] {
+            if let Err(error) = remove_file_if_exists(path)
+                && first_error.is_none()
+            {
+                first_error = Some(error);
+            }
+        }
+
+        if let Err(error) = remove_canonical_socket_artifacts(run_dir, name)
+            && first_error.is_none()
+        {
+            first_error = Some(error);
+        }
+
+        match first_error {
+            Some(error) => Err(error),
+            None => Ok(()),
+        }
+    }
+
+    #[cfg(windows)]
+    {
+        let _ = (run_dir, name);
+        Ok(())
+    }
+}
+
+#[cfg(unix)]
+fn publish_compatibility_link(run_dir: &Path, link: &Path, target: &Path) -> std::io::Result<()> {
+    use std::os::unix::fs::symlink;
+
+    let parent = link.parent().ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!("compatibility link has no parent: {}", link.display()),
+        )
+    })?;
+    std::fs::create_dir_all(parent)?;
+
+    // Prefer a relative target for endpoints under the same run directory so
+    // compatibility links do not bake the absolute MSB_HOME into the tree.
+    let link_target = target
+        .strip_prefix(run_dir)
+        .map(|relative| PathBuf::from("..").join(relative))
+        .unwrap_or_else(|_| target.to_path_buf());
+
+    match symlink(&link_target, link) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+            if std::fs::symlink_metadata(link)?.file_type().is_symlink()
+                && std::fs::read_link(link)? == link_target
+            {
+                return Ok(());
+            }
+
+            // Publication is deliberately no-replace. Lifecycle cleanup owns
+            // stale files; startup must never unlink a possibly-live legacy
+            // endpoint merely because the sandbox name matches.
+            Err(std::io::Error::new(
+                std::io::ErrorKind::AlreadyExists,
+                format!(
+                    "legacy runtime endpoint already exists at {}",
+                    link.display()
+                ),
+            ))
+        }
+        Err(error) => Err(error),
+    }
+}
+
+#[cfg(unix)]
+fn validate_compatibility_path(path: &Path) -> std::io::Result<()> {
+    if socket_path_fits(path) {
+        Ok(())
+    } else {
+        Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!(
+                "legacy Unix socket path is too long: {} bytes at {}; paths must be shorter than {} bytes",
+                socket_path_len(path),
+                path.display(),
+                unix_socket_path_capacity()
+            ),
+        ))
+    }
+}
+
+#[cfg(windows)]
+fn socket_hash(name: &str, bytes: usize) -> String {
+    encode_hash(&Sha256::digest(name.as_bytes()), bytes)
+}
+
+fn encode_hash(digest: &[u8], bytes: usize) -> String {
+    let mut hash = String::with_capacity(bytes * 2);
+    for byte in digest.iter().take(bytes) {
+        let _ = write!(hash, "{byte:02x}");
+    }
+    hash
+}
+
+#[cfg(unix)]
+fn is_canonical_agent_socket(path: &Path) -> bool {
+    let Some(id) = path
+        .parent()
+        .and_then(Path::file_name)
+        .and_then(|id| id.to_str())
+    else {
+        return false;
+    };
+
+    path.file_name().is_some_and(|name| name == "agent.sock")
+        && path
+            .parent()
+            .and_then(Path::parent)
+            .and_then(Path::file_name)
+            .is_some_and(|name| name == "sandboxes")
+        && id.len() == CANONICAL_SOCKET_HASH_BYTES * 2
+        && id
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+}
+
+#[cfg(unix)]
+fn remove_file_if_exists(path: &Path) -> std::io::Result<()> {
+    match std::fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error),
+    }
+}
+
+#[cfg(unix)]
+fn remove_canonical_socket_dir(paths: &SandboxSocketPaths) -> std::io::Result<()> {
+    let metadata = match std::fs::symlink_metadata(&paths.canonical_dir) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(error),
+    };
+
+    if metadata.file_type().is_symlink() {
+        // Remove the unexpected namespace entry itself without following it
+        // to attacker-controlled socket names elsewhere on the host.
+        return std::fs::remove_file(&paths.canonical_dir);
+    }
+    if !metadata.is_dir() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!(
+                "canonical socket path is not a directory: {}",
+                paths.canonical_dir.display()
+            ),
+        ));
+    }
+
+    let control_result = remove_file_if_exists(&paths.control);
+    let agent_result = remove_file_if_exists(&paths.agent);
+    control_result.and(agent_result)?;
+    std::fs::remove_dir(&paths.canonical_dir)
+}
+
+#[cfg(unix)]
+fn socket_path_len(path: &Path) -> usize {
+    use std::os::unix::ffi::OsStrExt;
+
+    path.as_os_str().as_bytes().len()
+}
+
+#[cfg(unix)]
+fn unix_socket_path_capacity() -> usize {
+    let storage = unsafe { std::mem::zeroed::<libc::sockaddr_un>() };
+    storage.sun_path.len()
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests
+//--------------------------------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    #[cfg(unix)]
+    fn derives_canonical_and_legacy_hashes_from_one_name() {
+        let paths = sandbox_socket_paths(Path::new("/tmp/msb/run"), "worker");
+
+        assert_eq!(
+            paths.agent,
+            Path::new("/tmp/msb/run/sandboxes/87eba76e7f3164534045ba92/agent.sock")
+        );
+        assert_eq!(
+            paths.control,
+            Path::new("/tmp/msb/run/sandboxes/87eba76e7f3164534045ba92/control.sock")
+        );
+        assert_eq!(
+            paths.legacy_agent,
+            Path::new("/tmp/msb/run/agent/87eba76e7f3164534045ba922e7770fb.sock")
+        );
+        assert_eq!(
+            paths.legacy_control,
+            Path::new("/tmp/msb/run/agent/87eba76e7f3164534045ba922e7770fb.control.sock")
+        );
+        assert_eq!(control_socket_path_for(&paths.agent), paths.control);
+        assert_eq!(
+            control_socket_path_for(Path::new("/tmp/msb/sandboxes/worker/runtime/agent.sock")),
+            Path::new("/tmp/msb/sandboxes/worker/runtime/agent.control.sock")
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn derives_hashes_from_utf8_name_bytes() {
+        let paths = sandbox_socket_paths(Path::new("/tmp/msb/run"), "工作");
+
+        assert_eq!(
+            paths.agent,
+            Path::new("/tmp/msb/run/sandboxes/bc62d1b6b936c78dbbd0bbe5/agent.sock")
+        );
+        assert_eq!(
+            paths.legacy_agent,
+            Path::new("/tmp/msb/run/agent/bc62d1b6b936c78dbbd0bbe5572e32d0.sock")
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn validates_the_control_endpoint_at_the_unix_path_boundary() {
+        let capacity = unix_socket_path_capacity();
+        let accepted = PathBuf::from(format!(
+            "/{}.sock",
+            "a".repeat(capacity - "/.control.sock".len() - 1)
+        ));
+        let rejected = PathBuf::from(format!(
+            "/{}.sock",
+            "a".repeat(capacity - "/.control.sock".len())
+        ));
+
+        assert_eq!(
+            socket_path_len(&control_socket_path_for(&accepted)),
+            capacity - 1
+        );
+        assert!(validate_socket_pair(&accepted).is_ok());
+        assert_eq!(
+            socket_path_len(&control_socket_path_for(&rejected)),
+            capacity
+        );
+        assert_eq!(
+            validate_socket_pair(&rejected).unwrap_err().kind(),
+            std::io::ErrorKind::InvalidInput
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn compatibility_links_reach_canonical_unix_sockets() {
+        let temp = tempfile::Builder::new()
+            .prefix("msb-ipc")
+            .tempdir_in("/tmp")
+            .unwrap();
+        let run_dir = temp.path().join("run");
+        let paths = sandbox_socket_paths(&run_dir, "compat");
+        std::fs::create_dir_all(&paths.canonical_dir).unwrap();
+        let _agent = std::os::unix::net::UnixListener::bind(&paths.agent).unwrap();
+        let _control = std::os::unix::net::UnixListener::bind(&paths.control).unwrap();
+
+        publish_legacy_agent_link(&run_dir, "compat", &paths.agent).unwrap();
+        publish_legacy_control_link(&run_dir, "compat", &paths.control).unwrap();
+
+        assert_eq!(
+            std::fs::read_link(&paths.legacy_agent).unwrap(),
+            Path::new("../sandboxes")
+                .join(paths.canonical_dir.file_name().unwrap())
+                .join("agent.sock")
+        );
+        assert_eq!(
+            std::fs::read_link(&paths.legacy_control).unwrap(),
+            Path::new("../sandboxes")
+                .join(paths.canonical_dir.file_name().unwrap())
+                .join("control.sock")
+        );
+        std::os::unix::net::UnixStream::connect(&paths.legacy_agent).unwrap();
+        std::os::unix::net::UnixStream::connect(&paths.legacy_control).unwrap();
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn compatibility_publication_never_replaces_a_live_legacy_socket() {
+        let temp = tempfile::Builder::new()
+            .prefix("msb-ipc")
+            .tempdir_in("/tmp")
+            .unwrap();
+        let run_dir = temp.path().join("run");
+        let paths = sandbox_socket_paths(&run_dir, "collision");
+        std::fs::create_dir_all(&paths.canonical_dir).unwrap();
+        std::fs::create_dir_all(paths.legacy_agent.parent().unwrap()).unwrap();
+        let _canonical = std::os::unix::net::UnixListener::bind(&paths.agent).unwrap();
+        let _legacy = std::os::unix::net::UnixListener::bind(&paths.legacy_agent).unwrap();
+
+        let error = publish_legacy_agent_link(&run_dir, "collision", &paths.agent).unwrap_err();
+
+        assert_eq!(error.kind(), std::io::ErrorKind::AlreadyExists);
+        std::os::unix::net::UnixStream::connect(&paths.legacy_agent).unwrap();
+        assert!(
+            !std::fs::symlink_metadata(&paths.legacy_agent)
+                .unwrap()
+                .file_type()
+                .is_symlink()
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn new_runtime_accepts_legacy_paths_supplied_by_an_old_launcher() {
+        let temp = tempfile::Builder::new()
+            .prefix("msb-ipc")
+            .tempdir_in("/tmp")
+            .unwrap();
+        let run_dir = temp.path().join("run");
+        let paths = sandbox_socket_paths(&run_dir, "old-launcher");
+        std::fs::create_dir_all(paths.legacy_agent.parent().unwrap()).unwrap();
+        let _agent = std::os::unix::net::UnixListener::bind(&paths.legacy_agent).unwrap();
+        let _control = std::os::unix::net::UnixListener::bind(&paths.legacy_control).unwrap();
+
+        publish_legacy_agent_link(&run_dir, "old-launcher", &paths.legacy_agent).unwrap();
+        publish_legacy_control_link(&run_dir, "old-launcher", &paths.legacy_control).unwrap();
+
+        assert!(
+            !std::fs::symlink_metadata(&paths.legacy_agent)
+                .unwrap()
+                .file_type()
+                .is_symlink()
+        );
+        assert!(
+            !std::fs::symlink_metadata(&paths.legacy_control)
+                .unwrap()
+                .file_type()
+                .is_symlink()
+        );
+        std::os::unix::net::UnixStream::connect(&paths.legacy_agent).unwrap();
+        std::os::unix::net::UnixStream::connect(&paths.legacy_control).unwrap();
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn sandbox_cleanup_removes_canonical_and_compatibility_artifacts() {
+        let temp = tempfile::Builder::new()
+            .prefix("msb-ipc")
+            .tempdir_in("/tmp")
+            .unwrap();
+        let run_dir = temp.path().join("run");
+        let paths = sandbox_socket_paths(&run_dir, "cleanup");
+        std::fs::create_dir_all(&paths.canonical_dir).unwrap();
+        let agent = std::os::unix::net::UnixListener::bind(&paths.agent).unwrap();
+        let control = std::os::unix::net::UnixListener::bind(&paths.control).unwrap();
+        publish_legacy_agent_link(&run_dir, "cleanup", &paths.agent).unwrap();
+        publish_legacy_control_link(&run_dir, "cleanup", &paths.control).unwrap();
+
+        remove_sandbox_socket_artifacts(&run_dir, "cleanup").unwrap();
+
+        assert!(!paths.agent.exists());
+        assert!(!paths.control.exists());
+        assert!(std::fs::symlink_metadata(&paths.legacy_agent).is_err());
+        assert!(std::fs::symlink_metadata(&paths.legacy_control).is_err());
+        assert!(!paths.canonical_dir.exists());
+
+        drop((agent, control));
+        remove_sandbox_socket_artifacts(&run_dir, "cleanup").unwrap();
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn sandbox_cleanup_does_not_follow_a_canonical_directory_symlink() {
+        use std::os::unix::fs::symlink;
+
+        let temp = tempfile::Builder::new()
+            .prefix("msb-ipc")
+            .tempdir_in("/tmp")
+            .unwrap();
+        let run_dir = temp.path().join("run");
+        let paths = sandbox_socket_paths(&run_dir, "symlink");
+        let external = temp.path().join("external");
+        std::fs::create_dir_all(paths.canonical_dir.parent().unwrap()).unwrap();
+        std::fs::create_dir_all(&external).unwrap();
+        std::fs::write(external.join("agent.sock"), b"do not remove").unwrap();
+        symlink(&external, &paths.canonical_dir).unwrap();
+
+        remove_sandbox_socket_artifacts(&run_dir, "symlink").unwrap();
+
+        assert!(external.join("agent.sock").exists());
+        assert!(std::fs::symlink_metadata(&paths.canonical_dir).is_err());
+    }
+}

--- a/crates/runtime/lib/launch.rs
+++ b/crates/runtime/lib/launch.rs
@@ -42,6 +42,10 @@ pub struct LaunchConfig {
     /// Root directory holding every sandbox's persisted state.
     pub sandboxes_dir: PathBuf,
 
+    /// Root directory holding ephemeral host-runtime artifacts.
+    #[serde(default)]
+    pub run_dir: PathBuf,
+
     /// Internal directory containing process-held CPU allocation leases.
     pub cpu_lease_dir: PathBuf,
 

--- a/crates/runtime/lib/launch.rs
+++ b/crates/runtime/lib/launch.rs
@@ -10,7 +10,7 @@
 
 use std::path::PathBuf;
 
-use microsandbox_types::{CpuPlacement, DeploymentProfile};
+use microsandbox_types::{CpuPlacement, DeploymentProfile, VsockRouteSpec};
 use serde::{Deserialize, Serialize};
 
 use microsandbox_types::TransparentHugePagePolicy;
@@ -118,6 +118,10 @@ pub struct LaunchConfig {
     /// Sandbox slot for deterministic network address derivation.
     #[cfg(feature = "net")]
     pub sandbox_slot: u64,
+
+    /// Host Unix sockets exposed through virtio-vsock.
+    #[serde(default)]
+    pub vsock: Vec<VsockRouteSpec>,
 }
 
 /// Lifetime bounds for the sandbox.

--- a/crates/runtime/lib/lib.rs
+++ b/crates/runtime/lib/lib.rs
@@ -19,6 +19,7 @@ pub mod control;
 pub mod cpu;
 pub mod exec_log;
 pub mod heartbeat;
+pub mod ipc;
 pub mod launch;
 pub mod logging;
 pub mod maintenance;

--- a/crates/runtime/lib/maintenance.rs
+++ b/crates/runtime/lib/maintenance.rs
@@ -325,6 +325,27 @@ pub async fn cleanup_terminal_ephemeral_sandbox(
     run_dir: &Path,
     sandbox_id: i32,
 ) -> RuntimeResult<CleanupOutcome> {
+    cleanup_terminal_ephemeral_sandbox_inner(db, sandboxes_dir, run_dir, sandbox_id, false).await
+}
+
+/// Remove a terminal ephemeral sandbox while its runtime still owns the
+/// lifecycle guard during the synchronous exit observer.
+pub(crate) async fn cleanup_terminal_ephemeral_sandbox_owned(
+    db: &DbWriteConnection,
+    sandboxes_dir: &Path,
+    run_dir: &Path,
+    sandbox_id: i32,
+) -> RuntimeResult<CleanupOutcome> {
+    cleanup_terminal_ephemeral_sandbox_inner(db, sandboxes_dir, run_dir, sandbox_id, true).await
+}
+
+async fn cleanup_terminal_ephemeral_sandbox_inner(
+    db: &DbWriteConnection,
+    sandboxes_dir: &Path,
+    run_dir: &Path,
+    sandbox_id: i32,
+    owner_holds_guard: bool,
+) -> RuntimeResult<CleanupOutcome> {
     let Some(sandbox) = sandbox_entity::Entity::find_by_id(sandbox_id)
         .one(db)
         .await?
@@ -336,6 +357,30 @@ pub async fn cleanup_terminal_ephemeral_sandbox(
         return Ok(CleanupOutcome::SkippedPersistent);
     }
 
+    if !is_terminal(sandbox.status) {
+        return Ok(CleanupOutcome::SkippedActive);
+    }
+
+    let _guard = if owner_holds_guard {
+        None
+    } else {
+        let Some(guard) = crate::ipc::try_acquire_lifecycle_guard(run_dir, &sandbox.name)? else {
+            return Ok(CleanupOutcome::SkippedLivePid);
+        };
+        Some(guard)
+    };
+
+    // Status can change while waiting for another lifecycle operation. Re-read
+    // under ownership before removing any name-derived filesystem state.
+    let Some(sandbox) = sandbox_entity::Entity::find_by_id(sandbox_id)
+        .one(db)
+        .await?
+    else {
+        return Ok(CleanupOutcome::AlreadyGone);
+    };
+    if !sandbox.ephemeral {
+        return Ok(CleanupOutcome::SkippedPersistent);
+    }
     if !is_terminal(sandbox.status) {
         return Ok(CleanupOutcome::SkippedActive);
     }
@@ -670,6 +715,22 @@ async fn reconcile_stale_active(
     run_dir: &Path,
     sandbox: &sandbox_entity::Model,
 ) -> RuntimeResult<bool> {
+    let Some(_guard) = crate::ipc::try_acquire_lifecycle_guard(run_dir, &sandbox.name)? else {
+        return Ok(false);
+    };
+    let Some(sandbox) = sandbox_entity::Entity::find_by_id(sandbox.id)
+        .one(db)
+        .await?
+    else {
+        return Ok(false);
+    };
+    if !matches!(
+        sandbox.status,
+        sandbox_entity::SandboxStatus::Running | sandbox_entity::SandboxStatus::Draining
+    ) {
+        return Ok(false);
+    }
+
     let run = run_entity::Entity::find()
         .filter(run_entity::Column::SandboxId.eq(sandbox.id))
         .filter(run_entity::Column::Status.eq(run_entity::RunStatus::Running))
@@ -980,6 +1041,33 @@ mod tests {
         assert!(!sandbox_dir.exists(), "directory should be removed");
         #[cfg(unix)]
         assert_socket_artifacts_absent(dir.path(), &socket_paths, "eph");
+    }
+
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn cleanup_does_not_cross_a_live_lifecycle_owner() {
+        let (dir, db) = test_db().await;
+        let id = insert_sandbox(
+            &db,
+            "successor",
+            sandbox_entity::SandboxStatus::Stopped,
+            true,
+        )
+        .await;
+        let run_dir = dir.path().join("run");
+        let paths = seed_socket_artifacts(dir.path(), &run_dir, "successor");
+        let _owner = crate::ipc::acquire_lifecycle_guard(&run_dir, "successor").unwrap();
+
+        let outcome = cleanup_terminal_ephemeral_sandbox(&db, dir.path(), &run_dir, id)
+            .await
+            .unwrap();
+
+        assert_eq!(outcome, CleanupOutcome::SkippedLivePid);
+        assert!(status_of(&db, id).await.is_some());
+        assert!(paths.agent.exists());
+        assert!(paths.control.exists());
+        assert!(std::fs::symlink_metadata(paths.legacy_agent).is_ok());
+        assert!(std::fs::symlink_metadata(paths.legacy_control).is_ok());
     }
 
     #[tokio::test]

--- a/crates/runtime/lib/maintenance.rs
+++ b/crates/runtime/lib/maintenance.rs
@@ -777,6 +777,9 @@ fn remove_runtime_socket_artifacts(
     sandboxes_dir: &Path,
     name: &str,
 ) -> std::io::Result<()> {
+    #[cfg(not(unix))]
+    let _ = sandboxes_dir;
+
     let canonical_result = crate::ipc::remove_sandbox_socket_artifacts(run_dir, name);
 
     #[cfg(unix)]

--- a/crates/runtime/lib/maintenance.rs
+++ b/crates/runtime/lib/maintenance.rs
@@ -75,6 +75,9 @@ pub enum CleanupOutcome {
     /// Directory removal failed; the row remains so cleanup can retry later.
     DirRemoveFailed,
 
+    /// Runtime socket cleanup failed; the row remains so cleanup can retry.
+    ArtifactRemoveFailed,
+
     /// The sandbox row was already gone (cleaned by another runtime).
     AlreadyGone,
 
@@ -156,7 +159,7 @@ impl Default for MaintenanceLimits {
 /// Best-effort: this must never abort the sandbox boot path, so all errors are
 /// logged and swallowed. When the lease is not won, returns immediately after a
 /// single indexed read.
-pub async fn run_startup_maintenance(db: &DbWriteConnection, sandboxes_dir: &Path) {
+pub async fn run_startup_maintenance(db: &DbWriteConnection, sandboxes_dir: &Path, run_dir: &Path) {
     match try_acquire_lease(db).await {
         Ok(true) => {}
         Ok(false) => {
@@ -169,7 +172,14 @@ pub async fn run_startup_maintenance(db: &DbWriteConnection, sandboxes_dir: &Pat
         }
     }
 
-    match run_sandbox_lifecycle_maintenance(db, sandboxes_dir, MaintenanceLimits::default()).await {
+    match run_sandbox_lifecycle_maintenance(
+        db,
+        sandboxes_dir,
+        run_dir,
+        MaintenanceLimits::default(),
+    )
+    .await
+    {
         Ok(report) => {
             tracing::debug!(
                 reconciled = report.reconciled,
@@ -197,6 +207,7 @@ pub async fn run_startup_maintenance(db: &DbWriteConnection, sandboxes_dir: &Pat
 pub async fn run_sandbox_lifecycle_maintenance(
     db: &DbWriteConnection,
     sandboxes_dir: &Path,
+    run_dir: &Path,
     limits: MaintenanceLimits,
 ) -> RuntimeResult<MaintenanceReport> {
     let mut report = MaintenanceReport::default();
@@ -219,7 +230,7 @@ pub async fn run_sandbox_lifecycle_maintenance(
             report.timed_out = true;
             break;
         }
-        match reconcile_stale_active(db, &sandbox).await {
+        match reconcile_stale_active(db, sandboxes_dir, run_dir, &sandbox).await {
             Ok(true) => report.reconciled += 1,
             Ok(false) => {}
             Err(err) => {
@@ -248,7 +259,7 @@ pub async fn run_sandbox_lifecycle_maintenance(
                 report.timed_out = true;
                 break;
             }
-            match cleanup_terminal_ephemeral_sandbox(db, sandboxes_dir, sandbox.id).await {
+            match cleanup_terminal_ephemeral_sandbox(db, sandboxes_dir, run_dir, sandbox.id).await {
                 Ok(CleanupOutcome::Removed) => report.removed += 1,
                 Ok(_) => {}
                 Err(err) => {
@@ -311,6 +322,7 @@ pub async fn active_sandboxes_for_schema_rollback(
 pub async fn cleanup_terminal_ephemeral_sandbox(
     db: &DbWriteConnection,
     sandboxes_dir: &Path,
+    run_dir: &Path,
     sandbox_id: i32,
 ) -> RuntimeResult<CleanupOutcome> {
     let Some(sandbox) = sandbox_entity::Entity::find_by_id(sandbox_id)
@@ -330,6 +342,15 @@ pub async fn cleanup_terminal_ephemeral_sandbox(
 
     if has_live_active_run(db, sandbox.id).await? {
         return Ok(CleanupOutcome::SkippedLivePid);
+    }
+
+    if let Err(err) = remove_runtime_socket_artifacts(run_dir, sandboxes_dir, &sandbox.name) {
+        tracing::warn!(
+            sandbox = %sandbox.name,
+            error = %err,
+            "ephemeral cleanup failed to remove runtime socket artifacts; keeping row for retry"
+        );
+        return Ok(CleanupOutcome::ArtifactRemoveFailed);
     }
 
     // Remove the on-disk state before deleting the DB row. If this fails, the
@@ -645,6 +666,8 @@ async fn seed_install_exclusive_lease(
 /// `true` when the sandbox was marked terminal.
 async fn reconcile_stale_active(
     db: &DbWriteConnection,
+    sandboxes_dir: &Path,
+    run_dir: &Path,
     sandbox: &sandbox_entity::Model,
 ) -> RuntimeResult<bool> {
     let run = run_entity::Entity::find()
@@ -660,6 +683,7 @@ async fn reconcile_stale_active(
     // the sandbox status instead of leaving future stop callers polling.
     let Some(run) = run else {
         if sandbox.status == sandbox_entity::SandboxStatus::Draining {
+            remove_runtime_socket_artifacts(run_dir, sandboxes_dir, &sandbox.name)?;
             let now = chrono::Utc::now().naive_utc();
             let (terminal_status, _) = stale_runtime_terminal_state(sandbox.status);
             let result = sandbox_entity::Entity::update_many()
@@ -688,6 +712,11 @@ async fn reconcile_stale_active(
     if run.pid.is_some_and(pid_is_alive) {
         return Ok(false);
     }
+
+    // Runtime artifacts are part of reaping this specific dead process. Do
+    // this before the terminal transition so a failure leaves the row in the
+    // active maintenance query and therefore retryable.
+    remove_runtime_socket_artifacts(run_dir, sandboxes_dir, &sandbox.name)?;
 
     let now = chrono::Utc::now().naive_utc();
     let (terminal_status, reason) = stale_runtime_terminal_state(sandbox.status);
@@ -741,6 +770,23 @@ fn stale_runtime_terminal_state(
             run_entity::TerminationReason::InternalError,
         ),
     }
+}
+
+fn remove_runtime_socket_artifacts(
+    run_dir: &Path,
+    sandboxes_dir: &Path,
+    name: &str,
+) -> std::io::Result<()> {
+    let canonical_result = crate::ipc::remove_sandbox_socket_artifacts(run_dir, name);
+
+    #[cfg(unix)]
+    let fallback_result = crate::ipc::remove_socket_pair(
+        &sandboxes_dir.join(name).join("runtime").join("agent.sock"),
+    );
+    #[cfg(not(unix))]
+    let fallback_result = Ok(());
+
+    canonical_result.and(fallback_result)
 }
 
 /// Whether the sandbox has any run that is still Running with a live PID.
@@ -799,6 +845,12 @@ mod tests {
     const DEAD_PID: i32 = 2_000_000_000;
 
     async fn test_db() -> (TempDir, DbWriteConnection) {
+        #[cfg(unix)]
+        let dir = tempfile::Builder::new()
+            .prefix("msb-maint")
+            .tempdir_in("/tmp")
+            .unwrap();
+        #[cfg(not(unix))]
         let dir = tempfile::tempdir().unwrap();
         let db = DbWriteConnection::open(
             &dir.path().join("test.db"),
@@ -859,20 +911,72 @@ mod tests {
             .map(|model| model.status)
     }
 
+    #[cfg(unix)]
+    fn seed_socket_artifacts(
+        sandboxes_dir: &Path,
+        run_dir: &Path,
+        name: &str,
+    ) -> crate::ipc::SandboxSocketPaths {
+        let paths = crate::ipc::sandbox_socket_paths(run_dir, name);
+        std::fs::create_dir_all(&paths.canonical_dir).unwrap();
+        let _agent = std::os::unix::net::UnixListener::bind(&paths.agent).unwrap();
+        let _control = std::os::unix::net::UnixListener::bind(&paths.control).unwrap();
+        crate::ipc::publish_legacy_agent_link(run_dir, name, &paths.agent).unwrap();
+        crate::ipc::publish_legacy_control_link(run_dir, name, &paths.control).unwrap();
+
+        let fallback = sandboxes_dir.join(name).join("runtime").join("agent.sock");
+        std::fs::create_dir_all(fallback.parent().unwrap()).unwrap();
+        let _fallback_agent = std::os::unix::net::UnixListener::bind(&fallback).unwrap();
+        let fallback_control = crate::ipc::control_socket_path_for(&fallback);
+        let _fallback_control = std::os::unix::net::UnixListener::bind(fallback_control).unwrap();
+
+        paths
+    }
+
+    #[cfg(unix)]
+    fn assert_socket_artifacts_absent(
+        sandboxes_dir: &Path,
+        paths: &crate::ipc::SandboxSocketPaths,
+        name: &str,
+    ) {
+        let fallback_agent = sandboxes_dir.join(name).join("runtime").join("agent.sock");
+        let fallback_control = crate::ipc::control_socket_path_for(&fallback_agent);
+        for path in [
+            &paths.agent,
+            &paths.control,
+            &paths.legacy_agent,
+            &paths.legacy_control,
+            &fallback_agent,
+            &fallback_control,
+        ] {
+            assert!(
+                std::fs::symlink_metadata(path).is_err(),
+                "socket artifact remains at {}",
+                path.display()
+            );
+        }
+        assert!(!paths.canonical_dir.exists());
+    }
+
     #[tokio::test]
     async fn cleanup_removes_terminal_ephemeral_row_and_dir() {
         let (dir, db) = test_db().await;
         let id = insert_sandbox(&db, "eph", sandbox_entity::SandboxStatus::Stopped, true).await;
         let sandbox_dir = dir.path().join("eph");
         std::fs::create_dir_all(&sandbox_dir).unwrap();
+        let run_dir = dir.path().join("run");
+        #[cfg(unix)]
+        let socket_paths = seed_socket_artifacts(dir.path(), &run_dir, "eph");
 
-        let outcome = cleanup_terminal_ephemeral_sandbox(&db, dir.path(), id)
+        let outcome = cleanup_terminal_ephemeral_sandbox(&db, dir.path(), &run_dir, id)
             .await
             .unwrap();
 
         assert_eq!(outcome, CleanupOutcome::Removed);
         assert!(status_of(&db, id).await.is_none(), "row should be deleted");
         assert!(!sandbox_dir.exists(), "directory should be removed");
+        #[cfg(unix)]
+        assert_socket_artifacts_absent(dir.path(), &socket_paths, "eph");
     }
 
     #[tokio::test]
@@ -880,9 +984,10 @@ mod tests {
         let (dir, db) = test_db().await;
         let id = insert_sandbox(&db, "keep", sandbox_entity::SandboxStatus::Stopped, false).await;
 
-        let outcome = cleanup_terminal_ephemeral_sandbox(&db, dir.path(), id)
-            .await
-            .unwrap();
+        let outcome =
+            cleanup_terminal_ephemeral_sandbox(&db, dir.path(), &dir.path().join("run"), id)
+                .await
+                .unwrap();
 
         assert_eq!(outcome, CleanupOutcome::SkippedPersistent);
         assert!(status_of(&db, id).await.is_some(), "row should remain");
@@ -893,9 +998,10 @@ mod tests {
         let (dir, db) = test_db().await;
         let id = insert_sandbox(&db, "run", sandbox_entity::SandboxStatus::Running, true).await;
 
-        let outcome = cleanup_terminal_ephemeral_sandbox(&db, dir.path(), id)
-            .await
-            .unwrap();
+        let outcome =
+            cleanup_terminal_ephemeral_sandbox(&db, dir.path(), &dir.path().join("run"), id)
+                .await
+                .unwrap();
 
         assert_eq!(outcome, CleanupOutcome::SkippedActive);
         assert!(status_of(&db, id).await.is_some());
@@ -914,9 +1020,10 @@ mod tests {
         )
         .await;
 
-        let outcome = cleanup_terminal_ephemeral_sandbox(&db, dir.path(), id)
-            .await
-            .unwrap();
+        let outcome =
+            cleanup_terminal_ephemeral_sandbox(&db, dir.path(), &dir.path().join("run"), id)
+                .await
+                .unwrap();
 
         assert_eq!(outcome, CleanupOutcome::SkippedLivePid);
         assert!(status_of(&db, id).await.is_some());
@@ -928,13 +1035,13 @@ mod tests {
         let id = insert_sandbox(&db, "eph", sandbox_entity::SandboxStatus::Stopped, true).await;
 
         assert_eq!(
-            cleanup_terminal_ephemeral_sandbox(&db, dir.path(), id)
+            cleanup_terminal_ephemeral_sandbox(&db, dir.path(), &dir.path().join("run"), id)
                 .await
                 .unwrap(),
             CleanupOutcome::Removed
         );
         assert_eq!(
-            cleanup_terminal_ephemeral_sandbox(&db, dir.path(), id)
+            cleanup_terminal_ephemeral_sandbox(&db, dir.path(), &dir.path().join("run"), id)
                 .await
                 .unwrap(),
             CleanupOutcome::AlreadyGone
@@ -1069,10 +1176,13 @@ mod tests {
     #[tokio::test]
     async fn sweep_reconciles_dead_active_and_cleans_terminal_ephemeral() {
         let (dir, db) = test_db().await;
+        let run_dir = dir.path().join("run");
 
         // Persistent Running sandbox with a dead PID should become Crashed.
         let dead = insert_sandbox(&db, "dead", sandbox_entity::SandboxStatus::Running, false).await;
         insert_run(&db, dead, Some(DEAD_PID), run_entity::RunStatus::Running).await;
+        #[cfg(unix)]
+        let dead_sockets = seed_socket_artifacts(dir.path(), &run_dir, "dead");
 
         // Persistent Draining sandbox with a dead PID completed a requested stop.
         let draining = insert_sandbox(
@@ -1089,6 +1199,8 @@ mod tests {
             run_entity::RunStatus::Running,
         )
         .await;
+        #[cfg(unix)]
+        let draining_sockets = seed_socket_artifacts(dir.path(), &run_dir, "draining");
 
         // Draining without an active run should also settle as Stopped.
         let draining_no_run = insert_sandbox(
@@ -1098,15 +1210,22 @@ mod tests {
             false,
         )
         .await;
+        #[cfg(unix)]
+        let draining_no_run_sockets =
+            seed_socket_artifacts(dir.path(), &run_dir, "draining-no-run");
 
         // Ephemeral Stopped sandbox should be removed in phase 2.
         let eph = insert_sandbox(&db, "eph", sandbox_entity::SandboxStatus::Stopped, true).await;
         std::fs::create_dir_all(dir.path().join("eph")).unwrap();
 
-        let report =
-            run_sandbox_lifecycle_maintenance(&db, dir.path(), MaintenanceLimits::default())
-                .await
-                .unwrap();
+        let report = run_sandbox_lifecycle_maintenance(
+            &db,
+            dir.path(),
+            &run_dir,
+            MaintenanceLimits::default(),
+        )
+        .await
+        .unwrap();
 
         assert_eq!(report.reconciled, 3);
         assert_eq!(report.removed, 1);
@@ -1125,5 +1244,11 @@ mod tests {
         );
         assert!(status_of(&db, eph).await.is_none());
         assert!(!dir.path().join("eph").exists());
+        #[cfg(unix)]
+        {
+            assert_socket_artifacts_absent(dir.path(), &dead_sockets, "dead");
+            assert_socket_artifacts_absent(dir.path(), &draining_sockets, "draining");
+            assert_socket_artifacts_absent(dir.path(), &draining_no_run_sockets, "draining-no-run");
+        }
     }
 }

--- a/crates/runtime/lib/relay.rs
+++ b/crates/runtime/lib/relay.rs
@@ -201,7 +201,9 @@ impl AgentListener {
     fn cleanup(&self, endpoint: &Path) {
         #[cfg(unix)]
         {
-            let _ = std::fs::remove_file(endpoint);
+            // The control endpoint is derived from the relay endpoint and is
+            // owned by the same runtime lifetime.
+            let _ = crate::ipc::remove_socket_pair(endpoint);
         }
 
         #[cfg(windows)]

--- a/crates/runtime/lib/vm.rs
+++ b/crates/runtime/lib/vm.rs
@@ -71,6 +71,10 @@ pub const PARENT_WATCH_FD: i32 = 97;
 /// Fixed fd used to pass startup JSON from `msb sandbox` to its launcher.
 pub const STARTUP_FD: i32 = 98;
 
+/// Fixed fd holding the inherited per-sandbox lifecycle ownership lock.
+#[cfg(unix)]
+pub const LIFECYCLE_LOCK_FD: i32 = 99;
+
 /// Control byte sent by the owner to stop parent-watch monitoring without stopping the sandbox.
 pub const PARENT_WATCH_DETACH: u8 = 1;
 
@@ -113,6 +117,9 @@ pub struct Config {
 
     /// Root directory holding ephemeral host-runtime artifacts.
     pub run_dir: PathBuf,
+
+    /// Process-lifetime ownership of this sandbox's runtime artifacts.
+    pub lifecycle_guard: crate::ipc::SandboxLifecycleGuard,
 
     /// Internal directory containing process-held CPU allocation leases.
     pub cpu_lease_dir: PathBuf,
@@ -599,7 +606,6 @@ fn run(config: Config) -> RuntimeResult<std::convert::Infallible> {
             tracing::warn!(%release_error, "release CPU placement after legacy endpoint publication failure");
         }
         let _ = tokio_rt.block_on(mark_run_failed(&db, run_db_id));
-        let _ = crate::ipc::remove_socket_pair(&config.agent_sock_path);
         // Publication is no-replace. If it collided with another legacy
         // endpoint, clean only this runtime's canonical namespace.
         let _ =
@@ -706,6 +712,22 @@ fn run(config: Config) -> RuntimeResult<std::convert::Infallible> {
                     tracing::warn!(%error, "release CPU placement at VM exit");
                 }
 
+                // Runtime ownership remains live until this observer returns.
+                // Remove its deterministic endpoints before publishing a
+                // restartable terminal state; on failure, leave the active row
+                // for dead-PID maintenance to retry after the process exits.
+                let bound_result = crate::ipc::remove_socket_pair(&exit_sock_path);
+                let owned_result =
+                    crate::ipc::remove_sandbox_socket_artifacts(&exit_run_dir, &exit_sandbox_name);
+                if let Err(error) = bound_result.and(owned_result) {
+                    tracing::warn!(
+                        sandbox = %exit_sandbox_name,
+                        error = %error,
+                        "runtime exit socket cleanup failed; leaving lifecycle active for reaping"
+                    );
+                    return;
+                }
+
                 // Mark run as terminated with exit code and reason.
                 let _ = run_entity::Entity::update_many()
                     .col_expr(
@@ -740,7 +762,7 @@ fn run(config: Config) -> RuntimeResult<std::convert::Infallible> {
                 // discrete flags, not the full policy) and no-ops for
                 // persistent sandboxes. Best-effort; recovery sweeps from
                 // other runtimes cover any failure here.
-                match crate::maintenance::cleanup_terminal_ephemeral_sandbox(
+                match crate::maintenance::cleanup_terminal_ephemeral_sandbox_owned(
                     &exit_db,
                     &exit_sandboxes_dir,
                     &exit_run_dir,
@@ -775,12 +797,6 @@ fn run(config: Config) -> RuntimeResult<std::convert::Infallible> {
             {
                 tracing::debug!(error = %err, slot = writer.slot(), "metrics slot release at exit");
             }
-
-            // The relay/control async cleanup cannot run because _exit() is
-            // called immediately after this observer returns. Remove the exact
-            // bound pair plus canonical and compatibility artifacts here.
-            let _ = crate::ipc::remove_socket_pair(&exit_sock_path);
-            let _ = crate::ipc::remove_sandbox_socket_artifacts(&exit_run_dir, &exit_sandbox_name);
         },
         tokio_rt.handle().clone(),
         cpu_guard.vcpu_targets(),
@@ -851,15 +867,26 @@ fn run(config: Config) -> RuntimeResult<std::convert::Infallible> {
             match crate::control::spawn_control_listener(control_sock_path.clone(), context) {
                 Ok(()) => {
                     #[cfg(unix)]
-                    if let Err(e) = crate::ipc::publish_legacy_control_link(
+                    if let Err(error) = crate::ipc::publish_legacy_control_link(
                         &config.run_dir,
                         &config.sandbox_name,
                         &control_sock_path,
                     ) {
-                        tracing::warn!(
-                            "failed to publish legacy runtime control endpoint for {}: {e}",
-                            config.sandbox_name
-                        );
+                        if error.kind() == std::io::ErrorKind::InvalidInput {
+                            tracing::warn!(
+                                "legacy runtime control endpoint is unavailable for {}: {error}",
+                                config.sandbox_name
+                            );
+                        } else {
+                            let _ = tokio_rt.block_on(mark_run_failed(&db, run_db_id));
+                            // Preserve the colliding compatibility entry. It
+                            // may belong to a still-live older runtime.
+                            let _ = crate::ipc::remove_canonical_socket_artifacts(
+                                &config.run_dir,
+                                &config.sandbox_name,
+                            );
+                            return Err(error.into());
+                        }
                     }
                 }
                 Err(e) => {

--- a/crates/runtime/lib/vm.rs
+++ b/crates/runtime/lib/vm.rs
@@ -111,6 +111,9 @@ pub struct Config {
     /// inferring the path from `log_dir`.
     pub sandboxes_dir: PathBuf,
 
+    /// Root directory holding ephemeral host-runtime artifacts.
+    pub run_dir: PathBuf,
+
     /// Internal directory containing process-held CPU allocation leases.
     pub cpu_lease_dir: PathBuf,
 
@@ -524,6 +527,13 @@ fn run(config: Config) -> RuntimeResult<std::convert::Infallible> {
     // Heartbeats are per boot, while the runtime directory persists across starts.
     heartbeat::clear_stale(&config.runtime_dir)?;
 
+    #[cfg(unix)]
+    crate::ipc::prepare_canonical_socket_dir(
+        &config.run_dir,
+        &config.sandbox_name,
+        &config.agent_sock_path,
+    )?;
+
     // Create the relay and persist the run record with a single runtime hop.
     let (mut relay, db, run_db_id) = tokio_rt.block_on(async {
         let relay = AgentRelay::new(&config.agent_sock_path, Arc::clone(&shared));
@@ -576,6 +586,27 @@ fn run(config: Config) -> RuntimeResult<std::convert::Infallible> {
         }
     };
 
+    #[cfg(unix)]
+    if let Err(error) = crate::ipc::publish_legacy_agent_link(
+        &config.run_dir,
+        &config.sandbox_name,
+        &config.agent_sock_path,
+    ) {
+        if let Err(release_error) = tokio_rt.block_on(writeback_guard.release(&db)) {
+            tracing::warn!(%release_error, "release writeback admission after legacy endpoint publication failure");
+        }
+        if let Err(release_error) = tokio_rt.block_on(cpu_guard.release(&db)) {
+            tracing::warn!(%release_error, "release CPU placement after legacy endpoint publication failure");
+        }
+        let _ = tokio_rt.block_on(mark_run_failed(&db, run_db_id));
+        let _ = crate::ipc::remove_socket_pair(&config.agent_sock_path);
+        // Publication is no-replace. If it collided with another legacy
+        // endpoint, clean only this runtime's canonical namespace.
+        let _ =
+            crate::ipc::remove_canonical_socket_artifacts(&config.run_dir, &config.sandbox_name);
+        return Err(error.into());
+    }
+
     // Attach the exec.log writer so the ring reader can capture the
     // primary session's stdout/stderr. Failure to open the file is
     // non-fatal — log capture is best-effort and must not block boot.
@@ -626,6 +657,8 @@ fn run(config: Config) -> RuntimeResult<std::convert::Infallible> {
     let exit_run_id = run_db_id;
     let exit_reason_for_observer = Arc::clone(&exit_reason);
     let exit_sock_path = config.agent_sock_path.clone();
+    let exit_run_dir = config.run_dir.clone();
+    let exit_sandbox_name = config.sandbox_name.clone();
     let exit_sandboxes_dir = config.sandboxes_dir.clone();
     let exit_log_writer = exec_log_writer.clone();
     // Capture the activated writer so the exit observer can release the slot
@@ -710,6 +743,7 @@ fn run(config: Config) -> RuntimeResult<std::convert::Infallible> {
                 match crate::maintenance::cleanup_terminal_ephemeral_sandbox(
                     &exit_db,
                     &exit_sandboxes_dir,
+                    &exit_run_dir,
                     exit_sandbox_id,
                 )
                 .await
@@ -742,9 +776,11 @@ fn run(config: Config) -> RuntimeResult<std::convert::Infallible> {
                 tracing::debug!(error = %err, slot = writer.slot(), "metrics slot release at exit");
             }
 
-            // Clean up agent.sock — the relay's async cleanup won't run because
-            // _exit() is called immediately after this observer returns.
-            let _ = std::fs::remove_file(&exit_sock_path);
+            // The relay/control async cleanup cannot run because _exit() is
+            // called immediately after this observer returns. Remove the exact
+            // bound pair plus canonical and compatibility artifacts here.
+            let _ = crate::ipc::remove_socket_pair(&exit_sock_path);
+            let _ = crate::ipc::remove_sandbox_socket_artifacts(&exit_run_dir, &exit_sandbox_name);
         },
         tokio_rt.handle().clone(),
         cpu_guard.vcpu_targets(),
@@ -774,6 +810,9 @@ fn run(config: Config) -> RuntimeResult<std::convert::Infallible> {
             } else {
                 release_reserved_metrics_slot(config.metrics_slot.as_ref());
             }
+            let _ = crate::ipc::remove_socket_pair(&config.agent_sock_path);
+            let _ =
+                crate::ipc::remove_sandbox_socket_artifacts(&config.run_dir, &config.sandbox_name);
             return Err(e);
         }
     };
@@ -809,13 +848,26 @@ fn run(config: Config) -> RuntimeResult<std::convert::Infallible> {
                 #[cfg(feature = "net")]
                 secrets,
             };
-            if let Err(e) =
-                crate::control::spawn_control_listener(control_sock_path.clone(), context)
-            {
-                tracing::warn!(
-                    "failed to start runtime control listener at {}: {e}",
-                    control_sock_path.display()
-                );
+            match crate::control::spawn_control_listener(control_sock_path.clone(), context) {
+                Ok(()) => {
+                    #[cfg(unix)]
+                    if let Err(e) = crate::ipc::publish_legacy_control_link(
+                        &config.run_dir,
+                        &config.sandbox_name,
+                        &control_sock_path,
+                    ) {
+                        tracing::warn!(
+                            "failed to publish legacy runtime control endpoint for {}: {e}",
+                            config.sandbox_name
+                        );
+                    }
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        "failed to start runtime control listener at {}: {e}",
+                        control_sock_path.display()
+                    );
+                }
             }
         }
     }
@@ -838,7 +890,9 @@ fn run(config: Config) -> RuntimeResult<std::convert::Infallible> {
             } else {
                 release_reserved_metrics_slot(config.metrics_slot.as_ref());
             }
-            let _ = std::fs::remove_file(&config.agent_sock_path);
+            let _ = crate::ipc::remove_socket_pair(&config.agent_sock_path);
+            let _ =
+                crate::ipc::remove_sandbox_socket_artifacts(&config.run_dir, &config.sandbox_name);
             return Err(e);
         }
     }
@@ -903,8 +957,14 @@ fn run(config: Config) -> RuntimeResult<std::convert::Infallible> {
     {
         let maintenance_db = db.clone();
         let maintenance_dir = config.sandboxes_dir.clone();
+        let maintenance_run_dir = config.run_dir.clone();
         tokio_rt.spawn(async move {
-            crate::maintenance::run_startup_maintenance(&maintenance_db, &maintenance_dir).await;
+            crate::maintenance::run_startup_maintenance(
+                &maintenance_db,
+                &maintenance_dir,
+                &maintenance_run_dir,
+            )
+            .await;
         });
     }
 

--- a/crates/runtime/lib/vm.rs
+++ b/crates/runtime/lib/vm.rs
@@ -28,6 +28,10 @@ use microsandbox_protocol::{
     message::{Message, MessageType},
 };
 use microsandbox_types::CpuPlacement;
+#[cfg(windows)]
+use microsandbox_vsock::WindowsNamedPipePortBackend;
+#[cfg(unix)]
+use microsandbox_vsock::{UnixDatagramPortBackend, UnixStreamPortBackend};
 use msb_krun::VmBuilder;
 use sea_orm::{ColumnTrait, EntityTrait, Set};
 use serde::{Deserialize, Serialize};
@@ -333,6 +337,9 @@ pub struct VmConfig {
 
     /// Disk-image volume mounts attached as extra virtio-blk devices.
     pub disks: Vec<DiskMountSpec>,
+
+    /// Host Unix sockets exposed through virtio-vsock.
+    pub vsock: Vec<microsandbox_types::VsockRouteSpec>,
 
     /// Pre-built filesystem backends as `(tag, backend)` pairs.
     #[cfg(unix)]
@@ -1559,6 +1566,97 @@ fn build_vm(
     let mut network_termination_handle = None;
     let mut network_metrics_handle = None;
     let mut network_secrets_handle = None;
+
+    // Vsock routes are independent of virtio-net. Microsandbox owns the host
+    // local IPC endpoints while libkrun retains framing, queues and credits.
+    #[cfg(unix)]
+    if !vm.vsock.is_empty() {
+        #[cfg(feature = "net")]
+        if vm.deployment_profile == microsandbox_types::DeploymentProfile::MultiTenant {
+            return Err(RuntimeError::Custom(
+                "host vsock routes are disabled for multi-tenant deployments".to_string(),
+            ));
+        }
+
+        let mut streams: Vec<(u32, Arc<dyn msb_krun::backends::vsock::VsockPortBackend>)> =
+            Vec::new();
+        let mut datagrams: Vec<(
+            u32,
+            Arc<dyn msb_krun::backends::vsock::VsockDatagramPortBackend>,
+        )> = Vec::new();
+
+        for route in &vm.vsock {
+            match route.socket_type {
+                microsandbox_types::VsockSocketType::Stream => {
+                    let backend =
+                        UnixStreamPortBackend::new(&route.host_socket).map_err(|err| {
+                            RuntimeError::Custom(format!(
+                                "initialize stream vsock route {}:{}: {err}",
+                                route.host_socket.display(),
+                                route.port
+                            ))
+                        })?;
+                    streams.push((route.port, Arc::new(backend)));
+                }
+                microsandbox_types::VsockSocketType::Dgram => {
+                    let backend =
+                        UnixDatagramPortBackend::new(&route.host_socket).map_err(|err| {
+                            RuntimeError::Custom(format!(
+                                "initialize datagram vsock route {}:{}: {err}",
+                                route.host_socket.display(),
+                                route.port
+                            ))
+                        })?;
+                    datagrams.push((route.port, Arc::new(backend)));
+                }
+            }
+        }
+
+        builder = builder.vsock(move |mut vsock| {
+            for (port, backend) in streams {
+                vsock = vsock.custom(port, backend);
+            }
+            for (port, backend) in datagrams {
+                vsock = vsock.custom_dgram(port, backend);
+            }
+            vsock
+        });
+    }
+
+    #[cfg(windows)]
+    if !vm.vsock.is_empty() {
+        #[cfg(feature = "net")]
+        if vm.deployment_profile == microsandbox_types::DeploymentProfile::MultiTenant {
+            return Err(RuntimeError::Custom(
+                "host vsock routes are disabled for multi-tenant deployments".to_string(),
+            ));
+        }
+
+        let mut streams: Vec<(u32, Arc<dyn msb_krun::backends::vsock::VsockPortBackend>)> =
+            Vec::new();
+        for route in &vm.vsock {
+            if route.socket_type == microsandbox_types::VsockSocketType::Dgram {
+                return Err(RuntimeError::Custom(
+                    "vsock datagram routes are not supported on Windows".to_string(),
+                ));
+            }
+            let backend = WindowsNamedPipePortBackend::new(&route.host_socket).map_err(|err| {
+                RuntimeError::Custom(format!(
+                    "initialize stream vsock route {}:{}: {err}",
+                    route.host_socket.display(),
+                    route.port
+                ))
+            })?;
+            streams.push((route.port, Arc::new(backend)));
+        }
+
+        builder = builder.vsock(move |mut vsock| {
+            for (port, backend) in streams {
+                vsock = vsock.custom(port, backend);
+            }
+            vsock
+        });
+    }
 
     // Network.
     #[cfg(feature = "net")]

--- a/crates/vsock/Cargo.toml
+++ b/crates/vsock/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "microsandbox-vsock"
+description = "Host local-IPC backends for microsandbox virtio-vsock routes."
+version.workspace = true
+authors.workspace = true
+repository.workspace = true
+license.workspace = true
+edition.workspace = true
+
+[lib]
+path = "lib/lib.rs"
+
+[dependencies]
+msb_krun.workspace = true
+
+[target.'cfg(unix)'.dependencies]
+libc = { workspace = true }
+nix = { workspace = true, features = ["fs", "socket"] }
+tempfile = { workspace = true }
+tracing = { workspace = true }
+
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.61.2", features = [
+    "Win32_Foundation",
+    "Win32_Security",
+    "Win32_Storage_FileSystem",
+    "Win32_System_IO",
+    "Win32_System_Pipes",
+] }
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/crates/vsock/lib/common.rs
+++ b/crates/vsock/lib/common.rs
@@ -1,0 +1,132 @@
+use std::io;
+#[cfg(unix)]
+use std::os::fd::{AsRawFd, OwnedFd};
+#[cfg(unix)]
+use std::path::Path;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+#[cfg(unix)]
+use nix::fcntl::{FcntlArg, FdFlag, OFlag, fcntl};
+#[cfg(unix)]
+use nix::sys::socket::{AddressFamily, SockFlag, SockType, socket};
+
+//--------------------------------------------------------------------------------------------------
+// Constants
+//--------------------------------------------------------------------------------------------------
+
+pub(crate) const DEFAULT_MAX_ACTIVE_PEERS: usize = 256;
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+pub(crate) struct PeerLimit {
+    active: Arc<AtomicUsize>,
+    max: usize,
+}
+
+pub(crate) struct PeerLease {
+    active: Arc<AtomicUsize>,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Methods
+//--------------------------------------------------------------------------------------------------
+
+impl PeerLimit {
+    pub(crate) fn new(max: usize) -> Self {
+        Self {
+            active: Arc::new(AtomicUsize::new(0)),
+            max,
+        }
+    }
+
+    pub(crate) fn acquire(&self) -> io::Result<PeerLease> {
+        self.active
+            .fetch_update(Ordering::AcqRel, Ordering::Acquire, |active| {
+                (active < self.max).then_some(active + 1)
+            })
+            .map_err(|_| {
+                io::Error::new(
+                    io::ErrorKind::ConnectionRefused,
+                    "vsock route peer limit reached",
+                )
+            })?;
+        Ok(PeerLease {
+            active: Arc::clone(&self.active),
+        })
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Trait Implementations
+//--------------------------------------------------------------------------------------------------
+
+impl Drop for PeerLease {
+    fn drop(&mut self) {
+        self.active.fetch_sub(1, Ordering::AcqRel);
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+#[cfg(unix)]
+pub(crate) fn validate_socket_path(path: &Path) -> io::Result<()> {
+    if !path.is_absolute() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "vsock host socket path must be absolute",
+        ));
+    }
+    if path.as_os_str().is_empty() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "vsock host socket path must not be empty",
+        ));
+    }
+    nix::sys::socket::UnixAddr::new(path)
+        .map(|_| ())
+        .map_err(|err| io::Error::new(io::ErrorKind::InvalidInput, err))
+}
+
+#[cfg(unix)]
+pub(crate) fn nonblocking_unix_socket(socket_type: SockType) -> io::Result<OwnedFd> {
+    let fd = socket(AddressFamily::Unix, socket_type, SockFlag::empty(), None)
+        .map_err(io::Error::from)?;
+
+    // Some host implementations have historically ignored SOCK_NONBLOCK for
+    // Unix sockets. Verify it explicitly so the VMM thread can never block.
+    let flags = fcntl(&fd, FcntlArg::F_GETFL).map_err(io::Error::from)?;
+    let flags = OFlag::from_bits_truncate(flags);
+    fcntl(&fd, FcntlArg::F_SETFL(flags | OFlag::O_NONBLOCK)).map_err(io::Error::from)?;
+    let descriptor_flags = fcntl(&fd, FcntlArg::F_GETFD).map_err(io::Error::from)?;
+    let descriptor_flags = FdFlag::from_bits_truncate(descriptor_flags);
+    fcntl(
+        &fd,
+        FcntlArg::F_SETFD(descriptor_flags | FdFlag::FD_CLOEXEC),
+    )
+    .map_err(io::Error::from)?;
+
+    #[cfg(target_os = "macos")]
+    {
+        let enabled: libc::c_int = 1;
+        // SAFETY: `fd` is live and the option points to a correctly sized int.
+        let result = unsafe {
+            libc::setsockopt(
+                fd.as_raw_fd(),
+                libc::SOL_SOCKET,
+                libc::SO_NOSIGPIPE,
+                &enabled as *const _ as *const libc::c_void,
+                std::mem::size_of_val(&enabled) as libc::socklen_t,
+            )
+        };
+        if result != 0 {
+            return Err(io::Error::last_os_error());
+        }
+    }
+
+    Ok(fd)
+}

--- a/crates/vsock/lib/common.rs
+++ b/crates/vsock/lib/common.rs
@@ -1,6 +1,8 @@
 use std::io;
+#[cfg(target_os = "macos")]
+use std::os::fd::AsRawFd;
 #[cfg(unix)]
-use std::os::fd::{AsRawFd, OwnedFd};
+use std::os::fd::OwnedFd;
 #[cfg(unix)]
 use std::path::Path;
 use std::sync::Arc;

--- a/crates/vsock/lib/dgram.rs
+++ b/crates/vsock/lib/dgram.rs
@@ -1,0 +1,214 @@
+use std::io;
+use std::os::fd::{AsRawFd, OwnedFd, RawFd};
+use std::os::unix::net::UnixDatagram as StdUnixDatagram;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use msb_krun::backends::vsock::{
+    VsockDatagramBackend, VsockDatagramPeer, VsockDatagramPortBackend, VsockDatagramRead,
+    VsockNotifier,
+};
+use nix::sys::socket::{MsgFlags, recv, send};
+use tempfile::TempDir;
+
+use crate::common::{DEFAULT_MAX_ACTIVE_PEERS, PeerLease, PeerLimit, validate_socket_path};
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// Factory that connects guest datagram peers to one host Unix datagram service.
+pub struct UnixDatagramPortBackend {
+    path: PathBuf,
+    peer_dir: TempDir,
+    next_peer: AtomicU64,
+    peers: PeerLimit,
+}
+
+struct UnixDatagramBackend {
+    fd: OwnedFd,
+    bound_path: PathBuf,
+    _lease: PeerLease,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Methods
+//--------------------------------------------------------------------------------------------------
+
+impl UnixDatagramPortBackend {
+    /// Create a route to an existing host `SOCK_DGRAM` Unix socket.
+    pub fn new(path: impl AsRef<Path>) -> io::Result<Self> {
+        Self::with_max_active_peers(path, DEFAULT_MAX_ACTIVE_PEERS)
+    }
+
+    /// Create a route with an explicit cap on active guest source peers.
+    pub fn with_max_active_peers(path: impl AsRef<Path>, max: usize) -> io::Result<Self> {
+        let path = path.as_ref().to_path_buf();
+        validate_socket_path(&path)?;
+        if max == 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "vsock datagram peer limit must be non-zero",
+            ));
+        }
+
+        // A short private directory keeps reply addresses within macOS's
+        // smaller sockaddr_un path limit. TempDir handles normal cleanup.
+        // Use the short, stable Unix temporary root rather than macOS's long
+        // per-user TMPDIR. `sockaddr_un` is only 104 bytes there and nix may
+        // otherwise return a truncated peer address that cannot be replied to.
+        let peer_dir = tempfile::Builder::new()
+            .prefix("msb-vsock-")
+            .tempdir_in("/tmp")?;
+        Ok(Self {
+            path,
+            peer_dir,
+            next_peer: AtomicU64::new(1),
+            peers: PeerLimit::new(max),
+        })
+    }
+
+    fn next_peer_path(&self) -> PathBuf {
+        let id = self.next_peer.fetch_add(1, Ordering::Relaxed);
+        self.peer_dir.path().join(format!("{id:x}.sock"))
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Trait Implementations
+//--------------------------------------------------------------------------------------------------
+
+impl VsockDatagramPortBackend for UnixDatagramPortBackend {
+    fn open_peer(
+        &self,
+        _peer: VsockDatagramPeer,
+        _notifier: VsockNotifier,
+    ) -> io::Result<Box<dyn VsockDatagramBackend>> {
+        let lease = self.peers.acquire()?;
+        let bound_path = self.next_peer_path();
+        // std includes the terminating NUL in sockaddr_un on BSD hosts. nix's
+        // shorter bind length makes macOS report a one-byte-truncated reply
+        // pathname to the receiving service.
+        let socket = StdUnixDatagram::bind(&bound_path)?;
+        if let Err(err) = socket.set_nonblocking(true) {
+            let _ = std::fs::remove_file(&bound_path);
+            return Err(err);
+        }
+        if let Err(err) = socket.connect(&self.path) {
+            let _ = std::fs::remove_file(&bound_path);
+            return Err(err);
+        }
+        let fd = socket.into();
+
+        Ok(Box::new(UnixDatagramBackend {
+            fd,
+            bound_path,
+            _lease: lease,
+        }))
+    }
+}
+
+impl VsockDatagramBackend for UnixDatagramBackend {
+    fn send(&self, payload: &[u8]) -> io::Result<()> {
+        let written =
+            send(self.fd.as_raw_fd(), payload, MsgFlags::empty()).map_err(io::Error::from)?;
+        if written != payload.len() {
+            return Err(io::Error::new(
+                io::ErrorKind::WriteZero,
+                "Unix datagram send did not consume the complete message",
+            ));
+        }
+        Ok(())
+    }
+
+    fn receive(&self, buf: &mut [u8]) -> io::Result<VsockDatagramRead> {
+        let received = recv(
+            self.fd.as_raw_fd(),
+            buf,
+            MsgFlags::MSG_DONTWAIT | MsgFlags::MSG_TRUNC,
+        )
+        .map_err(io::Error::from)?;
+        Ok(VsockDatagramRead {
+            len: received.min(buf.len()),
+            truncated: received > buf.len(),
+        })
+    }
+
+    fn pollable(&self) -> Option<RawFd> {
+        Some(self.fd.as_raw_fd())
+    }
+}
+
+impl Drop for UnixDatagramBackend {
+    fn drop(&mut self) {
+        if let Err(err) = std::fs::remove_file(&self.bound_path)
+            && err.kind() != io::ErrorKind::NotFound
+        {
+            tracing::debug!(
+                path = %self.bound_path.display(),
+                %err,
+                "failed to remove vsock datagram peer socket"
+            );
+        }
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests
+//--------------------------------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use std::os::unix::net::UnixDatagram;
+
+    use super::*;
+
+    #[test]
+    fn datagram_backend_preserves_messages_and_reply_address() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("service.sock");
+        let host = UnixDatagram::bind(&path).unwrap();
+        host.set_read_timeout(Some(std::time::Duration::from_secs(1)))
+            .unwrap();
+
+        let service = UnixDatagramPortBackend::new(&path).unwrap();
+        let endpoint = service
+            .open_peer(
+                VsockDatagramPeer {
+                    guest_cid: 3,
+                    guest_port: 4000,
+                    host_port: 5000,
+                },
+                VsockNotifier::new().unwrap(),
+            )
+            .unwrap();
+
+        endpoint.send(b"guest-event").unwrap();
+        let mut request = [0; 32];
+        let (len, peer) = host.recv_from(&mut request).unwrap();
+        assert_eq!(&request[..len], b"guest-event");
+        let reply_path = peer.as_pathname().unwrap();
+        assert!(
+            reply_path.exists(),
+            "reply path missing: {}",
+            reply_path.display()
+        );
+        host.send_to(b"host-event", reply_path).unwrap();
+
+        let mut response = [0; 32];
+        let mut read = None;
+        for _ in 0..100 {
+            match endpoint.receive(&mut response) {
+                Ok(received) => {
+                    read = Some(received);
+                    break;
+                }
+                Err(err) if err.kind() == io::ErrorKind::WouldBlock => std::thread::yield_now(),
+                result => panic!("unexpected datagram receive result: {result:?}"),
+            }
+        }
+        let read = read.expect("reply datagram should become readable");
+        assert_eq!(&response[..read.len], b"host-event");
+        assert!(!read.truncated);
+    }
+}

--- a/crates/vsock/lib/lib.rs
+++ b/crates/vsock/lib/lib.rs
@@ -1,0 +1,20 @@
+//! Host local-IPC backends for microsandbox virtio-vsock routes.
+
+mod common;
+#[cfg(unix)]
+mod dgram;
+#[cfg(unix)]
+mod stream;
+#[cfg(windows)]
+mod windows;
+
+//--------------------------------------------------------------------------------------------------
+// Re-Exports
+//--------------------------------------------------------------------------------------------------
+
+#[cfg(unix)]
+pub use dgram::UnixDatagramPortBackend;
+#[cfg(unix)]
+pub use stream::UnixStreamPortBackend;
+#[cfg(windows)]
+pub use windows::WindowsNamedPipePortBackend;

--- a/crates/vsock/lib/stream.rs
+++ b/crates/vsock/lib/stream.rs
@@ -1,0 +1,199 @@
+use std::io;
+use std::os::fd::{AsRawFd, OwnedFd, RawFd};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use msb_krun::backends::vsock::{
+    VsockConnectRequest, VsockConnectState, VsockNotifier, VsockPortBackend, VsockShutdown,
+    VsockStreamBackend,
+};
+use nix::errno::Errno;
+use nix::sys::socket::{
+    MsgFlags, Shutdown, SockType, UnixAddr, connect, getsockopt, recv, send, shutdown, sockopt,
+};
+
+use crate::common::{
+    DEFAULT_MAX_ACTIVE_PEERS, PeerLease, PeerLimit, nonblocking_unix_socket, validate_socket_path,
+};
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// Factory that connects guest streams to one existing host Unix socket.
+pub struct UnixStreamPortBackend {
+    path: PathBuf,
+    peers: PeerLimit,
+}
+
+struct UnixStreamBackend {
+    fd: OwnedFd,
+    connected: AtomicBool,
+    defer_connect_check: AtomicBool,
+    _lease: PeerLease,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Methods
+//--------------------------------------------------------------------------------------------------
+
+impl UnixStreamPortBackend {
+    /// Create a route to an existing host `SOCK_STREAM` Unix socket.
+    pub fn new(path: impl AsRef<Path>) -> io::Result<Self> {
+        Self::with_max_active_peers(path, DEFAULT_MAX_ACTIVE_PEERS)
+    }
+
+    /// Create a route with an explicit cap on active guest connections.
+    pub fn with_max_active_peers(path: impl AsRef<Path>, max: usize) -> io::Result<Self> {
+        let path = path.as_ref().to_path_buf();
+        validate_socket_path(&path)?;
+        if max == 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "vsock stream peer limit must be non-zero",
+            ));
+        }
+        Ok(Self {
+            path,
+            peers: PeerLimit::new(max),
+        })
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Trait Implementations
+//--------------------------------------------------------------------------------------------------
+
+impl VsockPortBackend for UnixStreamPortBackend {
+    fn connect(
+        &self,
+        _request: VsockConnectRequest,
+        _notifier: VsockNotifier,
+    ) -> io::Result<Box<dyn VsockStreamBackend>> {
+        let lease = self.peers.acquire()?;
+        let fd = nonblocking_unix_socket(SockType::Stream)?;
+        let address = UnixAddr::new(&self.path)
+            .map_err(|err| io::Error::new(io::ErrorKind::InvalidInput, err))?;
+
+        let (connected, pending) = match connect(fd.as_raw_fd(), &address) {
+            Ok(()) => (true, false),
+            // Linux reports EAGAIN for an in-progress nonblocking AF_UNIX
+            // connect, while BSD hosts normally use EINPROGRESS.
+            Err(Errno::EINPROGRESS | Errno::EAGAIN) => (false, true),
+            Err(err) => return Err(io::Error::from(err)),
+        };
+
+        Ok(Box::new(UnixStreamBackend {
+            fd,
+            connected: AtomicBool::new(connected),
+            // libkrun queries once immediately after `connect`. Defer SO_ERROR
+            // until the next writable event so zero cannot be mistaken for a
+            // completed nonblocking connection.
+            defer_connect_check: AtomicBool::new(pending),
+            _lease: lease,
+        }))
+    }
+}
+
+impl VsockStreamBackend for UnixStreamBackend {
+    fn connect_state(&self) -> io::Result<VsockConnectState> {
+        if self.connected.load(Ordering::Acquire) {
+            return Ok(VsockConnectState::Connected);
+        }
+        if self.defer_connect_check.swap(false, Ordering::AcqRel) {
+            return Ok(VsockConnectState::Connecting);
+        }
+
+        let error = getsockopt(&self.fd, sockopt::SocketError).map_err(io::Error::from)?;
+        if error != 0 {
+            return Err(io::Error::from_raw_os_error(error));
+        }
+        self.connected.store(true, Ordering::Release);
+        Ok(VsockConnectState::Connected)
+    }
+
+    fn read(&self, buf: &mut [u8]) -> io::Result<usize> {
+        recv(self.fd.as_raw_fd(), buf, MsgFlags::MSG_DONTWAIT).map_err(io::Error::from)
+    }
+
+    fn write(&self, buf: &[u8]) -> io::Result<usize> {
+        #[cfg(target_os = "linux")]
+        let flags = MsgFlags::MSG_NOSIGNAL;
+        #[cfg(not(target_os = "linux"))]
+        let flags = MsgFlags::empty();
+        send(self.fd.as_raw_fd(), buf, flags).map_err(io::Error::from)
+    }
+
+    fn shutdown(&self, how: VsockShutdown) -> io::Result<()> {
+        let how = match how {
+            VsockShutdown::Read => Shutdown::Read,
+            VsockShutdown::Write => Shutdown::Write,
+            VsockShutdown::Both => Shutdown::Both,
+        };
+        shutdown(self.fd.as_raw_fd(), how).map_err(io::Error::from)
+    }
+
+    fn pollable(&self) -> Option<RawFd> {
+        Some(self.fd.as_raw_fd())
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests
+//--------------------------------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use std::io::{Read, Write};
+    use std::os::unix::net::UnixListener;
+
+    use msb_krun::backends::vsock::{VsockConnectRequest, VsockPortBackend};
+
+    use super::*;
+
+    #[test]
+    fn stream_backend_connects_and_moves_bytes_in_both_directions() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("service.sock");
+        let listener = UnixListener::bind(&path).unwrap();
+        let service = UnixStreamPortBackend::new(&path).unwrap();
+        let endpoint = service
+            .connect(
+                VsockConnectRequest {
+                    guest_cid: 3,
+                    guest_port: 4000,
+                    host_port: 5000,
+                },
+                VsockNotifier::new().unwrap(),
+            )
+            .unwrap();
+        let (mut host, _) = listener.accept().unwrap();
+
+        for _ in 0..100 {
+            if endpoint.connect_state().unwrap() == VsockConnectState::Connected {
+                break;
+            }
+            std::thread::yield_now();
+        }
+        assert_eq!(
+            endpoint.connect_state().unwrap(),
+            VsockConnectState::Connected
+        );
+
+        endpoint.write(b"guest").unwrap();
+        let mut request = [0; 5];
+        host.read_exact(&mut request).unwrap();
+        assert_eq!(&request, b"guest");
+
+        host.write_all(b"host").unwrap();
+        let mut response = [0; 4];
+        for _ in 0..100 {
+            match endpoint.read(&mut response) {
+                Ok(4) => break,
+                Err(err) if err.kind() == io::ErrorKind::WouldBlock => std::thread::yield_now(),
+                result => panic!("unexpected stream read result: {result:?}"),
+            }
+        }
+        assert_eq!(&response, b"host");
+    }
+}

--- a/crates/vsock/lib/windows.rs
+++ b/crates/vsock/lib/windows.rs
@@ -1,0 +1,593 @@
+use std::collections::VecDeque;
+use std::ffi::OsStr;
+use std::io;
+use std::os::windows::ffi::OsStrExt;
+use std::os::windows::io::AsRawHandle;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Condvar, Mutex};
+use std::thread::JoinHandle;
+use std::time::Duration;
+
+use msb_krun::backends::vsock::{
+    VsockConnectRequest, VsockConnectState, VsockNotifier, VsockPortBackend, VsockShutdown,
+    VsockStreamBackend,
+};
+use windows_sys::Win32::Foundation::{
+    CloseHandle, ERROR_MORE_DATA, ERROR_PIPE_BUSY, GENERIC_READ, GENERIC_WRITE, HANDLE,
+    INVALID_HANDLE_VALUE,
+};
+use windows_sys::Win32::Storage::FileSystem::{
+    CreateFileW, OPEN_EXISTING, ReadFile, SECURITY_IDENTIFICATION, SECURITY_SQOS_PRESENT, WriteFile,
+};
+use windows_sys::Win32::System::IO::CancelSynchronousIo;
+use windows_sys::Win32::System::Pipes::{PeekNamedPipe, WaitNamedPipeW};
+
+use crate::common::{DEFAULT_MAX_ACTIVE_PEERS, PeerLease, PeerLimit};
+
+//--------------------------------------------------------------------------------------------------
+// Constants
+//--------------------------------------------------------------------------------------------------
+
+const LOCAL_PIPE_PREFIX: &str = r"\\.\pipe\";
+const MAX_BUFFERED_BYTES: usize = 8 * 1024 * 1024;
+const IO_CHUNK_SIZE: usize = 64 * 1024;
+const WORKER_WAIT: Duration = Duration::from_millis(10);
+const PIPE_BUSY_WAIT_MS: u32 = 50;
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// Factory that connects guest streams to one existing local Windows named pipe.
+pub struct WindowsNamedPipePortBackend {
+    path: PathBuf,
+    peers: PeerLimit,
+}
+
+struct WindowsNamedPipeBackend {
+    shared: Arc<SharedState>,
+    worker: JoinHandle<()>,
+    _lease: PeerLease,
+}
+
+struct SharedState {
+    state: Mutex<PipeState>,
+    wake_worker: Condvar,
+    notifier: VsockNotifier,
+}
+
+struct PipeState {
+    connection: ConnectionState,
+    incoming: VecDeque<u8>,
+    outgoing: VecDeque<u8>,
+    read_shutdown: bool,
+    write_shutdown: bool,
+    terminate: bool,
+}
+
+enum ConnectionState {
+    Connecting,
+    Connected,
+    Failed(StoredError),
+}
+
+#[derive(Clone)]
+struct StoredError {
+    kind: io::ErrorKind,
+    raw_os_error: Option<i32>,
+    message: String,
+}
+
+struct PipeHandle(HANDLE);
+
+// Windows named-pipe handles are process-wide opaque values and all access to
+// this one is confined to its worker thread.
+unsafe impl Send for PipeHandle {}
+
+//--------------------------------------------------------------------------------------------------
+// Methods
+//--------------------------------------------------------------------------------------------------
+
+impl WindowsNamedPipePortBackend {
+    /// Create a route to an existing local `\\.\pipe\...` named pipe.
+    pub fn new(path: impl AsRef<Path>) -> io::Result<Self> {
+        Self::with_max_active_peers(path, DEFAULT_MAX_ACTIVE_PEERS)
+    }
+
+    /// Create a route with an explicit cap on active guest connections.
+    pub fn with_max_active_peers(path: impl AsRef<Path>, max: usize) -> io::Result<Self> {
+        let path = path.as_ref().to_path_buf();
+        validate_named_pipe_path(&path)?;
+        if max == 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "vsock stream peer limit must be non-zero",
+            ));
+        }
+        Ok(Self {
+            path,
+            peers: PeerLimit::new(max),
+        })
+    }
+}
+
+impl StoredError {
+    fn capture(error: io::Error) -> Self {
+        Self {
+            kind: error.kind(),
+            raw_os_error: error.raw_os_error(),
+            message: error.to_string(),
+        }
+    }
+
+    fn to_io_error(&self) -> io::Error {
+        self.raw_os_error
+            .map(io::Error::from_raw_os_error)
+            .unwrap_or_else(|| io::Error::new(self.kind, self.message.clone()))
+    }
+}
+
+impl SharedState {
+    fn fail(&self, error: io::Error) {
+        let mut state = self.state.lock().unwrap();
+        state.connection = ConnectionState::Failed(StoredError::capture(error));
+        state.read_shutdown = true;
+        state.write_shutdown = true;
+        drop(state);
+        let _ = self.notifier.notify();
+    }
+
+    fn close(&self) {
+        let mut state = self.state.lock().unwrap();
+        state.read_shutdown = true;
+        state.write_shutdown = true;
+        drop(state);
+        let _ = self.notifier.notify();
+    }
+}
+
+impl PipeHandle {
+    fn raw(&self) -> HANDLE {
+        self.0
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Trait Implementations
+//--------------------------------------------------------------------------------------------------
+
+impl VsockPortBackend for WindowsNamedPipePortBackend {
+    fn connect(
+        &self,
+        _request: VsockConnectRequest,
+        notifier: VsockNotifier,
+    ) -> io::Result<Box<dyn VsockStreamBackend>> {
+        let lease = self.peers.acquire()?;
+        let shared = Arc::new(SharedState {
+            state: Mutex::new(PipeState {
+                connection: ConnectionState::Connecting,
+                incoming: VecDeque::new(),
+                outgoing: VecDeque::new(),
+                read_shutdown: false,
+                write_shutdown: false,
+                terminate: false,
+            }),
+            wake_worker: Condvar::new(),
+            notifier,
+        });
+        let worker_shared = Arc::clone(&shared);
+        let path = self.path.clone();
+        let worker = std::thread::Builder::new()
+            .name("vsock named pipe".to_string())
+            .spawn(move || named_pipe_worker(path, worker_shared))?;
+
+        Ok(Box::new(WindowsNamedPipeBackend {
+            shared,
+            worker,
+            _lease: lease,
+        }))
+    }
+}
+
+impl VsockStreamBackend for WindowsNamedPipeBackend {
+    fn connect_state(&self) -> io::Result<VsockConnectState> {
+        match &self.shared.state.lock().unwrap().connection {
+            ConnectionState::Connecting => Ok(VsockConnectState::Connecting),
+            ConnectionState::Connected => Ok(VsockConnectState::Connected),
+            ConnectionState::Failed(error) => Err(error.to_io_error()),
+        }
+    }
+
+    fn read(&self, buf: &mut [u8]) -> io::Result<usize> {
+        let mut state = self.shared.state.lock().unwrap();
+        if let ConnectionState::Failed(error) = &state.connection {
+            return Err(error.to_io_error());
+        }
+        if state.incoming.is_empty() {
+            return if state.read_shutdown {
+                Ok(0)
+            } else {
+                Err(io::Error::from(io::ErrorKind::WouldBlock))
+            };
+        }
+
+        let count = buf.len().min(state.incoming.len());
+        for slot in &mut buf[..count] {
+            *slot = state.incoming.pop_front().unwrap();
+        }
+        drop(state);
+        self.shared.wake_worker.notify_one();
+        Ok(count)
+    }
+
+    fn write(&self, buf: &[u8]) -> io::Result<usize> {
+        let mut state = self.shared.state.lock().unwrap();
+        if let ConnectionState::Failed(error) = &state.connection {
+            return Err(error.to_io_error());
+        }
+        if state.write_shutdown {
+            return Err(io::Error::from(io::ErrorKind::BrokenPipe));
+        }
+        if !matches!(state.connection, ConnectionState::Connected) {
+            return Err(io::Error::from(io::ErrorKind::WouldBlock));
+        }
+
+        let count = buf
+            .len()
+            .min(MAX_BUFFERED_BYTES.saturating_sub(state.outgoing.len()));
+        if count == 0 {
+            return Err(io::Error::from(io::ErrorKind::WouldBlock));
+        }
+        state.outgoing.extend(&buf[..count]);
+        drop(state);
+        self.shared.wake_worker.notify_one();
+        Ok(count)
+    }
+
+    fn shutdown(&self, how: VsockShutdown) -> io::Result<()> {
+        let terminate = how == VsockShutdown::Both;
+        let mut state = self.shared.state.lock().unwrap();
+        match how {
+            VsockShutdown::Read => state.read_shutdown = true,
+            VsockShutdown::Write => state.write_shutdown = true,
+            VsockShutdown::Both => {
+                state.read_shutdown = true;
+                state.write_shutdown = true;
+                state.terminate = true;
+            }
+        }
+        drop(state);
+        self.shared.wake_worker.notify_one();
+        if terminate {
+            cancel_worker_io(&self.worker);
+        }
+        Ok(())
+    }
+}
+
+impl Drop for WindowsNamedPipeBackend {
+    fn drop(&mut self) {
+        self.shared.state.lock().unwrap().terminate = true;
+        self.shared.wake_worker.notify_one();
+        // A named-pipe server can stop reading indefinitely. Cancel any
+        // synchronous ReadFile/WriteFile owned by this worker so dropping a
+        // guest connection cannot strand a thread outside the peer limit.
+        cancel_worker_io(&self.worker);
+    }
+}
+
+impl Drop for PipeHandle {
+    fn drop(&mut self) {
+        unsafe {
+            CloseHandle(self.raw());
+        }
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+fn validate_named_pipe_path(path: &Path) -> io::Result<()> {
+    let text = path.as_os_str().to_string_lossy();
+    let Some(name) = text.get(LOCAL_PIPE_PREFIX.len()..) else {
+        return Err(invalid_pipe_path());
+    };
+    if !text[..LOCAL_PIPE_PREFIX.len()].eq_ignore_ascii_case(LOCAL_PIPE_PREFIX)
+        || name.is_empty()
+        || name
+            .split(['\\', '/'])
+            .any(|part| part.is_empty() || part == "." || part == "..")
+    {
+        return Err(invalid_pipe_path());
+    }
+    Ok(())
+}
+
+fn invalid_pipe_path() -> io::Error {
+    io::Error::new(
+        io::ErrorKind::InvalidInput,
+        r"vsock host path must be a local Windows named pipe such as \\.\pipe\api",
+    )
+}
+
+fn wide_null(value: &OsStr) -> Vec<u16> {
+    value.encode_wide().chain(std::iter::once(0)).collect()
+}
+
+fn cancel_worker_io(worker: &JoinHandle<()>) {
+    unsafe {
+        // ERROR_NOT_FOUND is expected when the worker is between operations or
+        // has already exited, so cancellation is intentionally best-effort.
+        CancelSynchronousIo(worker.as_raw_handle());
+    }
+}
+
+fn connect_named_pipe(path: &Path, shared: &SharedState) -> io::Result<PipeHandle> {
+    let path = wide_null(path.as_os_str());
+    loop {
+        if shared.state.lock().unwrap().terminate {
+            return Err(io::Error::new(
+                io::ErrorKind::Interrupted,
+                "vsock named-pipe connection was cancelled",
+            ));
+        }
+
+        let handle = unsafe {
+            CreateFileW(
+                path.as_ptr(),
+                GENERIC_READ | GENERIC_WRITE,
+                0,
+                std::ptr::null(),
+                OPEN_EXISTING,
+                SECURITY_SQOS_PRESENT | SECURITY_IDENTIFICATION,
+                std::ptr::null_mut(),
+            )
+        };
+        if handle != INVALID_HANDLE_VALUE {
+            return Ok(PipeHandle(handle));
+        }
+
+        let error = io::Error::last_os_error();
+        if error.raw_os_error() != Some(ERROR_PIPE_BUSY as i32) {
+            return Err(error);
+        }
+        unsafe {
+            WaitNamedPipeW(path.as_ptr(), PIPE_BUSY_WAIT_MS);
+        }
+    }
+}
+
+fn named_pipe_worker(path: PathBuf, shared: Arc<SharedState>) {
+    let handle = match connect_named_pipe(&path, &shared) {
+        Ok(handle) => handle,
+        Err(error) => {
+            shared.fail(error);
+            return;
+        }
+    };
+    {
+        let mut state = shared.state.lock().unwrap();
+        if state.terminate {
+            return;
+        }
+        state.connection = ConnectionState::Connected;
+    }
+    let _ = shared.notifier.notify();
+
+    loop {
+        let mut progress = false;
+        let outgoing = {
+            let mut state = shared.state.lock().unwrap();
+            if state.terminate {
+                return;
+            }
+            let count = state.outgoing.len().min(IO_CHUNK_SIZE);
+            let bytes = state.outgoing.drain(..count).collect::<Vec<_>>();
+            if count > 0 {
+                progress = true;
+            }
+            bytes
+        };
+
+        if !outgoing.is_empty() {
+            let mut written = 0;
+            let success = unsafe {
+                WriteFile(
+                    handle.raw(),
+                    outgoing.as_ptr(),
+                    outgoing.len() as u32,
+                    &mut written,
+                    std::ptr::null_mut(),
+                )
+            };
+            if success == 0 {
+                shared.fail(io::Error::last_os_error());
+                return;
+            }
+            if written as usize != outgoing.len() {
+                shared.fail(io::Error::new(
+                    io::ErrorKind::WriteZero,
+                    "Windows named pipe accepted only part of a stream write",
+                ));
+                return;
+            }
+            let _ = shared.notifier.notify();
+        }
+
+        let read_capacity = {
+            let state = shared.state.lock().unwrap();
+            if state.read_shutdown {
+                0
+            } else {
+                MAX_BUFFERED_BYTES.saturating_sub(state.incoming.len())
+            }
+        };
+        if read_capacity > 0 {
+            let mut available = 0;
+            let peeked = unsafe {
+                PeekNamedPipe(
+                    handle.raw(),
+                    std::ptr::null_mut(),
+                    0,
+                    std::ptr::null_mut(),
+                    &mut available,
+                    std::ptr::null_mut(),
+                )
+            };
+            if peeked == 0 {
+                shared.close();
+                return;
+            }
+            if available > 0 {
+                let count = (available as usize).min(read_capacity).min(IO_CHUNK_SIZE);
+                let mut input = vec![0_u8; count];
+                let mut read = 0;
+                let success = unsafe {
+                    ReadFile(
+                        handle.raw(),
+                        input.as_mut_ptr(),
+                        count as u32,
+                        &mut read,
+                        std::ptr::null_mut(),
+                    )
+                };
+                let error = (success == 0).then(io::Error::last_os_error);
+                if let Some(error) = error
+                    && error.raw_os_error() != Some(ERROR_MORE_DATA as i32)
+                {
+                    shared.fail(error);
+                    return;
+                }
+                if read > 0 {
+                    input.truncate(read as usize);
+                    shared.state.lock().unwrap().incoming.extend(input);
+                    let _ = shared.notifier.notify();
+                    progress = true;
+                }
+            }
+        }
+
+        if !progress {
+            let state = shared.state.lock().unwrap();
+            let _ = shared.wake_worker.wait_timeout(state, WORKER_WAIT).unwrap();
+        }
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests
+//--------------------------------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use std::time::Instant;
+
+    use windows_sys::Win32::Foundation::ERROR_PIPE_CONNECTED;
+    use windows_sys::Win32::Storage::FileSystem::PIPE_ACCESS_DUPLEX;
+    use windows_sys::Win32::System::Pipes::{
+        ConnectNamedPipe, CreateNamedPipeW, PIPE_READMODE_BYTE, PIPE_TYPE_BYTE, PIPE_WAIT,
+    };
+
+    use super::*;
+
+    #[test]
+    fn rejects_remote_and_ambiguous_pipe_paths() {
+        assert!(validate_named_pipe_path(Path::new(r"\\.\pipe\api")).is_ok());
+        assert!(validate_named_pipe_path(Path::new(r"\\server\pipe\api")).is_err());
+        assert!(validate_named_pipe_path(Path::new(r"\\.\pipe\..\api")).is_err());
+        assert!(validate_named_pipe_path(Path::new(r"C:\api")).is_err());
+    }
+
+    #[test]
+    fn named_pipe_backend_moves_stream_bytes_in_both_directions() {
+        let name = format!(r"\\.\pipe\msb-vsock-test-{}", std::process::id());
+        let wide = wide_null(OsStr::new(&name));
+        let server = unsafe {
+            CreateNamedPipeW(
+                wide.as_ptr(),
+                PIPE_ACCESS_DUPLEX,
+                PIPE_TYPE_BYTE | PIPE_READMODE_BYTE | PIPE_WAIT,
+                1,
+                4096,
+                4096,
+                0,
+                std::ptr::null(),
+            )
+        };
+        assert_ne!(server, INVALID_HANDLE_VALUE);
+        let server = PipeHandle(server);
+        let host = std::thread::spawn(move || {
+            let connected = unsafe { ConnectNamedPipe(server.raw(), std::ptr::null_mut()) };
+            if connected == 0 {
+                assert_eq!(
+                    io::Error::last_os_error().raw_os_error(),
+                    Some(ERROR_PIPE_CONNECTED as i32)
+                );
+            }
+
+            let mut request = [0_u8; 5];
+            let mut read = 0;
+            assert_ne!(
+                unsafe {
+                    ReadFile(
+                        server.raw(),
+                        request.as_mut_ptr(),
+                        request.len() as u32,
+                        &mut read,
+                        std::ptr::null_mut(),
+                    )
+                },
+                0
+            );
+            assert_eq!(&request[..read as usize], b"guest");
+
+            let mut written = 0;
+            assert_ne!(
+                unsafe {
+                    WriteFile(
+                        server.raw(),
+                        b"host".as_ptr(),
+                        4,
+                        &mut written,
+                        std::ptr::null_mut(),
+                    )
+                },
+                0
+            );
+            assert_eq!(written, 4);
+        });
+
+        let service = WindowsNamedPipePortBackend::new(&name).unwrap();
+        let endpoint = service
+            .connect(
+                VsockConnectRequest {
+                    guest_cid: 3,
+                    guest_port: 4000,
+                    host_port: 5000,
+                },
+                VsockNotifier::new().unwrap(),
+            )
+            .unwrap();
+        let deadline = Instant::now() + Duration::from_secs(2);
+        while endpoint.connect_state().unwrap() != VsockConnectState::Connected {
+            assert!(Instant::now() < deadline, "named-pipe connect timed out");
+            std::thread::yield_now();
+        }
+        assert_eq!(endpoint.write(b"guest").unwrap(), 5);
+
+        let mut response = [0_u8; 4];
+        loop {
+            match endpoint.read(&mut response) {
+                Ok(4) => break,
+                Err(error) if error.kind() == io::ErrorKind::WouldBlock => {
+                    assert!(Instant::now() < deadline, "named-pipe read timed out");
+                    std::thread::yield_now();
+                }
+                result => panic!("unexpected named-pipe read result: {result:?}"),
+            }
+        }
+        assert_eq!(&response, b"host");
+        host.join().unwrap();
+    }
+}

--- a/docs/cli/sandbox-commands.mdx
+++ b/docs/cli/sandbox-commands.mdx
@@ -52,6 +52,7 @@ Common flags:
 | `-v`, `--volume` | Mount a host path or named volume, such as `./src:/app:ro` |
 | `--mount-dir`, `--mount-file`, `--mount-disk`, `--mount-named` | Mount a source with an explicit kind (`SOURCE:DEST[:OPTIONS]` or `NAME:DEST[:OPTIONS]`). `--mount-named` creates missing named volumes idempotently and accepts `kind=dir\|disk`, `size=...`, and `quota=...` |
 | `-p`, `--port` | Publish a port, such as `8000:8000` for loopback-only or `0.0.0.0:8000:8000` for all host interfaces |
+| `--vsock` | Expose local host IPC at host CID 2 using `HOST_PATH:PORT[/stream\|/dgram]`; Unix sockets and local Windows named pipes are supported, the flag is repeatable, and stream is the default |
 | `-e`, `--env` | Set an environment variable |
 | `--label` | Attach a label for metric attribution (`KEY=VALUE`, or bare `KEY`). Repeatable |
 | `-w`, `--workdir` | Set the working directory |

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -58,6 +58,7 @@
             "icon": "network-wired",
             "pages": [
               "networking/overview",
+              "networking/vsock",
               "networking/dns",
               "networking/tls"
             ]

--- a/docs/networking/vsock.mdx
+++ b/docs/networking/vsock.mdx
@@ -1,0 +1,124 @@
+---
+title: Virtio-vsock
+sidebarTitle: "Virtio-vsock"
+description: Expose explicit host Unix socket or Windows named-pipe services directly to guest AF_VSOCK applications
+icon: "arrows-left-right"
+---
+
+Virtio-vsock provides local guest-to-host communication without IP networking, TSI interception, SSH forwarding, or an agentd proxy. A guest application opens an `AF_VSOCK` socket and addresses host CID `2` plus the configured port. Microsandbox connects that route to one explicit local endpoint: a Unix socket on macOS or Linux, or a local named pipe on Windows.
+
+```bash
+# SOCK_STREAM is the default.
+msb run --vsock /run/host-api.sock:5000 alpine
+
+# The suffix can be explicit; repeat the flag for more routes.
+msb run \
+  --vsock /run/host-api.sock:5000/stream \
+  --vsock /run/events.sock:5001/dgram \
+  alpine
+```
+
+On Windows, the same flag and SDK method take a local named-pipe path. Stream routes are supported; `/dgram` remains Unix-only.
+
+```powershell
+msb run --vsock '\\.\pipe\host-api:5000' alpine
+```
+
+The path comes first, like the host side of `--port`; the number is the host-CID vsock port visible to the guest. Unlike `--port`, this is not a TCP or UDP mapping and there is no guest IP port. `/stream` and `/dgram` select vsock socket semantics. The same numeric port may be used once for each socket type because stream and datagram namespaces are distinct.
+
+```mermaid
+flowchart LR
+    G["Guest application\nAF_VSOCK, CID 2:5000"] -->|"virtio-vsock stream frames"| K["libkrun\nqueues, framing, stream credits"]
+    K -->|"typed stream backend"| M{"microsandbox host adapter"}
+    M -->|"macOS/Linux\nSOCK_STREAM bytes"| U["Unix service\n/run/host-api.sock"]
+    M -->|"Windows\nbounded byte stream"| W["Local named pipe\n\\\\.\\pipe\\host-api"]
+    U -->|"reply bytes"| M
+    W -->|"reply bytes"| M
+    M -->|"host reply"| K --> G
+```
+
+For Unix-host datagrams, libkrun identifies a peer by `(guest CID, guest source port, host port)`. Microsandbox creates a private, stable Unix datagram reply address for that peer, preserving message boundaries in both directions. Delivery is best-effort: backpressure may drop a datagram, and messages larger than 64 KiB are dropped rather than split. A host service can reply after it receives the guest's first message; this API does not initiate a new guest peer from the host. Windows rejects datagram routes because this implementation does not emulate messages over named pipes.
+
+Virtio-vsock datagrams are not yet supported by stock Linux virtio-vsock drivers. Microsandbox supports them through the datagram feature already carried by its bundled libkrunfw guest kernel, so `/dgram` is specific to the microsandbox guest stack rather than a portable expectation for arbitrary kernels.
+
+```mermaid
+sequenceDiagram
+    participant G as Guest AF_VSOCK DGRAM
+    participant K as libkrun
+    participant M as microsandbox Unix DGRAM backend
+    participant H as Host Unix DGRAM service
+    G->>K: sendto(CID 2, port 5001, message)
+    K->>M: open peer once, then send complete message
+    M->>H: Unix datagram from stable private reply path
+    H->>M: reply to that path
+    M->>K: receive complete message
+    K->>G: vsock datagram to the guest source port
+```
+
+## SDK APIs
+
+The compact API means stream in every SDK and accepts either platform's local path syntax. Use the explicit datagram variant on macOS or Linux when message boundaries matter.
+
+```rust Rust
+let sandbox = Sandbox::builder("worker")
+    .image("alpine")
+    .vsock("/run/host-api.sock", 5000)
+    .vsock_dgram("/run/events.sock", 5001)
+    .create()
+    .await?;
+```
+
+```typescript TypeScript
+const sandbox = await Sandbox.builder("worker")
+  .image("alpine")
+  .vsock("/run/host-api.sock", 5000)
+  .vsockDgram("/run/events.sock", 5001)
+  .create();
+```
+
+```python Python
+from microsandbox import Sandbox, VsockRoute
+
+# Mapping form is stream shorthand. Use VsockRoute for mixed socket types.
+sandbox = await Sandbox.create(
+    "worker",
+    image="alpine",
+    vsock=[
+        VsockRoute.stream("/run/host-api.sock", 5000),
+        VsockRoute.dgram("/run/events.sock", 5001),
+    ],
+)
+```
+
+```go Go
+sandbox, err := microsandbox.CreateSandbox(ctx, "worker",
+    microsandbox.WithImage("alpine"),
+    microsandbox.WithVsock(
+        microsandbox.VsockRoute{HostSocket: "/run/host-api.sock", Port: 5000},
+        microsandbox.VsockRoute{HostSocket: "/run/events.sock", Port: 5001, SocketType: microsandbox.VsockSocketTypeDgram},
+    ),
+)
+```
+
+```ruby Ruby
+sandbox = Microsandbox::Sandbox.builder("worker")
+  .image("alpine")
+  .vsock("/run/host-api.sock", 5000)
+  .vsock_dgram("/run/events.sock", 5001)
+  .create
+```
+
+## Security model and limits
+
+Vsock itself is a transport, not an authorization boundary. A route grants the guest whatever authority the selected host service grants to the `msb` process. Exposing a Docker socket, SSH agent, package-manager daemon, or privileged control API can therefore amount to host code execution or credential use even though the guest cannot read the socket path directly.
+
+Microsandbox limits this surface deliberately:
+
+- Routes are explicit, local-only creation settings. Unix hosts require absolute socket paths; Windows accepts only `\\.\pipe\...` and rejects remote `\\server\pipe\...` names.
+- Multi-tenant deployments reject host vsock routes. Cloud backends reject the unsupported setting instead of dropping it.
+- Unix adapters use nonblocking descriptors. The Windows adapter keeps blocking pipe I/O on a cancellable worker, exposes only bounded nonblocking queues to libkrun, and opens pipes with identification-only security QoS so the server cannot impersonate the client through this connection. Guest teardown cancels a worker blocked by a pipe server that stopped consuming data. Every route caps active stream connections or datagram peers at 256.
+- Datagram port `123` is reserved for libkrun's guest clock synchronization. Port `0` and `u32::MAX` are invalid.
+- Host filesystem or named-pipe ACLs still apply using the credentials of the `msb` process, but those permissions do not make a powerful service safe to expose.
+- Agentd does not create or manage these ports, and enabling a route does not enable TSI or IP networking.
+
+Use a narrowly scoped host service with its own authentication and request validation. Treat each route as an intentional capability granted to every process that can open the configured vsock port inside the guest.

--- a/packages/microsandbox-types/rust/lib/cloud.rs
+++ b/packages/microsandbox-types/rust/lib/cloud.rs
@@ -19,7 +19,7 @@ use crate::domain::{
     Rlimit, RlimitResource, RootDisk, RootfsSource, SandboxLogLevel, SandboxPolicy,
     SandboxResources, SandboxRuntimeOptions, SandboxSpec, SecretEntry, SecretInjection,
     SecretsConfig, SecurityProfile, StatVirtualization, TransparentHugePagePolicy, ViolationAction,
-    VolumeMount, default_private, default_strict,
+    VolumeMount, VsockSpec, default_private, default_strict,
 };
 use crate::modify::SecretSource;
 use crate::{TypesError, TypesResult};
@@ -1029,6 +1029,7 @@ impl TryFrom<CloudSandboxSpec> for SandboxSpec {
             mounts: spec.mounts.into_iter().map(Into::into).collect(),
             patches: spec.patches.into_iter().map(Into::into).collect(),
             network,
+            vsock: VsockSpec::default(),
             init: spec.init,
             pull_policy: spec.pull_policy.into(),
             security_profile: spec.security_profile,

--- a/packages/microsandbox-types/rust/lib/domain.rs
+++ b/packages/microsandbox-types/rust/lib/domain.rs
@@ -598,6 +598,58 @@ pub enum PortProtocol {
 }
 
 //--------------------------------------------------------------------------------------------------
+// Types: Vsock
+//--------------------------------------------------------------------------------------------------
+
+/// Host services exposed to a sandbox through virtio-vsock.
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS))]
+#[serde(default)]
+pub struct VsockSpec {
+    /// Guest-to-host routes registered before the VM starts.
+    pub routes: Vec<VsockRouteSpec>,
+}
+
+impl VsockSpec {
+    /// Return whether no host services are exposed through vsock.
+    pub fn is_empty(&self) -> bool {
+        self.routes.is_empty()
+    }
+}
+
+/// One host local-IPC endpoint exposed on a host-CID vsock port.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS))]
+pub struct VsockRouteSpec {
+    /// Existing Unix socket path or local Windows named-pipe path.
+    #[cfg_attr(feature = "utoipa", schema(value_type = String))]
+    pub host_socket: PathBuf,
+
+    /// Port guests address on `VMADDR_CID_HOST` (CID 2).
+    pub port: u32,
+
+    /// Message semantics used by the guest and host endpoints.
+    #[serde(default)]
+    pub socket_type: VsockSocketType,
+}
+
+/// Socket semantics for a host-CID vsock route.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS))]
+#[serde(rename_all = "snake_case")]
+pub enum VsockSocketType {
+    /// Reliable, ordered byte stream.
+    #[default]
+    Stream,
+
+    /// Best-effort message transport preserving datagram boundaries.
+    Dgram,
+}
+
+//--------------------------------------------------------------------------------------------------
 // Types: Init
 //--------------------------------------------------------------------------------------------------
 
@@ -732,6 +784,10 @@ pub struct SandboxSpec {
 
     /// Network specification.
     pub network: NetworkSpec,
+
+    /// Local host services exposed through virtio-vsock.
+    #[serde(default, skip_serializing_if = "VsockSpec::is_empty")]
+    pub vsock: VsockSpec,
 
     /// Hand off PID 1 to a guest init binary after agentd setup.
     pub init: Option<HandoffInit>,

--- a/packages/microsandbox-types/rust/lib/lib.rs
+++ b/packages/microsandbox-types/rust/lib/lib.rs
@@ -37,7 +37,8 @@ pub use domain::{
     SandboxPolicy, SandboxResources, SandboxRuntimeOptions, SandboxSpec, ScopedUpstreamCaCert,
     ScopedVerifyUpstream, SecretConfigError, SecretEntry, SecretInjection, SecretsConfig,
     SecurityProfile, SnapshotSpec, StatVirtualization, TlsConfig, TransparentHugePagePolicy,
-    ViolationAction, VolumeKind, VolumeMount, VolumeSpec,
+    ViolationAction, VolumeKind, VolumeMount, VolumeSpec, VsockRouteSpec, VsockSocketType,
+    VsockSpec,
 };
 pub use error::{TypesError, TypesResult};
 pub use modify::{

--- a/sdk/go/internal/ffi/ffi.go
+++ b/sdk/go/internal/ffi/ffi.go
@@ -1580,6 +1580,7 @@ type CreateOptions struct {
 	Ports           map[uint16]uint16    `json:"ports,omitempty"`
 	PortsUDP        map[uint16]uint16    `json:"ports_udp,omitempty"`
 	PortBindings    []PortBindingOptions `json:"port_bindings,omitempty"`
+	Vsock           []VsockRouteOptions  `json:"vsock,omitempty"`
 	Network         *NetworkOptions      `json:"network,omitempty"`
 	Secrets         []SecretOptions      `json:"secrets,omitempty"`
 	Patches         []PatchOptions       `json:"patches,omitempty"`
@@ -1654,6 +1655,13 @@ type PortBindingOptions struct {
 	HostPort  uint16 `json:"host_port"`
 	GuestPort uint16 `json:"guest_port"`
 	Protocol  string `json:"protocol,omitempty"`
+}
+
+// VsockRouteOptions exposes one host Unix socket on a host-CID vsock port.
+type VsockRouteOptions struct {
+	HostSocket string `json:"host_socket"`
+	Port       uint32 `json:"port"`
+	SocketType string `json:"socket_type,omitempty"`
 }
 
 // DNSOptions configures the in-VM DNS proxy.

--- a/sdk/go/native/src/lib.rs
+++ b/sdk/go/native/src/lib.rs
@@ -809,6 +809,10 @@ fn default_port_protocol() -> String {
     "tcp".into()
 }
 
+fn default_vsock_socket_type() -> String {
+    "stream".into()
+}
+
 /// Custom policy. Parity-aligned with Node/Python: `default_egress` and
 /// `default_ingress` are the asymmetric default actions. Empty defaults to
 /// deny egress / allow ingress (matching the default public profile).
@@ -1037,6 +1041,9 @@ struct SandboxCreateOpts {
     /// Top-level port bindings with explicit bind addresses.
     #[serde(default)]
     port_bindings: Vec<PortBindingOpts>,
+    /// Guest-to-host virtio-vsock routes backed by host Unix sockets.
+    #[serde(default)]
+    vsock: Vec<VsockRouteOpts>,
     #[serde(default)]
     secrets: Vec<SecretOpts>,
     #[serde(default)]
@@ -1064,6 +1071,14 @@ struct PortBindingOpts {
     guest_port: u16,
     #[serde(default = "default_port_protocol")]
     protocol: String,
+}
+
+#[derive(serde::Deserialize)]
+struct VsockRouteOpts {
+    host_socket: String,
+    port: u32,
+    #[serde(default = "default_vsock_socket_type")]
+    socket_type: String,
 }
 
 #[derive(serde::Deserialize, Default)]
@@ -2206,6 +2221,18 @@ pub unsafe extern "C" fn msb_sandbox_create(
             }
             for port in &opts.port_bindings {
                 builder = apply_port_binding(builder, port)?;
+            }
+            for route in opts.vsock {
+                builder = match route.socket_type.as_str() {
+                    "" | "stream" => builder.vsock(route.host_socket, route.port),
+                    "dgram" => builder.vsock_dgram(route.host_socket, route.port),
+                    other => {
+                        return Err(FfiError::new(
+                            error_kind::INVALID_CONFIG,
+                            format!("invalid vsock socket type: {other}"),
+                        ));
+                    }
+                };
             }
             // Network (policy, DNS, TLS, ports-in-network).
             if let Some(ref net) = opts.network {

--- a/sdk/go/options.go
+++ b/sdk/go/options.go
@@ -71,6 +71,7 @@ type SandboxConfig struct {
 	Ports               map[uint16]uint16 // host port → guest port (TCP)
 	PortsUDP            map[uint16]uint16 // host port → guest port (UDP)
 	PortBindings        []PortBinding     // explicit bind address host→guest ports
+	Vsock               []VsockRoute      // host local IPC → guest host-CID port
 	Network             *NetworkConfig
 	Secrets             []SecretEntry
 	Patches             []PatchConfig
@@ -931,6 +932,29 @@ const (
 func WithPortBindings(bindings ...PortBinding) SandboxOption {
 	return func(o *SandboxConfig) {
 		o.PortBindings = append(o.PortBindings, bindings...)
+	}
+}
+
+// VsockRoute exposes a host Unix socket or local Windows named pipe through
+// virtio-vsock host CID 2. SocketType defaults to stream when empty.
+type VsockRoute struct {
+	HostSocket string
+	Port       uint32
+	SocketType VsockSocketType
+}
+
+// VsockSocketType identifies the message semantics of a vsock route.
+type VsockSocketType string
+
+const (
+	VsockSocketTypeStream VsockSocketType = "stream"
+	VsockSocketTypeDgram  VsockSocketType = "dgram"
+)
+
+// WithVsock appends guest-to-host vsock routes backed by local host IPC.
+func WithVsock(routes ...VsockRoute) SandboxOption {
+	return func(o *SandboxConfig) {
+		o.Vsock = append(o.Vsock, routes...)
 	}
 }
 

--- a/sdk/go/sandbox.go
+++ b/sdk/go/sandbox.go
@@ -100,6 +100,7 @@ func buildFFICreateOptions(o SandboxConfig) ffi.CreateOptions {
 		Ports:             o.Ports,
 		PortsUDP:          o.PortsUDP,
 		PortBindings:      buildFFIPortBindings(o.PortBindings),
+		Vsock:             buildFFIVsockRoutes(o.Vsock),
 		RegistryInsecure:  o.RegistryInsecure,
 	}
 	if o.Entrypoint != nil {
@@ -380,6 +381,18 @@ func buildFFIPortBindings(bindings []PortBinding) []ffi.PortBindingOptions {
 			HostPort:  b.HostPort,
 			GuestPort: b.GuestPort,
 			Protocol:  string(b.Protocol),
+		})
+	}
+	return out
+}
+
+func buildFFIVsockRoutes(routes []VsockRoute) []ffi.VsockRouteOptions {
+	out := make([]ffi.VsockRouteOptions, 0, len(routes))
+	for _, route := range routes {
+		out = append(out, ffi.VsockRouteOptions{
+			HostSocket: route.HostSocket,
+			Port:       route.Port,
+			SocketType: string(route.SocketType),
 		})
 	}
 	return out

--- a/sdk/go/sandbox_options_test.go
+++ b/sdk/go/sandbox_options_test.go
@@ -466,6 +466,28 @@ func TestFFIWireShape_Ports(t *testing.T) {
 	}
 }
 
+func TestFFIWireShape_Vsock(t *testing.T) {
+	got := marshalCreateOptions(t,
+		WithImage("alpine"),
+		WithVsock(
+			VsockRoute{HostSocket: "/run/host-api.sock", Port: 5000},
+			VsockRoute{HostSocket: "/run/events.sock", Port: 5001, SocketType: VsockSocketTypeDgram},
+		),
+	)
+	routes := mustField(t, got, "vsock").([]any)
+	stream := routes[0].(map[string]any)
+	dgram := routes[1].(map[string]any)
+	if stream["host_socket"] != "/run/host-api.sock" || stream["port"] != float64(5000) {
+		t.Fatalf("stream vsock route = %v", stream)
+	}
+	if _, present := stream["socket_type"]; present {
+		t.Fatalf("default stream type should be omitted: %v", stream)
+	}
+	if dgram["socket_type"] != "dgram" || dgram["port"] != float64(5001) {
+		t.Fatalf("datagram vsock route = %v", dgram)
+	}
+}
+
 func TestFFIWireShape_RegistryAuth(t *testing.T) {
 	got := marshalCreateOptions(t,
 		WithImage("private.example.com/img"),
@@ -725,7 +747,7 @@ func TestFFIWireShape_EmptyConfigOmitsOptionalFields(t *testing.T) {
 		"image", "snapshot", "memory_mib", "cpus", "max_memory_mib", "max_cpus", "workdir", "shell",
 		"thp",
 		"hostname", "user", "replace", "detached", "env", "scripts",
-		"ports", "ports_udp", "network", "secrets", "patches", "volumes",
+		"ports", "ports_udp", "vsock", "network", "secrets", "patches", "volumes",
 		"init", "registry_auth", "registry_insecure", "registry_ca_certs", "root_disk",
 	} {
 		if _, present := got[key]; present {

--- a/sdk/node-ts/native/index.d.ts
+++ b/sdk/node-ts/native/index.d.ts
@@ -1126,6 +1126,10 @@ export declare class SandboxBuilder {
   portUdp(hostPort: number, guestPort: number): this
   /** Publish a UDP port from host -> guest on a specific host bind address. */
   portUdpBind(bind: string, hostPort: number, guestPort: number): this
+  /** Expose a host Unix stream socket or local Windows named pipe on a guest-to-host vsock port. */
+  vsock(hostPath: string, port: number): this
+  /** Expose a host Unix datagram socket on a guest-to-host vsock port. */
+  vsockDgram(hostPath: string, port: number): this
   /** Add a secret via a callback. */
   secret(configure: (arg: JsSecretBuilder) => JsSecretBuilder): this
   /**
@@ -1585,7 +1589,7 @@ export declare class Volume {
   static remove(name: string): Promise<void>
   get name(): string
   get path(): string
-  /** Host-side filesystem operations on this volume's directory. */
+  /** Direct filesystem operations through this volume's bound backend. */
   fs(): VolumeFs
 }
 export type JsVolume = Volume
@@ -1664,7 +1668,7 @@ export declare class VolumeHandle {
   get labels(): Record<string, string>
   get createdAt(): number | null
   remove(): Promise<void>
-  /** Host-side filesystem operations on this volume's directory. */
+  /** Direct filesystem operations through this volume's bound backend. */
   fs(): VolumeFs
 }
 export type JsVolumeHandle = VolumeHandle

--- a/sdk/node-ts/native/sandbox_builder.rs
+++ b/sdk/node-ts/native/sandbox_builder.rs
@@ -550,6 +550,22 @@ impl JsSandboxBuilder {
         Ok(self)
     }
 
+    /// Expose a host Unix stream socket or local Windows named pipe on a guest-to-host vsock port.
+    #[napi]
+    pub fn vsock(&mut self, host_path: String, port: u32) -> &Self {
+        let prev = self.take_inner();
+        self.inner = Some(prev.vsock(host_path, port));
+        self
+    }
+
+    /// Expose a host Unix datagram socket on a guest-to-host vsock port.
+    #[napi(js_name = "vsockDgram")]
+    pub fn vsock_dgram(&mut self, host_path: String, port: u32) -> &Self {
+        let prev = self.take_inner();
+        self.inner = Some(prev.vsock_dgram(host_path, port));
+        self
+    }
+
     /// Add a secret via a callback.
     #[napi]
     pub fn secret(

--- a/sdk/node-ts/src/internal/napi.ts
+++ b/sdk/node-ts/src/internal/napi.ts
@@ -213,6 +213,8 @@ export interface NapiSandboxBuilderSetters {
   portBind(bind: string, host: number, guest: number): this;
   portUdp(host: number, guest: number): this;
   portUdpBind(bind: string, host: number, guest: number): this;
+  vsock(hostPath: string, port: number): this;
+  vsockDgram(hostPath: string, port: number): this;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   secret(configure: (b: any) => any): this;
   secretEnv(envVar: string, value: string, allowedHost: string): this;

--- a/sdk/node-ts/tests/unit/builders.test.ts
+++ b/sdk/node-ts/tests/unit/builders.test.ts
@@ -415,6 +415,22 @@ describe("SandboxBuilder.build", () => {
     expect((cleared.runtime as { cmd: string[] }).cmd).toEqual([]);
   });
 
+  it("collects stream and datagram vsock routes", async () => {
+    const cfg = await Sandbox.builder("x")
+      .image("alpine")
+      .vsock("/run/host-api.sock", 5000)
+      .vsockDgram("/run/events.sock", 5001)
+      .build();
+    const routes = (cfg.vsock as {
+      routes: Array<{ hostSocket: string; port: number; socketType: string }>;
+    }).routes;
+
+    expect(routes).toEqual([
+      { hostSocket: "/run/host-api.sock", port: 5000, socketType: "stream" },
+      { hostSocket: "/run/events.sock", port: 5001, socketType: "dgram" },
+    ]);
+  });
+
   it("keeps libkrunfwPath as a chainable compatibility alias", async () => {
     const builder = Sandbox.builder("x");
     expect(builder.libkrunfwPath("/tmp/libkrunfw.dylib")).toBe(builder);

--- a/sdk/python/microsandbox/__init__.py
+++ b/sdk/python/microsandbox/__init__.py
@@ -171,6 +171,8 @@ from microsandbox.types import (
     ViolationAction,
     ViolationPolicy,
     VolumeKind,
+    VsockRoute,
+    VsockSocketType,
 )
 
 # Pass the bundled msb path to Rust explicitly. `MSB_PATH` remains a user
@@ -273,6 +275,8 @@ __all__ = [
     "Protocol",
     "PortBinding",
     "PortProtocol",
+    "VsockRoute",
+    "VsockSocketType",
     "DestGroup",
     # Secrets & TLS
     "Secret",

--- a/sdk/python/microsandbox/_microsandbox.pyi
+++ b/sdk/python/microsandbox/_microsandbox.pyi
@@ -42,6 +42,7 @@ from microsandbox.types import (
     ViolationAction,
     ViolationPolicy,
     VolumeKind,
+    VsockRoute,
 )
 
 class PyAgentClient:
@@ -118,6 +119,7 @@ class Sandbox:
         volumes: Mapping[str, MountConfig] | None = None,
         patches: Sequence[PatchConfig] | None = None,
         ports: Mapping[int, int] | Sequence[PortBinding] | None = None,
+        vsock: Mapping[str, int] | Sequence[VsockRoute] | None = None,
         network: Network | None = None,
         secrets: Sequence[SecretEntry] | None = None,
         on_secret_violation: ViolationAction | ViolationPolicy | None = None,
@@ -172,6 +174,7 @@ class Sandbox:
         volumes: Mapping[str, MountConfig] | None = None,
         patches: Sequence[PatchConfig] | None = None,
         ports: Mapping[int, int] | Sequence[PortBinding] | None = None,
+        vsock: Mapping[str, int] | Sequence[VsockRoute] | None = None,
         network: Network | None = None,
         secrets: Sequence[SecretEntry] | None = None,
         on_secret_violation: ViolationAction | ViolationPolicy | None = None,

--- a/sdk/python/microsandbox/types.py
+++ b/sdk/python/microsandbox/types.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import enum
+import os
 import sys
 from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass, field
@@ -183,6 +184,11 @@ class Protocol(StrEnum):
 class PortProtocol(StrEnum):
     TCP = "tcp"
     UDP = "udp"
+
+
+class VsockSocketType(StrEnum):
+    STREAM = "stream"
+    DGRAM = "dgram"
 
 
 class DestGroup(StrEnum):
@@ -1501,6 +1507,30 @@ class PortBinding:
             "guest_port": self.guest_port,
             "bind": self.bind,
             "protocol": _enum_value(self.protocol, PortProtocol, "PortBinding.protocol"),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class VsockRoute:
+    """Host Unix socket or Windows named pipe exposed on host CID 2."""
+
+    host_socket: str | os.PathLike[str]
+    port: int
+    socket_type: VsockSocketType = VsockSocketType.STREAM
+
+    @classmethod
+    def stream(cls, host_socket: str | os.PathLike[str], port: int) -> VsockRoute:
+        return cls(host_socket=host_socket, port=port)
+
+    @classmethod
+    def dgram(cls, host_socket: str | os.PathLike[str], port: int) -> VsockRoute:
+        return cls(host_socket=host_socket, port=port, socket_type=VsockSocketType.DGRAM)
+
+    def _to_dict(self) -> dict:
+        return {
+            "host_socket": os.fspath(self.host_socket),
+            "port": self.port,
+            "socket_type": _enum_value(self.socket_type, VsockSocketType, "VsockRoute.socket_type"),
         }
 
 

--- a/sdk/python/src/helpers.rs
+++ b/sdk/python/src/helpers.rs
@@ -47,6 +47,7 @@ const KNOWN_CREATE_KWARGS: &[&str] = &[
     "volumes",
     "patches",
     "ports",
+    "vsock",
     "network",
     "secrets",
     "on_secret_violation",
@@ -550,6 +551,11 @@ pub fn sandbox_builder_from_args(
     // Ports.
     if let Some(ports) = kwargs.get_item("ports")?.filter(|v| !v.is_none()) {
         builder = apply_ports(builder, &ports, PortBindingSource::PublicConfig)?;
+    }
+
+    // Guest-to-host vsock routes are independent of IP networking.
+    if let Some(vsock) = kwargs.get_item("vsock")?.filter(|v| !v.is_none()) {
+        builder = apply_vsock_routes(builder, &vsock)?;
     }
 
     // Network.
@@ -1388,6 +1394,44 @@ fn apply_ports(
             other => {
                 return Err(pyo3::exceptions::PyValueError::new_err(format!(
                     "invalid port protocol: {other}"
+                )));
+            }
+        };
+    }
+
+    Ok(builder)
+}
+
+/// Apply the compact `{host_socket: port}` stream shorthand or a sequence of
+/// typed `VsockRoute` values for stream/datagram routes.
+fn apply_vsock_routes(
+    mut builder: microsandbox::sandbox::SandboxBuilder,
+    routes: &Bound<'_, PyAny>,
+) -> PyResult<microsandbox::sandbox::SandboxBuilder> {
+    if let Some(routes_dict) = mapping_to_dict(routes)? {
+        for (host_socket, port) in routes_dict.iter() {
+            builder = builder.vsock(host_socket.extract::<String>()?, port.extract::<u32>()?);
+        }
+        return Ok(builder);
+    }
+
+    let iter = routes.try_iter().map_err(|_| {
+        pyo3::exceptions::PyTypeError::new_err(
+            "vsock must be a mapping of host_socket to port or a sequence of VsockRoute values",
+        )
+    })?;
+    for route in iter {
+        let route = config_dict(&route?, "VsockRoute")?;
+        let host_socket: String = extract_required(&route, "host_socket")?;
+        let port: u32 = extract_required(&route, "port")?;
+        let socket_type: String =
+            extract_opt(&route, "socket_type")?.unwrap_or_else(|| "stream".to_string());
+        builder = match socket_type.as_str() {
+            "stream" => builder.vsock(host_socket, port),
+            "dgram" => builder.vsock_dgram(host_socket, port),
+            other => {
+                return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                    "invalid vsock socket type: {other}"
                 )));
             }
         };

--- a/sdk/python/tests/test_create_stub.py
+++ b/sdk/python/tests/test_create_stub.py
@@ -38,6 +38,7 @@ EXPECTED_KWARGS = [
     "volumes",
     "patches",
     "ports",
+    "vsock",
     "network",
     "secrets",
     "on_secret_violation",

--- a/sdk/python/tests/test_vsock.py
+++ b/sdk/python/tests/test_vsock.py
@@ -1,0 +1,44 @@
+"""Unit tests for virtio-vsock create configuration."""
+
+from __future__ import annotations
+
+from types import MappingProxyType
+
+import pytest
+
+from microsandbox import Sandbox, VsockRoute, VsockSocketType
+
+
+def test_vsock_route_factories_serialize_stable_socket_types() -> None:
+    stream = VsockRoute.stream("/run/host-api.sock", 5000)
+    dgram = VsockRoute.dgram("/run/events.sock", 5001)
+
+    assert stream._to_dict() == {
+        "host_socket": "/run/host-api.sock",
+        "port": 5000,
+        "socket_type": "stream",
+    }
+    assert dgram.socket_type is VsockSocketType.DGRAM
+    assert dgram._to_dict()["socket_type"] == "dgram"
+
+
+def test_sandbox_create_accepts_vsock_mapping_and_typed_routes() -> None:
+    with pytest.raises(RuntimeError) as baseline:
+        Sandbox.create("vsock-baseline", image="alpine")
+
+    for routes in (
+        MappingProxyType({"/run/host-api.sock": 5000}),
+        (
+            VsockRoute.stream("/run/host-api.sock", 5000),
+            VsockRoute.dgram("/run/events.sock", 5001),
+        ),
+    ):
+        with pytest.raises(type(baseline.value)) as accepted:
+            Sandbox.create("vsock-config", image="alpine", vsock=routes)
+        assert str(accepted.value) == str(baseline.value)
+
+
+def test_sandbox_create_rejects_unknown_vsock_socket_type() -> None:
+    route = VsockRoute("/run/host-api.sock", 5000, "seqpacket")  # type: ignore[arg-type]
+    with pytest.raises(TypeError, match=r"VsockRoute\.socket_type"):
+        Sandbox.create("bad-vsock", image="alpine", vsock=[route])

--- a/sdk/ruby/ext/microsandbox/src/lib.rs
+++ b/sdk/ruby/ext/microsandbox/src/lib.rs
@@ -812,6 +812,12 @@ impl RubySandboxBuilder {
     fn init(this: typed_data::Obj<Self>, v: String) -> Result<(), Error> {
         put_builder(&this, |b| b.init(v))
     }
+    fn vsock(this: typed_data::Obj<Self>, host_path: String, port: u32) -> Result<(), Error> {
+        put_builder(&this, |b| b.vsock(host_path, port))
+    }
+    fn vsock_dgram(this: typed_data::Obj<Self>, host_path: String, port: u32) -> Result<(), Error> {
+        put_builder(&this, |b| b.vsock_dgram(host_path, port))
+    }
     fn create(ruby: &Ruby, this: typed_data::Obj<Self>) -> Result<RubySandbox, Error> {
         let b = take_builder(&this)?;
         let sb = run(ruby, b.create())?;
@@ -2073,6 +2079,8 @@ fn init(ruby: &Ruby) -> Result<(), Error> {
     builder.define_method("quiet_logs!", method!(RubySandboxBuilder::quiet_logs, 0))?;
     builder.define_method("entrypoint!", method!(RubySandboxBuilder::entrypoint, 1))?;
     builder.define_method("init!", method!(RubySandboxBuilder::init, 1))?;
+    builder.define_method("vsock!", method!(RubySandboxBuilder::vsock, 2))?;
+    builder.define_method("vsock_dgram!", method!(RubySandboxBuilder::vsock_dgram, 2))?;
     builder.define_method("create", method!(RubySandboxBuilder::create, 0))?;
 
     // -- ExecOutput ----------------------------------------------------------

--- a/sdk/ruby/ext/microsandbox/src/lib.rs
+++ b/sdk/ruby/ext/microsandbox/src/lib.rs
@@ -812,12 +812,6 @@ impl RubySandboxBuilder {
     fn init(this: typed_data::Obj<Self>, v: String) -> Result<(), Error> {
         put_builder(&this, |b| b.init(v))
     }
-    fn vsock(this: typed_data::Obj<Self>, host_path: String, port: u32) -> Result<(), Error> {
-        put_builder(&this, |b| b.vsock(host_path, port))
-    }
-    fn vsock_dgram(this: typed_data::Obj<Self>, host_path: String, port: u32) -> Result<(), Error> {
-        put_builder(&this, |b| b.vsock_dgram(host_path, port))
-    }
     fn create(ruby: &Ruby, this: typed_data::Obj<Self>) -> Result<RubySandbox, Error> {
         let b = take_builder(&this)?;
         let sb = run(ruby, b.create())?;
@@ -2079,8 +2073,6 @@ fn init(ruby: &Ruby) -> Result<(), Error> {
     builder.define_method("quiet_logs!", method!(RubySandboxBuilder::quiet_logs, 0))?;
     builder.define_method("entrypoint!", method!(RubySandboxBuilder::entrypoint, 1))?;
     builder.define_method("init!", method!(RubySandboxBuilder::init, 1))?;
-    builder.define_method("vsock!", method!(RubySandboxBuilder::vsock, 2))?;
-    builder.define_method("vsock_dgram!", method!(RubySandboxBuilder::vsock_dgram, 2))?;
     builder.define_method("create", method!(RubySandboxBuilder::create, 0))?;
 
     // -- ExecOutput ----------------------------------------------------------

--- a/sdk/ruby/lib/microsandbox.rb
+++ b/sdk/ruby/lib/microsandbox.rb
@@ -7,7 +7,7 @@ module Microsandbox
     %i[
       image cpus max_cpus memory max_memory workdir shell hostname user
       detached ephemeral max_duration idle_timeout replace root_disk
-      disable_network quiet_logs entrypoint init vsock vsock_dgram
+      disable_network quiet_logs entrypoint init
     ].each do |name|
       define_method(name) do |*args|
         public_send(:"#{name}!", *args)

--- a/sdk/ruby/lib/microsandbox.rb
+++ b/sdk/ruby/lib/microsandbox.rb
@@ -7,7 +7,7 @@ module Microsandbox
     %i[
       image cpus max_cpus memory max_memory workdir shell hostname user
       detached ephemeral max_duration idle_timeout replace root_disk
-      disable_network quiet_logs entrypoint init
+      disable_network quiet_logs entrypoint init vsock vsock_dgram
     ].each do |name|
       define_method(name) do |*args|
         public_send(:"#{name}!", *args)

--- a/sdk/ruby/test/microsandbox_test.rb
+++ b/sdk/ruby/test/microsandbox_test.rb
@@ -21,8 +21,6 @@ class MicrosandboxTest < Test::Unit::TestCase
       .env("GREETING", "hello")
       .label("suite", "ruby")
       .workdir("/tmp")
-      .vsock("/run/host-api.sock", 5000)
-      .vsock_dgram("/run/events.sock", 5001)
 
     assert_instance_of Microsandbox::SandboxBuilder, builder
   end

--- a/sdk/ruby/test/microsandbox_test.rb
+++ b/sdk/ruby/test/microsandbox_test.rb
@@ -21,6 +21,8 @@ class MicrosandboxTest < Test::Unit::TestCase
       .env("GREETING", "hello")
       .label("suite", "ruby")
       .workdir("/tmp")
+      .vsock("/run/host-api.sock", 5000)
+      .vsock_dgram("/run/events.sock", 5001)
 
     assert_instance_of Microsandbox::SandboxBuilder, builder
   end

--- a/sdk/rust/lib/agent/mod.rs
+++ b/sdk/rust/lib/agent/mod.rs
@@ -141,12 +141,12 @@ impl AgentClient {
     /// Resolve a sandbox name to its agent relay socket path **without
     /// connecting**.
     ///
-    /// Returns the same path [`connect_sandbox`] would dial — the hashed path
-    /// under the runtime directory when it fits the platform's Unix-socket
-    /// length limit, and the legacy name-derived path otherwise. Useful for
-    /// talking to `agentd` over a raw byte transport (e.g. a transparent relay
-    /// that splices bytes to/from the socket) instead of this frame client. The
-    /// sandbox need not be running.
+    /// Returns the same path [`connect_sandbox`] would dial: the canonical
+    /// per-sandbox runtime path, an existing legacy flat path when talking to
+    /// an older runtime, or the retained in-sandbox fallback for deep homes.
+    /// Useful for talking to `agentd` over a raw byte transport (e.g. a
+    /// transparent relay that splices bytes to/from the socket) instead of
+    /// this frame client. The sandbox need not be running.
     pub fn socket_path(name: &str) -> crate::MicrosandboxResult<std::path::PathBuf> {
         crate::runtime::agent_socket_path(name)
     }

--- a/sdk/rust/lib/backend/cloud/sandbox.rs
+++ b/sdk/rust/lib/backend/cloud/sandbox.rs
@@ -413,6 +413,9 @@ fn reject_dropped_cloud_create_fields(config: &SandboxConfig) -> MicrosandboxRes
     if config.snapshot_upper_source.is_some() {
         return Err(unsupported("from_snapshot"));
     }
+    if !config.spec.vsock.is_empty() {
+        return Err(unsupported("vsock"));
+    }
 
     Ok(())
 }

--- a/sdk/rust/lib/backend/local/sandbox/create.rs
+++ b/sdk/rust/lib/backend/local/sandbox/create.rs
@@ -98,8 +98,8 @@ impl LocalBackend {
         let mut pinned_reference: Option<String> = None;
 
         config.apply_runtime_defaults();
-        self.validate_sandbox_name_for_runtime(&config.spec.name)?;
         validate_hostname(config.spec.runtime.hostname.as_deref())?;
+        self.validate_sandbox_name_for_runtime(&config.spec.name)?;
         Self::validate_rootfs_source(&config.spec.image)?;
         validate_env(&config.spec.env)?;
         validate_labels(&config.spec.labels)?;
@@ -373,7 +373,7 @@ impl LocalBackend {
         // Spawn the sandbox process and create the bridge. On failure, mark the sandbox
         // as stopped so it doesn't appear as a phantom "Running" entry.
         let (local_state, returned_config) = match self
-            .create_sandbox_inner(config, sandbox_id, mode)
+            .create_sandbox_inner(config, sandbox_id, mode, None)
             .await
         {
             Ok(pair) => pair,
@@ -471,8 +471,10 @@ impl LocalBackend {
         config: SandboxConfig,
         sandbox_id: i32,
         mode: SpawnMode,
+        lifecycle_guard: Option<microsandbox_runtime::ipc::SandboxLifecycleGuard>,
     ) -> MicrosandboxResult<(crate::backend::SandboxLocalState, SandboxConfig)> {
-        let (mut handle, agent_sock_path) = spawn_sandbox(self, &config, sandbox_id, mode).await?;
+        let (mut handle, agent_sock_path) =
+            spawn_sandbox(self, &config, sandbox_id, mode, lifecycle_guard).await?;
         let log_dir = self.sandboxes_dir().join(&config.spec.name).join("logs");
 
         // Wait for the relay socket to become available.
@@ -958,6 +960,23 @@ impl LocalBackend {
                     .await?;
             }
 
+            let _guard = crate::runtime::acquire_sandbox_lifecycle_guard(
+                run_dir,
+                &config.spec.name,
+                std::time::Duration::from_secs(5),
+            )
+            .await?;
+            if Self::load_latest_run(pools.read(), model.id)
+                .await?
+                .and_then(|run| run.pid)
+                .is_some_and(Self::pid_is_alive)
+            {
+                return Err(crate::MicrosandboxError::SandboxStillRunning(format!(
+                    "cannot replace sandbox {:?}: its recorded runtime process is still alive",
+                    config.spec.name
+                )));
+            }
+
             microsandbox_runtime::ipc::remove_sandbox_socket_artifacts(run_dir, &config.spec.name)?;
             remove_dir_if_exists(sandbox_dir)?;
 
@@ -967,6 +986,18 @@ impl LocalBackend {
             return Ok(());
         }
 
+        let _guard = crate::runtime::acquire_sandbox_lifecycle_guard(
+            run_dir,
+            &config.spec.name,
+            std::time::Duration::from_secs(5),
+        )
+        .await?;
+        if sandbox_runtime_endpoint_is_live(run_dir, sandbox_dir, &config.spec.name)? {
+            return Err(crate::MicrosandboxError::SandboxStillRunning(format!(
+                "cannot replace sandbox {:?}: an untracked runtime endpoint is still live",
+                config.spec.name
+            )));
+        }
         microsandbox_runtime::ipc::remove_sandbox_socket_artifacts(run_dir, &config.spec.name)?;
         remove_dir_if_exists(sandbox_dir)?;
         Ok(())
@@ -1005,16 +1036,21 @@ impl LocalBackend {
                 Self::wait_for_pids_to_exit(&pids, grace).await;
             }
 
-            // SIGKILL anything still alive. We don't wait or verify after
-            // SIGKILL: it's uncatchable, so termination is bounded by kernel
-            // time, and the only state that would have us spin is the
-            // zombie window between exit and the parent's `waitpid`. That
-            // window is harmless: prepare_create_target wipes the DB row
-            // and the sandbox dir, the new spawn gets a fresh PID, and the
-            // zombie reaps on its own (tokio's SIGCHLD driver when we own
-            // it, or the foreign parent's wait machinery otherwise).
+            // SIGKILL anything still alive, then prove every recorded owner
+            // exited before deterministic sockets or storage can be reused.
             for pid in pids.iter().copied().filter(|p| Self::pid_is_alive(*p)) {
-                let _ = Self::kill_pid(pid);
+                if let Err(error) = Self::kill_pid(pid)
+                    && Self::pid_is_alive(pid)
+                {
+                    return Err(error);
+                }
+            }
+            Self::wait_for_pids_to_exit(&pids, std::time::Duration::from_secs(5)).await;
+            if pids.iter().any(|pid| !Self::pid_is_dead_or_reaped(*pid)) {
+                return Err(crate::MicrosandboxError::SandboxStillRunning(format!(
+                    "cannot replace sandbox {:?}: runtime did not exit after SIGKILL",
+                    sandbox.name
+                )));
             }
         }
 
@@ -1072,7 +1108,7 @@ impl LocalBackend {
         let poll_interval = std::time::Duration::from_millis(50);
 
         loop {
-            if pids.iter().all(|pid| !Self::pid_is_alive(*pid)) {
+            if pids.iter().all(|pid| Self::pid_is_dead_or_reaped(*pid)) {
                 return;
             }
 
@@ -1237,6 +1273,55 @@ impl LocalBackend {
 }
 
 //--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+/// Probe every backward-compatible Unix endpoint before recovering an
+/// untracked namespace. A successful connection is direct evidence that an
+/// older runtime (which predates lifecycle locks) still owns the name.
+#[cfg(unix)]
+fn sandbox_runtime_endpoint_is_live(
+    run_dir: &Path,
+    sandbox_dir: &Path,
+    name: &str,
+) -> std::io::Result<bool> {
+    let paths = microsandbox_runtime::ipc::sandbox_socket_paths(run_dir, name);
+    let fallback_agent = sandbox_dir.join("runtime").join("agent.sock");
+    let fallback_control = microsandbox_runtime::ipc::control_socket_path_for(&fallback_agent);
+    for path in [
+        paths.agent,
+        paths.control,
+        paths.legacy_agent,
+        paths.legacy_control,
+        fallback_agent,
+        fallback_control,
+    ] {
+        if std::fs::symlink_metadata(&path).is_err() {
+            continue;
+        }
+        match std::os::unix::net::UnixStream::connect(&path) {
+            Ok(_) => return Ok(true),
+            Err(error)
+                if matches!(
+                    error.kind(),
+                    std::io::ErrorKind::ConnectionRefused | std::io::ErrorKind::NotFound
+                ) => {}
+            Err(error) => return Err(error),
+        }
+    }
+    Ok(false)
+}
+
+#[cfg(not(unix))]
+fn sandbox_runtime_endpoint_is_live(
+    _run_dir: &Path,
+    _sandbox_dir: &Path,
+    _name: &str,
+) -> std::io::Result<bool> {
+    Ok(false)
+}
+
+//--------------------------------------------------------------------------------------------------
 // Tests
 //--------------------------------------------------------------------------------------------------
 
@@ -1257,7 +1342,7 @@ mod tests {
     use sea_orm::{EntityTrait, Set};
     use tempfile::tempdir;
 
-    use super::sandbox_entity;
+    use super::{sandbox_entity, sandbox_runtime_endpoint_is_live};
     use crate::backend::{Backend, LocalBackend};
     use crate::runtime::SpawnMode;
     use crate::sandbox::{
@@ -1280,6 +1365,24 @@ mod tests {
         .unwrap();
         Migrator::up(pools.write().inner(), None).await.unwrap();
         pools
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn untracked_runtime_probe_distinguishes_live_and_stale_endpoints() {
+        let temp = tempfile::Builder::new()
+            .prefix("msb-untracked")
+            .tempdir_in("/tmp")
+            .unwrap();
+        let run_dir = temp.path().join("run");
+        let sandbox_dir = temp.path().join("sandboxes").join("worker");
+        let paths = microsandbox_runtime::ipc::sandbox_socket_paths(&run_dir, "worker");
+        std::fs::create_dir_all(paths.legacy_agent.parent().unwrap()).unwrap();
+        let listener = std::os::unix::net::UnixListener::bind(&paths.legacy_agent).unwrap();
+
+        assert!(sandbox_runtime_endpoint_is_live(&run_dir, &sandbox_dir, "worker").unwrap());
+        drop(listener);
+        assert!(!sandbox_runtime_endpoint_is_live(&run_dir, &sandbox_dir, "worker").unwrap());
     }
 
     fn test_config(name: impl Into<String>) -> SandboxConfig {

--- a/sdk/rust/lib/backend/local/sandbox/create.rs
+++ b/sdk/rust/lib/backend/local/sandbox/create.rs
@@ -112,7 +112,7 @@ impl LocalBackend {
         // fail fast on conflicting persisted sandbox state.
         let db = self.db().await?;
         let sandbox_dir = self.sandboxes_dir().join(&config.spec.name);
-        Self::prepare_create_target(db, &config, &sandbox_dir).await?;
+        Self::prepare_create_target(db, &config, &sandbox_dir, &self.config().run_dir()).await?;
 
         // Resolve OCI images before spawning the sandbox process.
         if let RootfsSource::Oci(oci) = config.spec.image.clone() {
@@ -917,6 +917,7 @@ impl LocalBackend {
         pools: &DbPools,
         config: &SandboxConfig,
         sandbox_dir: &Path,
+        run_dir: &Path,
     ) -> MicrosandboxResult<()> {
         let existing = sandbox_entity::Entity::find()
             .filter(sandbox_entity::Column::Name.eq(&config.spec.name))
@@ -936,7 +937,18 @@ impl LocalBackend {
         }
 
         if let Some(model) = existing {
-            let model = Self::reconcile_sandbox_runtime_state(pools, model).await?;
+            let sandboxes_dir = sandbox_dir.parent().ok_or_else(|| {
+                crate::MicrosandboxError::InvalidConfig(format!(
+                    "sandbox directory has no storage root: {}",
+                    sandbox_dir.display()
+                ))
+            })?;
+            let model = Self::reconcile_sandbox_runtime_state_with_paths(
+                pools,
+                model,
+                Some((run_dir, sandboxes_dir)),
+            )
+            .await?;
             let active = matches!(
                 model.status,
                 SandboxStatus::Running | SandboxStatus::Draining | SandboxStatus::Paused
@@ -946,11 +958,16 @@ impl LocalBackend {
                     .await?;
             }
 
+            microsandbox_runtime::ipc::remove_sandbox_socket_artifacts(run_dir, &config.spec.name)?;
+            remove_dir_if_exists(sandbox_dir)?;
+
             sandbox_entity::Entity::delete_by_id(model.id)
                 .exec(pools.write())
                 .await?;
+            return Ok(());
         }
 
+        microsandbox_runtime::ipc::remove_sandbox_socket_artifacts(run_dir, &config.spec.name)?;
         remove_dir_if_exists(sandbox_dir)?;
         Ok(())
     }
@@ -1564,7 +1581,8 @@ mod tests {
 
         let config = test_config("existing");
 
-        let err = LocalBackend::prepare_create_target(&pools, &config, &sandbox_dir)
+        let run_dir = temp.path().join("run");
+        let err = LocalBackend::prepare_create_target(&pools, &config, &sandbox_dir, &run_dir)
             .await
             .unwrap_err();
         assert!(err.to_string().contains("already exists"));
@@ -1572,6 +1590,12 @@ mod tests {
 
     #[tokio::test]
     async fn test_prepare_create_target_force_replaces_stopped_sandbox_state() {
+        #[cfg(unix)]
+        let temp = tempfile::Builder::new()
+            .prefix("msb-replace")
+            .tempdir_in("/tmp")
+            .unwrap();
+        #[cfg(not(unix))]
         let temp = tempdir().unwrap();
         let db_path = temp.path().join("test.db");
         let pools = open_test_pools(&db_path).await;
@@ -1589,11 +1613,42 @@ mod tests {
         let mut forced = test_config("replaceable");
         forced.replace_existing = true;
 
-        LocalBackend::prepare_create_target(&pools, &forced, &sandbox_dir)
+        let run_dir = temp.path().join("run");
+        #[cfg(unix)]
+        let socket_paths = {
+            let paths = microsandbox_runtime::ipc::sandbox_socket_paths(&run_dir, "replaceable");
+            fs::create_dir_all(&paths.canonical_dir).unwrap();
+            fs::write(&paths.agent, b"stale").unwrap();
+            fs::write(&paths.control, b"stale").unwrap();
+            microsandbox_runtime::ipc::publish_legacy_agent_link(
+                &run_dir,
+                "replaceable",
+                &paths.agent,
+            )
+            .unwrap();
+            microsandbox_runtime::ipc::publish_legacy_control_link(
+                &run_dir,
+                "replaceable",
+                &paths.control,
+            )
+            .unwrap();
+            paths
+        };
+        LocalBackend::prepare_create_target(&pools, &forced, &sandbox_dir, &run_dir)
             .await
             .unwrap();
 
         assert!(!sandbox_dir.exists());
+        #[cfg(unix)]
+        for path in [
+            &socket_paths.agent,
+            &socket_paths.control,
+            &socket_paths.legacy_agent,
+            &socket_paths.legacy_control,
+            &socket_paths.canonical_dir,
+        ] {
+            assert!(std::fs::symlink_metadata(path).is_err());
+        }
         assert!(
             sandbox_entity::Entity::find_by_id(sandbox_id)
                 .one(pools.write())
@@ -1630,7 +1685,8 @@ mod tests {
         let mut forced = test_config("stale-running");
         forced.replace_existing = true;
 
-        LocalBackend::prepare_create_target(&pools, &forced, &sandbox_dir)
+        let run_dir = temp.path().join("run");
+        LocalBackend::prepare_create_target(&pools, &forced, &sandbox_dir, &run_dir)
             .await
             .unwrap();
 
@@ -1678,7 +1734,8 @@ mod tests {
         let mut forced = test_config("running");
         forced.replace_existing = true;
 
-        LocalBackend::prepare_create_target(&pools, &forced, &sandbox_dir)
+        let run_dir = temp.path().join("run");
+        LocalBackend::prepare_create_target(&pools, &forced, &sandbox_dir, &run_dir)
             .await
             .unwrap();
 

--- a/sdk/rust/lib/backend/local/sandbox/mod.rs
+++ b/sdk/rust/lib/backend/local/sandbox/mod.rs
@@ -72,7 +72,7 @@ impl LocalBackend {
         tracing::debug!(sandbox = name, ?mode, "start_local: loading record");
         let pools = self.db().await?;
         let write_db = pools.write();
-        let model = Self::load_sandbox_record_reconciled(pools, name).await?;
+        let model = self.load_sandbox_record_reconciled(pools, name).await?;
         tracing::debug!(sandbox = name, status = ?model.status, "start_local: current status");
 
         if model.status == SandboxStatus::Running || model.status == SandboxStatus::Draining {
@@ -268,7 +268,7 @@ impl LocalBackend {
             .one(pools.read())
             .await?
             .ok_or_else(|| crate::MicrosandboxError::SandboxNotFound(name.into()))?;
-        let model = Self::reconcile_sandbox_runtime_state(pools, model).await?;
+        let model = self.reconcile_sandbox_runtime_state(pools, model).await?;
         let run = Self::load_active_run(pools.read(), model.id).await?;
         let pid = Self::pid_from_run(run.as_ref());
         Ok((model, pid))
@@ -314,7 +314,7 @@ impl LocalBackend {
 
         let mut reconciled = Vec::with_capacity(sandboxes.len());
         for sandbox in sandboxes {
-            let model = Self::reconcile_sandbox_runtime_state(pools, sandbox).await?;
+            let model = self.reconcile_sandbox_runtime_state(pools, sandbox).await?;
             reconciled.push(model);
         }
 
@@ -390,18 +390,36 @@ impl LocalBackend {
 impl LocalBackend {
     /// Load a sandbox row by name and reconcile its runtime state.
     async fn load_sandbox_record_reconciled(
+        &self,
         pools: &DbPools,
         name: &str,
     ) -> MicrosandboxResult<sandbox_entity::Model> {
         let sandbox = load_sandbox_record(pools.read(), name).await?;
-        Self::reconcile_sandbox_runtime_state(pools, sandbox).await
+        self.reconcile_sandbox_runtime_state(pools, sandbox).await
     }
 
     /// Reconcile a Running/Draining row against the owning process's
     /// liveness, marking it terminal when the runtime is gone.
     async fn reconcile_sandbox_runtime_state(
+        &self,
         pools: &DbPools,
         sandbox: sandbox_entity::Model,
+    ) -> MicrosandboxResult<sandbox_entity::Model> {
+        let run_dir = self.config().run_dir();
+        let sandboxes_dir = self.config().sandboxes_dir();
+        Self::reconcile_sandbox_runtime_state_with_paths(
+            pools,
+            sandbox,
+            Some((&run_dir, &sandboxes_dir)),
+        )
+        .await
+    }
+
+    /// Reconcile runtime state with optional exact socket roots.
+    async fn reconcile_sandbox_runtime_state_with_paths(
+        pools: &DbPools,
+        sandbox: sandbox_entity::Model,
+        socket_roots: Option<(&Path, &Path)>,
     ) -> MicrosandboxResult<sandbox_entity::Model> {
         if !matches!(
             sandbox.status,
@@ -418,6 +436,13 @@ impl LocalBackend {
         // of view and should not keep stop callers polling forever.
         let Some(run) = run else {
             if sandbox.status == SandboxStatus::Draining {
+                if let Some((run_dir, sandboxes_dir)) = socket_roots {
+                    crate::runtime::remove_sandbox_socket_artifacts_at(
+                        run_dir,
+                        sandboxes_dir,
+                        &sandbox.name,
+                    )?;
+                }
                 let (terminal_status, reason) = Self::stale_runtime_terminal_state(sandbox.status);
                 Self::mark_sandbox_runtime_stale(
                     pools.write(),
@@ -441,6 +466,13 @@ impl LocalBackend {
             return Ok(sandbox);
         }
 
+        if let Some((run_dir, sandboxes_dir)) = socket_roots {
+            crate::runtime::remove_sandbox_socket_artifacts_at(
+                run_dir,
+                sandboxes_dir,
+                &sandbox.name,
+            )?;
+        }
         let (terminal_status, reason) = Self::stale_runtime_terminal_state(sandbox.status);
         Self::mark_sandbox_runtime_stale(
             pools.write(),
@@ -1063,6 +1095,12 @@ mod tests {
 
     #[tokio::test]
     async fn test_reconcile_sandbox_runtime_state_marks_dead_processes_crashed() {
+        #[cfg(unix)]
+        let temp = tempfile::Builder::new()
+            .prefix("msb-lazy-reap")
+            .tempdir_in("/tmp")
+            .unwrap();
+        #[cfg(not(unix))]
         let temp = tempdir().unwrap();
         let db_path = temp.path().join("test.db");
         let pools = open_test_pools(&db_path).await;
@@ -1090,10 +1128,42 @@ mod tests {
             .await
             .unwrap()
             .unwrap();
-        let reconciled = LocalBackend::reconcile_sandbox_runtime_state(&pools, sandbox)
-            .await
+        let run_dir = temp.path().join("run");
+        let sandboxes_dir = temp.path().join("sandboxes");
+        #[cfg(unix)]
+        let socket_paths = {
+            let paths = microsandbox_runtime::ipc::sandbox_socket_paths(&run_dir, "stale");
+            std::fs::create_dir_all(&paths.canonical_dir).unwrap();
+            std::fs::write(&paths.agent, b"stale").unwrap();
+            std::fs::write(&paths.control, b"stale").unwrap();
+            microsandbox_runtime::ipc::publish_legacy_agent_link(&run_dir, "stale", &paths.agent)
+                .unwrap();
+            microsandbox_runtime::ipc::publish_legacy_control_link(
+                &run_dir,
+                "stale",
+                &paths.control,
+            )
             .unwrap();
+            paths
+        };
+        let reconciled = LocalBackend::reconcile_sandbox_runtime_state_with_paths(
+            &pools,
+            sandbox,
+            Some((&run_dir, &sandboxes_dir)),
+        )
+        .await
+        .unwrap();
         assert_eq!(reconciled.status, SandboxStatus::Crashed);
+        #[cfg(unix)]
+        for path in [
+            &socket_paths.agent,
+            &socket_paths.control,
+            &socket_paths.legacy_agent,
+            &socket_paths.legacy_control,
+            &socket_paths.canonical_dir,
+        ] {
+            assert!(std::fs::symlink_metadata(path).is_err());
+        }
 
         let run = run_entity::Entity::find_by_id(run_id)
             .one(pools.write())
@@ -1139,9 +1209,10 @@ mod tests {
             .await
             .unwrap()
             .unwrap();
-        let reconciled = LocalBackend::reconcile_sandbox_runtime_state(&pools, sandbox)
-            .await
-            .unwrap();
+        let reconciled =
+            LocalBackend::reconcile_sandbox_runtime_state_with_paths(&pools, sandbox, None)
+                .await
+                .unwrap();
         assert_eq!(reconciled.status, SandboxStatus::Stopped);
 
         let run = run_entity::Entity::find_by_id(run_id)
@@ -1176,9 +1247,10 @@ mod tests {
             .await
             .unwrap()
             .unwrap();
-        let reconciled = LocalBackend::reconcile_sandbox_runtime_state(&pools, sandbox)
-            .await
-            .unwrap();
+        let reconciled =
+            LocalBackend::reconcile_sandbox_runtime_state_with_paths(&pools, sandbox, None)
+                .await
+                .unwrap();
 
         assert_eq!(reconciled.status, SandboxStatus::Stopped);
     }
@@ -1322,7 +1394,8 @@ mod tests {
             .unwrap();
 
         for sandbox in stale {
-            let _ = LocalBackend::reconcile_sandbox_runtime_state(&pools, sandbox).await;
+            let _ = LocalBackend::reconcile_sandbox_runtime_state_with_paths(&pools, sandbox, None)
+                .await;
         }
 
         // --- Assertions ---

--- a/sdk/rust/lib/backend/local/sandbox/mod.rs
+++ b/sdk/rust/lib/backend/local/sandbox/mod.rs
@@ -88,11 +88,59 @@ impl LocalBackend {
             )));
         }
 
+        let lifecycle_guard = crate::runtime::acquire_sandbox_lifecycle_guard(
+            &self.config().run_dir(),
+            name,
+            Duration::from_secs(5),
+        )
+        .await?;
+
+        // Removal or another start may have won while the initial reconciled
+        // snapshot was being loaded. Re-read under ownership and require the
+        // same persisted identity before changing state or touching sockets.
+        let current = load_sandbox_record(pools.read(), name).await?;
+        if current.id != model.id {
+            return Err(crate::MicrosandboxError::Runtime(format!(
+                "sandbox {name:?} identity changed from database id {} to {}; refusing stale start",
+                model.id, current.id
+            )));
+        }
+        if !matches!(
+            current.status,
+            SandboxStatus::Stopped | SandboxStatus::Crashed
+        ) {
+            return Err(crate::MicrosandboxError::SandboxStillRunning(format!(
+                "cannot start sandbox {name:?}: status changed to {:?}",
+                current.status
+            )));
+        }
+        let model = current;
+
+        // Older runtimes did not hold the lifecycle lock and published their
+        // terminal DB state just before process exit. Preserve upgrade safety
+        // by waiting for that recorded owner before the new runtime acquires
+        // and cleans the deterministic socket namespace.
+        if let Some(pid) = Self::load_latest_run(pools.read(), model.id)
+            .await?
+            .and_then(|run| run.pid)
+            .filter(|pid| Self::pid_is_alive(*pid))
+        {
+            let start = std::time::Instant::now();
+            while start.elapsed() < Duration::from_secs(5) && !Self::pid_is_dead_or_reaped(pid) {
+                tokio::time::sleep(Duration::from_millis(50)).await;
+            }
+            if !Self::pid_is_dead_or_reaped(pid) {
+                return Err(crate::MicrosandboxError::SandboxStillRunning(format!(
+                    "cannot start sandbox {name:?}: previous runtime pid {pid} is still alive"
+                )));
+            }
+        }
+
         let mut config: SandboxConfig = serde_json::from_str(&model.config)?;
         self.apply_deployment_profile(&mut config);
         config.apply_runtime_defaults();
-        self.validate_sandbox_name_for_runtime(&config.spec.name)?;
         validate_hostname(config.spec.runtime.hostname.as_deref())?;
+        self.validate_sandbox_name_for_runtime(&config.spec.name)?;
         Self::validate_rootfs_source(&config.spec.image)?;
         validate_env(&config.spec.env)?;
         validate_labels(&config.spec.labels)?;
@@ -100,7 +148,10 @@ impl LocalBackend {
         self.validate_start_state(&config, &self.sandboxes_dir().join(name))?;
         Self::update_sandbox_status(write_db, model.id, SandboxStatus::Running).await?;
 
-        match self.create_sandbox_inner(config, model.id, mode).await {
+        match self
+            .create_sandbox_inner(config, model.id, mode, Some(lifecycle_guard))
+            .await
+        {
             Ok((local_state, returned_config)) => {
                 let sandbox = Sandbox::from_local(backend.clone(), local_state, returned_config);
                 if let Err(err) = Self::update_sandbox_active_config(
@@ -429,6 +480,40 @@ impl LocalBackend {
         }
 
         let run = Self::load_active_run(pools.read(), sandbox.id).await?;
+        if run
+            .as_ref()
+            .and_then(|run| run.pid)
+            .is_some_and(Self::pid_is_alive)
+        {
+            return Ok(sandbox);
+        }
+
+        // A dead-PID snapshot is not sufficient: another process may already
+        // have reconciled and restarted this name. Serialize on the runtime
+        // ownership lock, then re-read the exact row/run before unlinking.
+        let _guard = if let Some((run_dir, _)) = socket_roots {
+            let Some(guard) =
+                microsandbox_runtime::ipc::try_acquire_lifecycle_guard(run_dir, &sandbox.name)?
+            else {
+                return Ok(sandbox);
+            };
+            Some(guard)
+        } else {
+            None
+        };
+        let Some(sandbox) = sandbox_entity::Entity::find_by_id(sandbox.id)
+            .one(pools.read())
+            .await?
+        else {
+            return Err(crate::MicrosandboxError::SandboxNotFound(sandbox.name));
+        };
+        if !matches!(
+            sandbox.status,
+            SandboxStatus::Running | SandboxStatus::Draining
+        ) {
+            return Ok(sandbox);
+        }
+        let run = Self::load_active_run(pools.read(), sandbox.id).await?;
 
         // No run record yet while Running means the sandbox is still starting up
         // (the child process has not inserted its PID). A Draining row with no
@@ -498,6 +583,19 @@ impl LocalBackend {
             .filter(run_entity::Column::SandboxId.eq(sandbox_id))
             .filter(run_entity::Column::Status.eq(run_entity::RunStatus::Running))
             .order_by_desc(run_entity::Column::StartedAt)
+            .one(db)
+            .await
+            .map_err(Into::into)
+    }
+
+    /// Load the most recent run record regardless of lifecycle status.
+    pub(crate) async fn load_latest_run(
+        db: &DbReadConnection,
+        sandbox_id: i32,
+    ) -> MicrosandboxResult<Option<run_entity::Model>> {
+        run_entity::Entity::find()
+            .filter(run_entity::Column::SandboxId.eq(sandbox_id))
+            .order_by_desc(run_entity::Column::Id)
             .one(db)
             .await
             .map_err(Into::into)

--- a/sdk/rust/lib/runtime/mod.rs
+++ b/sdk/rust/lib/runtime/mod.rs
@@ -18,10 +18,10 @@ pub(crate) mod spawn;
 pub use handle::ProcessHandle;
 pub use spawn::{SpawnMode, spawn_sandbox};
 pub(crate) use spawn::{
-    ensure_named_volumes, remove_sandbox_socket_artifacts_at, remove_sandbox_socket_artifacts_for,
-    resolve_sandbox_agent_socket_path, resolve_sandbox_agent_socket_path_for,
-    rollback_created_named_volumes, sandbox_agent_socket_path_candidates,
-    sandbox_agent_socket_path_candidates_for,
+    acquire_sandbox_lifecycle_guard, ensure_named_volumes, remove_sandbox_socket_artifacts_at,
+    remove_sandbox_socket_artifacts_for, resolve_sandbox_agent_socket_path,
+    resolve_sandbox_agent_socket_path_for, rollback_created_named_volumes,
+    sandbox_agent_socket_path_candidates, sandbox_agent_socket_path_candidates_for,
 };
 
 /// Resolve the host-side path of a sandbox's agentd relay socket by name.

--- a/sdk/rust/lib/runtime/mod.rs
+++ b/sdk/rust/lib/runtime/mod.rs
@@ -18,16 +18,17 @@ pub(crate) mod spawn;
 pub use handle::ProcessHandle;
 pub use spawn::{SpawnMode, spawn_sandbox};
 pub(crate) use spawn::{
-    ensure_named_volumes, resolve_sandbox_agent_socket_path, resolve_sandbox_agent_socket_path_for,
+    ensure_named_volumes, remove_sandbox_socket_artifacts_at, remove_sandbox_socket_artifacts_for,
+    resolve_sandbox_agent_socket_path, resolve_sandbox_agent_socket_path_for,
     rollback_created_named_volumes, sandbox_agent_socket_path_candidates,
     sandbox_agent_socket_path_candidates_for,
 };
 
 /// Resolve the host-side path of a sandbox's agentd relay socket by name.
 ///
-/// Returns the same path the runtime dials internally — the hashed path under
-/// the run directory when it fits the platform's Unix-socket length limit, and
-/// the legacy name-derived path otherwise.
+/// Returns the same path the runtime dials internally: the canonical
+/// per-sandbox path under the run directory, an existing legacy flat path for
+/// an older runtime, or the retained in-sandbox fallback for deep homes.
 ///
 /// Use this when you need to talk to agentd over a *raw byte transport* rather
 /// than the frame-protocol client in [`crate::agent`] — for example a

--- a/sdk/rust/lib/runtime/spawn.rs
+++ b/sdk/rust/lib/runtime/spawn.rs
@@ -273,6 +273,7 @@ pub async fn spawn_sandbox(
     config: &SandboxConfig,
     sandbox_id: i32,
     mode: SpawnMode,
+    lifecycle_guard: Option<microsandbox_runtime::ipc::SandboxLifecycleGuard>,
 ) -> MicrosandboxResult<(ProcessHandle, PathBuf)> {
     // Reference-model secrets store only a host-side source reference in the
     // durable config; resolve the actual values now so they travel to the
@@ -307,6 +308,34 @@ pub async fn spawn_sandbox(
     let scripts_dir = runtime_dir.join("scripts");
     let db_dir = global.home().join(DB_SUBDIR);
     let db_path = db_dir.join(DB_FILENAME);
+
+    // Own the sandbox's runtime namespace before touching any deterministic
+    // endpoint. The descriptor is duplicated into the child below and remains
+    // locked there for the runtime's entire lifetime.
+    #[cfg(unix)]
+    let lifecycle_guard = match lifecycle_guard {
+        Some(guard) => guard,
+        None => {
+            acquire_sandbox_lifecycle_guard(
+                &global.run_dir(),
+                &config.spec.name,
+                std::time::Duration::from_secs(5),
+            )
+            .await?
+        }
+    };
+
+    #[cfg(not(unix))]
+    let _ = lifecycle_guard;
+
+    // Lifecycle callers prove any previous owner dead before reaching spawn.
+    // With ownership now serialized, remove exact leftovers from that prior
+    // generation so compatibility-link publication cannot be masked by them.
+    remove_sandbox_socket_artifacts_at(
+        &global.run_dir(),
+        &global.sandboxes_dir(),
+        &config.spec.name,
+    )?;
 
     // Create directories concurrently.
     tokio::try_join!(
@@ -471,6 +500,10 @@ pub async fn spawn_sandbox(
         visible.push(OsString::from(
             microsandbox_runtime::vm::CONFIG_FD.to_string(),
         ));
+        visible.push(OsString::from("--lifecycle-lock-fd"));
+        visible.push(OsString::from(
+            microsandbox_runtime::vm::LIFECYCLE_LOCK_FD.to_string(),
+        ));
     }
 
     #[cfg(windows)]
@@ -501,11 +534,12 @@ pub async fn spawn_sandbox(
     cmd.stdin(Stdio::null());
 
     #[cfg(unix)]
-    if parent_watchdog.is_some() || startup_pipe.is_some() {
+    {
         let parent_watch_fd = parent_watchdog
             .as_ref()
             .map(|pipe| pipe.read_fd.as_raw_fd());
         let startup_write_fd = startup_pipe.as_ref().map(|pipe| pipe.write_fd.as_raw_fd());
+        let lifecycle_lock_fd = lifecycle_guard.as_raw_fd();
         unsafe {
             cmd.pre_exec(move || {
                 if startup_write_fd.is_some() {
@@ -519,12 +553,16 @@ pub async fn spawn_sandbox(
                 });
                 let mut startup_mapping = startup_write_fd
                     .map(|fd| InheritedFdMapping::new(fd, microsandbox_runtime::vm::STARTUP_FD));
+                let mut lifecycle_mapping = InheritedFdMapping::new(
+                    lifecycle_lock_fd,
+                    microsandbox_runtime::vm::LIFECYCLE_LOCK_FD,
+                );
 
                 // Parent runtimes such as Vitest or Go tests can have enough
                 // open files that pipe/tempfile allocation lands on one of the
                 // fixed inherited fd numbers. Move those sources away before
                 // any dup2 call can overwrite a later source fd.
-                let mut next_spare_fd = microsandbox_runtime::vm::STARTUP_FD + 1;
+                let mut next_spare_fd = microsandbox_runtime::vm::LIFECYCLE_LOCK_FD + 1;
                 move_reserved_source_fd(&mut config_mapping, &mut next_spare_fd)?;
                 if let Some(mapping) = parent_watch_mapping.as_mut() {
                     move_reserved_source_fd(mapping, &mut next_spare_fd)?;
@@ -532,6 +570,7 @@ pub async fn spawn_sandbox(
                 if let Some(mapping) = startup_mapping.as_mut() {
                     move_reserved_source_fd(mapping, &mut next_spare_fd)?;
                 }
+                move_reserved_source_fd(&mut lifecycle_mapping, &mut next_spare_fd)?;
 
                 dup_inherited_fd(config_mapping.src, config_mapping.dst)?;
                 if let Some(mapping) = parent_watch_mapping {
@@ -540,6 +579,7 @@ pub async fn spawn_sandbox(
                 if let Some(mapping) = startup_mapping {
                     dup_inherited_fd(mapping.src, mapping.dst)?;
                 }
+                dup_inherited_fd(lifecycle_mapping.src, lifecycle_mapping.dst)?;
 
                 Ok(())
             });
@@ -1175,6 +1215,7 @@ fn inherited_fd_source_needs_spare(src: i32, dst: i32) -> bool {
             microsandbox_runtime::vm::CONFIG_FD
                 | microsandbox_runtime::vm::PARENT_WATCH_FD
                 | microsandbox_runtime::vm::STARTUP_FD
+                | microsandbox_runtime::vm::LIFECYCLE_LOCK_FD
         )
 }
 
@@ -1869,10 +1910,10 @@ pub(crate) fn resolve_sandbox_agent_socket_path_for(
     name: &str,
 ) -> MicrosandboxResult<PathBuf> {
     #[cfg(unix)]
-    let candidates = vec![
-        microsandbox_runtime::ipc::canonical_agent_endpoint(&local.config().run_dir(), name),
-        in_sandbox_agent_socket_path(&local.config().sandboxes_dir(), name),
-    ];
+    let candidates = vec![microsandbox_runtime::ipc::canonical_agent_endpoint(
+        &local.config().run_dir(),
+        name,
+    )];
     #[cfg(not(unix))]
     let candidates = sandbox_agent_socket_path_candidates_for(local, name);
     resolve_sandbox_agent_socket_path_from_candidates(candidates)
@@ -1921,7 +1962,7 @@ fn resolve_sandbox_agent_socket_path_from_candidates(
     Err(crate::MicrosandboxError::InvalidConfig(format!(
         "sandbox runtime socket path is too long: shortest derived path is {shortest} bytes, \
          but Unix socket paths on this platform must be shorter than {} bytes; set \
-         MSB_HOME or paths.sandboxes to a shorter directory",
+         MSB_HOME to a shorter directory",
         unsafe { std::mem::zeroed::<libc::sockaddr_un>() }
             .sun_path
             .len()
@@ -2054,18 +2095,43 @@ pub(crate) fn remove_sandbox_socket_artifacts_at(
     sandboxes_dir: &Path,
     name: &str,
 ) -> MicrosandboxResult<()> {
-    microsandbox_runtime::ipc::remove_sandbox_socket_artifacts(run_dir, name)?;
+    let canonical_result =
+        microsandbox_runtime::ipc::remove_sandbox_socket_artifacts(run_dir, name);
 
     #[cfg(unix)]
-    microsandbox_runtime::ipc::remove_socket_pair(&in_sandbox_agent_socket_path(
-        sandboxes_dir,
-        name,
-    ))?;
+    let fallback_result = microsandbox_runtime::ipc::remove_socket_pair(
+        &in_sandbox_agent_socket_path(sandboxes_dir, name),
+    );
 
     #[cfg(not(unix))]
-    let _ = sandboxes_dir;
+    let fallback_result: std::io::Result<()> = {
+        let _ = sandboxes_dir;
+        Ok(())
+    };
 
+    canonical_result.and(fallback_result)?;
     Ok(())
+}
+
+/// Wait until no runtime generation owns a sandbox's deterministic namespace.
+pub(crate) async fn acquire_sandbox_lifecycle_guard(
+    run_dir: &Path,
+    name: &str,
+    timeout: std::time::Duration,
+) -> MicrosandboxResult<microsandbox_runtime::ipc::SandboxLifecycleGuard> {
+    let started = std::time::Instant::now();
+    loop {
+        if let Some(guard) = microsandbox_runtime::ipc::try_acquire_lifecycle_guard(run_dir, name)?
+        {
+            return Ok(guard);
+        }
+        if started.elapsed() >= timeout {
+            return Err(crate::MicrosandboxError::SandboxStillRunning(format!(
+                "sandbox {name:?} runtime still owns its lifecycle lock"
+            )));
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    }
 }
 
 async fn terminate_startup_process(

--- a/sdk/rust/lib/runtime/spawn.rs
+++ b/sdk/rust/lib/runtime/spawn.rs
@@ -20,7 +20,6 @@ use std::os::windows::io::AsRawHandle;
 use std::{
     collections::{BTreeMap, BTreeSet, HashMap},
     ffi::{OsStr, OsString},
-    fmt::Write,
     fs::File,
     io::{Seek, SeekFrom, Write as IoWrite},
     path::{Path, PathBuf},
@@ -96,7 +95,6 @@ use crate::{
 #[cfg(target_os = "linux")]
 static SIGCHLD_ALT_STACK_INIT: tokio::sync::OnceCell<()> = tokio::sync::OnceCell::const_new();
 
-const AGENT_SOCKET_HASH_HEX_LEN: usize = 32;
 #[cfg(windows)]
 const STARTUP_PIPE_HASH_HEX_LEN: usize = 32;
 #[cfg(target_os = "linux")]
@@ -1839,18 +1837,21 @@ fn sandbox_agent_socket_path_candidates_with_roots(
     sandboxes_dir: &Path,
     name: &str,
 ) -> Vec<PathBuf> {
-    let primary = sandbox_agent_socket_path(run_dir, name);
+    let primary = microsandbox_runtime::ipc::canonical_agent_endpoint(run_dir, name);
 
-    // On Unix a long sandbox name or a deep MSB_HOME can overflow the AF_UNIX
-    // `sun_path` limit, so keep the legacy
-    // `<sandboxes>/<name>/runtime/agent.sock` path as a fallback. Windows named
-    // pipes have no such length limit and never shipped a pre-hash naming
-    // scheme, so the primary pipe is the only candidate.
+    // New clients prefer the canonical per-sandbox endpoint, then the flat
+    // legacy path used by older runtimes, and finally the pre-hash in-sandbox
+    // fallback retained for unusually deep homes. Windows named pipes did not
+    // change layout, so the canonical endpoint is the only candidate there.
     #[cfg(unix)]
-    let candidates = vec![
-        primary,
-        legacy_sandbox_agent_socket_path(sandboxes_dir, name),
-    ];
+    let candidates = {
+        let paths = microsandbox_runtime::ipc::sandbox_socket_paths(run_dir, name);
+        vec![
+            primary,
+            paths.legacy_agent,
+            in_sandbox_agent_socket_path(sandboxes_dir, name),
+        ]
+    };
     #[cfg(not(unix))]
     let candidates = {
         let _ = sandboxes_dir;
@@ -1865,6 +1866,12 @@ pub(crate) fn resolve_sandbox_agent_socket_path_for(
     local: &LocalBackend,
     name: &str,
 ) -> MicrosandboxResult<PathBuf> {
+    #[cfg(unix)]
+    let candidates = vec![
+        microsandbox_runtime::ipc::canonical_agent_endpoint(&local.config().run_dir(), name),
+        in_sandbox_agent_socket_path(&local.config().sandboxes_dir(), name),
+    ];
+    #[cfg(not(unix))]
     let candidates = sandbox_agent_socket_path_candidates_for(local, name);
     resolve_sandbox_agent_socket_path_from_candidates(candidates)
 }
@@ -1872,7 +1879,18 @@ pub(crate) fn resolve_sandbox_agent_socket_path_for(
 /// Pick the first socket path usable on this platform.
 pub(crate) fn resolve_sandbox_agent_socket_path(name: &str) -> MicrosandboxResult<PathBuf> {
     let candidates = sandbox_agent_socket_path_candidates(name);
+
+    #[cfg(unix)]
+    if let Some(existing) = first_existing_socket_candidate(&candidates) {
+        return Ok(existing);
+    }
+
     resolve_sandbox_agent_socket_path_from_candidates(candidates)
+}
+
+#[cfg(unix)]
+fn first_existing_socket_candidate(candidates: &[PathBuf]) -> Option<PathBuf> {
+    candidates.iter().find(|path| path.exists()).cloned()
 }
 
 #[cfg(unix)]
@@ -1880,21 +1898,31 @@ fn resolve_sandbox_agent_socket_path_from_candidates(
     candidates: Vec<PathBuf>,
 ) -> MicrosandboxResult<PathBuf> {
     for path in &candidates {
-        if sandbox_agent_socket_path_fits(path) {
+        if microsandbox_runtime::ipc::validate_socket_pair(path).is_ok() {
             return Ok(path.clone());
         }
     }
 
     let shortest = candidates
         .iter()
-        .map(|path| sandbox_agent_socket_path_len(path))
+        .flat_map(|path| {
+            [
+                path.as_os_str().as_bytes().len(),
+                microsandbox_runtime::ipc::control_socket_path_for(path)
+                    .as_os_str()
+                    .as_bytes()
+                    .len(),
+            ]
+        })
         .min()
         .unwrap_or(0);
     Err(crate::MicrosandboxError::InvalidConfig(format!(
-        "agent relay socket path is too long: shortest derived path is {shortest} bytes, \
+        "sandbox runtime socket path is too long: shortest derived path is {shortest} bytes, \
          but Unix socket paths on this platform must be shorter than {} bytes; set \
          MSB_HOME or paths.sandboxes to a shorter directory",
-        unix_socket_path_capacity()
+        unsafe { std::mem::zeroed::<libc::sockaddr_un>() }
+            .sun_path
+            .len()
     )))
 }
 
@@ -1909,30 +1937,6 @@ fn resolve_sandbox_agent_socket_path_from_candidates(
             "no agent relay socket candidates were derived".to_string(),
         )
     })
-}
-
-#[cfg(unix)]
-fn sandbox_agent_socket_path(run_dir: &Path, name: &str) -> PathBuf {
-    run_dir
-        .join("agent")
-        .join(format!("{}.sock", agent_socket_hash(name)))
-}
-
-#[cfg(windows)]
-fn sandbox_agent_socket_path(_run_dir: &Path, name: &str) -> PathBuf {
-    PathBuf::from(format!(r"\\.\pipe\msb-agent-{}", agent_socket_hash(name)))
-}
-
-fn agent_socket_hash(name: &str) -> String {
-    let mut hasher = Sha256::new();
-    hasher.update(name.as_bytes());
-    let digest = hasher.finalize();
-
-    let mut hash = String::with_capacity(AGENT_SOCKET_HASH_HEX_LEN);
-    for byte in digest.iter().take(AGENT_SOCKET_HASH_HEX_LEN / 2) {
-        let _ = Write::write_fmt(&mut hash, format_args!("{byte:02x}"));
-    }
-    hash
 }
 
 /// What a client-side open of the agent pipe name revealed.
@@ -2026,26 +2030,40 @@ fn probe_agent_pipe_server(pipe_path: &Path) -> std::io::Result<AgentPipeProbe> 
 // backward compatibility with the pre-hash Unix layout; Windows never shipped a
 // different agent-pipe scheme, so this is Unix-only.
 #[cfg(unix)]
-fn legacy_sandbox_agent_socket_path(sandboxes_dir: &Path, name: &str) -> PathBuf {
+fn in_sandbox_agent_socket_path(sandboxes_dir: &Path, name: &str) -> PathBuf {
     sandboxes_dir.join(name).join("runtime").join("agent.sock")
 }
 
-// Agent socket path length only constrains AF_UNIX `sun_path` on Unix; Windows
-// named pipes have no equivalent limit, so these helpers are Unix-only.
-#[cfg(unix)]
-fn sandbox_agent_socket_path_fits(path: &Path) -> bool {
-    sandbox_agent_socket_path_len(path) < unix_socket_path_capacity()
+/// Remove every Unix runtime socket artifact deterministically owned by a sandbox.
+pub(crate) fn remove_sandbox_socket_artifacts_for(
+    local: &LocalBackend,
+    name: &str,
+) -> MicrosandboxResult<()> {
+    remove_sandbox_socket_artifacts_at(
+        &local.config().run_dir(),
+        &local.config().sandboxes_dir(),
+        name,
+    )
 }
 
-#[cfg(unix)]
-fn sandbox_agent_socket_path_len(path: &Path) -> usize {
-    path.as_os_str().as_bytes().len()
-}
+/// Remove runtime socket artifacts using explicit storage roots.
+pub(crate) fn remove_sandbox_socket_artifacts_at(
+    run_dir: &Path,
+    sandboxes_dir: &Path,
+    name: &str,
+) -> MicrosandboxResult<()> {
+    microsandbox_runtime::ipc::remove_sandbox_socket_artifacts(run_dir, name)?;
 
-#[cfg(unix)]
-fn unix_socket_path_capacity() -> usize {
-    let storage = unsafe { std::mem::zeroed::<libc::sockaddr_un>() };
-    storage.sun_path.len()
+    #[cfg(unix)]
+    microsandbox_runtime::ipc::remove_socket_pair(&in_sandbox_agent_socket_path(
+        sandboxes_dir,
+        name,
+    ))?;
+
+    #[cfg(not(unix))]
+    let _ = sandboxes_dir;
+
+    Ok(())
 }
 
 async fn terminate_startup_process(
@@ -2479,6 +2497,7 @@ fn sandbox_cli_args(
         log_dir: log_dir.to_path_buf(),
         runtime_dir: runtime_dir.to_path_buf(),
         sandboxes_dir: local.sandboxes_dir(),
+        run_dir: local.config().run_dir(),
         cpu_lease_dir: local.config().run_dir().join("cpu-leases"),
         writeback_lease_dir: local.config().run_dir().join("writeback-leases"),
         cpu_placement: config.spec.resources.cpu_placement,
@@ -3440,10 +3459,12 @@ mod tests {
 
         #[cfg(unix)]
         {
-            assert_eq!(candidates.len(), 2);
-            assert!(candidates[0].starts_with(backend.config().run_dir().join("agent")));
+            assert_eq!(candidates.len(), 3);
+            assert!(candidates[0].starts_with(backend.config().run_dir().join("sandboxes")));
+            assert_eq!(candidates[0].file_name().unwrap(), "agent.sock");
+            assert!(candidates[1].starts_with(backend.config().run_dir().join("agent")));
             assert_eq!(
-                candidates[1],
+                candidates[2],
                 backend
                     .config()
                     .sandboxes_dir()
@@ -3485,13 +3506,37 @@ mod tests {
             super::resolve_sandbox_agent_socket_path_for(&backend, "sdk-socket-test").unwrap();
 
         #[cfg(unix)]
-        assert!(resolved.starts_with(backend.config().run_dir().join("agent")));
+        assert!(resolved.starts_with(backend.config().run_dir().join("sandboxes")));
         #[cfg(windows)]
         assert!(
             resolved
                 .to_string_lossy()
                 .starts_with(r"\\.\pipe\msb-agent-")
         );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn test_new_client_selects_old_runtime_socket_when_canonical_is_absent() {
+        let temp = tempfile::Builder::new()
+            .prefix("msb-compat")
+            .tempdir_in("/tmp")
+            .unwrap();
+        let run_dir = temp.path().join("run");
+        let sandboxes_dir = temp.path().join("sandboxes");
+        let paths = microsandbox_runtime::ipc::sandbox_socket_paths(&run_dir, "old-runtime");
+        std::fs::create_dir_all(paths.legacy_agent.parent().unwrap()).unwrap();
+        let _listener = std::os::unix::net::UnixListener::bind(&paths.legacy_agent).unwrap();
+
+        let candidates = super::sandbox_agent_socket_path_candidates_with_roots(
+            &run_dir,
+            &sandboxes_dir,
+            "old-runtime",
+        );
+        let selected = super::first_existing_socket_candidate(&candidates).unwrap();
+
+        assert_eq!(selected, paths.legacy_agent);
+        std::os::unix::net::UnixStream::connect(selected).unwrap();
     }
 
     #[tokio::test]

--- a/sdk/rust/lib/runtime/spawn.rs
+++ b/sdk/rust/lib/runtime/spawn.rs
@@ -2577,6 +2577,7 @@ fn sandbox_cli_args(
             max_duration_secs: config.spec.lifecycle.max_duration_secs,
             idle_timeout_secs: config.spec.lifecycle.idle_timeout_secs,
         },
+        vsock: config.spec.vsock.routes.clone(),
         #[cfg(feature = "net")]
         deployment_profile: config.spec.deployment_profile,
         workdir: config.spec.runtime.workdir.as_ref().map(PathBuf::from),

--- a/sdk/rust/lib/runtime/spawn.rs
+++ b/sdk/rust/lib/runtime/spawn.rs
@@ -5,6 +5,8 @@
 //! sandbox process PID. The sandbox process runs the VMM and agent relay
 //! internally.
 
+#[cfg(windows)]
+use std::fmt::Write as _;
 #[cfg(unix)]
 use std::os::fd::AsRawFd;
 #[cfg(unix)]

--- a/sdk/rust/lib/sandbox/builder.rs
+++ b/sdk/rust/lib/sandbox/builder.rs
@@ -1,14 +1,15 @@
 //! Fluent builder for [`SandboxConfig`].
 
+use std::collections::HashSet;
 #[cfg(feature = "net")]
 use std::net::{IpAddr, Ipv4Addr};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use microsandbox_image::{PullProgressHandle, RegistryAuth};
 #[cfg(feature = "net")]
 use microsandbox_network::builder::{NetworkBuilder, SecretBuilder};
-use microsandbox_types::{CpuPlacement, EnvVar, PullPolicy};
+use microsandbox_types::{CpuPlacement, EnvVar, PullPolicy, VsockRouteSpec, VsockSocketType};
 #[cfg(feature = "net")]
 use microsandbox_types::{PortProtocol, PublishedPortSpec};
 
@@ -692,6 +693,39 @@ impl SandboxBuilder {
         self
     }
 
+    /// Expose a host Unix stream socket or local Windows named pipe on a guest-to-host vsock port.
+    ///
+    /// Guest applications connect directly to host CID 2 and `port`. No
+    /// in-guest proxy or agentd integration is required.
+    pub fn vsock(mut self, host_path: impl AsRef<Path>, port: u32) -> Self {
+        self.config.spec.vsock.routes.push(VsockRouteSpec {
+            host_socket: host_path.as_ref().to_path_buf(),
+            port,
+            socket_type: VsockSocketType::Stream,
+        });
+        self
+    }
+
+    /// Expose a host Unix datagram socket on a guest-to-host vsock port.
+    ///
+    /// Datagram boundaries are preserved end to end. Delivery remains
+    /// best-effort, matching Unix and vsock datagram semantics. Windows does
+    /// not support datagram routes.
+    pub fn vsock_dgram(mut self, host_path: impl AsRef<Path>, port: u32) -> Self {
+        self.config.spec.vsock.routes.push(VsockRouteSpec {
+            host_socket: host_path.as_ref().to_path_buf(),
+            port,
+            socket_type: VsockSocketType::Dgram,
+        });
+        self
+    }
+
+    /// Add a fully specified guest-to-host vsock route.
+    pub fn vsock_route(mut self, route: VsockRouteSpec) -> Self {
+        self.config.spec.vsock.routes.push(route);
+        self
+    }
+
     /// Add a secret with placeholder-based protection via a closure.
     ///
     /// The sandbox receives a placeholder; the real value is substituted
@@ -1266,6 +1300,7 @@ impl SandboxBuilder {
         super::types::validate_volume_mounts(&self.config.spec.mounts)?;
         super::validate_env(&self.config.spec.env)?;
         super::validate_labels(&self.config.spec.labels)?;
+        self.validate_vsock_routes()?;
 
         if let Err(error) = microsandbox_types::resolve_default_command(
             self.config.spec.runtime.entrypoint.as_deref(),
@@ -1315,6 +1350,77 @@ impl SandboxBuilder {
                     )));
                 }
                 seen.push(canonical);
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Validate the stable route key and the host resources it references.
+    fn validate_vsock_routes(&self) -> MicrosandboxResult<()> {
+        if self.config.spec.deployment_profile == DeploymentProfile::MultiTenant
+            && !self.config.spec.vsock.is_empty()
+        {
+            return Err(MicrosandboxError::InvalidConfig(
+                "host vsock routes are disabled for multi-tenant deployments".into(),
+            ));
+        }
+
+        let mut routes = HashSet::new();
+
+        for route in &self.config.spec.vsock.routes {
+            #[cfg(unix)]
+            if !route.host_socket.is_absolute() {
+                return Err(crate::MicrosandboxError::InvalidConfig(format!(
+                    "vsock host path must be absolute: {}",
+                    route.host_socket.display()
+                )));
+            }
+            #[cfg(windows)]
+            {
+                let path = route.host_socket.as_os_str().to_string_lossy();
+                let prefix = r"\\.\pipe\";
+                let local = path
+                    .get(..prefix.len())
+                    .is_some_and(|candidate| candidate.eq_ignore_ascii_case(prefix));
+                let name = path.get(prefix.len()..).unwrap_or_default();
+                if !local
+                    || name.is_empty()
+                    || name
+                        .split(['\\', '/'])
+                        .any(|part| part.is_empty() || part == "." || part == "..")
+                {
+                    return Err(crate::MicrosandboxError::InvalidConfig(format!(
+                        "vsock host path must be a local Windows named pipe such as \\\\.\\pipe\\api: {}",
+                        route.host_socket.display()
+                    )));
+                }
+                if route.socket_type == VsockSocketType::Dgram {
+                    return Err(MicrosandboxError::unsupported(
+                        Operation::SandboxCreate,
+                        UnsupportedReason::RequiresUnixHost,
+                    ));
+                }
+            }
+            if route.port == 0 || route.port == u32::MAX {
+                return Err(crate::MicrosandboxError::InvalidConfig(format!(
+                    "vsock port {} must be between 1 and {}",
+                    route.port,
+                    u32::MAX - 1
+                )));
+            }
+            // libkrun uses datagram port 123 for host-to-guest clock updates
+            // on macOS. Reserving it everywhere keeps configurations portable.
+            if route.socket_type == VsockSocketType::Dgram && route.port == 123 {
+                return Err(crate::MicrosandboxError::InvalidConfig(
+                    "vsock datagram port 123 is reserved for guest clock synchronization".into(),
+                ));
+            }
+            if !routes.insert((route.socket_type, route.port)) {
+                return Err(crate::MicrosandboxError::InvalidConfig(format!(
+                    "duplicate vsock {:?} route for port {}",
+                    route.socket_type, route.port
+                )));
             }
         }
 
@@ -1443,6 +1549,7 @@ mod tests {
     use microsandbox_types::PortProtocol;
     use microsandbox_types::{
         CpuPlacement, DeploymentProfile, SandboxLogLevel, TransparentHugePagePolicy,
+        VsockSocketType,
     };
     #[cfg(feature = "net")]
     use std::net::{IpAddr, Ipv4Addr};
@@ -2020,6 +2127,106 @@ mod tests {
         assert_eq!(config.spec.network.ports[4].host_port, 5354);
         assert_eq!(config.spec.network.ports[4].guest_port, 54);
         assert_eq!(config.spec.network.ports[4].protocol, PortProtocol::Udp);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_builder_vsock_routes_preserve_socket_type() {
+        let config = SandboxBuilder::new("test")
+            .image("alpine")
+            .vsock("/run/host-api.sock", 5000)
+            // Stream and datagram namespaces are independent.
+            .vsock_dgram("/run/events.sock", 5000)
+            .build()
+            .await
+            .unwrap();
+
+        assert_eq!(config.spec.vsock.routes.len(), 2);
+        assert_eq!(
+            config.spec.vsock.routes[0].socket_type,
+            VsockSocketType::Stream
+        );
+        assert_eq!(
+            config.spec.vsock.routes[1].socket_type,
+            VsockSocketType::Dgram
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_builder_rejects_duplicate_vsock_route_key() {
+        let err = SandboxBuilder::new("test")
+            .image("alpine")
+            .vsock("/run/one.sock", 5000)
+            .vsock("/run/two.sock", 5000)
+            .build()
+            .await
+            .unwrap_err();
+
+        assert!(err.to_string().contains("duplicate vsock Stream route"));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_builder_rejects_reserved_timesync_datagram_port() {
+        let err = SandboxBuilder::new("test")
+            .image("alpine")
+            .vsock_dgram("/run/events.sock", 123)
+            .build()
+            .await
+            .unwrap_err();
+
+        assert!(err.to_string().contains("reserved for guest clock"));
+    }
+
+    #[tokio::test]
+    async fn test_builder_rejects_vsock_for_multi_tenant_deployments() {
+        let err = SandboxBuilder::new("test")
+            .image("alpine")
+            .deployment_profile(DeploymentProfile::MultiTenant)
+            .vsock("/run/host-api.sock", 5000)
+            .build()
+            .await
+            .unwrap_err();
+
+        assert!(err.to_string().contains("multi-tenant"));
+    }
+
+    #[cfg(windows)]
+    #[tokio::test]
+    async fn test_builder_accepts_local_named_pipe_stream_route() {
+        let config = SandboxBuilder::new("test")
+            .image("alpine")
+            .vsock(r"\\.\pipe\host-api", 5000)
+            .build()
+            .await
+            .unwrap();
+
+        assert_eq!(config.spec.vsock.routes.len(), 1);
+        assert_eq!(
+            config.spec.vsock.routes[0].socket_type,
+            VsockSocketType::Stream
+        );
+    }
+
+    #[cfg(windows)]
+    #[tokio::test]
+    async fn test_builder_rejects_remote_named_pipe_and_datagram() {
+        let remote = SandboxBuilder::new("test")
+            .image("alpine")
+            .vsock(r"\\server\pipe\host-api", 5000)
+            .build()
+            .await
+            .unwrap_err();
+        assert!(remote.to_string().contains("local Windows named pipe"));
+
+        let datagram = SandboxBuilder::new("test")
+            .image("alpine")
+            .vsock_dgram(r"\\.\pipe\events", 5001)
+            .build()
+            .await
+            .unwrap_err();
+        assert!(datagram.to_string().contains("Unix host"));
     }
 
     #[cfg(feature = "net")]

--- a/sdk/rust/lib/sandbox/handle.rs
+++ b/sdk/rust/lib/sandbox/handle.rs
@@ -649,6 +649,7 @@ impl SandboxHandle {
                 super::reap_leaked_runtime_process(local_backend, local.db_id, &self.name).await?;
                 let pools = local_backend.db().await?;
 
+                crate::runtime::remove_sandbox_socket_artifacts_for(local_backend, &self.name)?;
                 super::remove_dir_if_exists(&local_backend.sandboxes_dir().join(&self.name))?;
                 sandbox_entity::Entity::delete_by_id(local.db_id)
                     .exec(pools.write())

--- a/sdk/rust/lib/sandbox/handle.rs
+++ b/sdk/rust/lib/sandbox/handle.rs
@@ -8,8 +8,6 @@
 
 use std::sync::Arc;
 
-use sea_orm::EntityTrait;
-
 use crate::{
     MicrosandboxError, MicrosandboxResult,
     backend::{
@@ -647,15 +645,7 @@ impl SandboxHandle {
                 // it (identity-checked) or fail before touching any state.
                 #[cfg(windows)]
                 super::reap_leaked_runtime_process(local_backend, local.db_id, &self.name).await?;
-                let pools = local_backend.db().await?;
-
-                crate::runtime::remove_sandbox_socket_artifacts_for(local_backend, &self.name)?;
-                super::remove_dir_if_exists(&local_backend.sandboxes_dir().join(&self.name))?;
-                sandbox_entity::Entity::delete_by_id(local.db_id)
-                    .exec(pools.write())
-                    .await?;
-
-                Ok(())
+                super::remove_local_persisted_sandbox(local_backend, &self.name, local.db_id).await
             }
             SandboxHandleInner::Cloud(_) => {
                 self.backend

--- a/sdk/rust/lib/sandbox/mod.rs
+++ b/sdk/rust/lib/sandbox/mod.rs
@@ -32,14 +32,15 @@ use microsandbox_protocol::{
     message::MessageType,
 };
 use microsandbox_types::hostname_from_sandbox_name as derive_hostname;
-use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
+use sea_orm::{ColumnTrait, EntityTrait, QueryFilter, QueryOrder};
 
 use microsandbox_image::progress_channel;
 
 use crate::{
     MicrosandboxResult,
     agent::AgentClient,
-    db::entity::sandbox as sandbox_entity,
+    backend::LocalBackend,
+    db::entity::{run as run_entity, sandbox as sandbox_entity},
     error::{Operation, UnsupportedReason},
     runtime::SpawnMode,
 };
@@ -567,15 +568,7 @@ impl Sandbox {
                 UnsupportedReason::UseInstead(Operation::SandboxRemove),
             )
         })?;
-        let pools = local_backend.db().await?;
-
-        crate::runtime::remove_sandbox_socket_artifacts_for(local_backend, &self.name)?;
-        remove_dir_if_exists(&local_backend.sandboxes_dir().join(&self.name))?;
-        sandbox_entity::Entity::delete_by_id(local.db_id)
-            .exec(pools.write())
-            .await?;
-
-        Ok(())
+        remove_local_persisted_sandbox(local_backend, &self.name, local.db_id).await
     }
 
     /// Unique name identifying this sandbox.
@@ -1525,6 +1518,66 @@ pub(super) fn remove_dir_if_exists(path: &Path) -> MicrosandboxResult<()> {
     }
 }
 
+/// Remove one exact local sandbox identity after proving no runtime owns it.
+pub(super) async fn remove_local_persisted_sandbox(
+    local_backend: &LocalBackend,
+    name: &str,
+    expected_id: i32,
+) -> MicrosandboxResult<()> {
+    let _guard = crate::runtime::acquire_sandbox_lifecycle_guard(
+        &local_backend.config().run_dir(),
+        name,
+        std::time::Duration::from_secs(5),
+    )
+    .await?;
+
+    // Re-read only after acquiring ownership. A stale `Sandbox` object must
+    // never delete a newer sandbox that reused the same deterministic name.
+    let pools = local_backend.db().await?;
+    let current = sandbox_entity::Entity::find()
+        .filter(sandbox_entity::Column::Name.eq(name))
+        .one(pools.read())
+        .await?
+        .ok_or_else(|| crate::MicrosandboxError::SandboxNotFound(name.to_string()))?;
+    if current.id != expected_id {
+        return Err(crate::MicrosandboxError::Runtime(format!(
+            "sandbox {name:?} identity changed from database id {expected_id} to {}; refusing stale removal",
+            current.id
+        )));
+    }
+    if !matches!(
+        current.status,
+        SandboxStatus::Stopped | SandboxStatus::Crashed
+    ) {
+        return Err(crate::MicrosandboxError::SandboxStillRunning(format!(
+            "cannot remove sandbox {name:?}: status is {:?}",
+            current.status
+        )));
+    }
+
+    let latest_run = run_entity::Entity::find()
+        .filter(run_entity::Column::SandboxId.eq(expected_id))
+        .order_by_desc(run_entity::Column::Id)
+        .one(pools.read())
+        .await?;
+    if latest_run
+        .and_then(|run| run.pid)
+        .is_some_and(microsandbox_utils::process::pid_is_alive)
+    {
+        return Err(crate::MicrosandboxError::SandboxStillRunning(format!(
+            "cannot remove sandbox {name:?}: its recorded runtime process is still alive"
+        )));
+    }
+
+    crate::runtime::remove_sandbox_socket_artifacts_for(local_backend, name)?;
+    remove_dir_if_exists(&local_backend.sandboxes_dir().join(name))?;
+    sandbox_entity::Entity::delete_by_id(expected_id)
+        .exec(pools.write())
+        .await?;
+
+    Ok(())
+}
+
 /// Load a sandbox row by name.
 pub(super) async fn load_sandbox_record(
     db: &DbReadConnection,
@@ -1547,13 +1600,15 @@ mod tests {
     #[cfg(unix)]
     use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
 
+    use sea_orm::{ActiveModelTrait, Set};
     use tempfile::tempdir;
 
     use super::{
         MAX_HOSTNAME_BYTES, MAX_SANDBOX_NAME_BYTES, SandboxStatus, ephemeral_cleanup_stop_result,
-        hostname_from_sandbox_name, remove_dir_if_exists, sandbox_not_found_for_name,
-        validate_hostname,
+        hostname_from_sandbox_name, remove_dir_if_exists, remove_local_persisted_sandbox,
+        sandbox_not_found_for_name, validate_hostname,
     };
+    use crate::backend::LocalBackend;
 
     #[test]
     fn test_sandbox_not_found_for_name_requires_exact_match() {
@@ -1770,5 +1825,36 @@ mod tests {
         remove_dir_if_exists(&sandbox_dir).unwrap();
 
         assert!(!sandbox_dir.exists());
+    }
+
+    #[tokio::test]
+    async fn persisted_removal_rejects_a_stale_sandbox_identity() {
+        let temp = tempdir().unwrap();
+        let backend = LocalBackend::builder()
+            .home(temp.path().join("home"))
+            .build()
+            .await
+            .unwrap();
+        let pools = backend.db().await.unwrap();
+        let current = super::sandbox_entity::ActiveModel {
+            name: Set("recreated".to_string()),
+            config: Set("{}".to_string()),
+            status: Set(SandboxStatus::Stopped),
+            ephemeral: Set(false),
+            ..Default::default()
+        }
+        .insert(pools.write())
+        .await
+        .unwrap();
+        let sandbox_dir = backend.sandboxes_dir().join("recreated");
+        std::fs::create_dir_all(&sandbox_dir).unwrap();
+        std::fs::write(sandbox_dir.join("marker"), b"successor").unwrap();
+
+        let error = remove_local_persisted_sandbox(&backend, "recreated", current.id + 1)
+            .await
+            .unwrap_err();
+
+        assert!(error.to_string().contains("identity changed"));
+        assert!(sandbox_dir.join("marker").exists());
     }
 }

--- a/sdk/rust/lib/sandbox/mod.rs
+++ b/sdk/rust/lib/sandbox/mod.rs
@@ -120,7 +120,7 @@ pub use microsandbox_types::{CpuPlacement, PullPolicy};
 pub use microsandbox_types::{
     EnvVar, MAX_HOSTNAME_BYTES, MAX_SANDBOX_NAME_BYTES, NetworkSpec, PortProtocol,
     PublishedPortSpec, SandboxLogLevel, SandboxResources, SandboxRuntimeOptions, SandboxSpec,
-    TransparentHugePagePolicy,
+    TransparentHugePagePolicy, VsockRouteSpec, VsockSocketType, VsockSpec,
 };
 pub use modify::{
     ChangeKind, ConfigPlannedChange, ModificationConflict, ModificationDisposition,

--- a/sdk/rust/lib/sandbox/mod.rs
+++ b/sdk/rust/lib/sandbox/mod.rs
@@ -569,6 +569,7 @@ impl Sandbox {
         })?;
         let pools = local_backend.db().await?;
 
+        crate::runtime::remove_sandbox_socket_artifacts_for(local_backend, &self.name)?;
         remove_dir_if_exists(&local_backend.sandboxes_dir().join(&self.name))?;
         sandbox_entity::Entity::delete_by_id(local.db_id)
             .exec(pools.write())

--- a/sdk/rust/lib/sandbox/modify.rs
+++ b/sdk/rust/lib/sandbox/modify.rs
@@ -591,35 +591,38 @@ async fn grow_root_disk_now(
 }
 
 /// Path of the sandbox's host-side runtime control socket.
+#[cfg(windows)]
 fn control_socket_path(name: &str) -> MicrosandboxResult<std::path::PathBuf> {
-    #[cfg(unix)]
-    if let Some(path) =
-        first_existing_control_socket(crate::runtime::sandbox_agent_socket_path_candidates(name))
-    {
-        return Ok(path);
-    }
-
-    // With no live endpoint, retain the same forward-path behavior as the
-    // public agent resolver and return its corresponding control path.
     Ok(microsandbox_runtime::control::control_socket_path_for(
         &crate::runtime::agent_socket_path(name)?,
     ))
 }
 
 #[cfg(unix)]
-fn first_existing_control_socket(
+fn control_socket_path_candidates(name: &str) -> Vec<std::path::PathBuf> {
+    control_socket_paths(crate::runtime::sandbox_agent_socket_path_candidates(name))
+}
+
+#[cfg(unix)]
+fn control_socket_paths(
     agent_candidates: impl IntoIterator<Item = std::path::PathBuf>,
-) -> Option<std::path::PathBuf> {
+) -> Vec<std::path::PathBuf> {
     agent_candidates
         .into_iter()
         .map(|path| microsandbox_runtime::control::control_socket_path_for(&path))
-        .find(|path| path.exists())
+        .collect()
 }
 
 /// Whether the running sandbox exposes the runtime control socket. Its absence
 /// means the runtime predates live control or the VM booted without any
 /// live-mutable capacity, so everything classifies as restart-required.
 fn control_socket_exists(name: &str) -> bool {
+    #[cfg(unix)]
+    return control_socket_path_candidates(name)
+        .into_iter()
+        .any(|path| path.exists());
+
+    #[cfg(not(unix))]
     control_socket_path(name).is_ok_and(|path| path.exists())
 }
 
@@ -686,18 +689,59 @@ async fn control_request(
     name: &str,
     request: String,
 ) -> MicrosandboxResult<microsandbox_runtime::control::ControlResponse> {
+    #[cfg(unix)]
+    {
+        let stream = connect_control_socket(control_socket_path_candidates(name))
+            .await
+            .map_err(|error| {
+                crate::MicrosandboxError::Runtime(format!(
+                    "failed to reach a runtime control socket for sandbox {name:?}: {error}"
+                ))
+            })?;
+        return control_request_over_stream(stream, &request).await;
+    }
+
+    #[cfg(windows)]
+    {
+        let path = control_socket_path(name)?;
+        let stream = connect_control_pipe(&path).await?;
+        control_request_over_stream(stream, &request).await
+    }
+}
+
+#[cfg(unix)]
+async fn connect_control_socket(
+    candidates: impl IntoIterator<Item = std::path::PathBuf>,
+) -> std::io::Result<tokio::net::UnixStream> {
+    let mut last_error = None;
+    for path in candidates {
+        if !path.exists() {
+            continue;
+        }
+        match tokio::net::UnixStream::connect(&path).await {
+            Ok(stream) => return Ok(stream),
+            Err(error) => last_error = Some(error),
+        }
+    }
+
+    Err(last_error.unwrap_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            "no runtime control endpoint exists",
+        )
+    }))
+}
+
+/// Send and receive one control exchange over an already-connected transport.
+async fn control_request_over_stream<S>(
+    mut stream: S,
+    request: &str,
+) -> MicrosandboxResult<microsandbox_runtime::control::ControlResponse>
+where
+    S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin,
+{
     use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 
-    let path = control_socket_path(name)?;
-    #[cfg(unix)]
-    let mut stream = tokio::net::UnixStream::connect(&path).await.map_err(|e| {
-        crate::MicrosandboxError::Runtime(format!(
-            "failed to reach the runtime control socket at {}: {e}",
-            path.display()
-        ))
-    })?;
-    #[cfg(windows)]
-    let mut stream = connect_control_pipe(&path).await?;
     stream
         .write_all(request.as_bytes())
         .await
@@ -2277,12 +2321,35 @@ mod tests {
         std::fs::create_dir_all(paths.legacy_control.parent().unwrap()).unwrap();
         let _listener = std::os::unix::net::UnixListener::bind(&paths.legacy_control).unwrap();
 
-        let selected =
-            first_existing_control_socket(vec![paths.agent.clone(), paths.legacy_agent.clone()])
-                .unwrap();
+        let selected = control_socket_paths(vec![paths.agent.clone(), paths.legacy_agent.clone()])
+            .into_iter()
+            .find(|path| path.exists())
+            .unwrap();
 
         assert_eq!(selected, paths.legacy_control);
         std::os::unix::net::UnixStream::connect(selected).unwrap();
+    }
+
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn new_control_client_skips_stale_canonical_socket() {
+        let temp = tempfile::Builder::new()
+            .prefix("msb-control-fallback")
+            .tempdir_in("/tmp")
+            .unwrap();
+        let run_dir = temp.path().join("run");
+        let paths = microsandbox_runtime::ipc::sandbox_socket_paths(&run_dir, "old-runtime");
+        std::fs::create_dir_all(&paths.canonical_dir).unwrap();
+        let stale = std::os::unix::net::UnixListener::bind(&paths.control).unwrap();
+        drop(stale);
+        std::fs::create_dir_all(paths.legacy_control.parent().unwrap()).unwrap();
+        let _live = tokio::net::UnixListener::bind(&paths.legacy_control).unwrap();
+
+        let stream = connect_control_socket(vec![paths.control, paths.legacy_control])
+            .await
+            .unwrap();
+
+        assert!(stream.peer_addr().is_ok());
     }
 
     fn config(cpus: u8, memory_mib: u32) -> SandboxConfig {

--- a/sdk/rust/lib/sandbox/modify.rs
+++ b/sdk/rust/lib/sandbox/modify.rs
@@ -592,9 +592,28 @@ async fn grow_root_disk_now(
 
 /// Path of the sandbox's host-side runtime control socket.
 fn control_socket_path(name: &str) -> MicrosandboxResult<std::path::PathBuf> {
+    #[cfg(unix)]
+    if let Some(path) =
+        first_existing_control_socket(crate::runtime::sandbox_agent_socket_path_candidates(name))
+    {
+        return Ok(path);
+    }
+
+    // With no live endpoint, retain the same forward-path behavior as the
+    // public agent resolver and return its corresponding control path.
     Ok(microsandbox_runtime::control::control_socket_path_for(
         &crate::runtime::agent_socket_path(name)?,
     ))
+}
+
+#[cfg(unix)]
+fn first_existing_control_socket(
+    agent_candidates: impl IntoIterator<Item = std::path::PathBuf>,
+) -> Option<std::path::PathBuf> {
+    agent_candidates
+        .into_iter()
+        .map(|path| microsandbox_runtime::control::control_socket_path_for(&path))
+        .find(|path| path.exists())
 }
 
 /// Whether the running sandbox exposes the runtime control socket. Its absence
@@ -2245,6 +2264,26 @@ fn format_mib(mib: u32) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    #[cfg(unix)]
+    fn new_control_client_selects_old_runtime_socket() {
+        let temp = tempfile::Builder::new()
+            .prefix("msb-control")
+            .tempdir_in("/tmp")
+            .unwrap();
+        let run_dir = temp.path().join("run");
+        let paths = microsandbox_runtime::ipc::sandbox_socket_paths(&run_dir, "old-runtime");
+        std::fs::create_dir_all(paths.legacy_control.parent().unwrap()).unwrap();
+        let _listener = std::os::unix::net::UnixListener::bind(&paths.legacy_control).unwrap();
+
+        let selected =
+            first_existing_control_socket(vec![paths.agent.clone(), paths.legacy_agent.clone()])
+                .unwrap();
+
+        assert_eq!(selected, paths.legacy_control);
+        std::os::unix::net::UnixStream::connect(selected).unwrap();
+    }
 
     fn config(cpus: u8, memory_mib: u32) -> SandboxConfig {
         let mut config = SandboxConfig::default();


### PR DESCRIPTION
## TL;DR
Add explicit guest-to-host virtio-vsock routes backed by Unix stream or datagram sockets and Windows named pipes, with matching CLI and SDK APIs.

This PR is stacked on #1297. Merge #1297 first; its socket-lifecycle commits will then disappear from this PR's diff automatically.

## Description

- Add bounded, nonblocking host adapters for Unix stream sockets, Unix datagram sockets, and Windows named-pipe streams.
- Connect routes directly through libkrun's typed virtio-vsock interfaces without an agentd proxy, TSI, or guest IP networking.
- Reject invalid paths, reserved or duplicate route keys, Windows datagrams, cloud use, and routes under the multi-tenant deployment profile.
- Preserve Unix datagram message boundaries and stable reply addresses while bounding peers, connections, queues, and message size.
- Update the libkrun family to 0.1.28 for datagram reply wakeups and proxy registration ordering.
- Expose `--vsock HOST_PATH:PORT[/stream|/dgram]` and matching Rust, Python, TypeScript, Go, and Ruby APIs.
- Keep the Ruby source gem pinned to the published core crate while Ruby CI temporarily tests unreleased bindings against the checkout SDK.
- Document transport behavior, platform support, limits, and the authority granted by exposing a host service.

```bash
msb run --vsock /run/host-api.sock:5000/stream --vsock /run/events.sock:5001/dgram alpine
```

```rust
let sandbox = Sandbox::builder("worker")
    .image("alpine")
    .vsock("/run/host-api.sock", 5000)
    .vsock_dgram("/run/events.sock", 5001)
    .create()
    .await?;
```

```typescript
const sandbox = await Sandbox.builder("worker")
  .image("alpine")
  .vsock("/run/host-api.sock", 5000)
  .vsockDgram("/run/events.sock", 5001)
  .create();
```

```python
sandbox = await Sandbox.create(
    "worker",
    image="alpine",
    vsock=[
        VsockRoute.stream("/run/host-api.sock", 5000),
        VsockRoute.dgram("/run/events.sock", 5001),
    ],
)
```

```go
sandbox, err := microsandbox.CreateSandbox(ctx, "worker",
    microsandbox.WithImage("alpine"),
    microsandbox.WithVsock(
        microsandbox.VsockRoute{HostSocket: "/run/host-api.sock", Port: 5000},
        microsandbox.VsockRoute{HostSocket: "/run/events.sock", Port: 5001, SocketType: microsandbox.VsockSocketTypeDgram},
    ),
)
```

```ruby
sandbox = Microsandbox::Sandbox.builder("worker")
  .image("alpine")
  .vsock("/run/host-api.sock", 5000)
  .vsock_dgram("/run/events.sock", 5001)
  .create
```

Closes #663

## Test Plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p microsandbox --lib vsock` passes 3 focused builder tests
- [x] `cargo test -p microsandbox-vsock --lib` passes both Unix backend tests
- [x] Ruby extension `cargo check` and `cargo clippy -- -D warnings` pass against the checkout SDK
- [x] Ruby source-tree tests pass 16 tests with 6 hardware integrations omitted
- [x] The source gem builds, installs, and exposes `vsock` and `vsock_dgram`
- [x] Pre-commit workspace formatting, clippy, docs, agentd, and CLI build checks pass
- [ ] Full GitHub CI (runs after the stacked PR opens)
