### PR TITLE
feat(mount): add uid=/gid= owner override for host-created files

### DIFF
--- a/crates/cli/lib/commands/common.rs
+++ b/crates/cli/lib/commands/common.rs
@@ -128,10 +128,16 @@ pub struct SandboxOpts {
     pub volume: Vec<String>,
 
     /// Explicitly mount a host directory into the sandbox (`SOURCE:DEST[:OPTIONS]`).
+    ///
+    /// OPTIONS may include `uid=<N>,gid=<N>` to present host-created files (no
+    /// per-file stat override) as that guest owner; both are required together.
     #[arg(long = "mount-dir", value_name = "SOURCE:DEST[:OPTIONS]")]
     pub mount_dir: Vec<String>,
 
     /// Explicitly mount a host file into the sandbox (`SOURCE:DEST[:OPTIONS]`).
+    ///
+    /// OPTIONS may include `uid=<N>,gid=<N>` to present the host file (no
+    /// per-file stat override) as that guest owner; both are required together.
     #[arg(long = "mount-file", value_name = "SOURCE:DEST[:OPTIONS]")]
     pub mount_file: Vec<String>,
 
@@ -554,6 +560,8 @@ struct CliMountOptions {
     named_kind: Option<VolumeKind>,
     fstype: Option<String>,
     format: Option<DiskImageFormat>,
+    override_uid: Option<u32>,
+    override_gid: Option<u32>,
 }
 
 /// Which keyed options are valid for a public CLI mount flag.
@@ -565,6 +573,7 @@ struct CliMountOptionSupport {
     named_kind: bool,
     fstype: bool,
     format: bool,
+    owner: bool,
 }
 
 /// Parsed `SOURCE:DEST[:OPTIONS]` mount specification.
@@ -1490,6 +1499,7 @@ pub fn apply_explicit_dir_mount(
         CliMountOptionSupport {
             policies: true,
             quota: true,
+            owner: true,
             ..CliMountOptionSupport::default()
         },
     )?;
@@ -1513,6 +1523,7 @@ pub fn apply_explicit_file_mount(
         spec,
         CliMountOptionSupport {
             policies: true,
+            owner: true,
             ..CliMountOptionSupport::default()
         },
     )?;
@@ -1652,6 +1663,9 @@ fn apply_common_mount_options(mut mount: MountBuilder, options: CliMountOptions)
     if let Some(quota) = options.quota_mib {
         mount = mount.quota(quota);
     }
+    if let (Some(uid), Some(gid)) = (options.override_uid, options.override_gid) {
+        mount = mount.owner(uid, gid);
+    }
     mount
 }
 
@@ -1751,6 +1765,8 @@ fn parse_cli_mount_options(
     let mut seen_named_kind = false;
     let mut seen_fstype = false;
     let mut seen_format = false;
+    let mut seen_uid = false;
+    let mut seen_gid = false;
 
     let Some(opts) = opts else {
         return Ok(parsed);
@@ -1878,14 +1894,36 @@ fn parse_cli_mount_options(
                             anyhow::anyhow!("invalid disk image format {value:?}: {e}")
                         })?);
                     }
+                    "uid" if support.owner => {
+                        if seen_uid {
+                            anyhow::bail!("mount option `uid` specified more than once");
+                        }
+                        seen_uid = true;
+                        parsed.override_uid = Some(value.parse::<u32>().map_err(|_| {
+                            anyhow::anyhow!("invalid uid {value:?} (expected an unsigned integer)")
+                        })?);
+                    }
+                    "gid" if support.owner => {
+                        if seen_gid {
+                            anyhow::bail!("mount option `gid` specified more than once");
+                        }
+                        seen_gid = true;
+                        parsed.override_gid = Some(value.parse::<u32>().map_err(|_| {
+                            anyhow::anyhow!("invalid gid {value:?} (expected an unsigned integer)")
+                        })?);
+                    }
                     "stat-virt" | "host-perms" | "size" | "quota" | "kind" | "fstype"
-                    | "format" => {
+                    | "format" | "uid" | "gid" => {
                         anyhow::bail!("mount option `{key}` is not valid here");
                     }
                     other => anyhow::bail!("unknown mount option {other:?}"),
                 }
             }
         }
+    }
+
+    if parsed.override_uid.is_some() != parsed.override_gid.is_some() {
+        anyhow::bail!("mount options `uid` and `gid` must be specified together");
     }
 
     Ok(parsed)
@@ -3687,6 +3725,46 @@ mod tests {
             }
             other => panic!("expected Bind, got {other:?}"),
         }
+    }
+
+    #[tokio::test]
+    async fn test_apply_explicit_dir_mount_owner() {
+        let dir = make_temp_dir("msb-mount-dir-owner");
+        let spec = format!("{}:/work:uid=4242,gid=4242", dir.display());
+        let mount = build_explicit(&spec, apply_explicit_dir_mount).await;
+        match mount {
+            VolumeMount::Bind {
+                host,
+                guest,
+                options,
+                ..
+            } => {
+                assert_eq!(host, dir);
+                assert_eq!(guest, "/work");
+                assert_eq!(options.override_uid, Some(4242));
+                assert_eq!(options.override_gid, Some(4242));
+            }
+            other => panic!("expected Bind, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_parse_cli_mount_options_uid_gid() {
+        let owner = CliMountOptionSupport {
+            owner: true,
+            ..CliMountOptionSupport::default()
+        };
+        let parsed = parse_cli_mount_options(Some("uid=4242,gid=4242"), owner).unwrap();
+        assert_eq!(parsed.override_uid, Some(4242));
+        assert_eq!(parsed.override_gid, Some(4242));
+        // uid and gid must come as a pair.
+        assert!(parse_cli_mount_options(Some("uid=4242"), owner).is_err());
+        assert!(parse_cli_mount_options(Some("gid=4242"), owner).is_err());
+        // Rejected where owner is unsupported (e.g. --mount-disk).
+        assert!(
+            parse_cli_mount_options(Some("uid=4242,gid=4242"), CliMountOptionSupport::default())
+                .is_err()
+        );
     }
 
     #[tokio::test]

--- a/crates/filesystem/lib/backends/passthroughfs/windows/builder.rs
+++ b/crates/filesystem/lib/backends/passthroughfs/windows/builder.rs
@@ -75,6 +75,15 @@ pub struct PassthroughConfig {
     /// `None` means unbounded. When set, guest-attributable growth past this
     /// many bytes is rejected with `ENOSPC`.
     pub quota_bytes: Option<u64>,
+
+    /// Guest `(uid, gid)` to present for host files that carry no per-file
+    /// override in the metadata store.
+    ///
+    /// Host-created files have no store entry, so without this they surface as
+    /// `0:0` (root). When set, such files are presented as this owner instead.
+    /// `None` keeps the legacy `0:0` fallback. Only consulted while stat
+    /// virtualization is enabled.
+    pub default_owner: Option<(u32, u32)>,
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -204,6 +213,7 @@ impl Default for PassthroughConfig {
             attr_timeout: Duration::from_secs(5),
             inject_init: true,
             quota_bytes: None,
+            default_owner: None,
         }
     }
 }

--- a/crates/filesystem/lib/backends/passthroughfs/windows/metadata.rs
+++ b/crates/filesystem/lib/backends/passthroughfs/windows/metadata.rs
@@ -34,7 +34,18 @@ impl PassthroughFs {
             return Ok(st);
         }
 
-        Ok(stat_from_metadata(metadata, data))
+        // Storeless path (e.g. relaxed mode with no persistent stat store):
+        // virtual metadata lives only in memory. A host-created file the guest
+        // never touched has no virtual mode set, so present the configured
+        // default owner instead of the raw 0:0 from the default VirtualMetadata.
+        let mut st = stat_from_metadata(metadata, data);
+        if let Some((uid, gid)) = self.cfg.default_owner
+            && data.virtual_meta.read().unwrap().mode.is_none()
+        {
+            st.st_uid = uid;
+            st.st_gid = gid;
+        }
+        Ok(st)
     }
 
     pub(super) fn entry_from_metadata(
@@ -64,15 +75,26 @@ impl PassthroughFs {
         }
 
         if self.stat_store.is_some() {
-            return Ok(OverrideStat::new(0, 0, mode_from_metadata(metadata), 0));
+            // No stored entry yet: a host-created file. Seed the mutation
+            // baseline with the configured default owner (falling back to 0:0)
+            // so a later setattr persists that owner instead of resetting it to
+            // root — matching the read path in `stat_from_metadata`.
+            let (uid, gid) = self.cfg.default_owner.unwrap_or((0, 0));
+            return Ok(OverrideStat::new(uid, gid, mode_from_metadata(metadata), 0));
         }
 
         let virtual_meta = data.virtual_meta.read().unwrap();
+        // Storeless host-created file (no virtual mode set): baseline its owner
+        // to default_owner too, so a partial setattr does not collapse it to 0:0.
+        let (uid, gid) = match self.cfg.default_owner {
+            Some(owner) if virtual_meta.mode.is_none() => owner,
+            _ => (virtual_meta.uid, virtual_meta.gid),
+        };
         Ok(OverrideStat {
             version: OVERRIDE_VERSION,
             _pad: [0; 3],
-            uid: virtual_meta.uid,
-            gid: virtual_meta.gid,
+            uid,
+            gid,
             mode: virtual_meta
                 .mode
                 .unwrap_or_else(|| mode_from_metadata(metadata)),

--- a/crates/filesystem/lib/backends/passthroughfs/windows/metadata.rs
+++ b/crates/filesystem/lib/backends/passthroughfs/windows/metadata.rs
@@ -25,6 +25,11 @@ impl PassthroughFs {
             let mut st = host_stat_from_metadata(metadata, data.inode);
             if let Some(override_stat) = store.read(&data.path)? {
                 apply_override_stat(&mut st, override_stat);
+            } else if let Some((uid, gid)) = self.cfg.default_owner {
+                // No per-file override: a host-created file. Present the
+                // configured default owner instead of the raw 0:0.
+                st.st_uid = uid;
+                st.st_gid = gid;
             }
             return Ok(st);
         }

--- a/crates/filesystem/lib/backends/passthroughfs/windows/tests.rs
+++ b/crates/filesystem/lib/backends/passthroughfs/windows/tests.rs
@@ -1091,3 +1091,32 @@ fn no_symlink_root_allows_deep_real_path() {
 
     build_no_symlink(deep).expect("deep real path should mount");
 }
+
+#[test]
+fn no_override_falls_back_to_configured_default_owner() {
+    let temp = TempDir::new();
+    std::fs::write(temp.path.join("hostfile.txt"), b"host-created").unwrap();
+
+    // A host-created file has no override stored; with default_owner set it is
+    // presented as that owner instead of the raw 0:0.
+    let fs = PassthroughFs::new(PassthroughConfig {
+        root_dir: temp.path.clone(),
+        inject_init: false,
+        default_owner: Some((1000, 1000)),
+        ..Default::default()
+    })
+    .unwrap();
+    fs.init(FsOptions::empty()).unwrap();
+
+    let entry = fs.lookup(context(), ROOT_INODE, c"hostfile.txt").unwrap();
+    assert_eq!(entry.attr.st_uid, 1000);
+    assert_eq!(entry.attr.st_gid, 1000);
+
+    // Without default_owner the same host file falls back to 0:0.
+    let plain = fs_for(&temp.path);
+    let entry = plain
+        .lookup(context(), ROOT_INODE, c"hostfile.txt")
+        .unwrap();
+    assert_eq!(entry.attr.st_uid, 0);
+    assert_eq!(entry.attr.st_gid, 0);
+}

--- a/crates/filesystem/lib/backends/passthroughfs/windows/tests.rs
+++ b/crates/filesystem/lib/backends/passthroughfs/windows/tests.rs
@@ -1120,3 +1120,35 @@ fn no_override_falls_back_to_configured_default_owner() {
     assert_eq!(entry.attr.st_uid, 0);
     assert_eq!(entry.attr.st_gid, 0);
 }
+
+#[test]
+fn setattr_preserves_default_owner_for_host_created_file() {
+    let temp = TempDir::new();
+    std::fs::write(temp.path.join("hostfile.txt"), b"host-created").unwrap();
+
+    let fs = PassthroughFs::new(PassthroughConfig {
+        root_dir: temp.path.clone(),
+        inject_init: false,
+        default_owner: Some((1000, 1000)),
+        ..Default::default()
+    })
+    .unwrap();
+    fs.init(FsOptions::empty()).unwrap();
+
+    let entry = fs.lookup(context(), ROOT_INODE, c"hostfile.txt").unwrap();
+
+    // The guest changes only the mode (chmod, no chown). The mutation baseline
+    // must seed the configured default owner rather than 0:0, so the file does
+    // not silently become root-owned after the metadata write.
+    let attr = stat64 {
+        st_mode: S_IFREG | 0o640,
+        ..Default::default()
+    };
+    fs.setattr(context(), entry.inode, attr, None, SetattrValid::MODE)
+        .unwrap();
+
+    let (st, _) = fs.getattr(context(), entry.inode, None).unwrap();
+    assert_eq!(st.st_uid, 1000);
+    assert_eq!(st.st_gid, 1000);
+    assert_eq!(st.st_mode & 0o7777, 0o640);
+}

--- a/crates/filesystem/lib/backends/shared/stat_override.rs
+++ b/crates/filesystem/lib/backends/shared/stat_override.rs
@@ -501,4 +501,27 @@ mod tests {
     fn test_unsupported_xattr_is_none_in_non_strict_mode() {
         assert!(handle_unsupported_xattr(false).unwrap().is_none());
     }
+
+    #[test]
+    fn test_bind_identity_map_applies_owner_and_overflow() {
+        use super::BindIdentityMap;
+
+        let map = BindIdentityMap::new(501, 1000, 1000);
+
+        // A file owned by the host owner is presented as the mapped guest owner.
+        let mut st: crate::stat64 = unsafe { std::mem::zeroed() };
+        st.st_uid = 501;
+        st.st_gid = 20;
+        map.apply(&mut st);
+        assert_eq!(st.st_uid, 1000);
+        assert_eq!(st.st_gid, 1000);
+
+        // Any other owner falls through to the overflow identity (65534).
+        let mut other: crate::stat64 = unsafe { std::mem::zeroed() };
+        other.st_uid = 4242;
+        other.st_gid = 4242;
+        map.apply(&mut other);
+        assert_eq!(other.st_uid, 65534);
+        assert_eq!(other.st_gid, 65534);
+    }
 }

--- a/crates/runtime/lib/relay.rs
+++ b/crates/runtime/lib/relay.rs
@@ -271,6 +271,18 @@ impl AgentRelay {
             return Ok(());
         };
 
+        // A mount may have pinned an explicit guest owner (`uid=`/`gid=`), which
+        // is installed host-side before the guest reports its default user. Keep
+        // that value; only fall back to the resolved default user when no
+        // explicit owner was set.
+        if handle.get().is_some() {
+            tracing::info!(
+                mounts = self.bind_identity_map_mount_count,
+                "agent relay: bind identity map already set by an explicit mount owner"
+            );
+            return Ok(());
+        }
+
         let host_owner_uid = unsafe { libc::getuid() as u32 };
         let map = BindIdentityMap::new(
             host_owner_uid,
@@ -278,9 +290,8 @@ impl AgentRelay {
             resolved.default_user.gid,
         );
 
-        handle
-            .set(map)
-            .map_err(|_| RuntimeError::Custom("bind identity map already installed".into()))?;
+        // Ignore a lost race: a concurrent explicit install winning here is fine.
+        let _ = handle.set(map);
 
         tracing::info!(
             host_owner_uid,

--- a/crates/runtime/lib/vm.rs
+++ b/crates/runtime/lib/vm.rs
@@ -18,7 +18,7 @@ use std::time::Duration;
 use microsandbox_db::DbWriteConnection;
 use microsandbox_db::entity::run as run_entity;
 #[cfg(unix)]
-use microsandbox_filesystem::{BindIdentityMapHandle, DynFileSystem};
+use microsandbox_filesystem::{BindIdentityMap, BindIdentityMapHandle, DynFileSystem};
 use microsandbox_filesystem::{
     HostPermissions, PassthroughConfig, PassthroughFs, StatVirtualization,
 };
@@ -1592,9 +1592,18 @@ fn build_vm(
         // Keep the host path as a PathBuf so mount failures can format it
         // without relying on the string-only mount spec field.
         let host_path = PathBuf::from(&parsed.host_path);
+        // Explicit guest owner for host files with no per-file override. Parsing
+        // guarantees uid/gid come as a pair, so this is Some only when both are set.
+        let override_owner = match (parsed.override_uid, parsed.override_gid) {
+            (Some(uid), Some(gid)) => Some((uid, gid)),
+            _ => None,
+        };
         #[cfg(unix)]
-        let mount_bind_identity_map =
-            bind_identity_map_for_mount(&mut bind_identity_map, parsed.stat_virtualization);
+        let mount_bind_identity_map = bind_identity_map_for_mount(
+            &mut bind_identity_map,
+            parsed.stat_virtualization,
+            override_owner,
+        );
         let cfg = PassthroughConfig {
             root_dir: host_path.clone(),
             inject_init: false,
@@ -1606,6 +1615,8 @@ fn build_vm(
             no_symlink_root: !parsed.follow_root_symlinks,
             #[cfg(unix)]
             bind_identity_map: mount_bind_identity_map,
+            #[cfg(windows)]
+            default_owner: override_owner,
             quota_bytes: parsed.quota_bytes,
             ..Default::default()
         };
@@ -2081,6 +2092,7 @@ fn release_reserved_metrics_slot(handoff: Option<&MetricsSlotHandoff>) {
 fn bind_identity_map_for_mount(
     registration: &mut BindIdentityMapRegistration,
     stat_virtualization: StatVirtualization,
+    override_owner: Option<(u32, u32)>,
 ) -> Option<BindIdentityMapHandle> {
     if matches!(stat_virtualization, StatVirtualization::Off) {
         return None;
@@ -2090,6 +2102,24 @@ fn bind_identity_map_for_mount(
     let handle = registration
         .handle
         .get_or_insert_with(|| Arc::new(OnceLock::new()));
+
+    // When the mount pins an explicit guest owner, install the map now (host
+    // side): the host owner uid is the process uid, so nothing has to wait for
+    // the guest to report its default user.
+    //
+    // LIMITATION (Unix only): the map handle is a single `OnceLock` shared by
+    // every stat-virtualized mount in this VM (see `BindIdentityMapRegistration`),
+    // so `set` is first-wins. If two mounts request DIFFERENT owners, only the
+    // first-registered one takes effect and the others are silently dropped;
+    // mounts that pin the SAME owner (the common case) are unaffected. Windows is
+    // not subject to this -- each mount carries its own `default_owner` on its
+    // `PassthroughConfig` and is honored per-mount. Lifting this would mean a
+    // per-mount map handle instead of the shared registration handle.
+    if let Some((guest_uid, guest_gid)) = override_owner {
+        let host_owner_uid = unsafe { libc::getuid() as u32 };
+        let _ = handle.set(BindIdentityMap::new(host_owner_uid, guest_uid, guest_gid));
+    }
+
     Some(Arc::clone(handle))
 }
 
@@ -2412,15 +2442,25 @@ struct ParsedMountSpec {
     readonly: bool,
     follow_root_symlinks: bool,
     quota_bytes: Option<u64>,
+    /// Guest uid to present for host files that carry no per-file override
+    /// (`uid=` option). `None` keeps the runtime default. Must be set together
+    /// with [`override_gid`](Self::override_gid).
+    override_uid: Option<u32>,
+    /// Guest gid to present for host files that carry no per-file override
+    /// (`gid=` option). `None` keeps the runtime default. Must be set together
+    /// with [`override_uid`](Self::override_uid).
+    override_gid: Option<u32>,
 }
 
 /// Parse a `--mount` spec into [`ParsedMountSpec`].
 ///
 /// Wire grammar: `tag:host_path[:opts]`, where `opts` is a comma-separated
 /// option block of flags (`ro`, `rw`, `noexec`, `nosuid`, `nodev`,
-/// `follow-root-symlinks`) and keyed policies (`stat-virt=...`, `host-perms=...`).
-/// The `follow-root-symlinks` flag opts the mount out of the default no-follow
-/// root resolution; its absence keeps the protective default on.
+/// `follow-root-symlinks`) and keyed policies (`stat-virt=...`, `host-perms=...`,
+/// `uid=...`, `gid=...`). The `follow-root-symlinks` flag opts the mount out of the
+/// default no-follow root resolution; its absence keeps the protective default on.
+/// `uid=`/`gid=` set the guest owner presented for host files that have no per-file
+/// override (see [`ParsedMountSpec::override_uid`]); they must be given together.
 fn parse_mount_spec(spec: &str) -> Result<ParsedMountSpec, String> {
     let (tag, rest) = spec
         .split_once(':')
@@ -2445,6 +2485,8 @@ fn parse_mount_spec(spec: &str) -> Result<ParsedMountSpec, String> {
     let mut readonly = false;
     let mut follow_root_symlinks = false;
     let mut quota_bytes = None;
+    let mut override_uid = None;
+    let mut override_gid = None;
     let mut seen_stat_virt = false;
     let mut seen_host_perms = false;
     let mut seen_access = false;
@@ -2453,6 +2495,8 @@ fn parse_mount_spec(spec: &str) -> Result<ParsedMountSpec, String> {
     let mut seen_nodev = false;
     let mut seen_follow_root = false;
     let mut seen_quota = false;
+    let mut seen_uid = false;
+    let mut seen_gid = false;
 
     if let Some(opts) = options {
         for opt in opts.split(',') {
@@ -2552,11 +2596,40 @@ fn parse_mount_spec(spec: &str) -> Result<ParsedMountSpec, String> {
                             })?;
                             quota_bytes = Some(mib.saturating_mul(1024 * 1024));
                         }
+                        "uid" => {
+                            if seen_uid {
+                                return Err(
+                                    "mount option `uid` specified more than once".to_string()
+                                );
+                            }
+                            seen_uid = true;
+                            override_uid = Some(value.parse::<u32>().map_err(|_| {
+                                format!("invalid uid {value:?} (expected an unsigned integer)")
+                            })?);
+                        }
+                        "gid" => {
+                            if seen_gid {
+                                return Err(
+                                    "mount option `gid` specified more than once".to_string()
+                                );
+                            }
+                            seen_gid = true;
+                            override_gid = Some(value.parse::<u32>().map_err(|_| {
+                                format!("invalid gid {value:?} (expected an unsigned integer)")
+                            })?);
+                        }
                         other => return Err(format!("unknown mount option {other:?}")),
                     }
                 }
             }
         }
+    }
+
+    // The override owner is applied host-side (before the guest resolves its
+    // default user), so both halves must be known up front: reject a lone
+    // `uid=`/`gid=`.
+    if override_uid.is_some() != override_gid.is_some() {
+        return Err("mount options `uid` and `gid` must be specified together".to_string());
     }
 
     Ok(ParsedMountSpec {
@@ -2567,6 +2640,8 @@ fn parse_mount_spec(spec: &str) -> Result<ParsedMountSpec, String> {
         readonly,
         follow_root_symlinks,
         quota_bytes,
+        override_uid,
+        override_gid,
     })
 }
 
@@ -2794,6 +2869,31 @@ mod tests {
         assert!(matches!(p.stat_virtualization, StatVirtualization::Strict));
         assert!(matches!(p.host_permissions, HostPermissions::Private));
         assert!(!p.readonly);
+        assert_eq!(p.override_uid, None);
+        assert_eq!(p.override_gid, None);
+    }
+
+    #[test]
+    fn test_parse_mount_spec_uid_gid() {
+        let p = parse_mount_spec("home:/host/home:uid=1000,gid=1000").unwrap();
+        assert_eq!(p.override_uid, Some(1000));
+        assert_eq!(p.override_gid, Some(1000));
+
+        // uid 0 (root) is a valid, distinct value from "unset".
+        let p = parse_mount_spec("home:/host/home:uid=0,gid=0").unwrap();
+        assert_eq!(p.override_uid, Some(0));
+        assert_eq!(p.override_gid, Some(0));
+    }
+
+    #[test]
+    fn test_parse_mount_spec_uid_gid_must_be_paired() {
+        assert!(parse_mount_spec("home:/host/home:uid=1000").is_err());
+        assert!(parse_mount_spec("home:/host/home:gid=1000").is_err());
+    }
+
+    #[test]
+    fn test_parse_mount_spec_rejects_invalid_uid() {
+        assert!(parse_mount_spec("home:/host/home:uid=abc,gid=1000").is_err());
     }
 
     #[test]
@@ -2946,10 +3046,12 @@ mod tests {
         };
 
         let first =
-            bind_identity_map_for_mount(&mut registration, StatVirtualization::Strict).unwrap();
+            bind_identity_map_for_mount(&mut registration, StatVirtualization::Strict, None)
+                .unwrap();
         let second =
-            bind_identity_map_for_mount(&mut registration, StatVirtualization::Relaxed).unwrap();
-        let off = bind_identity_map_for_mount(&mut registration, StatVirtualization::Off);
+            bind_identity_map_for_mount(&mut registration, StatVirtualization::Relaxed, None)
+                .unwrap();
+        let off = bind_identity_map_for_mount(&mut registration, StatVirtualization::Off, None);
 
         assert!(Arc::ptr_eq(&first, &second));
         assert!(off.is_none());

--- a/packages/microsandbox-types/rust/lib/domain.rs
+++ b/packages/microsandbox-types/rust/lib/domain.rs
@@ -273,6 +273,22 @@ pub struct MountOptions {
 
     /// Whether device files on the mount are ignored.
     pub nodev: bool,
+
+    /// Guest uid presented for host files under this mount that carry no
+    /// per-file stat override.
+    ///
+    /// Host-created files (written outside the guest) have no override, so
+    /// without this they surface with the runtime's fallback owner. When set,
+    /// such files are presented as this uid instead. Must be set together with
+    /// [`override_gid`](Self::override_gid). `None` keeps the fallback.
+    #[serde(default)]
+    pub override_uid: Option<u32>,
+
+    /// Guest gid presented for host files under this mount that carry no
+    /// per-file stat override. See [`override_uid`](Self::override_uid); the two
+    /// must be set together.
+    #[serde(default)]
+    pub override_gid: Option<u32>,
 }
 
 /// Storage kind for a named volume.

--- a/packages/microsandbox-types/typescript/src/domain.ts
+++ b/packages/microsandbox-types/typescript/src/domain.ts
@@ -75,6 +75,22 @@ export type MountOptions = {
    * Whether device files on the mount are ignored.
    */
   nodev: boolean;
+  /**
+   * Guest uid presented for host files under this mount that carry no
+   * per-file stat override.
+   *
+   * Host-created files (written outside the guest) have no override, so
+   * without this they surface with the runtime's fallback owner. When set,
+   * such files are presented as this uid instead. Must be set together with
+   * [`override_gid`](Self::override_gid). `None` keeps the fallback.
+   */
+  override_uid: number | null;
+  /**
+   * Guest gid presented for host files under this mount that carry no
+   * per-file stat override. See [`override_uid`](Self::override_uid); the two
+   * must be set together.
+   */
+  override_gid: number | null;
 };
 
 export type StatVirtualization = "strict" | "relaxed" | "off";

--- a/sdk/go/internal/ffi/ffi.go
+++ b/sdk/go/internal/ffi/ffi.go
@@ -1615,22 +1615,24 @@ type RootDiskSpec struct {
 
 // MountSpec describes a volume mount for a sandbox.
 type MountSpec struct {
-	Bind               string `json:"bind,omitempty"`
-	Named              string `json:"named,omitempty"`
-	NamedMode          string `json:"named_mode,omitempty"`
-	NamedKind          string `json:"named_kind,omitempty"`
-	Tmpfs              bool   `json:"tmpfs,omitempty"`
-	Disk               string `json:"disk,omitempty"`
-	Format             string `json:"format,omitempty"`
-	Fstype             string `json:"fstype,omitempty"`
-	Readonly           bool   `json:"readonly,omitempty"`
-	Noexec             bool   `json:"noexec,omitempty"`
-	Nosuid             bool   `json:"nosuid,omitempty"`
-	Nodev              bool   `json:"nodev,omitempty"`
-	SizeMiB            uint32 `json:"size_mib,omitempty"`
-	QuotaMiB           uint32 `json:"quota_mib,omitempty"`
-	StatVirtualization string `json:"stat_virtualization,omitempty"`
-	HostPermissions    string `json:"host_permissions,omitempty"`
+	Bind               string  `json:"bind,omitempty"`
+	Named              string  `json:"named,omitempty"`
+	NamedMode          string  `json:"named_mode,omitempty"`
+	NamedKind          string  `json:"named_kind,omitempty"`
+	Tmpfs              bool    `json:"tmpfs,omitempty"`
+	Disk               string  `json:"disk,omitempty"`
+	Format             string  `json:"format,omitempty"`
+	Fstype             string  `json:"fstype,omitempty"`
+	Readonly           bool    `json:"readonly,omitempty"`
+	Noexec             bool    `json:"noexec,omitempty"`
+	Nosuid             bool    `json:"nosuid,omitempty"`
+	Nodev              bool    `json:"nodev,omitempty"`
+	SizeMiB            uint32  `json:"size_mib,omitempty"`
+	QuotaMiB           uint32  `json:"quota_mib,omitempty"`
+	StatVirtualization string  `json:"stat_virtualization,omitempty"`
+	HostPermissions    string  `json:"host_permissions,omitempty"`
+	OverrideUid        *uint32 `json:"override_uid,omitempty"`
+	OverrideGid        *uint32 `json:"override_gid,omitempty"`
 }
 
 // NetworkOptions is the JSON representation of the network config block.

--- a/sdk/go/native/src/lib.rs
+++ b/sdk/go/native/src/lib.rs
@@ -1183,6 +1183,12 @@ struct MountSpec {
     /// Per-mount host-permission policy ("private" | "mirror").
     /// Only valid for bind / named mounts.
     host_permissions: Option<String>,
+    /// Guest uid presented for host files with no per-file stat override.
+    /// Must be set together with `override_gid`. Only valid for bind / named mounts.
+    override_uid: Option<u32>,
+    /// Guest gid presented for host files with no per-file stat override.
+    /// Must be set together with `override_uid`. Only valid for bind / named mounts.
+    override_gid: Option<u32>,
 }
 
 #[derive(Clone, Copy)]
@@ -1903,6 +1909,8 @@ fn apply_volume(
     let nodev = m.nodev;
     let size_mib = m.size_mib;
     let quota_mib = m.quota_mib;
+    let override_uid = m.override_uid;
+    let override_gid = m.override_gid;
     let raw_named_mode = m.named_mode.clone();
     let raw_named_kind = m.named_kind.clone();
 
@@ -1942,6 +1950,16 @@ fn apply_volume(
     if quota_mib.is_some() && bind.is_none() && named.is_none() {
         return Err(FfiError::invalid_argument(
             "quota_mib is only valid for bind mounts or named volume provisioning",
+        ));
+    }
+    if override_uid.is_some() != override_gid.is_some() {
+        return Err(FfiError::invalid_argument(
+            "override_uid and override_gid must be specified together",
+        ));
+    }
+    if override_uid.is_some() && bind.is_none() && named.is_none() {
+        return Err(FfiError::invalid_argument(
+            "override_uid/override_gid are only valid for bind or named mounts",
         ));
     }
 
@@ -2010,6 +2028,9 @@ fn apply_volume(
         }
         if let Some(p) = host_perms {
             mb = mb.host_permissions(p);
+        }
+        if let (Some(uid), Some(gid)) = (override_uid, override_gid) {
+            mb = mb.owner(uid, gid);
         }
         mb
     }))

--- a/sdk/go/options.go
+++ b/sdk/go/options.go
@@ -1600,6 +1600,20 @@ type MountConfig struct {
 	// Only meaningful for Bind and Named mounts. Zero value preserves the
 	// conservative default (Private).
 	HostPermissions HostPermissions
+
+	// Owner, when set, pins the guest owner presented for host files under this
+	// mount that carry no per-file stat override. Only meaningful for Bind and
+	// Named mounts. Nil keeps the runtime's fallback owner.
+	Owner *MountOwner
+}
+
+// MountOwner pins the guest owner presented for host files under a bind or named
+// mount that carry no per-file stat override (host-created files). Both fields
+// are required together; because uid 0 (root) is a valid value, this is passed
+// by pointer so that "unset" is distinct from "root".
+type MountOwner struct {
+	Uid uint32
+	Gid uint32
 }
 
 // MountKind discriminates between the four mount flavours.
@@ -1631,6 +1645,10 @@ type MountOptions struct {
 	Nodev              bool
 	StatVirtualization StatVirtualization
 	HostPermissions    HostPermissions
+	// Owner pins the guest owner presented for host files under this mount that
+	// carry no per-file stat override. Bind and Named mounts only. Nil keeps the
+	// runtime's fallback owner.
+	Owner *MountOwner
 	// QuotaMiB sets a guest-write quota for a bind mount, bounding how much
 	// the guest may add beyond the host directory's existing contents. Zero
 	// keeps the runtime's protective default. Bind mounts only; named volume
@@ -1690,6 +1708,7 @@ func (mountFactory) Bind(hostPath string, opts MountOptions) MountConfig {
 		Nodev:              opts.Nodev,
 		StatVirtualization: opts.StatVirtualization,
 		HostPermissions:    opts.HostPermissions,
+		Owner:              opts.Owner,
 		QuotaMiB:           opts.QuotaMiB,
 	}
 }
@@ -1705,6 +1724,7 @@ func (mountFactory) Named(name string, opts MountOptions) MountConfig {
 		Nodev:              opts.Nodev,
 		StatVirtualization: opts.StatVirtualization,
 		HostPermissions:    opts.HostPermissions,
+		Owner:              opts.Owner,
 	}
 }
 
@@ -1724,6 +1744,7 @@ func (mountFactory) NamedWith(name string, opts MountOptions, namedOpts NamedVol
 		Nodev:              opts.Nodev,
 		StatVirtualization: opts.StatVirtualization,
 		HostPermissions:    opts.HostPermissions,
+		Owner:              opts.Owner,
 	}
 }
 

--- a/sdk/go/sandbox.go
+++ b/sdk/go/sandbox.go
@@ -152,7 +152,7 @@ func buildFFICreateOptions(o SandboxConfig) ffi.CreateOptions {
 	if len(o.Volumes) > 0 {
 		ffiOpts.Volumes = make(map[string]ffi.MountSpec, len(o.Volumes))
 		for guestPath, m := range o.Volumes {
-			ffiOpts.Volumes[guestPath] = ffi.MountSpec{
+			spec := ffi.MountSpec{
 				Bind:               m.Bind,
 				Named:              m.Named,
 				NamedMode:          m.NamedMode,
@@ -170,6 +170,11 @@ func buildFFICreateOptions(o SandboxConfig) ffi.CreateOptions {
 				StatVirtualization: string(m.StatVirtualization),
 				HostPermissions:    string(m.HostPermissions),
 			}
+			if m.Owner != nil {
+				uid, gid := m.Owner.Uid, m.Owner.Gid
+				spec.OverrideUid, spec.OverrideGid = &uid, &gid
+			}
+			ffiOpts.Volumes[guestPath] = spec
 		}
 	}
 

--- a/sdk/go/sandbox_options_test.go
+++ b/sdk/go/sandbox_options_test.go
@@ -624,6 +624,31 @@ func TestFFIWireShape_Volumes(t *testing.T) {
 	}
 }
 
+func TestFFIWireShape_MountOwner(t *testing.T) {
+	got := marshalCreateOptions(t,
+		WithImage("alpine"),
+		WithMounts(map[string]MountConfig{
+			"/owned":   Mount.Bind("/host/owned", MountOptions{Owner: &MountOwner{Uid: 1000, Gid: 1000}}),
+			"/root":    Mount.Bind("/host/root", MountOptions{Owner: &MountOwner{Uid: 0, Gid: 0}}),
+			"/default": Mount.Bind("/host/default", MountOptions{}),
+		}),
+	)
+	volumes := mustField(t, got, "volumes").(map[string]any)
+
+	// An explicit owner rides the wire as override_uid/override_gid.
+	if v := volumes["/owned"].(map[string]any); v["override_uid"] != float64(1000) || v["override_gid"] != float64(1000) {
+		t.Fatalf("/owned = %v", v)
+	}
+	// uid 0 (root) is a real value and must be present, not omitted.
+	if v := volumes["/root"].(map[string]any); v["override_uid"] != float64(0) || v["override_gid"] != float64(0) {
+		t.Fatalf("/root = %v", v)
+	}
+	// No owner → the keys are omitted entirely (unset, not 0).
+	if v := volumes["/default"].(map[string]any); v["override_uid"] != nil || v["override_gid"] != nil {
+		t.Fatalf("/default should omit override_uid/override_gid, got %v", v)
+	}
+}
+
 func TestFFIWireShape_SecurityProfile(t *testing.T) {
 	got := marshalCreateOptions(t,
 		WithImage("alpine"),

--- a/sdk/node-ts/native/index.d.ts
+++ b/sdk/node-ts/native/index.d.ts
@@ -2491,4 +2491,8 @@ export interface VolumeMount {
   statVirtualization?: string
   /** `"private" | "mirror"` for bind/named mounts; `None` for tmpfs/disk. */
   hostPermissions?: string
+  /** Guest owner uid for host-created files under bind/named mounts; unset otherwise. Set with `overrideGid`. */
+  overrideUid?: number
+  /** Guest owner gid for host-created files under bind/named mounts; unset otherwise. Set with `overrideUid`. */
+  overrideGid?: number
 }

--- a/sdk/node-ts/native/index.d.ts
+++ b/sdk/node-ts/native/index.d.ts
@@ -440,6 +440,11 @@ export declare class MountBuilder {
    */
   hostPermissions(policy: string): this
   /**
+   * Present host files that carry no per-file stat override as this guest
+   * owner. Valid only for bind and directory-backed named volume mounts.
+   */
+  owner(uid: number, gid: number): this
+  /**
    * Materialize the mount spec. Returns a flat `VolumeMount` with a
    * `kind` discriminator and per-variant fields.
    */

--- a/sdk/node-ts/native/mount_builder.rs
+++ b/sdk/node-ts/native/mount_builder.rs
@@ -266,6 +266,15 @@ impl JsMountBuilder {
         Ok(self)
     }
 
+    /// Present host files that carry no per-file stat override as this guest
+    /// owner. Valid only for bind and directory-backed named volume mounts.
+    #[napi]
+    pub fn owner(&mut self, uid: u32, gid: u32) -> &Self {
+        let prev = self.take_inner();
+        self.inner = Some(prev.owner(uid, gid));
+        self
+    }
+
     /// Materialize the mount spec. Returns a flat `VolumeMount` with a
     /// `kind` discriminator and per-variant fields.
     #[napi]

--- a/sdk/node-ts/native/mount_builder.rs
+++ b/sdk/node-ts/native/mount_builder.rs
@@ -41,6 +41,12 @@ pub struct JsBuiltVolumeMount {
     pub stat_virtualization: Option<String>,
     /// `"private" | "mirror"` for bind/named mounts; `None` for tmpfs/disk.
     pub host_permissions: Option<String>,
+    /// Guest owner uid for host-created files under bind/named mounts; `None`
+    /// when unset or for tmpfs/disk. Set together with `override_gid`.
+    pub override_uid: Option<u32>,
+    /// Guest owner gid for host-created files under bind/named mounts; `None`
+    /// when unset or for tmpfs/disk. Set together with `override_uid`.
+    pub override_gid: Option<u32>,
 }
 
 /// Fluent builder for a sandbox volume mount.
@@ -333,6 +339,8 @@ fn to_built_mount(mount: RustVolumeMount) -> JsBuiltVolumeMount {
             fstype: None,
             stat_virtualization: Some(sv_str(stat_virtualization)),
             host_permissions: Some(hp_str(host_permissions)),
+            override_uid: options.override_uid,
+            override_gid: options.override_gid,
         },
         RustVolumeMount::Named {
             name,
@@ -372,6 +380,8 @@ fn to_built_mount(mount: RustVolumeMount) -> JsBuiltVolumeMount {
                 fstype: None,
                 stat_virtualization: Some(sv_str(stat_virtualization)),
                 host_permissions: Some(hp_str(host_permissions)),
+                override_uid: options.override_uid,
+                override_gid: options.override_gid,
             }
         }
         RustVolumeMount::Tmpfs {
@@ -395,6 +405,8 @@ fn to_built_mount(mount: RustVolumeMount) -> JsBuiltVolumeMount {
             fstype: None,
             stat_virtualization: None,
             host_permissions: None,
+            override_uid: None,
+            override_gid: None,
         },
         RustVolumeMount::DiskImage {
             host,
@@ -426,6 +438,8 @@ fn to_built_mount(mount: RustVolumeMount) -> JsBuiltVolumeMount {
             fstype,
             stat_virtualization: None,
             host_permissions: None,
+            override_uid: None,
+            override_gid: None,
         },
     }
 }

--- a/sdk/node-ts/src/internal/napi.ts
+++ b/sdk/node-ts/src/internal/napi.ts
@@ -1146,6 +1146,8 @@ export interface NapiVolumeMount {
   readonly fstype?: string;
   readonly statVirtualization?: string;
   readonly hostPermissions?: string;
+  readonly overrideUid?: number;
+  readonly overrideGid?: number;
 }
 
 export interface NapiPatchBuilder {

--- a/sdk/python/microsandbox/types.py
+++ b/sdk/python/microsandbox/types.py
@@ -702,6 +702,10 @@ class MountConfig:
     fstype: str | None = None
     stat_virtualization: StatVirtualization | None = None
     host_permissions: HostPermissions | None = None
+    #: Guest owner presented for host files with no per-file stat override.
+    #: Must be set together with ``override_gid``. BIND/NAMED mounts only.
+    override_uid: int | None = None
+    override_gid: int | None = None
 
     def _to_dict(self) -> dict:
         # Validate every supplied enum before selecting a mount arm. This
@@ -789,10 +793,22 @@ class MountConfig:
                 d["stat_virtualization"] = stat_virtualization
             if host_permissions is not None:
                 d["host_permissions"] = host_permissions
-        elif self.stat_virtualization is not None or self.host_permissions is not None:
+            if (self.override_uid is None) != (self.override_gid is None):
+                raise ValueError(
+                    "MountConfig.override_uid and override_gid must be set together"
+                )
+            if self.override_uid is not None:
+                d["override_uid"] = self.override_uid
+                d["override_gid"] = self.override_gid
+        elif (
+            self.stat_virtualization is not None
+            or self.host_permissions is not None
+            or self.override_uid is not None
+            or self.override_gid is not None
+        ):
             raise ValueError(
-                f"stat_virtualization/host_permissions are only valid for "
-                f"BIND/NAMED mounts (got kind={self.kind.value})"
+                f"stat_virtualization/host_permissions/override_uid/override_gid are only "
+                f"valid for BIND/NAMED mounts (got kind={self.kind.value})"
             )
         return d
 

--- a/sdk/python/src/helpers.rs
+++ b/sdk/python/src/helpers.rs
@@ -806,6 +806,8 @@ fn apply_mount(
     let host_perms = extract_opt::<String>(mount, "host_permissions")?
         .map(parse_host_perms)
         .transpose()?;
+    let override_uid = extract_opt::<u32>(mount, "override_uid")?;
+    let override_gid = extract_opt::<u32>(mount, "override_gid")?;
 
     if let Some(bind_path) = extract_opt::<String>(mount, "bind")? {
         let quota_mib = extract_opt::<u32>(mount, "quota_mib")?;
@@ -828,6 +830,9 @@ fn apply_mount(
             }
             if let Some(p) = host_perms {
                 m = m.host_permissions(p);
+            }
+            if let (Some(uid), Some(gid)) = (override_uid, override_gid) {
+                m = m.owner(uid, gid);
             }
             if let Some(quota_mib) = quota_mib {
                 m = m.quota(quota_mib);
@@ -889,6 +894,9 @@ fn apply_mount(
             }
             if let Some(p) = host_perms {
                 m = m.host_permissions(p);
+            }
+            if let (Some(uid), Some(gid)) = (override_uid, override_gid) {
+                m = m.owner(uid, gid);
             }
             m
         }))

--- a/sdk/python/tests/test_mount_policies.py
+++ b/sdk/python/tests/test_mount_policies.py
@@ -64,6 +64,36 @@ def test_bind_with_relaxed_and_mirror_serializes_lowercase() -> None:
     assert d["host_permissions"] == "mirror"
 
 
+def test_bind_owner_serializes() -> None:
+    mc = MountConfig(
+        kind=MountKind.BIND,
+        bind="/host/data",
+        override_uid=1000,
+        override_gid=1000,
+    )
+    d = mc._to_dict()
+    assert d["override_uid"] == 1000
+    assert d["override_gid"] == 1000
+
+
+def test_bind_owner_omitted_when_unset() -> None:
+    d = MountConfig(kind=MountKind.BIND, bind="/host/data")._to_dict()
+    assert "override_uid" not in d
+    assert "override_gid" not in d
+
+
+def test_owner_must_be_paired() -> None:
+    mc = MountConfig(kind=MountKind.BIND, bind="/host/data", override_uid=1000)
+    with pytest.raises(ValueError, match="together"):
+        mc._to_dict()
+
+
+def test_owner_rejected_on_tmpfs() -> None:
+    mc = MountConfig(kind=MountKind.TMPFS, override_uid=1000, override_gid=1000)
+    with pytest.raises(ValueError, match="BIND/NAMED"):
+        mc._to_dict()
+
+
 def test_named_with_off_serializes() -> None:
     mc = MountConfig(
         kind=MountKind.NAMED,

--- a/sdk/rust/lib/runtime/spawn.rs
+++ b/sdk/rust/lib/runtime/spawn.rs
@@ -2258,6 +2258,8 @@ fn push_dir_mount_arg(
         stat_virtualization,
         host_permissions,
         follow_root_symlinks,
+        options.override_uid,
+        options.override_gid,
     );
     if let Some(mib) = quota_mib {
         opts.push(format!("quota={mib}"));
@@ -2279,7 +2281,14 @@ fn push_file_mount_arg(
     let mut opts = mount_option_tokens(options);
     // The staging directory is canonicalized at creation, so it is symlink-free
     // and stays under the default no-follow root protection — no opt-out here.
-    append_policy_options(&mut opts, stat_virtualization, host_permissions, false);
+    append_policy_options(
+        &mut opts,
+        stat_virtualization,
+        host_permissions,
+        false,
+        options.override_uid,
+        options.override_gid,
+    );
     append_option_block(&mut arg, opts);
     mounts.push(arg);
 }
@@ -2330,6 +2339,8 @@ fn append_policy_options(
     stat_virtualization: StatVirtualization,
     host_permissions: HostPermissions,
     follow_root_symlinks: bool,
+    override_uid: Option<u32>,
+    override_gid: Option<u32>,
 ) {
     match stat_virtualization {
         StatVirtualization::Strict => {}
@@ -2344,6 +2355,18 @@ fn append_policy_options(
     // resolution); its absence keeps the default protection on.
     if follow_root_symlinks {
         opts.push("follow-root-symlinks".to_string());
+    }
+    // Explicit guest owner for host files with no per-file override. This is a
+    // host-side virtiofs presentation policy (like stat-virt/host-perms above):
+    // it rides the `--mount` arg the VMM parses and must NOT leak into the guest
+    // mount specs (`MSB_DIR_MOUNTS`/`MSB_FILE_MOUNTS`), where agentd would reject
+    // `uid`/`gid` as unknown. The runtime requires the pair together; the SDK's
+    // `owner()` setter always sets both.
+    if let Some(uid) = override_uid {
+        opts.push(format!("uid={uid}"));
+    }
+    if let Some(gid) = override_gid {
+        opts.push(format!("gid={gid}"));
     }
 }
 
@@ -4120,6 +4143,41 @@ mod tests {
         assert!(
             arg.contains("follow-root-symlinks"),
             "opt-out mount must carry the token, got {arg:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_sandbox_cli_args_bind_mount_owner_host_only() {
+        // An explicit owner is a host-side virtiofs presentation policy: it must
+        // ride the `--mount` arg the VMM parses, and must NOT leak into the guest
+        // `MSB_DIR_MOUNTS` spec (where agentd rejects `uid`/`gid` as unknown).
+        let config = SandboxBuilder::new("test")
+            .image("/tmp/rootfs")
+            .volume("/data", |m| m.bind("/host/data").owner(1000, 1000))
+            .build()
+            .await
+            .unwrap();
+        let rendered = render_args(&config);
+        let data_tag = super::guest_mount_tag("/data");
+
+        let mount_arg = rendered
+            .windows(2)
+            .find(|p| p[0] == "--mount" && p[1].starts_with(&format!("{data_tag}:/host/data")))
+            .map(|p| p[1].clone())
+            .unwrap_or_default();
+        assert!(
+            mount_arg.contains("uid=1000") && mount_arg.contains("gid=1000"),
+            "host --mount arg must carry the owner, got {mount_arg:?}"
+        );
+
+        let dir_mounts = rendered
+            .iter()
+            .find(|a| a.starts_with("MSB_DIR_MOUNTS="))
+            .cloned()
+            .unwrap_or_default();
+        assert!(
+            !dir_mounts.contains("uid=") && !dir_mounts.contains("gid="),
+            "guest MSB_DIR_MOUNTS must not carry uid/gid, got {dir_mounts:?}"
         );
     }
 

--- a/sdk/rust/lib/sandbox/types.rs
+++ b/sdk/rust/lib/sandbox/types.rs
@@ -361,6 +361,19 @@ impl MountBuilder {
         self
     }
 
+    /// Present host files that carry no per-file stat override as this guest
+    /// owner.
+    ///
+    /// Files created outside the guest (directly on the host) have no override,
+    /// so by default they surface with the runtime's fallback owner. Pinning an
+    /// owner here makes them appear as `(uid, gid)` instead. Valid only for bind
+    /// and named-directory/file mounts (requires stat virtualization).
+    pub fn owner(mut self, uid: u32, gid: u32) -> Self {
+        self.options.override_uid = Some(uid);
+        self.options.override_gid = Some(gid);
+        self
+    }
+
     /// Set size limit (for tmpfs).
     ///
     /// Accepts bare `u32` (interpreted as MiB) or a [`SizeExt`](crate::size::SizeExt) helper:

--- a/sdk/rust/lib/sandbox/types.rs
+++ b/sdk/rust/lib/sandbox/types.rs
@@ -508,6 +508,22 @@ impl MountBuilder {
             .unwrap_or(StatVirtualization::Strict);
         let host_permissions = self.host_permissions.unwrap_or(HostPermissions::Private);
 
+        // An explicit owner needs stat virtualization to carry it: on Unix the
+        // BindIdentityMap is only installed when virtualization is on, and the
+        // Windows `default_owner` stat path is likewise gated. With `Off` the
+        // owner would be silently dropped, so reject the combination rather than
+        // accept a no-op.
+        if matches!(stat_virtualization, StatVirtualization::Off)
+            && (self.options.override_uid.is_some() || self.options.override_gid.is_some())
+        {
+            return Err(crate::MicrosandboxError::InvalidConfig(
+                "mount owner (uid/gid) requires stat virtualization and cannot be combined \
+                 with stat_virtualization=Off: Off installs no identity map, so the owner \
+                 would be silently dropped. Drop one or the other."
+                    .into(),
+            ));
+        }
+
         let mount = match self.mount {
             MountKind::Bind(host) => {
                 // The spawn → VM wire format encodes mount specs as
@@ -1393,6 +1409,38 @@ mod tests {
             err.to_string()
                 .contains(".format() is only valid for disk image mounts")
         );
+    }
+
+    #[test]
+    fn test_mount_builder_owner_rejected_with_stat_virt_off() {
+        let err = MountBuilder::new("/data")
+            .bind("/host/data")
+            .stat_virtualization(StatVirtualization::Off)
+            .owner(1000, 1000)
+            .build()
+            .unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("mount owner (uid/gid) requires stat virtualization"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn test_mount_builder_owner_accepted_with_default_stat_virt() {
+        // Default stat virtualization is Strict, so owner is honored.
+        let mount = MountBuilder::new("/data")
+            .bind("/host/data")
+            .owner(1000, 1000)
+            .build()
+            .unwrap();
+        match mount {
+            VolumeMount::Bind { options, .. } => {
+                assert_eq!(options.override_uid, Some(1000));
+                assert_eq!(options.override_gid, Some(1000));
+            }
+            other => panic!("expected bind mount, got {other:?}"),
+        }
     }
 
     #[test]


### PR DESCRIPTION
Bind and named mounts gain `uid=<N>` / `gid=<N>` options that set the guest owner presented for host files which have no per-file stat override.

Files created directly on the host (outside the guest) have no override, so they surface with the runtime's fallback owner: the guest's resolved default user on Unix, or 0:0 on Windows. When the sandbox process runs as a different user than the one owning the host files, those files become unreadable inside the guest. `uid=`/`gid=` let a caller pin the owner explicitly (e.g. `uid=1000,gid=1000`), following the vfat/ntfs/cifs/9p convention for filesystems without native ownership.

- parse_mount_spec: parse uid=/gid= (rejected unless given as a pair)
- Unix: construct the BindIdentityMap host-side from the explicit owner; the relay's default-user install now yields to an already-installed map
- Windows: present the configured owner in the no-override stat path instead of the hardcoded 0:0
- threaded through MountOptions, the MountBuilder owner() setter, the spawn mount-spec renderer, the Go FFI MountSpec, and the Go SDK MountOptions
- unspecified uid/gid preserves the prior per-platform behavior

Known limitation (Unix: shared identity map)

On Unix, the bind-identity map is a single shared handle (Arc<OnceLock<BindIdentityMap>>) registered once via BindIdentityMapRegistration and reused by every stat-virtualized mount in the VM. When a mount pins an explicit owner, bind_identity_map_for_mount installs it with handle.set(...), which is first-wins: a later mount that sets a different uid=/gid= is silently ignored (let _ = handle.set(...)).

Consequences:
- Multiple mounts using the same explicit owner (e.g. every bind mount pinned to uid=1000,gid=1000) — fine.
- A single mount with uid=/gid= — fine.
- Multiple mounts requesting different owners on Unix — only the first-registered mount's owner takes effect for all of them; the others' values are dropped without error.

This does not affect Windows, where each mount carries its own default_owner on its PassthroughConfig, so per-mount owners are honored independently.

Lifting this would mean giving each virtualized mount its own BindIdentityMap handle instead of the shared registration handle; it was left as a single shared map here to match the existing BindIdentityMapRegistration design, since the motivating use case pins the same owner on all mounts.