### PR TITLE
fix(sandbox): unify secret placeholder defaults

### DIFF
--- a/crates/network/lib/builder.rs
+++ b/crates/network/lib/builder.rs
@@ -583,7 +583,7 @@ impl SecretBuilder {
         );
         let placeholder = self
             .placeholder
-            .unwrap_or_else(|| format!("$MSB_{env_var}"));
+            .unwrap_or_else(|| microsandbox_utils::secret::default_placeholder(&env_var));
 
         SecretEntry {
             env_var,

--- a/crates/utils/lib/lib.rs
+++ b/crates/utils/lib/lib.rs
@@ -6,6 +6,7 @@ pub mod format;
 pub mod log_text;
 pub mod process;
 pub mod process_lock;
+pub mod secret;
 pub mod size;
 pub mod ttl_reverse_index;
 pub mod wake_pipe;

--- a/crates/utils/lib/secret.rs
+++ b/crates/utils/lib/secret.rs
@@ -1,0 +1,24 @@
+//! Shared secret conventions.
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+/// Build the default guest-visible placeholder for a secret environment variable.
+pub fn default_placeholder(env_var: &str) -> String {
+    format!("$MSB_{env_var}")
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests
+//--------------------------------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_placeholder_prefixes_environment_variable() {
+        assert_eq!(default_placeholder("API_KEY"), "$MSB_API_KEY");
+    }
+}

--- a/sdk/rust/lib/sandbox/modify.rs
+++ b/sdk/rust/lib/sandbox/modify.rs
@@ -430,9 +430,10 @@ impl SecretPatchBuilder {
         self
     }
 
-    /// Set the guest-visible placeholder. Placeholder changes cannot reach
-    /// already-running processes, so they classify as restart-required on a
-    /// running sandbox.
+    /// Set the guest-visible placeholder. New secrets default to
+    /// `$MSB_<env_var>`, matching create-time secret configuration.
+    /// Placeholder changes cannot reach already-running processes, so they
+    /// classify as restart-required on a running sandbox.
     pub fn placeholder(mut self, placeholder: impl Into<String>) -> Self {
         self.spec.placeholder = Some(placeholder.into());
         self
@@ -1005,7 +1006,7 @@ fn apply_secret_spec(
             placeholder: spec
                 .placeholder
                 .clone()
-                .unwrap_or_else(|| default_secret_ref(&spec.name)),
+                .unwrap_or_else(|| microsandbox_utils::secret::default_placeholder(&spec.name)),
             allowed_hosts: parse_host_patterns(&spec.allowed_hosts),
             injection: SecretInjection::default(),
             on_violation: None,
@@ -1529,7 +1530,7 @@ fn push_secret_changes(
                 spec.placeholder
                     .clone()
                     .or_else(|| existing.as_ref().map(|secret| secret.placeholder.clone()))
-                    .unwrap_or_else(|| default_secret_ref(&spec.name)),
+                    .unwrap_or_else(|| microsandbox_utils::secret::default_placeholder(&spec.name)),
             ),
             disposition,
             allow_hosts: if spec.allowed_hosts.is_empty() {
@@ -1582,7 +1583,7 @@ fn push_secret_changes(
                 existing
                     .as_ref()
                     .map(|secret| secret.placeholder.clone())
-                    .unwrap_or_else(|| default_secret_ref(name)),
+                    .unwrap_or_else(|| microsandbox_utils::secret::default_placeholder(name)),
             ),
             after_ref: None,
             disposition,
@@ -2251,10 +2252,6 @@ fn status_name(status: SandboxStatus) -> &'static str {
         SandboxStatus::Stopped => "stopped",
         SandboxStatus::Crashed => "crashed",
     }
-}
-
-fn default_secret_ref(name: &str) -> String {
-    format!("${name}")
 }
 
 fn format_mib(mib: u32) -> String {
@@ -3300,7 +3297,7 @@ mod tests {
         );
         let json = serde_json::to_string(&plan).unwrap();
 
-        assert!(json.contains("$API_KEY"));
+        assert!(json.contains("$MSB_API_KEY"));
         assert!(json.contains("api.example.com"));
         assert!(!json.contains("real-secret-value"));
 
@@ -3750,7 +3747,7 @@ mod tests {
 
     #[cfg(feature = "net")]
     #[test]
-    fn applying_new_source_spec_records_reference_not_value() {
+    fn applying_new_source_spec_uses_create_placeholder_default() {
         use microsandbox_network::secrets::config::HostPattern;
 
         let mut config = config(2, 1024);
@@ -3768,7 +3765,7 @@ mod tests {
                 var: "API_KEY".into()
             })
         );
-        assert_eq!(entry.placeholder, "$API_KEY");
+        assert_eq!(entry.placeholder, "$MSB_API_KEY");
         assert_eq!(
             entry.allowed_hosts,
             vec![HostPattern::Exact("api.example.com".into())]


### PR DESCRIPTION
## TL;DR

make secret placeholders consistent between `msb create` and `msb modify`

fixes #1312

## Description

- use one shared helper for the default `$MSB_<NAME>` placeholder
- remove the separate create and modify defaults that drifted apart
- preserve existing placeholders when rotating secrets