### PR TITLE
fix(image): load nested OCI image indexes

### DIFF
--- a/crates/image/lib/archive/docker.rs
+++ b/crates/image/lib/archive/docker.rs
@@ -34,6 +34,8 @@ const OCI_REF_NAME_ANNOTATION: &str = "org.opencontainers.image.ref.name";
 const ARCHIVE_METADATA_MAX_BYTES: u64 = 16 * 1024 * 1024;
 const ARCHIVE_LAYER_MAX_BYTES: u64 = 10 * 1024 * 1024 * 1024;
 const ARCHIVE_MAX_ENTRY_COUNT: u64 = 1_000_000;
+const OCI_INDEX_MAX_DEPTH: usize = 32;
+const OCI_INDEX_MAX_COUNT: usize = 1_024;
 static TEMP_FILE_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 //--------------------------------------------------------------------------------------------------
@@ -119,6 +121,17 @@ struct PreparedLoadedImage {
 struct PreparedArchiveLoad {
     images: Vec<PreparedLoadedImage>,
     staged_layers: HashMap<String, PathBuf>,
+}
+
+#[derive(Debug)]
+struct OciManifestCandidate {
+    descriptor: oci_spec::image::Descriptor,
+    reference: Option<String>,
+    /// Position of this descriptor within the index tree, one entry per level:
+    /// the index into `index.json` followed by the index into each nested image
+    /// index traversed to reach it. Sorting candidates by `tree_path` restores the
+    /// original depth-first order regardless of the level they were resolved at.
+    tree_path: Vec<usize>,
 }
 
 #[derive(Debug)]
@@ -876,23 +889,24 @@ fn load_oci_archive_blocking(
         .ok_or_else(|| ImageError::ManifestParse("OCI layout missing index.json".into()))?;
     let index: oci_spec::image::ImageIndex = serde_json::from_slice(&index_json)
         .map_err(|e| ImageError::ManifestParse(format!("OCI index.json: {e}")))?;
-    let manifest_descriptors = selectable_oci_manifests(index.manifests())?;
-    if manifest_descriptors.is_empty() {
+    let manifest_candidates = resolve_oci_manifest_candidates(input, index.manifests())?;
+    if manifest_candidates.is_empty() {
         return Err(ImageError::ManifestParse(
             "OCI layout contains no image manifests for the host platform".into(),
         ));
     }
 
-    let manifest_paths = manifest_descriptors
+    let manifest_paths = manifest_candidates
         .iter()
-        .map(|descriptor| blob_path_from_digest(descriptor.digest().as_ref()))
+        .map(|candidate| blob_path_from_digest(candidate.descriptor.digest().as_ref()))
         .collect::<ImageResult<HashSet<_>>>()?;
     let manifest_blobs = read_archive_entries(input, &manifest_paths)?;
-    let mut manifests = Vec::with_capacity(manifest_descriptors.len());
+    let mut manifests = Vec::with_capacity(manifest_candidates.len());
     let mut required_configs = HashSet::new();
     let mut required_layers = HashSet::new();
 
-    for descriptor in &manifest_descriptors {
+    for candidate in manifest_candidates {
+        let descriptor = &candidate.descriptor;
         let manifest_path = blob_path_from_digest(descriptor.digest().as_ref())?;
         let manifest_bytes = manifest_blobs.get(&manifest_path).ok_or_else(|| {
             ImageError::ManifestParse(format!("OCI layout missing manifest blob {manifest_path}"))
@@ -905,7 +919,7 @@ fn load_oci_archive_blocking(
         for layer in manifest.layers() {
             required_layers.insert(blob_path_from_digest(layer.digest().as_ref())?);
         }
-        manifests.push((descriptor.clone(), manifest, manifest_bytes.clone()));
+        manifests.push((candidate, manifest, manifest_bytes.clone()));
     }
 
     // Fast path: skip re-importing an image that is already fully materialized.
@@ -920,7 +934,7 @@ fn load_oci_archive_blocking(
     'early_gate: {
         let config_blobs = read_archive_entries(input, &required_configs)?;
         let mut early_images = Vec::new();
-        for (image_index, (descriptor, manifest, manifest_bytes)) in manifests.iter().enumerate() {
+        for (image_index, (candidate, manifest, manifest_bytes)) in manifests.iter().enumerate() {
             let config_path = blob_path_from_digest(manifest.config().digest().as_ref())?;
             let Some(config_bytes) = config_blobs.get(&config_path) else {
                 break 'early_gate;
@@ -966,13 +980,7 @@ fn load_oci_archive_blocking(
                 layers: layer_metadata,
             };
 
-            let mut refs = descriptor
-                .annotations()
-                .as_ref()
-                .and_then(|annotations| annotations.get(OCI_REF_NAME_ANNOTATION))
-                .cloned()
-                .into_iter()
-                .collect::<Vec<_>>();
+            let mut refs = candidate.reference.clone().into_iter().collect::<Vec<_>>();
             if image_index == 0 {
                 refs.extend(options.tags.iter().cloned());
             }
@@ -1035,7 +1043,7 @@ fn load_oci_archive_blocking(
     }
 
     let mut loaded = Vec::new();
-    for (image_index, (descriptor, manifest, manifest_bytes)) in manifests.into_iter().enumerate() {
+    for (image_index, (candidate, manifest, manifest_bytes)) in manifests.into_iter().enumerate() {
         let config_path = blob_path_from_digest(manifest.config().digest().as_ref())?;
         let config_bytes = configs.get(&config_path).ok_or_else(|| {
             ImageError::ConfigParse(format!("OCI layout missing config blob {config_path}"))
@@ -1075,13 +1083,7 @@ fn load_oci_archive_blocking(
             layers: layer_metadata,
         };
 
-        let mut refs = descriptor
-            .annotations()
-            .as_ref()
-            .and_then(|annotations| annotations.get(OCI_REF_NAME_ANNOTATION))
-            .cloned()
-            .into_iter()
-            .collect::<Vec<_>>();
+        let mut refs = candidate.reference.into_iter().collect::<Vec<_>>();
 
         if image_index == 0 {
             refs.extend(options.tags.iter().cloned());
@@ -1203,18 +1205,104 @@ fn archive_contains_entries(input: &Path, wanted_paths: &HashSet<String>) -> Ima
     Ok(false)
 }
 
-fn selectable_oci_manifests(
+fn resolve_oci_manifest_candidates(
+    input: &Path,
     descriptors: &[oci_spec::image::Descriptor],
-) -> ImageResult<Vec<oci_spec::image::Descriptor>> {
+) -> ImageResult<Vec<OciManifestCandidate>> {
     let host = Platform::host_linux();
-    let selected = descriptors
+    let mut pending = descriptors
         .iter()
-        .filter(|descriptor| is_oci_image_manifest_descriptor(descriptor))
-        .filter(|descriptor| descriptor_matches_platform(descriptor, &host))
         .cloned()
-        .collect();
+        .enumerate()
+        .map(|(index, descriptor)| OciManifestCandidate {
+            reference: descriptor
+                .annotations()
+                .as_ref()
+                .and_then(|annotations| annotations.get(OCI_REF_NAME_ANNOTATION))
+                .cloned(),
+            descriptor,
+            tree_path: vec![index],
+        })
+        .collect::<Vec<_>>();
 
-    Ok(selected)
+    // Every candidate in a given pass sits at the same nesting depth, so a single
+    // counter tracks the level being expanded (top-level descriptors are depth 0).
+    let mut depth = 0usize;
+    let mut index_count = 0usize;
+    let mut resolved = Vec::new();
+
+    while !pending.is_empty() {
+        // Classify every pending candidate once for this level: drop
+        // platform-incompatible and unknown media types, keep image manifests as
+        // resolved, and collect image indexes to expand into the next level.
+        let mut indexes = Vec::new();
+        for candidate in pending {
+            if !descriptor_matches_platform(&candidate.descriptor, &host) {
+                continue;
+            }
+
+            if is_oci_image_manifest_descriptor(&candidate.descriptor) {
+                resolved.push(candidate);
+            } else if is_oci_image_index_descriptor(&candidate.descriptor) {
+                indexes.push(candidate);
+            }
+        }
+
+        if indexes.is_empty() {
+            break;
+        }
+
+        // Enforce both nesting and total-index limits before reading any blobs.
+        if depth >= OCI_INDEX_MAX_DEPTH {
+            return Err(ImageError::ManifestParse(format!(
+                "OCI image index nesting exceeds {OCI_INDEX_MAX_DEPTH} levels"
+            )));
+        }
+
+        index_count = index_count.saturating_add(indexes.len());
+        if index_count > OCI_INDEX_MAX_COUNT {
+            return Err(ImageError::ManifestParse(format!(
+                "OCI layout contains more than {OCI_INDEX_MAX_COUNT} nested image indexes"
+            )));
+        }
+
+        // Batch-read every image index blob for this level in a single archive pass.
+        let index_paths = indexes
+            .iter()
+            .map(|candidate| blob_path_from_digest(candidate.descriptor.digest().as_ref()))
+            .collect::<ImageResult<HashSet<_>>>()?;
+        let index_blobs = read_archive_entries(input, &index_paths)?;
+        let mut next = Vec::new();
+
+        for candidate in indexes {
+            let index_path = blob_path_from_digest(candidate.descriptor.digest().as_ref())?;
+            let index_bytes = index_blobs.get(&index_path).ok_or_else(|| {
+                ImageError::ManifestParse(format!(
+                    "OCI layout missing image index blob {index_path}"
+                ))
+            })?;
+            verify_descriptor_blob(&candidate.descriptor, index_bytes)?;
+            let index: oci_spec::image::ImageIndex = serde_json::from_slice(index_bytes)
+                .map_err(|e| ImageError::ManifestParse(format!("OCI image index: {e}")))?;
+
+            for (child_index, descriptor) in index.manifests().iter().cloned().enumerate() {
+                let mut tree_path = candidate.tree_path.clone();
+                tree_path.push(child_index);
+                next.push(OciManifestCandidate {
+                    descriptor,
+                    reference: candidate.reference.clone(),
+                    tree_path,
+                });
+            }
+        }
+
+        pending = next;
+        depth += 1;
+    }
+
+    resolved.sort_by(|left, right| left.tree_path.cmp(&right.tree_path));
+
+    Ok(resolved)
 }
 
 fn is_oci_image_manifest_descriptor(descriptor: &oci_spec::image::Descriptor) -> bool {
@@ -1223,6 +1311,14 @@ fn is_oci_image_manifest_descriptor(descriptor: &oci_spec::image::Descriptor) ->
         oci_spec::image::MediaType::ImageManifest
     ) || descriptor.media_type().to_string()
         == "application/vnd.docker.distribution.manifest.v2+json"
+}
+
+fn is_oci_image_index_descriptor(descriptor: &oci_spec::image::Descriptor) -> bool {
+    matches!(
+        descriptor.media_type(),
+        oci_spec::image::MediaType::ImageIndex
+    ) || descriptor.media_type().to_string()
+        == "application/vnd.docker.distribution.manifest.list.v2+json"
 }
 
 fn descriptor_matches_platform(descriptor: &oci_spec::image::Descriptor, host: &Platform) -> bool {
@@ -1974,6 +2070,87 @@ mod tests {
     }
 
     #[test]
+    fn oci_layout_archive_loads_nested_indexes() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let temp = tempdir().unwrap();
+        let input = temp.path().join("nested-oci-layout.tar");
+        write_test_nested_oci_archive(&input, Some("nested:latest"), simple_layer_tar(), 2);
+
+        let loaded = runtime
+            .block_on(load_archive(
+                &temp.path().join("cache"),
+                &input,
+                ImageLoadOptions::default(),
+            ))
+            .unwrap();
+
+        assert_eq!(loaded.len(), 1);
+        assert_eq!(loaded[0].reference, "nested:latest");
+        assert_eq!(
+            loaded[0].metadata.config.cmd,
+            Some(vec!["cat".into(), "/hello.txt".into()])
+        );
+    }
+
+    #[test]
+    fn oci_layout_nested_index_without_reference_uses_explicit_tag() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let temp = tempdir().unwrap();
+        let input = temp.path().join("untagged-nested-oci-layout.tar");
+        write_test_nested_oci_archive(&input, None, simple_layer_tar(), 1);
+
+        let loaded = runtime
+            .block_on(load_archive(
+                &temp.path().join("cache"),
+                &input,
+                ImageLoadOptions {
+                    tags: vec!["explicit:latest".into()],
+                    ..ImageLoadOptions::default()
+                },
+            ))
+            .unwrap();
+
+        assert_eq!(loaded.len(), 1);
+        assert_eq!(loaded[0].reference, "explicit:latest");
+    }
+
+    #[test]
+    fn oci_layout_nested_index_skips_incompatible_and_unknown_siblings() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let temp = tempdir().unwrap();
+        let input = temp.path().join("mixed-nested-oci-layout.tar");
+        // The nested index level holds three siblings: a host-compatible image
+        // index that resolves to a valid manifest, an incompatible-platform image
+        // index, and an unknown media type. The latter two point at blobs left out
+        // of the archive, so a successful load proves neither branch was traversed.
+        write_test_mixed_nested_oci_archive(&input, "mixed-nested:latest", simple_layer_tar());
+
+        let loaded = runtime
+            .block_on(load_archive(
+                &temp.path().join("cache"),
+                &input,
+                ImageLoadOptions::default(),
+            ))
+            .unwrap();
+
+        assert_eq!(loaded.len(), 1);
+        assert_eq!(loaded[0].reference, "mixed-nested:latest");
+        assert_eq!(
+            loaded[0].metadata.config.cmd,
+            Some(vec!["cat".into(), "/hello.txt".into()])
+        );
+    }
+
+    #[test]
     fn docker_archive_save_preserves_layer_semantics() {
         let runtime = tokio::runtime::Builder::new_current_thread()
             .enable_all()
@@ -2396,6 +2573,223 @@ mod tests {
             config_bytes,
             layer_bytes,
         );
+    }
+
+    fn write_test_nested_oci_archive(
+        path: &Path,
+        reference: Option<&str>,
+        layer_bytes: Vec<u8>,
+        index_depth: usize,
+    ) {
+        assert!(index_depth > 0);
+
+        let diff_id = format!("sha256:{}", sha256_hex(&layer_bytes));
+        let config_bytes = test_config_bytes(&diff_id);
+        let config_hex = sha256_hex(&config_bytes);
+        let layer_hex = sha256_hex(&layer_bytes);
+        let manifest_bytes = serde_json::to_vec(&serde_json::json!({
+            "schemaVersion": 2,
+            "mediaType": OCI_MANIFEST_MEDIA_TYPE,
+            "config": {
+                "mediaType": OCI_CONFIG_MEDIA_TYPE,
+                "digest": format!("sha256:{config_hex}"),
+                "size": config_bytes.len(),
+            },
+            "layers": [{
+                "mediaType": OCI_LAYER_MEDIA_TYPE,
+                "digest": format!("sha256:{layer_hex}"),
+                "size": layer_bytes.len(),
+            }],
+        }))
+        .unwrap();
+        let manifest_hex = sha256_hex(&manifest_bytes);
+        let host = Platform::host_linux();
+        let mut target_descriptor = serde_json::json!({
+            "mediaType": OCI_MANIFEST_MEDIA_TYPE,
+            "digest": format!("sha256:{manifest_hex}"),
+            "size": manifest_bytes.len(),
+            "platform": {
+                "architecture": host.arch.to_string(),
+                "os": host.os.to_string(),
+            },
+        });
+        let mut metadata_blobs = vec![(manifest_hex, manifest_bytes)];
+
+        for _ in 0..index_depth {
+            let index_bytes = serde_json::to_vec(&serde_json::json!({
+                "schemaVersion": 2,
+                "mediaType": OCI_INDEX_MEDIA_TYPE,
+                "manifests": [target_descriptor],
+            }))
+            .unwrap();
+            let index_hex = sha256_hex(&index_bytes);
+            target_descriptor = serde_json::json!({
+                "mediaType": OCI_INDEX_MEDIA_TYPE,
+                "digest": format!("sha256:{index_hex}"),
+                "size": index_bytes.len(),
+            });
+            metadata_blobs.push((index_hex, index_bytes));
+        }
+
+        if let Some(reference) = reference {
+            target_descriptor["annotations"] = serde_json::json!({
+                (OCI_REF_NAME_ANNOTATION): reference,
+            });
+        }
+        let root_index_bytes = serde_json::to_vec(&serde_json::json!({
+            "schemaVersion": 2,
+            "mediaType": OCI_INDEX_MEDIA_TYPE,
+            "manifests": [target_descriptor],
+        }))
+        .unwrap();
+
+        let file = File::create(path).unwrap();
+        let mut archive = tar::Builder::new(file);
+        append_bytes(
+            &mut archive,
+            "oci-layout",
+            br#"{"imageLayoutVersion":"1.0.0"}"#,
+        )
+        .unwrap();
+        append_bytes(&mut archive, "index.json", &root_index_bytes).unwrap();
+        append_bytes(
+            &mut archive,
+            &format!("blobs/sha256/{config_hex}"),
+            &config_bytes,
+        )
+        .unwrap();
+        for (hex, bytes) in metadata_blobs {
+            append_bytes(&mut archive, &format!("blobs/sha256/{hex}"), &bytes).unwrap();
+        }
+        append_bytes(
+            &mut archive,
+            &format!("blobs/sha256/{layer_hex}"),
+            &layer_bytes,
+        )
+        .unwrap();
+        archive.finish().unwrap();
+    }
+
+    /// Builds an OCI layout whose nested index level mixes a resolvable
+    /// host-compatible image index with two branches that must never be read:
+    /// an incompatible-platform image index and an unknown media type. Both of
+    /// those descriptors reference blobs that are intentionally omitted from the
+    /// archive, so the load only succeeds if their branches are skipped.
+    fn write_test_mixed_nested_oci_archive(path: &Path, reference: &str, layer_bytes: Vec<u8>) {
+        let host = Platform::host_linux();
+        let diff_id = format!("sha256:{}", sha256_hex(&layer_bytes));
+        let config_bytes = test_config_bytes(&diff_id);
+        let config_hex = sha256_hex(&config_bytes);
+        let layer_hex = sha256_hex(&layer_bytes);
+
+        let manifest_bytes = serde_json::to_vec(&serde_json::json!({
+            "schemaVersion": 2,
+            "mediaType": OCI_MANIFEST_MEDIA_TYPE,
+            "config": {
+                "mediaType": OCI_CONFIG_MEDIA_TYPE,
+                "digest": format!("sha256:{config_hex}"),
+                "size": config_bytes.len(),
+            },
+            "layers": [{
+                "mediaType": OCI_LAYER_MEDIA_TYPE,
+                "digest": format!("sha256:{layer_hex}"),
+                "size": layer_bytes.len(),
+            }],
+        }))
+        .unwrap();
+        let manifest_hex = sha256_hex(&manifest_bytes);
+
+        // Host-compatible branch: an image index that resolves to the manifest.
+        let inner_index_bytes = serde_json::to_vec(&serde_json::json!({
+            "schemaVersion": 2,
+            "mediaType": OCI_INDEX_MEDIA_TYPE,
+            "manifests": [{
+                "mediaType": OCI_MANIFEST_MEDIA_TYPE,
+                "digest": format!("sha256:{manifest_hex}"),
+                "size": manifest_bytes.len(),
+                "platform": {
+                    "architecture": host.arch.to_string(),
+                    "os": host.os.to_string(),
+                },
+            }],
+        }))
+        .unwrap();
+        let inner_index_hex = sha256_hex(&inner_index_bytes);
+
+        // Digests for descriptors whose blobs are deliberately absent from the
+        // archive: reaching either branch would fail the load.
+        let absent_incompatible_hex = sha256_hex(b"absent-incompatible-platform-index");
+        let absent_unknown_hex = sha256_hex(b"absent-unknown-media-type");
+
+        // Nested index level holding the three siblings under test.
+        let mixed_index_bytes = serde_json::to_vec(&serde_json::json!({
+            "schemaVersion": 2,
+            "mediaType": OCI_INDEX_MEDIA_TYPE,
+            "manifests": [
+                {
+                    "mediaType": OCI_INDEX_MEDIA_TYPE,
+                    "digest": format!("sha256:{inner_index_hex}"),
+                    "size": inner_index_bytes.len(),
+                },
+                {
+                    "mediaType": OCI_INDEX_MEDIA_TYPE,
+                    "digest": format!("sha256:{absent_incompatible_hex}"),
+                    "size": 0,
+                    "platform": {
+                        "architecture": "sparc64",
+                        "os": "solaris",
+                    },
+                },
+                {
+                    "mediaType": "application/vnd.example.unknown.v1+json",
+                    "digest": format!("sha256:{absent_unknown_hex}"),
+                    "size": 0,
+                },
+            ],
+        }))
+        .unwrap();
+        let mixed_index_hex = sha256_hex(&mixed_index_bytes);
+
+        // Root index nests the mixed level one level below index.json and carries
+        // the reference annotation so it propagates to the resolved manifest.
+        let root_index_bytes = serde_json::to_vec(&serde_json::json!({
+            "schemaVersion": 2,
+            "mediaType": OCI_INDEX_MEDIA_TYPE,
+            "manifests": [{
+                "mediaType": OCI_INDEX_MEDIA_TYPE,
+                "digest": format!("sha256:{mixed_index_hex}"),
+                "size": mixed_index_bytes.len(),
+                "annotations": {
+                    (OCI_REF_NAME_ANNOTATION): reference,
+                },
+            }],
+        }))
+        .unwrap();
+
+        let file = File::create(path).unwrap();
+        let mut archive = tar::Builder::new(file);
+        append_bytes(
+            &mut archive,
+            "oci-layout",
+            br#"{"imageLayoutVersion":"1.0.0"}"#,
+        )
+        .unwrap();
+        append_bytes(&mut archive, "index.json", &root_index_bytes).unwrap();
+        for (hex, bytes) in [
+            (config_hex, config_bytes),
+            (manifest_hex, manifest_bytes),
+            (inner_index_hex, inner_index_bytes),
+            (mixed_index_hex, mixed_index_bytes),
+        ] {
+            append_bytes(&mut archive, &format!("blobs/sha256/{hex}"), &bytes).unwrap();
+        }
+        append_bytes(
+            &mut archive,
+            &format!("blobs/sha256/{layer_hex}"),
+            &layer_bytes,
+        )
+        .unwrap();
+        archive.finish().unwrap();
     }
 
     fn write_test_oci_archive_from_layer(path: &Path, reference: &str, layer_bytes: Vec<u8>) {


### PR DESCRIPTION
## TL;DR

Load OCI image layouts whose entrypoint points through one or more nested image indexes.

## Description

- Resolve nested OCI and Docker-compatible indexes level by level until host-compatible image manifests are reached.
- Preserve top-level references and descriptor order while skipping incompatible platforms and unknown media types.
- Verify nested index blobs before parsing and bound traversal depth and total index count.
- Cover multi-level indexes, explicitly tagged unannotated layouts, and skipped sibling descriptors.

Fixes #1287.

## Test Plan

- `cargo test -p microsandbox-image` (199 passed, 3 ignored)
- `cargo clippy -p microsandbox-image --all-targets -- -D warnings`
- Repository pre-commit hooks