### PR TITLE
docs(sdk): streamline reference pages

### DIFF
--- a/docs/changelog/2026-08-07.mdx
+++ b/docs/changelog/2026-08-07.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Week of August 7, 2026"
-description: "A production-ready Ruby SDK, flat OCI root disks for faster boots, single- and multi-tenant deployment profiles, explicit default-workload execution across every SDK, an integrated host performance stack, cloud filesystem access on default volumes, and fixes for cloud TLS trust, Windows read-only closes, agentd reaping, and stale metrics."
+description: "A first-class Ruby SDK, flat OCI root disks, deployment profiles, default-workload execution, host performance improvements, cloud volume filesystem access, and reliability fixes."
 icon: "bolt"
 ---
 

--- a/docs/sandboxes/secrets.mdx
+++ b/docs/sandboxes/secrets.mdx
@@ -106,7 +106,7 @@ In the CLI form, `ENV@HOST[,HOST...]` records a host-side source reference: the 
 
 <Tooltip tip="modify is not yet available on microsandbox cloud; recreate the sandbox to change its secrets."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
 
-Add, rotate, or remove secrets without a restart. Guest code keeps using the same placeholder; only the value injected at the network boundary changes.
+Rotate or remove existing secrets without a restart. Adding a secret or changing its guest-visible placeholder requires a restart so the new environment reaches the guest. Later rotations keep that placeholder stable and only change the value injected at the network boundary.
 
 <CodeGroup>
 ```rust Rust
@@ -115,16 +115,60 @@ let plan = sb.modify()
         .env("API_KEY")
         .source(SecretSource::Env { var: "API_KEY".into() })
         .allow_host("api.example.com"))
+    .restart()
     .apply()
     .await?;
 ```
 
+```typescript TypeScript
+await sandbox.modify({
+  secrets: {
+    API_KEY: { env: "API_KEY", allowedHosts: ["api.example.com"] },
+  },
+  policy: "restart",
+});
+
+await sandbox.modify({ secretsRemove: ["SERVICE_API_KEY"] });
+```
+
+```python Python
+from microsandbox import ModificationPolicy
+
+await sb.modify(
+    secrets={
+        "API_KEY": {
+            "env": "API_KEY",
+            "allowed_hosts": ["api.example.com"],
+        },
+    },
+    policy=ModificationPolicy.RESTART,
+)
+
+await sb.modify(secrets_rm=["SERVICE_API_KEY"])
+```
+
+```go Go
+_, err := sb.Modify(ctx, m.ModifyOptions{
+    Secrets: map[string]m.SecretModifySpec{
+        "API_KEY": {
+            Env:          "API_KEY",
+            AllowedHosts: []string{"api.example.com"},
+        },
+    },
+    Policy: m.ModificationPolicyRestart,
+})
+
+_, err = sb.Modify(ctx, m.ModifyOptions{
+    SecretsRemove: []string{"SERVICE_API_KEY"},
+})
+```
+
 ```bash CLI
-msb modify worker --secret GITHUB_TOKEN@api.github.com   # add or rotate
-msb modify worker --secret-rm SERVICE_API_KEY            # remove
+msb modify worker --secret GITHUB_TOKEN@api.github.com --restart  # add or rotate
+msb modify worker --secret-rm SERVICE_API_KEY                       # remove
 ```
 </CodeGroup>
 
-Secret changes through modify are Rust-SDK and CLI only for now. See [Tuning](/sandboxes/tuning) for how changes are planned and applied.
+Secret modification is available through every SDK and the CLI. See [Tuning](/sandboxes/tuning) for how changes are planned and applied.
 
 For API details, see the SDK references: [Rust](/sdk/rust/secrets) | [TypeScript](/sdk/typescript/secrets) | [Python](/sdk/python/secrets) | [Go](/sdk/go/secrets).

--- a/docs/sdk/go/agent-client.mdx
+++ b/docs/sdk/go/agent-client.mdx
@@ -7,39 +7,6 @@ description: Go SDK - Low-level agentd client reference
 
 All request and response bodies are raw CBOR bytes. The SDK handles framing and correlation ids, but it does not encode or decode the CBOR message body for you: decode it with a library such as `fxamacker/cbor`. The raw body is the full CBOR-encoded protocol `Message` body (`v`, `t`, `p`), not just the inner payload.
 
-<p className="msb-label" id="typical-flow">Typical flow</p>
-
-```go
-import (
-    "context"
-
-    "github.com/fxamacker/cbor/v2"
-    m "github.com/superradcompany/microsandbox/sdk/go"
-)
-
-ctx := context.Background()
-
-client, err := m.ConnectAgentSandbox(ctx, "dev")             // 1. connect
-if err != nil {
-    return err
-}
-defer client.Close()
-
-body, err := cbor.Marshal(map[string]any{                    // 2. build a CBOR Message
-    "v": 1,
-    "t": "core.fs.request",
-    "p": fsRequestBytes,
-})
-if err != nil {
-    return err
-}
-
-frame, err := client.Request(ctx, m.FlagSessionStart, body)  // 3. request / response
-if err != nil {
-    return err
-}
-_ = frame.Body
-```
 
 ## Constants
 

--- a/docs/sdk/go/execution.mdx
+++ b/docs/sdk/go/execution.mdx
@@ -7,20 +7,6 @@ Run commands inside a running sandbox, collect their output, stream events live,
 
 The exec API mirrors `os/exec` conventions: a **non-zero exit code is not a Go error**. Transport, timeout, and spawn-failure paths return an `error`; a program that ran and exited non-zero is a normal [`*ExecOutput`](#execoutput) result, inspect [`Success()`](#out-success) or [`ExitCode()`](#out-exitcode).
 
-<p className="msb-label" id="typical-flow">Typical flow</p>
-
-```go
-import m "github.com/superradcompany/microsandbox/sdk/go"
-
-out, err := sb.Exec(ctx, "python3", []string{"-c", "print(1 + 1)"})
-if err != nil {
-    return err // transport / timeout / spawn failure
-}
-if !out.Success() {
-    log.Printf("exited %d: %s", out.ExitCode(), out.Stderr())
-}
-fmt.Print(out.Stdout())
-```
 
 ## Sandbox methods
 

--- a/docs/sdk/go/filesystem.mdx
+++ b/docs/sdk/go/filesystem.mdx
@@ -5,24 +5,6 @@ description: Go SDK - Filesystem API reference
 
 Read and write files inside a running sandbox over the same host-guest channel as command execution: no SSH, no network. See [Filesystem](/sandboxes/filesystem) for usage examples. For bulk file transfer, prefer a [volume](/sdk/go/volumes).
 
-<p className="msb-label" id="typical-flow">Typical flow</p>
-
-```go
-import m "github.com/superradcompany/microsandbox/sdk/go"
-
-fs := sb.FS()                                                     // 1. get the accessor
-
-err := fs.WriteString(ctx, "/tmp/config.json", `{"debug":true}`)  // 2. write
-if err != nil {
-    return err
-}
-
-content, err := fs.ReadString(ctx, "/tmp/config.json")            // 3. read back
-if err != nil {
-    return err
-}
-fmt.Println(content)
-```
 
 ## Methods
 

--- a/docs/sdk/go/images.mdx
+++ b/docs/sdk/go/images.mdx
@@ -11,25 +11,6 @@ Inspect and prune the local OCI image cache: the images that sandbox creation ha
 import m "github.com/superradcompany/microsandbox/sdk/go"
 ```
 
-<p className="msb-label" id="typical-flow">Typical flow</p>
-
-```go
-import m "github.com/superradcompany/microsandbox/sdk/go"
-
-images, err := m.Image.List(ctx)        // 1. enumerate the cache
-if err != nil {
-    return err
-}
-for _, img := range images {
-    fmt.Println(img.Reference(), img.LayerCount())
-}
-
-report, err := m.Image.Prune(ctx)       // 2. reclaim unused data
-if err != nil {
-    return err
-}
-fmt.Println(report.LayersRemoved, "layers removed")
-```
 
 ## Functions
 

--- a/docs/sdk/go/networking.mdx
+++ b/docs/sdk/go/networking.mdx
@@ -7,35 +7,6 @@ Configure a sandbox's network stack: a first-match-wins egress/ingress policy, p
 
 The Go SDK exposes networking as a single [`NetworkConfig`](#networkconfig) struct passed to [`WithNetwork`](#m-withnetwork). Common shapes come from the [`NetworkPolicy`](#networkpolicy) factory; custom firewalls are built by populating `NetworkConfig.Rules` directly.
 
-<p className="msb-label" id="typical-flow">Typical flow</p>
-
-```go
-import m "github.com/superradcompany/microsandbox/sdk/go"
-
-// Public internet profile
-sb, err := m.CreateSandbox(ctx, "worker",
-    m.WithImage("alpine"),
-    m.WithNetwork(m.NetworkPolicy.FromProfiles(m.NetworkProfilePublic)),
-)
-
-// Or a custom first-match-wins firewall
-sb, err = m.CreateSandbox(ctx, "ci-runner",
-    m.WithImage("python:3.12"),
-    m.WithNetwork(&m.NetworkConfig{
-        DefaultEgress:  m.PolicyActionDeny,
-        DefaultIngress: m.PolicyActionAllow,
-        Rules: []m.PolicyRule{
-            {
-                Action:      m.PolicyActionAllow,
-                Direction:   m.PolicyDirectionEgress,
-                Destination: "api.example.com",
-                Protocol:    m.PolicyProtocolTCP,
-                Port:        "443",
-            },
-        },
-    }),
-)
-```
 
 ## Functions
 

--- a/docs/sdk/go/sandbox.mdx
+++ b/docs/sdk/go/sandbox.mdx
@@ -7,30 +7,6 @@ Create and control a microVM sandbox: boot it from an image, run commands, strea
 
 For local sandboxes, call [`EnsureInstalled`](#m-ensureinstalled) once at process startup. It installs the `msb` + `libkrunfw` runtime into `~/.microsandbox/` when needed, is idempotent, and surfaces runtime setup failures before the first sandbox operation. Use [`IsInstalled`](#m-isinstalled) when you only need to check whether the runtime is already present.
 
-<p className="msb-label" id="typical-flow">Typical flow</p>
-
-```go
-import m "github.com/superradcompany/microsandbox/sdk/go"
-
-if err := m.EnsureInstalled(ctx); err != nil {      // 1. prepare local runtime
-    return err
-}
-
-sb, err := m.CreateSandbox(ctx, "api",              // 2. configure + boot
-    m.WithImage("python"),
-    m.WithMemory(1024),
-)
-if err != nil {
-    return err
-}
-defer sb.Close()                                    // 5. release handle
-
-out, err := sb.Exec(ctx, "python", []string{"-V"})  // 3. run
-if err != nil {
-    return err
-}
-fmt.Println(out.Stdout())                           // 4. read output
-```
 
 ## Functions
 
@@ -662,6 +638,27 @@ _, err = sb.Modify(ctx, m.ModifyOptions{
     Env:    map[string]string{"MODE": "prod"},
     Policy: m.ModificationPolicyRestart,
 })
+// Grow the managed OCI root disk offline and restart
+_, err = sb.Modify(ctx, m.ModifyOptions{
+    RootDiskSizeMiB: 8192,
+    Policy:          m.ModificationPolicyRestart,
+})
+
+// Add or rotate a host-environment secret; restart if it is newly added
+_, err = sb.Modify(ctx, m.ModifyOptions{
+    Secrets: map[string]m.SecretModifySpec{
+        "API_KEY": {
+            Env:          "API_KEY",
+            AllowedHosts: []string{"api.example.com"},
+        },
+    },
+    Policy: m.ModificationPolicyRestart,
+})
+
+// Remove an existing secret
+_, err = sb.Modify(ctx, m.ModifyOptions{
+    SecretsRemove: []string{"OLD_API_KEY"},
+})
 ```
 
 </Accordion>
@@ -670,7 +667,7 @@ Plan or apply a configuration change. The returned plan labels each change `"liv
 
 `CPUs` and `MemoryMiB` resize live within the [`WithMaxCPUs`](#withmaxcpus) / [`WithMaxMemory`](#withmaxmemory) ceilings; raising a ceiling requires a restart. Env and workdir changes affect future execs only. On a stopped sandbox, changes are saved for the next boot.
 
-Secret changes are Rust-SDK and CLI only for now. The CLI equivalent is [`msb modify`](/cli/sandbox-commands#msb-modify).
+Secret specs are keyed by stable secret name. Each `SecretModifySpec` selects at most one source—`Env`, `Value`, or `Store`—and may also set `Placeholder` and `AllowedHosts`; omitting a source updates only the other supplied fields. Plans expose only safe references and metadata; raw secret values never appear in a plan. Removal is explicit through `SecretsRemove`.
 
 A live CPU or memory resize can take a moment to settle. The new limits are enforced immediately, and the returned plan's `ResizeStatus` reports when the sandbox has finished adjusting. See [`SandboxModificationPlan`](#sandboxmodificationplan).
 
@@ -995,7 +992,7 @@ Convenience wrapper around [`OwnsLifecycle`](#sb-ownslifecycle) that swallows th
 
 ## Options
 
-Functional options for [`CreateSandbox`](#m-createsandbox). Map and slice options merge across repeated calls; single-value setters like [`WithImage`](#withimage) replace. Simple setters are demonstrated by the [Typical flow](#typical-flow) above.
+Functional options for [`CreateSandbox`](#m-createsandbox). Map and slice options merge across repeated calls; single-value setters like [`WithImage`](#withimage) replace.
 
 #### <span className="msb-recv"></span><span className="msb-hn">WithImage()</span>
 
@@ -1999,7 +1996,7 @@ Explicit idle-refresh result.
 
 <p className="msb-backref">Used by <a href="#sb-modify">Modify()</a></p>
 
-A requested sandbox modification. Zero-valued fields are left unchanged (`0` is not a valid CPU or memory size). Secret changes are Rust-SDK and CLI only for now.
+A requested sandbox modification. Zero-valued fields are left unchanged (`0` is not a valid CPU or memory size).
 
 | Field | Type | Description |
 |-------|------|-------------|
@@ -2007,13 +2004,30 @@ A requested sandbox modification. Zero-valued fields are left unchanged (`0` is 
 | MaxCPUs | `uint8` | Boot-time maximum possible vCPUs (restart-backed) |
 | MemoryMiB | `uint32` | Desired effective guest memory in MiB. Live when within the booted `MaxMemoryMiB` |
 | MaxMemoryMiB | `uint32` | Boot-time maximum hotpluggable memory in MiB (restart-backed) |
+| RootDiskSizeMiB | `uint64` | Desired root disk size in MiB. Managed and flat OCI disks are grow-only; applies on restart or next start |
 | Env | `map[string]string` | Environment variables to set for future execs |
 | EnvRemove | `[]string` | Environment variable keys to remove |
 | Labels | `map[string]string` | Labels to set |
 | LabelsRemove | `[]string` | Label keys to remove |
 | Workdir | `string` | Working directory for future execs |
+| Secrets | `map[string]SecretModifySpec` | Desired secret specs keyed by stable secret name |
+| SecretsRemove | `[]string` | Secret names to remove explicitly |
 | Policy | `ModificationPolicy` | `ModificationPolicyNoRestart` (default) applies only changes that can complete without restarting; `ModificationPolicyNextStart` persists changes for the next start without mutating a running VM; `ModificationPolicyRestart` restarts if needed so restart-required changes become active now |
 | DryRun | `bool` | Compute the plan without applying anything |
+
+### SecretModifySpec
+
+<p className="msb-backref">Used by <a href="#sb-modify">Modify()</a></p>
+
+Desired state for one secret. `Env`, `Value`, and `Store` are mutually exclusive sources. Leave all three empty to update only the placeholder or allowed hosts.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| Env | `string` | Host environment variable to resolve when applying the modification |
+| Value | `string` | Raw secret value. Stored in the durable sandbox config until replaced by a source reference |
+| Store | `string` | Reserved for a host-side secret store reference; currently unsupported |
+| Placeholder | `string` | Explicit guest-visible placeholder. New secrets default to `$MSB_<NAME>` |
+| AllowedHosts | `[]string` | Desired allowed host patterns. A new secret requires at least one; an empty slice leaves existing hosts unchanged |
 
 ### SandboxModificationPlan
 

--- a/docs/sdk/go/secrets.mdx
+++ b/docs/sdk/go/secrets.mdx
@@ -7,22 +7,6 @@ See [Secrets](/sandboxes/secrets) for how placeholder substitution works and usa
 
 Secrets never enter the VM. The Go SDK passes each [`SecretEntry`](#secretentrystruct) to the runtime, which exposes a placeholder string inside the guest (e.g. `$MSB_SERVICE_API_KEY`) and substitutes the real value at the network layer only when traffic reaches an allowed host.
 
-<p className="msb-label" id="typical-flow">Typical flow</p>
-
-```go
-import m "github.com/superradcompany/microsandbox/sdk/go"
-
-sb, err := m.CreateSandbox(ctx, "worker",
-    m.WithImage("python:3.12"),
-    m.WithSecrets(m.Secret.Env(
-        "SERVICE_API_KEY",
-        os.Getenv("SERVICE_API_KEY"),
-        m.SecretEnvOptions{
-            AllowHosts: []string{"api.example.com"},
-        },
-    )),
-)
-```
 
 ## Host matching
 

--- a/docs/sdk/go/snapshots.mdx
+++ b/docs/sdk/go/snapshots.mdx
@@ -9,30 +9,6 @@ Disk-only snapshots of a sandbox that is not running. Create artifacts from a st
   Snapshots are **disk-only** and require a sandbox that is stopped or crashed.
 </Note>
 
-<p className="msb-label" id="typical-flow">Typical flow</p>
-
-```go
-import m "github.com/superradcompany/microsandbox/sdk/go"
-
-// 1. stop the sandbox; snapshots are disk-only
-_ = sb.Stop(ctx)
-_ = sb.Close()
-
-// 2. snapshot it under a bare name
-snap, err := m.Snapshot.Create(ctx, m.SnapshotCreateOptions{
-    Name:            "after-pip-install",
-    FromSandbox:     "baseline",
-    RecordIntegrity: true,
-})
-if err != nil {
-    return err
-}
-
-// 3. boot a fresh sandbox from the snapshot
-sb2, err := m.CreateSandbox(ctx, "worker",
-    m.WithFromSnapshot("after-pip-install"),
-)
-```
 
 ## Snapshot functions
 

--- a/docs/sdk/go/ssh.mdx
+++ b/docs/sdk/go/ssh.mdx
@@ -5,29 +5,6 @@ description: Go SDK - SSH API reference
 
 Reach a running sandbox over SSH: open a native in-process SSH client, run exec requests, attach an interactive shell, transfer files over SFTP, or stand up a reusable SSH server endpoint. See [SSH](/sandboxes/ssh) for usage flows.
 
-<p className="msb-label" id="typical-flow">Typical flow</p>
-
-```go
-import (
-    "context"
-
-    m "github.com/superradcompany/microsandbox/sdk/go"
-)
-
-ctx := context.Background()
-
-client, err := sb.SSH().OpenClient(ctx)   // 1. open a native client
-if err != nil {
-    return err
-}
-defer client.Close(ctx)
-
-out, err := client.Exec(ctx, "uname -a")  // 2. run a command
-if err != nil {
-    return err
-}
-fmt.Printf("%s (exit %d)\n", out.Stdout, out.Status)
-```
 
 ## Methods
 

--- a/docs/sdk/go/volumes.mdx
+++ b/docs/sdk/go/volumes.mdx
@@ -5,27 +5,6 @@ description: Go SDK - Volume API reference
 
 Create and manage named persistent volumes, read and write their data directly on the host, and attach them (or bind mounts, tmpfs, and disk images) to sandboxes. See [Volumes](/sandboxes/volumes) for usage examples and patterns.
 
-<p className="msb-label" id="typical-flow">Typical flow</p>
-
-```go
-import m "github.com/superradcompany/microsandbox/sdk/go"
-
-vol, err := m.CreateVolume(ctx, "my-data",         // 1. create a named volume
-    m.WithVolumeQuota(64),
-    m.WithVolumeLabels(map[string]string{"env": "prod"}),
-)
-
-vfs := vol.FS()                                    // 2. seed it from the host
-err = vfs.WriteString("seed.txt", "hello")
-
-sb, err := m.CreateSandbox(ctx, "worker",          // 3. attach it to a sandbox
-    m.WithImage("alpine"),
-    m.WithMounts(map[string]m.MountConfig{
-        "/data": m.Mount.Named("my-data", m.MountOptions{}),
-    }),
-)
-```
-
 Named volumes are managed by microsandbox and stored by default under `~/.microsandbox/volumes/<name>/`. They persist independently of any sandbox. There is no Rust-side resource to release: `Remove` deletes the on-disk state and the DB record.
 
 ## Functions

--- a/docs/sdk/python/agent-client.mdx
+++ b/docs/sdk/python/agent-client.mdx
@@ -7,16 +7,6 @@ description: Python SDK - Low-level agentd client reference
 
 All request and response bodies are raw CBOR bytes. The SDK handles framing and correlation ids, but it does not encode or decode the CBOR message body for you. The raw body is the full CBOR-encoded protocol `Message` body (`v`, `t`, and `p`), not just the inner payload.
 
-<p className="msb-label" id="typical-flow">Typical flow</p>
-
-```python
-from microsandbox import AgentClient
-
-client = await AgentClient.connect_sandbox("dev")   # 1. connect
-ready = client.ready_bytes()                        # 2. inspect handshake
-frame = await client.request(0, body)               # 3. raw request/response
-await client.close()                                # 4. close
-```
 
 ## Constants
 

--- a/docs/sdk/python/execution.mdx
+++ b/docs/sdk/python/execution.mdx
@@ -5,30 +5,6 @@ description: Python SDK - Command execution API reference
 
 Run commands inside a running sandbox: collect output in one shot, stream events as they arrive, or bridge your terminal to an interactive PTY. These methods live on a running [`Sandbox`](/sdk/python/sandbox). See [Commands](/sandboxes/commands) for usage examples.
 
-<p className="msb-label" id="typical-flow">Typical flow</p>
-
-```python
-import sys
-
-from microsandbox import Sandbox
-
-sandbox = await Sandbox.create("api", image="python")
-
-# 1. one-shot
-out = await sandbox.exec("python3", ["-c", "print(1 + 1)"])
-print(out.stdout_text)  # "2\n"
-
-# 2. stream
-handle = await sandbox.exec_stream("tail", ["-f", "/var/log/app.log"])
-async for event in handle:
-    if event.event_type == "stdout":
-        sys.stdout.buffer.write(event.data)
-    elif event.event_type == "exited":
-        break
-
-await sandbox.stop()
-```
-
 ## Run and collect
 
 #### <span className="msb-recv">sandbox.</span><span className="msb-hn">exec()</span>

--- a/docs/sdk/python/filesystem.mdx
+++ b/docs/sdk/python/filesystem.mdx
@@ -5,20 +5,6 @@ description: Python SDK - Filesystem API reference
 
 Read, write, and manage files inside a running sandbox. Operations go through the same host-guest channel as command execution: no SSH, no network. See [Filesystem](/sandboxes/filesystem) for usage examples. For bulk file movement, prefer a [volume](/sandboxes/volumes).
 
-<p className="msb-label" id="typical-flow">Typical flow</p>
-
-```python
-from microsandbox import Sandbox
-
-async with await Sandbox.create("api", image="python") as sb:
-    fs = sb.fs                                     # 1. grab the handle
-
-    await fs.mkdir("/app")                         # 2. set up
-    await fs.write("/app/config.json", b'{"ok": true}')
-
-    data = await fs.read_text("/app/config.json")  # 3. read it back
-    print(data)
-```
 
 The handle is reached through the `sb.fs` property on a running [`Sandbox`](/sdk/python/sandbox). All methods are coroutines, so `await` each call.
 

--- a/docs/sdk/python/images.mdx
+++ b/docs/sdk/python/images.mdx
@@ -9,22 +9,6 @@ description: Python SDK - Image cache API reference
 from microsandbox import Image
 ```
 
-<p className="msb-label" id="typical-flow">Typical flow</p>
-
-```python
-from microsandbox import Image, Sandbox
-
-# Pull happens implicitly on creation
-async with await Sandbox.create("api", image="python:3.12") as sb:
-    await sb.exec("python", ["-V"])
-
-# Later, inspect and prune the local cache
-for image in await Image.list():
-    print(image.reference, image.layer_count)
-
-report = await Image.prune()
-print(f"reclaimed {report.bytes_reclaimed} bytes")
-```
 
 ## Source factory
 

--- a/docs/sdk/python/networking.mdx
+++ b/docs/sdk/python/networking.mdx
@@ -5,43 +5,6 @@ description: Python SDK - Network API reference
 
 Configure a sandbox's network stack: a first-match-wins egress/ingress policy, published ports, DNS interception, TLS interception, and secret-violation handling. Pass a [`Network`](#network) as the `network=` kwarg to [`Sandbox.create()`](/sdk/python/sandbox#sandbox-create). See [Networking](/networking/overview) for the conceptual overview and [TLS Interception](/networking/tls) for proxy details.
 
-<p className="msb-label" id="typical-flow">Typical flow</p>
-
-```python
-from microsandbox import (
-    Action,
-    DestGroup,
-    Destination,
-    Network,
-    NetworkPolicy,
-    NetworkProfile,
-    PortBinding,
-    Protocol,
-    Rule,
-    Sandbox,
-)
-
-policy = NetworkPolicy(                             # 1. compose a policy
-    default_egress=Action.DENY,
-    rules=(
-        *Rule.allow_dns(),
-        Rule.allow(
-            protocol=Protocol.TCP,
-            port=443,
-            destination=Destination.group(DestGroup.PUBLIC),
-        ),
-    ),
-)
-
-sb = await Sandbox.create(                          # 2. wire it into the sandbox
-    "api",
-    image="python",
-    network=Network(
-        policy=policy,
-        ports=(PortBinding.tcp(8080, 80),),
-    ),
-)
-```
 
 The default policy denies egress except for an implicit allow-public rule, and allows ingress with no rules. See the [defaults rationale](/networking/overview#defaults) for the asymmetry. `Network`, `Rule`, `Destination`, and `PortBinding` are all frozen dataclasses re-exported from `microsandbox`, each carrying class-method or static-method constructors for the common cases.
 

--- a/docs/sdk/python/sandbox.mdx
+++ b/docs/sdk/python/sandbox.mdx
@@ -5,18 +5,6 @@ description: Python SDK - Sandbox API reference
 
 Create and control a microVM sandbox: boot it from an image, run commands, stream logs and metrics, then shut it down. See [Overview](/sandboxes/overview) for configuration examples and [Lifecycle](/sandboxes/lifecycle) for state management.
 
-<p className="msb-label" id="typical-flow">Typical flow</p>
-
-```python
-from microsandbox import Sandbox
-
-# 1. configure + 2. boot the microVM
-async with await Sandbox.create("api", image="python", memory=1024) as sb:
-    # 3. run
-    out = await sb.exec("python", ["-V"])
-    print(out.stdout_text)
-# 4. on exit the sandbox is killed and its state removed
-```
 
 ## Static methods
 
@@ -523,19 +511,24 @@ async def modify(
     max_cpus: int | None = None,
     memory: int | None = None,
     max_memory: int | None = None,
+    root_disk_size: int | None = None,
     env: Mapping[str, str] | None = None,
     env_rm: list[str] | None = None,
     labels: Mapping[str, str] | None = None,
     labels_rm: list[str] | None = None,
     workdir: str | None = None,
-    policy: str | None = None,
+    secrets: Mapping[str, SecretModifySpec] | None = None,
+    secrets_rm: list[str] | None = None,
+    policy: ModificationPolicy | None = None,
     dry_run: bool = False,
-) -> dict[str, Any]
+) -> SandboxModificationPlan
 ```
 
 <Accordion title="Example">
 
 ```python
+from microsandbox import ModificationPolicy
+
 # Live resize: applies to the running VM when within the booted capacity
 plan = await sb.modify(cpus=4, memory=4096)
 for r in plan.get("resize_status", []):
@@ -547,7 +540,24 @@ for change in plan["changes"]:
     print(f'{change["field"]}: {change["disposition"]}')
 
 # Make an env change active now by restarting
-await sb.modify(env={"MODE": "prod"}, policy="restart")
+await sb.modify(env={"MODE": "prod"}, policy=ModificationPolicy.RESTART)
+
+# Grow the managed OCI root disk offline and restart
+await sb.modify(root_disk_size=8192, policy=ModificationPolicy.RESTART)
+
+# Add or rotate a host-environment secret; restart if it is newly added
+await sb.modify(
+    secrets={
+        "API_KEY": {
+            "env": "API_KEY",
+            "allowed_hosts": ["api.example.com"],
+        },
+    },
+    policy=ModificationPolicy.RESTART,
+)
+
+# Remove an existing secret
+await sb.modify(secrets_rm=["OLD_API_KEY"])
 ```
 
 </Accordion>
@@ -555,8 +565,6 @@ await sb.modify(env={"MODE": "prod"}, policy="restart")
 Plan or apply a configuration change. The returned plan labels each change `"live"`, `"next start"`, `"requires restart"`, or `"unsupported"`, and apply is all-or-nothing.
 
 `cpus` and `memory` resize live within the `max_cpus` / `max_memory` ceilings; raising a ceiling requires a restart. Env and workdir changes affect future execs only. On a stopped sandbox, changes are saved for the next boot.
-
-Secret changes are Rust-SDK and CLI only for now. The CLI equivalent is [`msb modify`](/cli/sandbox-commands#msb-modify).
 
 The returned plan dict mirrors the canonical JSON shape:
 
@@ -1289,7 +1297,7 @@ A lightweight handle to an existing sandbox (running or stopped). Provides statu
 | refresh() | `Awaitable[`[`SandboxHandle`](#sandboxhandle)`]` | Re-fetch status and metadata, returning a fresh handle |
 | ping() | `Awaitable[`[`SandboxPingResult`](#sandboxpingresult)`]` | Check agent reachability without refreshing idle activity; does not start stopped sandboxes |
 | touch() | `Awaitable[`[`SandboxTouchResult`](#sandboxtouchresult)`]` | Explicitly refresh idle activity; does not start stopped sandboxes |
-| modify(...) | `Awaitable[dict[str, Any]]` | Plan or apply a configuration change; same kwargs as [`modify()`](#sb-modify). Does not start stopped sandboxes; changes persist for the next boot |
+| modify(...) | `Awaitable[`[`SandboxModificationPlan`](#sandboxmodificationplan)`]` | Plan or apply a configuration change; same kwargs as [`modify()`](#sb-modify). Does not start stopped sandboxes; changes persist for the next boot |
 | connect(timeout=None) | `Awaitable[`[`Sandbox`](#instance-methods)`]` | Connect to a running sandbox, optionally with an explicit timeout in seconds |
 | start(*, detached=False) | `Awaitable[`[`Sandbox`](#instance-methods)`]` | Start in attached or detached mode |
 | stop(timeout=None) | `Awaitable[None]` | Gracefully shut down and wait until stopped state is observed |
@@ -1347,13 +1355,139 @@ Observed terminal sandbox state returned by [`wait_until_stopped()`](#sb-wait_un
 
 The string status values a sandbox can report. A `StrEnum`, exposed as plain strings on `status` fields.
 
-| Value | Description |
-|-------|-------------|
-| `"running"` | Guest agent is ready; `exec`, `shell`, `fs` work |
-| `"stopped"` | VM shut down; configuration persisted; can be restarted |
-| `"crashed"` | VM exited unexpectedly (kernel panic, OOM, etc.) |
-| `"draining"` | Graceful shutdown in progress; existing commands finish, new ones rejected |
-| `"paused"` | VM paused |
+| Member | Value | Description |
+|--------|-------|-------------|
+| `SandboxStatus.CREATED` | `"created"` | Sandbox metadata exists but the VM has not started |
+| `SandboxStatus.STARTING` | `"starting"` | A start request is in progress |
+| `SandboxStatus.RUNNING` | `"running"` | Guest agent is ready; `exec`, `shell`, and `fs` work |
+| `SandboxStatus.STOPPED` | `"stopped"` | VM shut down; configuration persisted; can be restarted |
+| `SandboxStatus.CRASHED` | `"crashed"` | VM exited unexpectedly (kernel panic, OOM, etc.) |
+| `SandboxStatus.DRAINING` | `"draining"` | Graceful shutdown in progress; existing commands finish, new ones rejected |
+| `SandboxStatus.PAUSED` | `"paused"` | VM paused |
+
+### BackendKind
+
+<p className="msb-backref">Used by <code>set_default_backend()</code> · <code>backend_scope()</code> · returned by <code>default_backend_kind()</code></p>
+
+Selected sandbox backend.
+
+| Member | Value | Description |
+|--------|-------|-------------|
+| `BackendKind.LOCAL` | `"local"` | Local libkrun backend |
+| `BackendKind.CLOUD` | `"cloud"` | Microsandbox cloud backend; requires an API key or named profile |
+
+```python
+from microsandbox import BackendKind, set_default_backend
+
+set_default_backend(BackendKind.CLOUD, profile="production")
+```
+
+### ModificationPolicy
+
+<p className="msb-backref">Used by <a href="#sb-modify">modify(policy=...)</a></p>
+
+Controls how sandbox modifications that cannot apply live are handled.
+
+| Member | Value | Description |
+|--------|-------|-------------|
+| `ModificationPolicy.NO_RESTART` | `"no_restart"` | Apply only changes that do not require a restart |
+| `ModificationPolicy.NEXT_START` | `"next_start"` | Persist changes for the next start without restarting a running VM |
+| `ModificationPolicy.RESTART` | `"restart"` | Restart when required so changes become active immediately |
+
+### SecretModifySpec
+
+<p className="msb-backref">Used by <a href="#sb-modify">modify(secrets=...)</a></p>
+
+Desired state for one secret. `env`, `value`, and `store` are mutually exclusive sources. Omit all three to update only the placeholder or allowed hosts.
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `env` | `str` | Host environment variable to resolve when applying the modification |
+| `value` | `str` | Raw secret value. Stored in the durable sandbox config until replaced by a source reference |
+| `store` | `str` | Reserved for a host-side secret store reference; currently unsupported |
+| `placeholder` | `str` | Explicit guest-visible placeholder. New secrets default to `$MSB_<NAME>` |
+| `allowed_hosts` | `list[str]` | Desired allowed host patterns. A new secret requires at least one; an empty list leaves existing hosts unchanged |
+
+### SandboxModificationPlan
+
+Typed dictionary returned by `Sandbox.modify()` and `SandboxHandle.modify()`. Config changes and secret changes use different typed shapes and are discriminated by their `kind` member.
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `sandbox` | `str` | Sandbox being modified |
+| `status` | [`SandboxStatus`](#sandboxstatus) | Status used to classify the requested changes |
+| `applied` | `bool` | Whether the plan was applied |
+| `policy` | [`ModificationPolicy`](#modificationpolicy) | Policy used to produce the plan |
+| `changes` | `list[ConfigPlannedChange \| SecretPlannedChange]` | Planned changes |
+| `conflicts` | `list[ModificationConflict]` | Blocking conflicts, each with `field` and `message` |
+| `warnings` | `list[ModificationWarning]` | Non-fatal warnings, each with `field` and `message` |
+| `resize_status` | `list[ResourceResizeStatus]` | Optional live-resize convergence results |
+
+`ConfigPlannedChange` has `kind`, `field`, `change`, and `disposition`, plus optional `before`, `after`, and `reason`. `SecretPlannedChange` has `kind`, `field`, `name`, `change`, and `disposition`, plus optional `before_ref`, `after_ref`, `allow_hosts`, and `reason`. Secret values never appear in a plan.
+
+### PlannedChangeKind
+
+Discriminator for entries in `SandboxModificationPlan.changes`.
+
+| Member | Value | Description |
+|--------|-------|-------------|
+| `PlannedChangeKind.CONFIG` | `"config"` | Ordinary configuration change |
+| `PlannedChangeKind.SECRET` | `"secret"` | Secret metadata or material change |
+
+### ChangeKind
+
+Natural operation for a configuration change.
+
+| Member | Value | Description |
+|--------|-------|-------------|
+| `ChangeKind.ADDED` | `"added"` | A field is being added |
+| `ChangeKind.UPDATED` | `"updated"` | A field is being updated |
+| `ChangeKind.REMOVED` | `"removed"` | A field is being removed |
+
+### SecretChangeKind
+
+Natural operation for a secret change.
+
+| Member | Value | Description |
+|--------|-------|-------------|
+| `SecretChangeKind.ADDED` | `"added"` | A secret is being added |
+| `SecretChangeKind.ROTATED` | `"rotated"` | Secret material is being rotated |
+| `SecretChangeKind.REMOVED` | `"removed"` | A secret is being removed |
+| `SecretChangeKind.RENAMED` | `"renamed"` | A secret is being renamed |
+| `SecretChangeKind.HOSTS_UPDATED` | `"hosts updated"` | Allowed hosts are being updated |
+| `SecretChangeKind.PLACEHOLDER_UPDATED` | `"placeholder updated"` | The guest-visible placeholder is being updated |
+
+### ModificationDisposition
+
+When or whether a planned change can take effect.
+
+| Member | Value | Description |
+|--------|-------|-------------|
+| `ModificationDisposition.LIVE` | `"live"` | Applies to the running VM now |
+| `ModificationDisposition.NEXT_START` | `"next start"` | Applies the next time the sandbox starts |
+| `ModificationDisposition.REQUIRES_RESTART` | `"requires restart"` | Requires a restart before taking effect |
+| `ModificationDisposition.UNSUPPORTED` | `"unsupported"` | Cannot be changed through `modify()` |
+
+### ResourceKind
+
+Resource reported by a live-resize result.
+
+| Member | Value | Description |
+|--------|-------|-------------|
+| `ResourceKind.CPUS` | `"cpus"` | vCPU count |
+| `ResourceKind.MEMORY` | `"memory"` | Guest memory |
+
+### ResourceConvergenceState
+
+Observed convergence state for an accepted live resize.
+
+| Member | Value | Description |
+|--------|-------|-------------|
+| `ResourceConvergenceState.ACCEPTED` | `"accepted"` | Runtime accepted the request |
+| `ResourceConvergenceState.CONVERGING` | `"converging"` | Guest and VMM are still converging |
+| `ResourceConvergenceState.APPLIED` | `"applied"` | Desired, actual, and enforced values match |
+| `ResourceConvergenceState.GUEST_REFUSED` | `"guest-refused"` | Guest refused or failed to cooperate |
+| `ResourceConvergenceState.FAILED` | `"failed"` | Resize failed |
 
 ### SandboxMetrics
 

--- a/docs/sdk/python/secrets.mdx
+++ b/docs/sdk/python/secrets.mdx
@@ -5,25 +5,6 @@ description: Python SDK - Secret injection API reference
 
 Bind a credential to an environment variable so the guest only ever sees a placeholder: the real value is substituted by the TLS proxy when traffic reaches an allowed host, and blocked everywhere else. See [Secrets](/sandboxes/secrets) for how placeholder substitution works and usage examples.
 
-<p className="msb-label" id="typical-flow">Typical flow</p>
-
-```python
-import os
-from microsandbox import Sandbox, Secret
-
-sb = await Sandbox.create(
-    "worker",
-    image="python",
-    secrets=[
-        Secret.env(
-            "GITHUB_TOKEN",
-            value=os.environ["GITHUB_TOKEN"],
-            allow_hosts=["api.github.com"],
-            allow_host_patterns=["*.githubusercontent.com"],
-        ),
-    ],
-)
-```
 
 ## Factory methods
 

--- a/docs/sdk/python/snapshots.mdx
+++ b/docs/sdk/python/snapshots.mdx
@@ -5,23 +5,6 @@ description: Python SDK - Snapshot API reference
 
 Capture the disk state of a stopped sandbox as a reusable artifact, then boot fresh sandboxes from it. Snapshots are disk-only and require a sandbox that is not running. See [Snapshots](/sandboxes/snapshots) for concepts and walkthroughs.
 
-<p className="msb-label" id="typical-flow">Typical flow</p>
-
-```python
-from microsandbox import Sandbox, Snapshot
-
-# Run setup work, then stop the sandbox (snapshots are stopped-only)
-sb = await Sandbox.create("baseline", image="python:3.12")
-await sb.exec("pip", ["install", "numpy"])
-await sb.stop()
-
-# Capture its disk state under a name
-snap = await Snapshot.create("after-pip-install", from_sandbox="baseline")
-print(snap.digest)
-
-# Boot a fresh sandbox from the artifact
-sb2 = await Sandbox.create("worker", from_snapshot="after-pip-install")
-```
 
 ## Take a snapshot
 

--- a/docs/sdk/python/ssh.mdx
+++ b/docs/sdk/python/ssh.mdx
@@ -5,18 +5,6 @@ description: Python SDK - SSH API reference
 
 Reach a running sandbox over SSH: open a native in-process SSH client, run exec requests, attach an interactive shell, transfer files over SFTP, or stand up a reusable server endpoint that serves connections over stdin/stdout. See [SSH](/sandboxes/ssh) for usage flows.
 
-<p className="msb-label" id="typical-flow">Typical flow</p>
-
-```python
-from microsandbox import Sandbox
-
-async with await Sandbox.create("api", image="python") as sb:
-    client = await sb.ssh().open_client()       # 1. open an SSH client
-    out = await client.exec("python -V")        # 2. run a command
-    print(out.stdout_text)
-
-    await client.close()                        # 3. close the session
-```
 
 ## Sandbox
 

--- a/docs/sdk/python/volumes.mdx
+++ b/docs/sdk/python/volumes.mdx
@@ -5,25 +5,6 @@ description: Python SDK - Volume API reference
 
 Create and manage named persistent volumes, and build the mount configs that attach storage to a sandbox. See [Volumes](/sandboxes/volumes) for usage examples and patterns.
 
-<p className="msb-label" id="typical-flow">Typical flow</p>
-
-```python
-from microsandbox import Sandbox, Volume
-
-# 1. create a persistent named volume
-await Volume.create("pip-cache", quota_mib=2048)
-
-# 2. mount it into a sandbox via a mount factory
-sb = await Sandbox.create(
-    "worker",
-    image="python",
-    volumes={"/root/.cache/pip": Volume.named("pip-cache")},
-)
-
-# 3. inspect or edit the volume from the host, no sandbox required
-handle = await Volume.get("pip-cache")
-print(handle.used_bytes)
-```
 
 ## Static methods
 

--- a/docs/sdk/rust/agent-client.mdx
+++ b/docs/sdk/rust/agent-client.mdx
@@ -12,34 +12,6 @@ The client has two tiers that share one socket and one background reader task:
 
 The raw body is the full CBOR-encoded protocol `Message` body (`v`, `t`, and `p`), not just the inner payload. The typed and raw methods reach the connection through `Deref` to the underlying client; everything below is callable directly on the value `connect_sandbox` returns.
 
-<p className="msb-label" id="typical-flow">Typical flow</p>
-
-```rust
-use microsandbox::{
-    agent,
-    protocol::{
-        fs::{FsOp, FsRequest, FsResponse},
-        message::MessageType,
-    },
-};
-
-let client = agent::connect_sandbox("dev").await?;   // 1. resolve name + connect
-
-let response = client                                // 2. one-shot typed RPC
-    .request(
-        MessageType::FsRequest,
-        &FsRequest {
-            op: FsOp::Stat {
-                path: "/etc/os-release".to_string(),
-                follow_symlink: true,
-            },
-        },
-    )
-    .await?;
-
-let fs_response: FsResponse = response.payload()?;   // 3. decode the payload
-client.close().await;                                // 4. close
-```
 
 ## Module functions
 

--- a/docs/sdk/rust/execution.mdx
+++ b/docs/sdk/rust/execution.mdx
@@ -5,27 +5,6 @@ description: Rust SDK - Command execution API reference
 
 Run commands inside a running sandbox: buffer the output in one call, stream it event by event, drive a shell, or bridge your terminal to an interactive PTY session. See [Commands](/sandboxes/commands) for usage examples.
 
-<p className="msb-label" id="typical-flow">Typical flow</p>
-
-```rust
-use microsandbox::Sandbox;
-
-let sb = Sandbox::builder("api").image("python").create().await?;
-
-// Buffered: run and collect everything
-let out = sb.exec("python", ["-c", "print('hi')"]).await?;
-println!("{}", out.stdout()?);
-
-// Streaming: process output as it arrives
-let mut handle = sb.exec_stream("tail", ["-f", "/var/log/app.log"]).await?;
-while let Some(event) = handle.recv().await {
-    if let microsandbox::ExecEvent::Stdout(chunk) = event {
-        print!("{}", String::from_utf8_lossy(&chunk));
-    }
-}
-
-sb.stop().await?;
-```
 
 ## Run methods
 

--- a/docs/sdk/rust/filesystem.mdx
+++ b/docs/sdk/rust/filesystem.mdx
@@ -5,22 +5,6 @@ description: Rust SDK - Filesystem API reference
 
 Read, write, list, and manipulate files inside a running sandbox. Obtained via [`sb.fs()`](/sdk/rust/sandbox#sb-fs). Every op dispatches through the same host-guest channel as command execution, so there is no SSH and no network involved. Path-style helpers are the usual choice; handle-style helpers are available for callers that need POSIX-like file descriptor reuse. For bulk file movement, prefer a [volume](/sdk/rust/volumes) that gives the guest direct filesystem access. See [Filesystem](/sandboxes/filesystem) for conceptual usage.
 
-<p className="msb-label" id="typical-flow">Typical flow</p>
-
-```rust
-use microsandbox::Sandbox;
-
-let sb = Sandbox::builder("api").image("python").create().await?;
-let fs = sb.fs();
-
-fs.write("/tmp/config.json", r#"{"debug": true}"#).await?;
-let text = fs.read_to_string("/tmp/config.json").await?;
-println!("{text}");
-
-for entry in fs.list("/tmp").await? {
-    println!("{} ({} bytes)", entry.path, entry.size);
-}
-```
 
 `sb.fs()` is synchronous and just borrows the sandbox's backend and name; the work happens on the `await`ed methods below, every one of which is `async`.
 

--- a/docs/sdk/rust/images.mdx
+++ b/docs/sdk/rust/images.mdx
@@ -9,21 +9,6 @@ Inspect, remove, prune, and import/export the local OCI image cache: the images 
 use microsandbox::{Image, ImagePruneReport};
 ```
 
-<p className="msb-label" id="typical-flow">Typical flow</p>
-
-```rust
-use microsandbox::Image;
-
-for image in Image::list().await? {
-    println!("{} ({} layers)", image.reference(), image.layer_count());
-}
-
-let detail = Image::inspect("python:3.12").await?;
-println!("{:?}", detail.config.as_ref().and_then(|c| c.working_dir.as_deref()));
-
-let report = Image::prune().await?;
-println!("removed {} refs", report.image_refs_removed);
-```
 
 ## Ambient cache methods
 

--- a/docs/sdk/rust/networking.mdx
+++ b/docs/sdk/rust/networking.mdx
@@ -5,26 +5,6 @@ description: Rust SDK - Network API reference
 
 Configure a sandbox's network stack: a first-match-wins egress/ingress policy, published ports, DNS interception, TLS interception, and secret-violation handling. See [Networking](/networking/overview) for the conceptual overview and [TLS Interception](/networking/tls) for proxy details.
 
-<p className="msb-label" id="typical-flow">Typical flow</p>
-
-```rust
-use microsandbox::{NetworkPolicy, Sandbox};
-
-let policy = NetworkPolicy::builder()       // 1. compose a policy
-    .default_deny()
-    .egress(|e| e.tcp().port(443).allow_public())
-    .rule(|r| r.any().deny().ip("198.51.100.5"))
-    .build()?;
-
-let sb = Sandbox::builder("api")
-    .image("python")
-    .network(|n| n                          // 2. wire it into the sandbox
-        .policy(policy)
-        .port(8080, 80)
-        .dns(|d| d.rebind_protection(true)))
-    .create()
-    .await?;
-```
 
 The default policy denies egress except for an implicit allow-public rule (plus DNS), and allows ingress with no rules. See the [defaults rationale](/networking/overview#defaults) for the asymmetry. `NetworkPolicy` and the builders live in `microsandbox_network`; `NetworkPolicy` is also re-exported from the crate root as `microsandbox::NetworkPolicy`.
 

--- a/docs/sdk/rust/sandbox.mdx
+++ b/docs/sdk/rust/sandbox.mdx
@@ -5,22 +5,6 @@ description: Rust SDK - Sandbox API reference
 
 Create and control a microVM sandbox: boot it from an image, run commands, stream logs and metrics, then shut it down. See [Overview](/sandboxes/overview) for configuration examples and [Lifecycle](/sandboxes/lifecycle) for state management.
 
-<p className="msb-label" id="typical-flow">Typical flow</p>
-
-```rust
-use microsandbox::Sandbox;
-
-let sb = Sandbox::builder("api")             // 1. configure
-    .image("python")
-    .memory(1024)
-    .create()                                // 2. boot the microVM
-    .await?;
-
-let out = sb.exec("python", ["-V"]).await?;  // 3. run
-println!("{}", out.stdout()?);
-
-sb.stop().await?;                            // 4. shut down
-```
 
 ## Static methods
 
@@ -757,7 +741,7 @@ Block until the sandbox is observed in a terminal non-running state. Owned local
 
 ## SandboxBuilder
 
-Builder for configuring a sandbox before creation. Obtained via [`Sandbox::builder(name)`](#sandboxbuilder). Every setter returns `Self`, so calls chain. Examples are shown on the methods where usage is non-obvious; simple setters are demonstrated by the [Typical flow](#typical-flow) above.
+Builder for configuring a sandbox before creation. Obtained via [`Sandbox::builder(name)`](#sandboxbuilder). Every setter returns `Self`, so calls chain. Examples are shown on the methods where usage is non-obvious.
 
 #### <span className="msb-recv">.</span><span className="msb-hn">build()</span>
 

--- a/docs/sdk/rust/secrets.mdx
+++ b/docs/sdk/rust/secrets.mdx
@@ -5,24 +5,6 @@ description: Rust SDK - Secret injection API reference
 
 Inject credentials into outbound HTTP without ever exposing the real value to the guest. The guest only ever sees a placeholder; microsandbox's TLS proxy swaps in the real secret on connections to allowed hosts and blocks everything else. See [Secrets](/sandboxes/secrets) for how placeholder substitution works and usage examples.
 
-<p className="msb-label" id="typical-flow">Typical flow</p>
-
-```rust
-use microsandbox::Sandbox;
-
-let sb = Sandbox::builder("agent")
-    .image("python")
-    .secret(|s| s
-        .env("OPENAI_API_KEY")             // guest sees $MSB_OPENAI_API_KEY
-        .value(std::env::var("OPENAI_API_KEY")?)
-        .allow_host("api.openai.com"))     // real value only reaches this host
-    .create()
-    .await?;
-
-// In the guest, the placeholder is swapped for the real key
-// only on TLS connections to api.openai.com.
-let out = sb.exec("python", ["agent.py"]).await?;
-```
 
 ## Static methods
 

--- a/docs/sdk/rust/snapshots.mdx
+++ b/docs/sdk/rust/snapshots.mdx
@@ -9,29 +9,6 @@ Capture a stopped sandbox's writable upper layer into a self-describing, content
   Snapshots are **local-only** and **disk-only** today: they capture a sandbox that is stopped or crashed, and every operation runs against the default local backend. Cloud snapshots and qcow2 backing chains are deferred.
 </Note>
 
-<p className="msb-label" id="typical-flow">Typical flow</p>
-
-```rust
-use microsandbox::{Sandbox, Snapshot};
-
-// 1. stop the sandbox you want to capture
-let sb = Sandbox::get("api").await?;
-sb.stop().await?;
-
-// 2. capture its writable upper layer
-let snap = Snapshot::builder("after-pip-install")
-    .from_sandbox("api")           // sandbox to capture
-    .record_integrity()            // hash the upper layer
-    .create()
-    .await?;
-println!("{} ({} bytes)", snap.digest(), snap.size_bytes());
-
-// 3. boot a fresh sandbox from it
-let restored = Sandbox::builder("api-restored")
-    .from_snapshot("after-pip-install")
-    .create()
-    .await?;
-```
 
 ## Static methods
 

--- a/docs/sdk/rust/ssh.mdx
+++ b/docs/sdk/rust/ssh.mdx
@@ -9,22 +9,6 @@ Reach a running sandbox over SSH: open a native in-process SSH client, run exec 
 microsandbox = { version = "0.5.8", features = ["ssh"] }
 ```
 
-<p className="msb-label" id="typical-flow">Typical flow</p>
-
-```rust
-use microsandbox::Sandbox;
-
-let sb = Sandbox::builder("api")
-    .image("python")
-    .create()
-    .await?;
-
-let client = sb.ssh().connect().await?;      // 1. open an SSH client
-let out = client.exec("python -V").await?;   // 2. run a command
-println!("{}", String::from_utf8_lossy(&out.stdout));
-
-client.close().await?;                       // 3. close the session
-```
 
 ## Sandbox
 

--- a/docs/sdk/rust/volumes.mdx
+++ b/docs/sdk/rust/volumes.mdx
@@ -5,27 +5,6 @@ description: Rust SDK - Volume API reference
 
 Create and manage named volumes: persistent storage that lives independently of any sandbox. Read and write a volume's files directly from the host, or mount it into a sandbox. See [Volumes](/sandboxes/volumes) for usage examples and patterns.
 
-<p className="msb-label" id="typical-flow">Typical flow</p>
-
-```rust
-use microsandbox::{Sandbox, Volume};
-
-// 1. create a persistent named volume
-let vol = Volume::builder("pip-cache").create().await?;
-
-// 2. seed it from the host, no sandbox required
-vol.fs().write("/note.txt", "shared cache").await?;
-
-// 3. mount it into a sandbox
-let sb = Sandbox::builder("api")
-    .image("python")
-    .volume("/root/.cache/pip", |v| v.named("pip-cache"))
-    .create()
-    .await?;
-
-sb.exec("pip", ["install", "requests"]).await?;
-sb.stop().await?;
-```
 
 ## Static methods
 

--- a/docs/sdk/typescript/agent-client.mdx
+++ b/docs/sdk/typescript/agent-client.mdx
@@ -7,25 +7,6 @@ description: TypeScript SDK - Low-level agentd client reference
 
 All request and response bodies are raw CBOR bytes. The SDK handles framing and correlation ids, but it does not encode or decode the CBOR message body for you: decode it with a library such as `cbor-x`. The raw body is the full CBOR-encoded protocol `Message` body (`v`, `t`, `p`), not just the inner payload.
 
-<p className="msb-label" id="typical-flow">Typical flow</p>
-
-```typescript
-import { encode, decode } from "cbor-x";
-import { AgentClient, FLAG_SESSION_START } from "microsandbox";
-
-const client = await AgentClient.connectSandbox("dev");        // 1. connect
-
-const body = encode({                                          // 2. build a CBOR Message
-  v: 1,
-  t: "core.fs.request",
-  p: encode({ op: { Stat: { path: "/etc" } } }),
-});
-
-const frame = await client.request(FLAG_SESSION_START, body);  // 3. request / response
-console.log(decode(frame.body));
-
-await client.close();                                          // 4. close
-```
 
 ## Constants
 

--- a/docs/sdk/typescript/execution.mdx
+++ b/docs/sdk/typescript/execution.mdx
@@ -5,26 +5,6 @@ description: TypeScript SDK - Command execution API reference
 
 Run commands inside a running sandbox: collect output in one shot, stream it as it arrives, attach an interactive PTY, or pipe data to stdin. These methods live on a running [`Sandbox`](/sdk/typescript/sandbox). See [Commands](/sandboxes/commands) for usage examples.
 
-<p className="msb-label" id="typical-flow">Typical flow</p>
-
-```typescript
-import { Sandbox } from "microsandbox";
-
-const sandbox = await Sandbox.create("api", { image: "python" });
-
-// 1. one-shot
-const out = await sandbox.exec("python3", ["-c", "print(1 + 1)"]);
-console.log(out.stdout()); // "2\n"
-
-// 2. stream
-const handle = await sandbox.execStream("tail", ["-f", "/var/log/app.log"]);
-for await (const event of handle) {
-  if (event.kind === "stdout") process.stdout.write(event.data);
-  if (event.kind === "exited") break;
-}
-
-await sandbox.stop();
-```
 
 ## Run and collect
 

--- a/docs/sdk/typescript/filesystem.mdx
+++ b/docs/sdk/typescript/filesystem.mdx
@@ -5,19 +5,6 @@ description: TypeScript SDK - Filesystem API reference
 
 Read and write files inside a running sandbox over the same host-guest channel as command execution: no SSH, no network. Obtain a handle with `sandbox.fs()`. See [Filesystem](/sandboxes/filesystem) for usage examples. For bulk transfers, consider a [bind-mounted volume](/sandboxes/volumes) instead.
 
-<p className="msb-label" id="typical-flow">Typical flow</p>
-
-```typescript
-const fs = sandbox.fs();
-
-await fs.write("/tmp/config.json", '{"debug": true}');     // write
-const content = await fs.readToString("/tmp/config.json"); // read back
-console.log(content);
-
-for (const entry of await fs.list("/tmp")) {               // list
-  console.log(entry.path);
-}
-```
 
 ## SandboxFsOps
 

--- a/docs/sdk/typescript/images.mdx
+++ b/docs/sdk/typescript/images.mdx
@@ -10,21 +10,6 @@ import { Image, ImageHandle } from "microsandbox";
 import type { ImageDetail, ImagePruneReport } from "microsandbox";
 ```
 
-<p className="msb-label" id="typical-flow">Typical flow</p>
-
-```typescript
-import { Image } from "microsandbox";
-
-for (const image of await Image.list()) {
-  console.log(image.reference, image.layerCount);
-}
-
-const detail = await Image.inspect("python:3.12");
-console.log(detail.config?.workingDir);
-
-const report = await Image.prune();
-console.log(report.bytesReclaimed);
-```
 
 ## Static methods
 

--- a/docs/sdk/typescript/networking.mdx
+++ b/docs/sdk/typescript/networking.mdx
@@ -5,27 +5,6 @@ description: TypeScript SDK - Network API reference
 
 Configure a sandbox's network stack: a first-match-wins egress/ingress policy, published ports, DNS interception, TLS interception, and secret-violation handling. See [Networking](/networking/overview) for the conceptual overview and [TLS Interception](/networking/tls) for proxy details.
 
-<p className="msb-label" id="typical-flow">Typical flow</p>
-
-```typescript
-import { NetworkPolicy, Sandbox } from "microsandbox";
-
-const policy = NetworkPolicy.builder()           // 1. compose a policy
-  .defaultDeny()
-  .egress((e) => e.tcp().port(443).allowPublic())
-  .rule((r) => r.any().deny((d) => d.ip("198.51.100.5")))
-  .build();
-
-const sb = await Sandbox.builder("api")
-  .image("python")
-  .network((n) =>
-    n                                            // 2. wire it into the sandbox
-      .policy(policy)
-      .port(8080, 80)
-      .dns((d) => d.rebindProtection(true)),
-  )
-  .create();
-```
 
 The default policy denies egress except for an implicit allow-public rule (plus DNS), and allows ingress with no rules. See the [defaults rationale](/networking/overview#defaults) for the asymmetry. `NetworkPolicy`, `Rule`, `Destination`, and `PortRange` each merge a value-type interface with a factory namespace under one name, all re-exported from `microsandbox`.
 

--- a/docs/sdk/typescript/sandbox.mdx
+++ b/docs/sdk/typescript/sandbox.mdx
@@ -9,21 +9,6 @@ The TypeScript SDK uses a **builder-only** entry point. Start every new sandbox 
 
 `libkrunfw` selection is process-level, not per sandbox. To use a custom library, call `setRuntimeLibkrunfwPath(path)` before creating local sandboxes, set `MSB_LIBKRUNFW_PATH`, or configure `paths.libkrunfw`.
 
-<p className="msb-label" id="typical-flow">Typical flow</p>
-
-```typescript
-import { Sandbox } from "microsandbox";
-
-await using sandbox = await Sandbox.builder("api")  // 1. configure
-  .image("python")
-  .memory(1024)
-  .create();                                        // 2. boot the microVM
-
-const out = await sandbox.exec("python", ["-V"]);   // 3. run
-console.log(out.stdout);
-
-await sandbox.stop();                               // 4. shut down
-```
 
 ## Static methods
 
@@ -561,6 +546,19 @@ for (const c of preview.changes) {
 
 // Make an env change active now by restarting
 await sandbox.modify({ env: { MODE: "prod" }, policy: "restart" });
+// Grow the managed OCI root disk offline and restart
+await sandbox.modify({ rootDiskSize: 8192, policy: "restart" });
+
+// Add or rotate a host-environment secret; restart if it is newly added
+await sandbox.modify({
+  secrets: {
+    API_KEY: { env: "API_KEY", allowedHosts: ["api.example.com"] },
+  },
+  policy: "restart",
+});
+
+// Remove an existing secret
+await sandbox.modify({ secretsRemove: ["OLD_API_KEY"] });
 ```
 
 </Accordion>
@@ -569,7 +567,7 @@ Plan or apply a configuration change. The returned plan labels each change `"liv
 
 `cpus` and `memory` resize live within the [`maxCpus`](#maxcpus) / [`maxMemory`](#maxmemory) ceilings; raising a ceiling requires a restart. Env and workdir changes affect future execs only. On a stopped sandbox, changes are saved for the next boot.
 
-Secret changes are Rust-SDK and CLI only for now. The CLI equivalent is [`msb modify`](/cli/sandbox-commands#msb-modify).
+Secret specs are keyed by stable secret name. Each `SecretModifySpec` selects at most one source—`env`, `value`, or `store`—and may also set `placeholder` and `allowedHosts`; omitting a source updates only the other supplied fields. Plans expose only safe references and metadata; raw secret values never appear in a plan. Removal is explicit through `secretsRemove`.
 
 A live CPU or memory resize can take a moment to settle. The new limits are enforced immediately, and the returned plan's `resizeStatus` reports when the sandbox has finished adjusting. See [`SandboxModificationPlan`](#sandboxmodificationplan).
 
@@ -818,7 +816,7 @@ Implements `AsyncDisposable` so the sandbox can be used with `await using`. When
 
 ## SandboxBuilder
 
-Fluent builder for configuring a sandbox before creation. Obtained via [`Sandbox.builder(name)`](#sandbox-builder). Every setter returns the same builder so calls chain. Examples are shown on the methods where usage is non-obvious; simple setters are demonstrated by the [Typical flow](#typical-flow) above.
+Fluent builder for configuring a sandbox before creation. Obtained via [`Sandbox.builder(name)`](#sandbox-builder). Every setter returns the same builder so calls chain. Examples are shown on the methods where usage is non-obvious.
 
 #### <span className="msb-recv">.</span><span className="msb-hn">build()</span>
 
@@ -2109,7 +2107,7 @@ Async stream for receiving periodic metrics snapshots. Implements `AsyncDisposab
 
 <p className="msb-backref">Used by <a href="#sandbox-modify">modify()</a></p>
 
-A requested sandbox modification. Omitted fields are left unchanged. Secret changes are Rust-SDK and CLI only for now.
+A requested sandbox modification. Omitted fields are left unchanged.
 
 | Field | Type | Description |
 |-------|------|-------------|
@@ -2117,13 +2115,30 @@ A requested sandbox modification. Omitted fields are left unchanged. Secret chan
 | maxCpus | `number` | Boot-time maximum possible vCPUs (restart-backed) |
 | memory | `number` | Desired effective guest memory in MiB. Live when within the booted `maxMemory` |
 | maxMemory | `number` | Boot-time maximum hotpluggable memory in MiB (restart-backed) |
+| rootDiskSize | `number` | Desired root disk size in MiB. Managed and flat OCI disks are grow-only; applies on restart or next start |
 | env | `Record<string, string>` | Environment variables to set for future execs |
 | envRemove | `string[]` | Environment variable keys to remove |
 | labels | `Record<string, string>` | Labels to set |
 | labelsRemove | `string[]` | Label keys to remove |
 | workdir | `string` | Working directory for future execs |
+| secrets | `Record<string, SecretModifySpec>` | Desired secret specs keyed by stable secret name |
+| secretsRemove | `string[]` | Secret names to remove explicitly |
 | policy | `"no_restart" \| "next_start" \| "restart"` | `"no_restart"` (default) applies only changes that can complete without restarting; `"next_start"` persists changes for the next start without mutating a running VM; `"restart"` restarts if needed so restart-required changes become active now |
 | dryRun | `boolean` | Compute the plan without applying anything. Defaults to `false` |
+
+### SecretModifySpec
+
+<p className="msb-backref">Used by <a href="#sandbox-modify">modify()</a></p>
+
+Desired state for one secret. `env`, `value`, and `store` are mutually exclusive sources. Omit all three to update only the placeholder or allowed hosts.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| env | `string` | Host environment variable to resolve when applying the modification |
+| value | `string` | Raw secret value. Stored in the durable sandbox config until replaced by a source reference |
+| store | `string` | Reserved for a host-side secret store reference; currently unsupported |
+| placeholder | `string` | Explicit guest-visible placeholder. New secrets default to `$MSB_<NAME>` |
+| allowedHosts | `string[]` | Desired allowed host patterns. A new secret requires at least one; an empty list leaves existing hosts unchanged |
 
 ### PullPolicy
 

--- a/docs/sdk/typescript/secrets.mdx
+++ b/docs/sdk/typescript/secrets.mdx
@@ -5,24 +5,6 @@ description: TypeScript SDK - Secret injection API reference
 
 Inject credentials into outbound HTTP without ever exposing the real value to the guest. The guest only ever sees a placeholder; microsandbox's TLS proxy swaps in the real secret on connections to allowed hosts and blocks everything else. See [Secrets](/sandboxes/secrets) for how placeholder substitution works and usage examples.
 
-<p className="msb-label" id="typical-flow">Typical flow</p>
-
-```typescript
-import { Sandbox } from "microsandbox";
-
-await using sb = await Sandbox.builder("agent")
-  .image("python")
-  .secret((s) =>
-    s.env("OPENAI_API_KEY")              // guest sees $MSB_OPENAI_API_KEY
-      .value(process.env.OPENAI_API_KEY!)
-      .allowHost("api.openai.com"),      // real value only reaches this host
-  )
-  .create();
-
-// In the guest, the placeholder is swapped for the real key
-// only on TLS connections to api.openai.com.
-const out = await sb.exec("python", ["agent.py"]);
-```
 
 ## SecretBuilder
 

--- a/docs/sdk/typescript/snapshots.mdx
+++ b/docs/sdk/typescript/snapshots.mdx
@@ -14,24 +14,6 @@ import type { SaveOpts, SnapshotScope, SnapshotVerifyReport } from "microsandbox
   Snapshots are **disk-only** and require a sandbox that is not running (stopped or crashed).
 </Note>
 
-<p className="msb-label" id="typical-flow">Typical flow</p>
-
-```typescript
-import { Sandbox, Snapshot } from "microsandbox";
-
-// 1. capture: stop the sandbox, then snapshot its disk
-const sb = await Sandbox.get("baseline");
-await sb.stop();
-const snap = await Snapshot.builder("after-pip-install")
-  .fromSandbox("baseline")       // sandbox to capture
-  .recordIntegrity()             // hash the upper layer
-  .create();
-
-// 2. boot a fresh sandbox from the snapshot
-const fresh = await Sandbox.builder("worker")
-  .fromSnapshot(snap.path)
-  .create();
-```
 
 ## Capture and boot
 

--- a/docs/sdk/typescript/ssh.mdx
+++ b/docs/sdk/typescript/ssh.mdx
@@ -5,21 +5,6 @@ description: TypeScript SDK - SSH API reference
 
 Reach a running sandbox over SSH: open an in-process client, run commands or attach an interactive shell, transfer files over SFTP, or expose the sandbox as a server endpoint. See [SSH](/sandboxes/ssh) for usage flows.
 
-<p className="msb-label" id="typical-flow">Typical flow</p>
-
-```typescript
-import { Sandbox } from "microsandbox";
-
-await using sandbox = await Sandbox.builder("api")   // 1. boot the sandbox
-  .image("python")
-  .create();
-
-const client = await sandbox.ssh().openClient();     // 2. open an SSH client
-const out = await client.exec("python -V");          // 3. run a command
-console.log(out.stdout.toString());
-
-await client.close();                                // 4. close the client
-```
 
 ## SandboxSshOps
 

--- a/docs/sdk/typescript/volumes.mdx
+++ b/docs/sdk/typescript/volumes.mdx
@@ -5,21 +5,6 @@ description: TypeScript SDK - Volume API reference
 
 Create and manage named volumes: persistent storage that lives independently of any sandbox. Build a volume, look one up, read and write its files from the host, then delete it. See [Volumes](/sandboxes/volumes) for usage examples and patterns.
 
-<p className="msb-label" id="typical-flow">Typical flow</p>
-
-```typescript
-import { Volume } from "microsandbox";
-
-const data = await Volume.builder("my-data")    // 1. configure
-  .label("env", "prod")
-  .create();                                    // 2. create on disk
-
-const vfs = data.fs();                          // 3. host-side I/O
-await vfs.write("seed.txt", "hello");
-console.log(await vfs.list(""));
-
-await Volume.remove("my-data");                 // 4. delete
-```
 
 ## Static methods
 


### PR DESCRIPTION
## TL;DR

Makes the SDK reference pages lighter and brings secret modification docs up to date across every SDK.

## Description

- removes the large `Typical flow` snippets from 40 SDK reference pages
- adds secret modification examples and types for TypeScript, Python, and Go
- clarifies placeholder stability and restart behavior
- tightens the August 7 changelog summary