### PR TITLE
fix(sandbox): keep label projection consistent

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3912,6 +3912,7 @@ dependencies = [
  "opentelemetry-otlp",
  "opentelemetry_sdk",
  "sea-orm",
+ "serde_json",
  "tempfile",
  "thiserror 2.0.19",
  "tokio",
@@ -3926,6 +3927,7 @@ version = "0.6.8"
 dependencies = [
  "sea-orm-migration",
  "serde_json",
+ "tokio",
 ]
 
 [[package]]

--- a/crates/cli/lib/commands/self_cmd.rs
+++ b/crates/cli/lib/commands/self_cmd.rs
@@ -3467,7 +3467,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn rollback_schema_rolls_back_latest_migration() {
+    async fn rollback_schema_steps_through_latest_migrations() {
         let dir = tempfile::tempdir().unwrap();
         let db_path = dir.path().join("msb.db");
         let db = microsandbox_db::connection::DbWriteConnection::open(
@@ -3479,8 +3479,34 @@ mod tests {
         .unwrap();
         Migrator::up(db.inner(), None).await.unwrap();
 
-        // Writeback admission is the latest migration; one step must drop its
-        // allocation table while every older coordination table stays intact.
+        // The label rebuild is compatible with older releases, so its down
+        // migration only removes the migration record. Writeback state must
+        // remain until the next rollback step.
+        rollback_schema(db.inner(), 1).await.unwrap();
+
+        let rows = db
+            .query_all_raw(Statement::from_sql_and_values(
+                DatabaseBackend::Sqlite,
+                "SELECT version FROM seaql_migrations WHERE version = ?",
+                [schema_metadata::SANDBOX_LABEL_REBUILD_MIGRATION_ID.into()],
+            ))
+            .await
+            .unwrap();
+        assert!(rows.is_empty(), "label rebuild should be rolled back");
+
+        let rows = db
+            .query_all_raw(Statement::from_string(
+                DatabaseBackend::Sqlite,
+                "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'writeback_allocation'",
+            ))
+            .await
+            .unwrap();
+        assert_eq!(
+            rows.len(),
+            1,
+            "writeback allocation should remain after one rollback"
+        );
+
         rollback_schema(db.inner(), 1).await.unwrap();
 
         let rows = db

--- a/crates/metrics-collector/Cargo.toml
+++ b/crates/metrics-collector/Cargo.toml
@@ -41,6 +41,8 @@ tracing-subscriber = { workspace = true, features = ["env-filter", "json"] }
 microsandbox-db.workspace = true
 # Query traits (EntityTrait, ColumnTrait, QueryFilter) for the label lookup.
 sea-orm = { workspace = true }
+# Parse the effective sandbox config used for label enrichment.
+serde_json.workspace = true
 # Used by the binary to derive the shm registry name from `$MSB_HOME`.
 microsandbox-utils.workspace = true
 # CLI duration parsing (e.g. "1s", "500ms").

--- a/crates/metrics-collector/lib/core/label_cache.rs
+++ b/crates/metrics-collector/lib/core/label_cache.rs
@@ -1,19 +1,16 @@
 //! In-process cache of per-sandbox labels for the metrics read path.
 //!
 //! On each tick the collector reads the active sandboxes from shared memory and
-//! needs their labels (set at create time, stored in the `sandbox_labels`
-//! catalog table) to attach as attributes. This cache keeps one sqlite read per
-//! newly-seen sandbox; everything else is an in-memory hit.
+//! resolves their labels from the catalog config that describes the running VM.
+//! The cache avoids reparsing unchanged configs while still refreshing when a
+//! sandbox restarts quickly enough to remain in consecutive snapshots.
 
 use std::{
-    collections::{HashMap, HashSet},
+    collections::{BTreeMap, HashMap, HashSet},
     sync::Arc,
 };
 
-use microsandbox_db::entity::sandbox_label;
-use sea_orm::{ColumnTrait, ConnectionTrait, EntityTrait, QueryFilter};
-
-use crate::error::MetricsCollectorResult;
+use crate::error::{MetricsCollectorError, MetricsCollectorResult};
 
 //--------------------------------------------------------------------------------------------------
 // Types
@@ -23,15 +20,19 @@ use crate::error::MetricsCollectorResult;
 /// output.
 pub(crate) type LabelSet = Vec<(String, String)>;
 
+/// A parsed label set and the config JSON from which it was derived.
+struct CacheEntry {
+    config_json: String,
+    labels: Arc<LabelSet>,
+}
+
 /// Caches each active sandbox's labels, keyed on `sandbox_id`.
 ///
-/// Labels are immutable per sandbox, so a cached entry is never stale. Eviction
-/// is purely presence-based: [`sync`](Self::sync) drops entries whose sandbox is
-/// no longer in the shm snapshot, bounding the cache to the active sandbox
-/// count. There is no TTL, max-size, or LRU.
+/// An entry is reparsed when its effective config changes. Presence-based
+/// eviction still bounds the cache to the active sandbox count.
 #[derive(Default)]
 pub(crate) struct LabelCache {
-    by_sandbox_id: HashMap<i32, Arc<LabelSet>>,
+    by_sandbox_id: HashMap<i32, CacheEntry>,
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -44,38 +45,36 @@ impl LabelCache {
         Self::default()
     }
 
-    /// Drop cached entries for sandboxes absent from the current snapshot. Call
-    /// once per tick, before any [`get_or_fetch`](Self::get_or_fetch).
+    /// Drop cached entries for sandboxes absent from the current snapshot.
     pub(crate) fn sync(&mut self, active: &HashSet<i32>) {
         self.by_sandbox_id.retain(|id, _| active.contains(id));
     }
 
-    /// Labels for `sandbox_id`: an in-memory hit, otherwise one sqlite read.
-    ///
-    /// A sandbox with no labels caches an empty set; that is the normal case for
-    /// an unlabeled sandbox, not an error.
-    pub(crate) async fn get_or_fetch<C: ConnectionTrait>(
+    /// Labels parsed from `config_json`, reusing an unchanged cached entry.
+    pub(crate) fn get_or_parse(
         &mut self,
         sandbox_id: i32,
-        db: &C,
+        config_json: &str,
     ) -> MetricsCollectorResult<Arc<LabelSet>> {
-        if let Some(set) = self.by_sandbox_id.get(&sandbox_id) {
-            return Ok(set.clone());
+        if let Some(entry) = self.by_sandbox_id.get(&sandbox_id)
+            && entry.config_json == config_json
+        {
+            return Ok(entry.labels.clone());
         }
 
-        let mut rows = sandbox_label::Entity::find()
-            .filter(sandbox_label::Column::SandboxId.eq(sandbox_id))
-            .all(db)
-            .await?;
-        rows.sort_by(|a, b| a.key.cmp(&b.key));
-
-        let set = Arc::new(
-            rows.into_iter()
-                .map(|row| (row.key, row.value))
-                .collect::<LabelSet>(),
+        let labels = Arc::new(extract_labels(config_json).map_err(|error| {
+            MetricsCollectorError::Custom(format!(
+                "parse active config labels for sandbox id {sandbox_id}: {error}"
+            ))
+        })?);
+        self.by_sandbox_id.insert(
+            sandbox_id,
+            CacheEntry {
+                config_json: config_json.to_owned(),
+                labels: labels.clone(),
+            },
         );
-        self.by_sandbox_id.insert(sandbox_id, set.clone());
-        Ok(set)
+        Ok(labels)
     }
 
     /// Number of cached sandboxes. Test helper for asserting eviction.
@@ -86,130 +85,87 @@ impl LabelCache {
 }
 
 //--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+fn extract_labels(config_json: &str) -> Result<LabelSet, String> {
+    let config = serde_json::from_str::<serde_json::Value>(config_json)
+        .map_err(|error| format!("invalid JSON: {error}"))?;
+    let Some(labels) = config.get("labels") else {
+        return Ok(LabelSet::new());
+    };
+    let labels = labels
+        .as_object()
+        .ok_or_else(|| "labels must be an object".to_string())?;
+
+    let mut labels_by_key = BTreeMap::new();
+    for (key, value) in labels {
+        let value = value
+            .as_str()
+            .ok_or_else(|| format!("label {key:?} must have a string value"))?;
+        labels_by_key.insert(key.clone(), value.to_owned());
+    }
+    Ok(labels_by_key.into_iter().collect())
+}
+
+//--------------------------------------------------------------------------------------------------
 // Tests
 //--------------------------------------------------------------------------------------------------
 
 #[cfg(test)]
 mod tests {
-    use microsandbox_db::entity::sandbox;
-    use microsandbox_migration::{Migrator, MigratorTrait};
-    use sea_orm::{ActiveModelTrait, Database, DatabaseConnection, Set};
-
     use super::*;
 
-    /// Open a fresh temp-file sqlite DB with the catalog schema applied.
-    async fn open_db(dir: &tempfile::TempDir) -> DatabaseConnection {
-        let path = dir.path().join("test.db");
-        let url = format!("sqlite://{}?mode=rwc", path.display());
-        let db = Database::connect(url).await.unwrap();
-        Migrator::up(&db, None).await.unwrap();
-        db
-    }
-
-    /// Insert a parent sandbox row; labels reference it via a foreign key.
-    async fn insert_sandbox(db: &DatabaseConnection, id: i32) {
-        sandbox::ActiveModel {
-            id: Set(id),
-            name: Set(format!("sandbox-{id}")),
-            config: Set("{}".to_string()),
-            active_config: Set(None),
-            status: Set(sandbox::SandboxStatus::Running),
-            ephemeral: Set(false),
-            created_at: Set(None),
-            updated_at: Set(None),
-        }
-        .insert(db)
-        .await
-        .unwrap();
-    }
-
-    async fn insert_label(db: &DatabaseConnection, sandbox_id: i32, key: &str, value: &str) {
-        sandbox_label::ActiveModel {
-            sandbox_id: Set(sandbox_id),
-            key: Set(key.to_string()),
-            value: Set(value.to_string()),
-        }
-        .insert(db)
-        .await
-        .unwrap();
-    }
-
-    #[tokio::test]
-    async fn get_or_fetch_reads_then_caches() {
-        let dir = tempfile::tempdir().unwrap();
-        let db = open_db(&dir).await;
-        insert_sandbox(&db, 1).await;
-        insert_sandbox(&db, 2).await;
-        insert_label(&db, 1, "user.id", "alice").await;
-        insert_label(&db, 1, "tier", "web").await;
-        insert_label(&db, 2, "user.id", "bob").await;
-
+    #[test]
+    fn get_or_parse_sorts_then_caches_labels() {
         let mut cache = LabelCache::new();
+        let config = r#"{"labels":{"user.id":"alice","tier":"web"}}"#;
 
-        // Sorted by key.
-        let s1 = cache.get_or_fetch(1, &db).await.unwrap();
+        let first = cache.get_or_parse(1, config).unwrap();
         assert_eq!(
-            *s1,
+            *first,
             vec![
                 ("tier".to_string(), "web".to_string()),
                 ("user.id".to_string(), "alice".to_string()),
             ]
         );
-        let s2 = cache.get_or_fetch(2, &db).await.unwrap();
-        assert_eq!(*s2, vec![("user.id".to_string(), "bob".to_string())]);
+        let cached = cache.get_or_parse(1, config).unwrap();
 
-        // Unlabeled sandbox caches an empty set, no error.
-        let s3 = cache.get_or_fetch(3, &db).await.unwrap();
-        assert!(s3.is_empty());
-        assert_eq!(cache.len(), 3);
+        assert!(Arc::ptr_eq(&first, &cached));
     }
 
-    #[tokio::test]
-    async fn cached_entry_is_not_re_read() {
-        let dir = tempfile::tempdir().unwrap();
-        let db = open_db(&dir).await;
-        insert_sandbox(&db, 1).await;
-        insert_label(&db, 1, "user.id", "alice").await;
-
+    #[test]
+    fn changed_config_refreshes_same_sandbox_id() {
         let mut cache = LabelCache::new();
-        let first = cache.get_or_fetch(1, &db).await.unwrap();
-        assert_eq!(first.len(), 1);
-
-        // Delete the row underneath the cache; a cache hit must not re-read.
-        sandbox_label::Entity::delete_many()
-            .filter(sandbox_label::Column::SandboxId.eq(1))
-            .exec(&db)
-            .await
+        let first = cache
+            .get_or_parse(1, r#"{"labels":{"user.id":"alice"}}"#)
+            .unwrap();
+        let refreshed = cache
+            .get_or_parse(1, r#"{"labels":{"user.id":"bob"}}"#)
             .unwrap();
 
-        let cached = cache.get_or_fetch(1, &db).await.unwrap();
-        assert_eq!(cached.len(), 1, "cache hit should not re-query the db");
+        assert!(!Arc::ptr_eq(&first, &refreshed));
+        assert_eq!(*refreshed, vec![("user.id".to_string(), "bob".to_string())]);
     }
 
-    #[tokio::test]
-    async fn sync_evicts_absent_sandboxes_then_refetches() {
-        let dir = tempfile::tempdir().unwrap();
-        let db = open_db(&dir).await;
-        insert_sandbox(&db, 1).await;
-        insert_label(&db, 1, "user.id", "alice").await;
-
+    #[test]
+    fn missing_labels_caches_an_empty_set() {
         let mut cache = LabelCache::new();
-        cache.get_or_fetch(1, &db).await.unwrap();
-        cache.get_or_fetch(2, &db).await.unwrap();
-        assert_eq!(cache.len(), 2);
 
-        // Sandbox 1 left the snapshot: evict it, keep 2.
-        cache.sync(&HashSet::from([2]));
+        let labels = cache.get_or_parse(1, r#"{"name":"api"}"#).unwrap();
+
+        assert!(labels.is_empty());
         assert_eq!(cache.len(), 1);
+    }
 
-        // Re-create the row and confirm the next get_or_fetch re-reads.
-        sandbox_label::Entity::delete_many()
-            .filter(sandbox_label::Column::SandboxId.eq(1))
-            .exec(&db)
-            .await
-            .unwrap();
-        insert_label(&db, 1, "tier", "worker").await;
-        let refetched = cache.get_or_fetch(1, &db).await.unwrap();
-        assert_eq!(*refetched, vec![("tier".to_string(), "worker".to_string())]);
+    #[test]
+    fn sync_evicts_absent_sandboxes() {
+        let mut cache = LabelCache::new();
+        cache.get_or_parse(1, "{}").unwrap();
+        cache.get_or_parse(2, "{}").unwrap();
+
+        cache.sync(&HashSet::from([2]));
+
+        assert_eq!(cache.len(), 1);
     }
 }

--- a/crates/metrics-collector/lib/core/label_source.rs
+++ b/crates/metrics-collector/lib/core/label_source.rs
@@ -2,8 +2,9 @@
 //!
 //! [`LabelSource`] abstracts *where* labels come from, so the collect loop and
 //! the builder depend on a trait rather than a database connection. The
-//! production implementation ([`CatalogLabelSource`]) reads the sqlite catalog
-//! and caches per sandbox; tests can inject an in-memory map instead.
+//! production implementation ([`CatalogLabelSource`]) reads each sandbox's
+//! effective config from the sqlite catalog and caches per sandbox; tests can
+//! inject an in-memory map instead.
 
 use std::collections::HashSet;
 use std::path::PathBuf;
@@ -11,8 +12,9 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use async_trait::async_trait;
-use microsandbox_db::DbReadConnection;
 use microsandbox_db::pool::DEFAULT_BUSY_TIMEOUT_SECS;
+use microsandbox_db::{DbReadConnection, entity::sandbox};
+use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
 use tokio::sync::Mutex;
 use tracing::{info, warn};
 
@@ -57,8 +59,9 @@ pub trait LabelSource: Send + Sync {
 /// Connects lazily and retries: if the catalog DB is not yet present (e.g.
 /// msb-metrics started before msb initialized `$MSB_HOME`), each tick emits no
 /// labels and tries again, so enrichment switches on automatically once the
-/// catalog appears. Reads go through an internal cache (one sqlite read per
-/// newly-seen sandbox, presence-based eviction).
+/// catalog appears. A bulk read on each tick selects the config that describes
+/// each running VM; unchanged configs reuse their parsed labels from the
+/// internal cache.
 pub struct CatalogLabelSource {
     db_path: PathBuf,
 
@@ -173,7 +176,7 @@ impl LabelSource for CatalogLabelSource {
 // Functions
 //--------------------------------------------------------------------------------------------------
 
-/// Sync the cache to the active snapshot, then resolve each sandbox's labels.
+/// Read the active configs, sync the cache, then resolve each sandbox's labels.
 async fn resolve_labels(
     db: &DbReadConnection,
     cache: &mut LabelCache,
@@ -182,11 +185,23 @@ async fn resolve_labels(
 ) -> MetricsCollectorResult<SandboxLabels> {
     cache.sync(sandbox_ids);
 
+    if sandbox_ids.is_empty() {
+        return Ok(SandboxLabels::new());
+    }
+
+    let models = sandbox::Entity::find()
+        .filter(sandbox::Column::Id.is_in(sandbox_ids.iter().copied()))
+        .all(db)
+        .await?;
     let mut labels = SandboxLabels::with_capacity(sandbox_ids.len());
-    for &sandbox_id in sandbox_ids {
-        let set = apply_exclusions(cache.get_or_fetch(sandbox_id, db).await?, exclude_keys);
+    for model in models {
+        // `active_config` is the snapshot used by the running VM. Falling back
+        // to desired config covers older catalogs and the short startup window
+        // before the active snapshot is persisted.
+        let config_json = model.active_config.as_deref().unwrap_or(&model.config);
+        let set = apply_exclusions(cache.get_or_parse(model.id, config_json)?, exclude_keys);
         if !set.is_empty() {
-            labels.insert(sandbox_id, set);
+            labels.insert(model.id, set);
         }
     }
     Ok(labels)
@@ -234,11 +249,12 @@ mod tests {
         .await
         .unwrap();
         Migrator::up(write.inner(), None).await.unwrap();
+        let config = r#"{"name":"s1","labels":{"user.id":"alice"}}"#.to_string();
         sandbox::ActiveModel {
             id: Set(1),
             name: Set("s1".to_string()),
-            config: Set("{}".to_string()),
-            active_config: Set(None),
+            config: Set(config.clone()),
+            active_config: Set(Some(config)),
             status: Set(sandbox::SandboxStatus::Running),
             ephemeral: Set(false),
             created_at: Set(None),
@@ -310,6 +326,17 @@ mod tests {
         .await
         .unwrap();
 
+        let config = r#"{"name":"s1","labels":{"org.opencontainers.image.revision":"abc123","user.id":"alice"}}"#.to_string();
+        sandbox::ActiveModel {
+            id: Set(1),
+            config: Set(config.clone()),
+            active_config: Set(Some(config)),
+            ..Default::default()
+        }
+        .update(write.inner())
+        .await
+        .unwrap();
+
         let source = CatalogLabelSource::new(db_path)
             .with_excluded_keys(["org.opencontainers.image.revision".to_string()]);
 
@@ -339,6 +366,61 @@ mod tests {
         assert_eq!(
             labels.get(&1).map(|l| l.as_slice()),
             Some([("user.id".to_string(), "alice".to_string())].as_slice())
+        );
+    }
+
+    #[tokio::test]
+    async fn same_id_refreshes_only_when_active_config_changes() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("db").join("msb.db");
+        seed_catalog(&db_path).await;
+        let source = CatalogLabelSource::new(db_path.clone());
+
+        let labels = source.labels_for(HashSet::from([1])).await.unwrap();
+        assert_eq!(
+            labels.get(&1).map(|l| l.as_slice()),
+            Some([("user.id".to_string(), "alice".to_string())].as_slice())
+        );
+
+        let write = DbWriteConnection::open(
+            &db_path,
+            CONNECT_TIMEOUT,
+            Duration::from_secs(DEFAULT_BUSY_TIMEOUT_SECS),
+        )
+        .await
+        .unwrap();
+        let desired = r#"{"name":"s1","labels":{"user.id":"bob"}}"#.to_string();
+        sandbox::ActiveModel {
+            id: Set(1),
+            config: Set(desired.clone()),
+            ..Default::default()
+        }
+        .update(write.inner())
+        .await
+        .unwrap();
+
+        // A next-start change must not relabel the still-running VM.
+        let labels = source.labels_for(HashSet::from([1])).await.unwrap();
+        assert_eq!(
+            labels.get(&1).map(|l| l.as_slice()),
+            Some([("user.id".to_string(), "alice".to_string())].as_slice())
+        );
+
+        sandbox::ActiveModel {
+            id: Set(1),
+            active_config: Set(Some(desired)),
+            ..Default::default()
+        }
+        .update(write.inner())
+        .await
+        .unwrap();
+
+        // A rapid restart can retain the same id in adjacent snapshots. The
+        // changed active config still invalidates and refreshes the cache.
+        let labels = source.labels_for(HashSet::from([1])).await.unwrap();
+        assert_eq!(
+            labels.get(&1).map(|l| l.as_slice()),
+            Some([("user.id".to_string(), "bob".to_string())].as_slice())
         );
     }
 }

--- a/crates/migration/Cargo.toml
+++ b/crates/migration/Cargo.toml
@@ -14,3 +14,6 @@ path = "lib/lib.rs"
 [dependencies]
 sea-orm-migration.workspace = true
 serde_json.workspace = true
+
+[dev-dependencies]
+tokio.workspace = true

--- a/crates/migration/lib/lib.rs
+++ b/crates/migration/lib/lib.rs
@@ -20,6 +20,7 @@ mod m20260714_000001_add_snapshot_scope;
 mod m20260719_000001_create_cpu_allocations;
 mod m20260723_000001_snapshot_artifact_transition;
 mod m20260803_000001_create_writeback_allocations;
+mod m20260810_000001_rebuild_sandbox_labels;
 pub mod schema_metadata;
 
 use sea_orm_migration::prelude::*;
@@ -65,6 +66,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20260723_000001_snapshot_artifact_transition::Migration),
             Box::new(m20260719_000001_create_cpu_allocations::Migration),
             Box::new(m20260803_000001_create_writeback_allocations::Migration),
+            Box::new(m20260810_000001_rebuild_sandbox_labels::Migration),
         ]
     }
 }

--- a/crates/migration/lib/m20260810_000001_rebuild_sandbox_labels.rs
+++ b/crates/migration/lib/m20260810_000001_rebuild_sandbox_labels.rs
@@ -1,0 +1,267 @@
+//! Migration: Rebuild the sandbox label index from persisted configs.
+//!
+//! Sandbox config JSON is the canonical label source. Releases affected by a
+//! backend-routing regression persisted labels there without updating the
+//! `sandbox_labels` projection consumed by label selection. Rebuild the complete
+//! projection so both missing and stale rows are repaired.
+
+use std::collections::BTreeMap;
+
+use sea_orm_migration::{
+    prelude::*,
+    sea_orm::{ConnectionTrait, DatabaseBackend, Statement, TransactionError, TransactionTrait},
+};
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+pub struct Migration;
+
+//--------------------------------------------------------------------------------------------------
+// Trait Implementations
+//--------------------------------------------------------------------------------------------------
+
+impl MigrationName for Migration {
+    fn name(&self) -> &str {
+        "m20260810_000001_rebuild_sandbox_labels"
+    }
+}
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let conn = manager.get_connection();
+        conn.transaction::<_, (), DbErr>(|txn| {
+            Box::pin(async move {
+                let rows = txn
+                    .query_all_raw(Statement::from_string(
+                        DatabaseBackend::Sqlite,
+                        "SELECT id, config FROM sandbox".to_owned(),
+                    ))
+                    .await?;
+                let mut labels_by_sandbox = Vec::with_capacity(rows.len());
+
+                // Parse every config before changing the projection. A
+                // malformed row rolls the transaction back without deleting
+                // labels from otherwise valid rows.
+                for row in rows {
+                    let sandbox_id = row.try_get_by_index::<i32>(0)?;
+                    let config = row.try_get_by_index::<String>(1)?;
+                    let labels = extract_labels(&config).map_err(|error| {
+                        DbErr::Custom(format!(
+                            "rebuild labels for sandbox id {sandbox_id}: {error}"
+                        ))
+                    })?;
+                    labels_by_sandbox.push((sandbox_id, labels));
+                }
+
+                txn.execute_raw(Statement::from_string(
+                    DatabaseBackend::Sqlite,
+                    "DELETE FROM sandbox_labels".to_owned(),
+                ))
+                .await?;
+
+                for (sandbox_id, labels) in labels_by_sandbox {
+                    for (key, value) in labels {
+                        txn.execute_raw(Statement::from_sql_and_values(
+                            DatabaseBackend::Sqlite,
+                            "INSERT INTO sandbox_labels (sandbox_id, key, value) VALUES (?, ?, ?)",
+                            [sandbox_id.into(), key.into(), value.into()],
+                        ))
+                        .await?;
+                    }
+                }
+
+                Ok(())
+            })
+        })
+        .await
+        .map_err(|error| match error {
+            TransactionError::Connection(error) | TransactionError::Transaction(error) => error,
+        })?;
+
+        Ok(())
+    }
+
+    async fn down(&self, _manager: &SchemaManager) -> Result<(), DbErr> {
+        // Repaired projection rows are compatible with older releases and
+        // should not be reverted to the inconsistent pre-migration state.
+        Ok(())
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+fn extract_labels(config: &str) -> Result<BTreeMap<String, String>, DbErr> {
+    let value = serde_json::from_str::<serde_json::Value>(config)
+        .map_err(|error| DbErr::Custom(format!("parse sandbox config JSON: {error}")))?;
+    let Some(labels) = value.get("labels") else {
+        return Ok(BTreeMap::new());
+    };
+    let labels = labels.as_object().ok_or_else(|| {
+        DbErr::Custom("parse sandbox config JSON: labels must be an object".into())
+    })?;
+
+    labels
+        .iter()
+        .map(|(key, value)| {
+            let value = value.as_str().ok_or_else(|| {
+                DbErr::Custom(format!(
+                    "parse sandbox config JSON: label {key:?} must have a string value"
+                ))
+            })?;
+            Ok((key.clone(), value.to_owned()))
+        })
+        .collect()
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests
+//--------------------------------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use sea_orm_migration::sea_orm::{Database, DatabaseConnection};
+
+    use super::*;
+
+    async fn open_catalog() -> DatabaseConnection {
+        let db = Database::connect("sqlite::memory:").await.unwrap();
+        db.execute_unprepared(
+            "CREATE TABLE sandbox (id INTEGER PRIMARY KEY, config TEXT NOT NULL);\
+             CREATE TABLE sandbox_labels (\
+                 sandbox_id INTEGER NOT NULL,\
+                 key TEXT NOT NULL,\
+                 value TEXT NOT NULL,\
+                 PRIMARY KEY (sandbox_id, key)\
+             );",
+        )
+        .await
+        .unwrap();
+        db
+    }
+
+    #[test]
+    fn extract_labels_reads_canonical_config_shape() {
+        let labels =
+            extract_labels(r#"{"name":"api","labels":{"team":"metrics","tier":"gold"}}"#).unwrap();
+
+        assert_eq!(labels.get("team").map(String::as_str), Some("metrics"));
+        assert_eq!(labels.get("tier").map(String::as_str), Some("gold"));
+    }
+
+    #[test]
+    fn extract_labels_accepts_configs_without_labels() {
+        let labels = extract_labels(r#"{"name":"api","resources":{"cpus":2}}"#).unwrap();
+
+        assert!(labels.is_empty());
+    }
+
+    #[test]
+    fn extract_labels_rejects_non_string_values() {
+        let error = extract_labels(r#"{"labels":{"attempt":3}}"#).unwrap_err();
+
+        assert!(error.to_string().contains("must have a string value"));
+    }
+
+    #[tokio::test]
+    async fn migration_replaces_missing_and_stale_projection_rows() {
+        let db = open_catalog().await;
+        for (id, config) in [
+            (
+                1,
+                r#"{"name":"first","labels":{"team":"metrics","tier":"gold"}}"#,
+            ),
+            (2, r#"{"name":"second","labels":{}}"#),
+        ] {
+            db.execute_raw(Statement::from_sql_and_values(
+                DatabaseBackend::Sqlite,
+                "INSERT INTO sandbox (id, config) VALUES (?, ?)",
+                [id.into(), config.into()],
+            ))
+            .await
+            .unwrap();
+        }
+        for (sandbox_id, key, value) in [
+            (1, "team", "stale"),
+            (1, "removed", "ghost"),
+            (2, "removed", "ghost"),
+        ] {
+            db.execute_raw(Statement::from_sql_and_values(
+                DatabaseBackend::Sqlite,
+                "INSERT INTO sandbox_labels (sandbox_id, key, value) VALUES (?, ?, ?)",
+                [sandbox_id.into(), key.into(), value.into()],
+            ))
+            .await
+            .unwrap();
+        }
+
+        Migration.up(&SchemaManager::new(&db)).await.unwrap();
+        // Running the operation again rebuilds the same projection without
+        // duplicate or stale rows.
+        Migration.up(&SchemaManager::new(&db)).await.unwrap();
+
+        let rows = db
+            .query_all_raw(Statement::from_string(
+                DatabaseBackend::Sqlite,
+                "SELECT sandbox_id, key, value FROM sandbox_labels ORDER BY sandbox_id, key"
+                    .to_owned(),
+            ))
+            .await
+            .unwrap();
+        let rows: Vec<(i32, String, String)> = rows
+            .into_iter()
+            .map(|row| {
+                (
+                    row.try_get_by_index(0).unwrap(),
+                    row.try_get_by_index(1).unwrap(),
+                    row.try_get_by_index(2).unwrap(),
+                )
+            })
+            .collect();
+
+        assert_eq!(
+            rows,
+            vec![
+                (1, "team".into(), "metrics".into()),
+                (1, "tier".into(), "gold".into()),
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn migration_preserves_projection_when_a_config_is_invalid() {
+        let db = open_catalog().await;
+        db.execute_raw(Statement::from_sql_and_values(
+            DatabaseBackend::Sqlite,
+            "INSERT INTO sandbox (id, config) VALUES (?, ?)",
+            [1.into(), r#"{"labels":{"attempt":3}}"#.into()],
+        ))
+        .await
+        .unwrap();
+        db.execute_raw(Statement::from_sql_and_values(
+            DatabaseBackend::Sqlite,
+            "INSERT INTO sandbox_labels (sandbox_id, key, value) VALUES (?, ?, ?)",
+            [1.into(), "team".into(), "existing".into()],
+        ))
+        .await
+        .unwrap();
+
+        let error = Migration.up(&SchemaManager::new(&db)).await.unwrap_err();
+
+        assert!(error.to_string().contains("sandbox id 1"));
+        let rows = db
+            .query_all_raw(Statement::from_string(
+                DatabaseBackend::Sqlite,
+                "SELECT key, value FROM sandbox_labels".to_owned(),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].try_get_by_index::<String>(0).unwrap(), "team");
+        assert_eq!(rows[0].try_get_by_index::<String>(1).unwrap(), "existing");
+    }
+}

--- a/crates/migration/lib/schema_metadata.rs
+++ b/crates/migration/lib/schema_metadata.rs
@@ -36,6 +36,9 @@ pub const CPU_ALLOCATION_MIGRATION_ID: &str = "m20260719_000001_create_cpu_alloc
 /// Migration that introduces host-global writeback dirty-credit reservations.
 pub const WRITEBACK_ALLOCATION_MIGRATION_ID: &str = "m20260803_000001_create_writeback_allocations";
 
+/// Migration that rebuilds the sandbox label index from persisted configs.
+pub const SANDBOX_LABEL_REBUILD_MIGRATION_ID: &str = "m20260810_000001_rebuild_sandbox_labels";
+
 /// Frozen migration baseline for the transitional 0.6.0 release.
 ///
 /// The released 0.6.0 binary predates `msb __schema-baseline --json`, so
@@ -200,6 +203,13 @@ pub const MIGRATION_METADATA: &[MigrationMetadata] = &[
         affects_user_data: false,
         summary: "remove host-global writeback allocation state",
     },
+    MigrationMetadata {
+        id: SANDBOX_LABEL_REBUILD_MIGRATION_ID,
+        reversible: true,
+        affects_cache: false,
+        affects_user_data: false,
+        summary: "retain the rebuilt sandbox label index",
+    },
 ];
 
 //--------------------------------------------------------------------------------------------------
@@ -286,6 +296,7 @@ mod tests {
     #[test]
     fn canonical_applied_prefix_uses_metadata_order() {
         let applied = [
+            SANDBOX_LABEL_REBUILD_MIGRATION_ID,
             WRITEBACK_ALLOCATION_MIGRATION_ID,
             SNAPSHOT_ARTIFACT_TRANSITION_MIGRATION_ID,
             CPU_ALLOCATION_MIGRATION_ID,

--- a/sdk/rust/lib/backend/local/sandbox/create.rs
+++ b/sdk/rust/lib/backend/local/sandbox/create.rs
@@ -1237,10 +1237,10 @@ mod tests {
     use microsandbox_db::entity::{run as run_entity, sandbox_rootfs as sandbox_rootfs_entity};
     use microsandbox_db::pool::DbPools;
     use microsandbox_migration::{Migrator, MigratorTrait};
-    use sea_orm::{EntityTrait, Set};
+    use sea_orm::{ColumnTrait, ConnectionTrait, EntityTrait, QueryFilter, Set};
     use tempfile::tempdir;
 
-    use super::sandbox_entity;
+    use super::{sandbox_entity, sandbox_label_entity};
     use crate::backend::{Backend, LocalBackend};
     use crate::runtime::SpawnMode;
     use crate::sandbox::{
@@ -1551,6 +1551,82 @@ mod tests {
         let decoded: SandboxConfig = serde_json::from_str(&row.config).unwrap();
 
         assert_eq!(decoded.manifest_digest, config.manifest_digest);
+    }
+
+    #[tokio::test]
+    async fn test_insert_sandbox_record_persists_label_projection() {
+        let temp = tempdir().unwrap();
+        let db_path = temp.path().join("test.db");
+        let pools = open_test_pools(&db_path).await;
+        let mut config = test_config("labelled");
+        config.spec.labels.insert("team".into(), "metrics".into());
+        config.spec.labels.insert("tier".into(), "gold".into());
+
+        let sandbox_id = LocalBackend::insert_sandbox_record(pools.write(), &config)
+            .await
+            .unwrap();
+        let mut rows = sandbox_label_entity::Entity::find()
+            .filter(sandbox_label_entity::Column::SandboxId.eq(sandbox_id))
+            .all(pools.read())
+            .await
+            .unwrap();
+        rows.sort_by(|left, right| left.key.cmp(&right.key));
+
+        assert_eq!(
+            rows.into_iter()
+                .map(|row| (row.key, row.value))
+                .collect::<Vec<_>>(),
+            vec![
+                ("team".into(), "metrics".into()),
+                ("tier".into(), "gold".into()),
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_label_rebuild_migrates_serialized_sandbox_config() {
+        let temp = tempdir().unwrap();
+        let db_path = temp.path().join("test.db");
+        let pools = open_test_pools(&db_path).await;
+        let mut config = test_config("migration-labels");
+        config.spec.labels.insert("team".into(), "metrics".into());
+        config.spec.labels.insert("tier".into(), "gold".into());
+        let sandbox_id = LocalBackend::insert_sandbox_record(pools.write(), &config)
+            .await
+            .unwrap();
+
+        sandbox_label_entity::Entity::delete_many()
+            .filter(sandbox_label_entity::Column::SandboxId.eq(sandbox_id))
+            .exec(pools.write())
+            .await
+            .unwrap();
+        pools
+            .write()
+            .inner()
+            .execute_unprepared(
+                "DELETE FROM seaql_migrations \
+                 WHERE version = 'm20260810_000001_rebuild_sandbox_labels'",
+            )
+            .await
+            .unwrap();
+
+        Migrator::up(pools.write().inner(), None).await.unwrap();
+
+        let mut rows = sandbox_label_entity::Entity::find()
+            .filter(sandbox_label_entity::Column::SandboxId.eq(sandbox_id))
+            .all(pools.read())
+            .await
+            .unwrap();
+        rows.sort_by(|left, right| left.key.cmp(&right.key));
+        assert_eq!(
+            rows.into_iter()
+                .map(|row| (row.key, row.value))
+                .collect::<Vec<_>>(),
+            vec![
+                ("team".into(), "metrics".into()),
+                ("tier".into(), "gold".into()),
+            ]
+        );
     }
 
     #[tokio::test]

--- a/sdk/rust/lib/sandbox/modify.rs
+++ b/sdk/rust/lib/sandbox/modify.rs
@@ -3,11 +3,11 @@
 use std::sync::Arc;
 
 use microsandbox_types::{EnvVar, RootDisk, RootfsSource};
-use sea_orm::{ActiveModelTrait, Set};
+use sea_orm::{ActiveModelTrait, ColumnTrait, EntityTrait, QueryFilter, Set};
 
 use crate::MicrosandboxResult;
 use crate::backend::Backend;
-use crate::db::entity::sandbox as sandbox_entity;
+use crate::db::entity::{sandbox as sandbox_entity, sandbox_label as sandbox_label_entity};
 use crate::error::{Operation, UnsupportedReason};
 use crate::size::Mebibytes;
 
@@ -1147,16 +1147,43 @@ async fn persist_config(
         .ok_or_else(|| crate::MicrosandboxError::local_only(Operation::SandboxModify))?;
 
     let config_json = serde_json::to_string(config)?;
-    sandbox_entity::ActiveModel {
-        id: Set(local.db_id),
-        config: Set(config_json),
-        updated_at: Set(Some(chrono::Utc::now().naive_utc())),
-        ..Default::default()
-    }
-    .update(local_backend.db().await?.write())
-    .await?;
+    let labels = config.spec.labels.clone();
+    let write_db = local_backend.db().await?.write();
 
-    Ok(())
+    write_db
+        .transaction(|txn| {
+            let config_json = config_json.clone();
+            let labels = labels.clone();
+            async move {
+                sandbox_entity::ActiveModel {
+                    id: Set(local.db_id),
+                    config: Set(config_json),
+                    updated_at: Set(Some(chrono::Utc::now().naive_utc())),
+                    ..Default::default()
+                }
+                .update(&txn)
+                .await?;
+
+                sandbox_label_entity::Entity::delete_many()
+                    .filter(sandbox_label_entity::Column::SandboxId.eq(local.db_id))
+                    .exec(&txn)
+                    .await?;
+                if !labels.is_empty() {
+                    sandbox_label_entity::Entity::insert_many(labels.into_iter().map(
+                        |(key, value)| sandbox_label_entity::ActiveModel {
+                            sandbox_id: Set(local.db_id),
+                            key: Set(key),
+                            value: Set(value),
+                        },
+                    ))
+                    .exec(&txn)
+                    .await?;
+                }
+
+                Ok((txn, ()))
+            }
+        })
+        .await
 }
 
 async fn persist_active_config(
@@ -2244,7 +2271,10 @@ fn format_mib(mib: u32) -> String {
 
 #[cfg(test)]
 mod tests {
+    use tempfile::tempdir;
+
     use super::*;
+    use crate::backend::LocalBackend;
 
     fn config(cpus: u8, memory_mib: u32) -> SandboxConfig {
         let mut config = SandboxConfig::default();
@@ -2254,6 +2284,101 @@ mod tests {
         config.spec.resources.max_cpus = cpus;
         config.spec.resources.max_memory_mib = memory_mib;
         config
+    }
+
+    #[tokio::test]
+    async fn persist_config_replaces_label_projection() {
+        let temp = tempdir().unwrap();
+        let backend: Arc<dyn Backend> = Arc::new(
+            LocalBackend::builder()
+                .home(temp.path())
+                .build()
+                .await
+                .unwrap(),
+        );
+        let pools = backend.as_local().unwrap().db().await.unwrap();
+        let mut current = config(2, 1024);
+        current.spec.labels.insert("team".into(), "stale".into());
+        current.spec.labels.insert("removed".into(), "ghost".into());
+        let model = sandbox_entity::ActiveModel {
+            name: Set(current.spec.name.clone()),
+            config: Set(serde_json::to_string(&current).unwrap()),
+            active_config: Set(None),
+            status: Set(SandboxStatus::Stopped),
+            ephemeral: Set(false),
+            created_at: Set(None),
+            updated_at: Set(None),
+            ..Default::default()
+        }
+        .insert(pools.write())
+        .await
+        .unwrap();
+        let sandbox_id = model.id;
+        for (key, value) in [("team", "stale"), ("removed", "ghost")] {
+            sandbox_label_entity::ActiveModel {
+                sandbox_id: Set(sandbox_id),
+                key: Set(key.into()),
+                value: Set(value.into()),
+            }
+            .insert(pools.write())
+            .await
+            .unwrap();
+        }
+
+        let mut updated = current;
+        updated.spec.labels.remove("removed");
+        updated.spec.labels.insert("team".into(), "metrics".into());
+        updated.spec.labels.insert("tier".into(), "gold".into());
+        let handle = backend
+            .sandboxes()
+            .get(backend.clone(), &updated.spec.name)
+            .await
+            .unwrap();
+
+        persist_config(&backend, &handle, &updated).await.unwrap();
+
+        let mut rows = sandbox_label_entity::Entity::find()
+            .filter(sandbox_label_entity::Column::SandboxId.eq(sandbox_id))
+            .all(pools.read())
+            .await
+            .unwrap();
+        rows.sort_by(|left, right| left.key.cmp(&right.key));
+        assert_eq!(
+            rows.into_iter()
+                .map(|row| (row.key, row.value))
+                .collect::<Vec<_>>(),
+            vec![
+                ("team".into(), "metrics".into()),
+                ("tier".into(), "gold".into()),
+            ]
+        );
+        let stored = sandbox_entity::Entity::find_by_id(sandbox_id)
+            .one(pools.read())
+            .await
+            .unwrap()
+            .unwrap();
+        let stored: SandboxConfig = serde_json::from_str(&stored.config).unwrap();
+        assert_eq!(stored.spec.labels, updated.spec.labels);
+
+        let mut without_labels = updated;
+        without_labels.spec.labels.clear();
+        persist_config(&backend, &handle, &without_labels)
+            .await
+            .unwrap();
+
+        let rows = sandbox_label_entity::Entity::find()
+            .filter(sandbox_label_entity::Column::SandboxId.eq(sandbox_id))
+            .all(pools.read())
+            .await
+            .unwrap();
+        assert!(rows.is_empty());
+        let stored = sandbox_entity::Entity::find_by_id(sandbox_id)
+            .one(pools.read())
+            .await
+            .unwrap()
+            .unwrap();
+        let stored: SandboxConfig = serde_json::from_str(&stored.config).unwrap();
+        assert!(stored.spec.labels.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## TL;DR

Keep sandbox labels consistent across modification, migration, and metrics enrichment.

## Description

The modify path persisted label changes only in the canonical config JSON, leaving `sandbox_labels` stale, while metrics cached labels as if they were immutable. Update the config and projection atomically, rebuild existing projection rows from canonical configs, and refresh metrics labels from the active config.

Fixes #1176.