### PR TITLE
fix(go): use alternate signal stack on macOS

### DIFF
--- a/sdk/rust/lib/runtime/spawn.rs
+++ b/sdk/rust/lib/runtime/spawn.rs
@@ -93,7 +93,7 @@ use crate::{
 // Constants
 //--------------------------------------------------------------------------------------------------
 
-#[cfg(target_os = "linux")]
+#[cfg(unix)]
 static SIGCHLD_ALT_STACK_INIT: tokio::sync::OnceCell<()> = tokio::sync::OnceCell::const_new();
 
 const AGENT_SOCKET_HASH_HEX_LEN: usize = 32;
@@ -1227,7 +1227,7 @@ fn release_metrics_reservation(config: &SandboxConfig, reservation: Option<&Metr
     }
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(unix)]
 async fn ensure_sigchld_handler_uses_alt_stack_before_spawn() -> MicrosandboxResult<()> {
     SIGCHLD_ALT_STACK_INIT
         .get_or_try_init(|| async {
@@ -1239,19 +1239,19 @@ async fn ensure_sigchld_handler_uses_alt_stack_before_spawn() -> MicrosandboxRes
     Ok(())
 }
 
-#[cfg(not(target_os = "linux"))]
+#[cfg(not(unix))]
 async fn ensure_sigchld_handler_uses_alt_stack_before_spawn() -> MicrosandboxResult<()> {
     Ok(())
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(unix)]
 fn install_tokio_sigchld_handler() -> MicrosandboxResult<()> {
     let signal = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::child())?;
     let _ = Box::leak(Box::new(signal));
     Ok(())
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(unix)]
 fn patch_sigchld_handler_uses_alt_stack() {
     unsafe {
         let mut action = std::mem::MaybeUninit::<libc::sigaction>::uninit();
@@ -2910,7 +2910,7 @@ mod tests {
         ));
     }
 
-    #[cfg(target_os = "linux")]
+    #[cfg(unix)]
     #[tokio::test]
     async fn test_sigchld_handler_uses_alt_stack_after_prepare() {
         super::ensure_sigchld_handler_uses_alt_stack_before_spawn()


### PR DESCRIPTION
## TL;DR

Fix the Go SDK crash on macOS when the host process spawns a child after starting a sandbox. Closes #1288.

## Description

- Tokio installs a SIGCHLD handler without `SA_ONSTACK`, which violates Go's cgo signal handling contract.
- Apply the existing pre-spawn handler patch to all Unix targets instead of Linux only.
- Run the existing regression test on macOS too.