### PR TITLE
docs: clarify SDK lifecycle and CLI setup guidance

### DIFF
--- a/docs/cli/overview.mdx
+++ b/docs/cli/overview.mdx
@@ -88,6 +88,9 @@ msb self doctor          # Check runtime files and supported host prerequisites
 msb self update          # Update msb to latest
 msb self downgrade 0.6.0 # Downgrade to a supported older release
 msb self uninstall       # Remove msb
+
+# Shell completion
+msb completion zsh       # Print the zsh completion script
 ```
 
 <Tip>
@@ -104,6 +107,48 @@ msb self uninstall       # Remove msb
 | `--info` | Show info, warnings, and errors |
 | `--debug` | Show debug output |
 | `--trace` | Show all output including trace |
+
+## Shell completion
+
+`msb completion <shell>` prints a completion script for `bash`, `zsh`, `fish`, `elvish`, or `powershell`. Write it to the location your shell loads completions from:
+
+<CodeGroup>
+```bash bash
+# Requires the bash-completion package. Without it, add this line to
+# ~/.bashrc instead:  source <(msb completion bash)
+mkdir -p ~/.local/share/bash-completion/completions
+msb completion bash > ~/.local/share/bash-completion/completions/msb
+```
+
+```zsh zsh
+mkdir -p ~/.zsh/completions
+msb completion zsh > ~/.zsh/completions/_msb
+# Add this line to ~/.zshrc before compinit runs:
+#   fpath=(~/.zsh/completions $fpath)
+```
+
+```fish fish
+mkdir -p ~/.config/fish/completions
+msb completion fish > ~/.config/fish/completions/msb.fish
+```
+
+```elvish elvish
+mkdir -p ~/.config/elvish/completions
+msb completion elvish > ~/.config/elvish/completions/msb.elv
+# Add this line to ~/.config/elvish/rc.elv:
+#   eval (slurp < ~/.config/elvish/completions/msb.elv)
+```
+
+```powershell PowerShell
+$completions = Join-Path (Split-Path $PROFILE) "completions"
+New-Item -Path $completions -ItemType Directory -Force | Out-Null
+msb completion powershell > (Join-Path $completions "msb.ps1")
+# Add this line to your profile ($PROFILE):
+#   . "$PSScriptRoot/completions/msb.ps1"
+```
+</CodeGroup>
+
+Then restart your shell.
 
 ## Command tree
 

--- a/docs/cli/overview.mdx
+++ b/docs/cli/overview.mdx
@@ -16,12 +16,16 @@ The same CLI drives [microsandbox cloud](/cloud/overview) when an API key is set
 curl -fsSL https://install.microsandbox.dev | sh
 ```
 
+```bash Homebrew (macOS)
+brew install superradcompany/tap/microsandbox
+```
+
 ```powershell CLI (Windows)
 irm https://install.microsandbox.dev/windows | iex
 ```
 </CodeGroup>
 
-On Linux and macOS, the installer writes the runtime to `~/.microsandbox/` and creates command links in `~/.local/bin/`. It does not edit shell startup files. If `~/.local/bin` is not on your `PATH`, the installer prints the command to add it. On Windows, use PowerShell; Windows support is currently in preview, and Windows 11 is the tested path.
+On Linux and macOS, the install script writes the runtime to `~/.microsandbox/` and creates command links in `~/.local/bin/`. It does not edit shell startup files. If `~/.local/bin` is not on your `PATH`, the installer prints the command to add it. On macOS, Homebrew provides the same CLI through the official tap. On Windows, use PowerShell; Windows support is currently in preview, and Windows 11 is the tested path.
 
 <Note>
   microsandbox requires glibc-based Linux with KVM enabled, macOS with Apple Silicon (M-series chip), or Windows 11 with Windows Hypervisor Platform enabled. Local sandboxes use hardware virtualization. See [Linux troubleshooting](/troubleshooting/linux), [macOS troubleshooting](/troubleshooting/macos), or [Windows troubleshooting](/troubleshooting/windows) for platform-specific notes.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -105,6 +105,7 @@
             "icon": "flag",
             "pages": [
               "sdk/overview",
+              "sdk/setup",
               "sdk/errors",
               "configuration"
             ]

--- a/docs/getting-started/quickstart.mdx
+++ b/docs/getting-started/quickstart.mdx
@@ -41,6 +41,10 @@ icon: "bolt"
     curl -fsSL https://install.microsandbox.dev | sh
     ```
 
+    ```bash Homebrew (macOS)
+    brew install superradcompany/tap/microsandbox
+    ```
+
     ```powershell CLI (Windows)
     irm https://install.microsandbox.dev/windows | iex
     ```

--- a/docs/sandboxes/lifecycle.mdx
+++ b/docs/sandboxes/lifecycle.mdx
@@ -293,7 +293,7 @@ result, err := sb.WaitUntilStopped(ctx)
 
 ## Remove
 
-Delete a stopped sandbox and its associated state from disk.
+Delete a stopped sandbox. Every local SDK entry point and `msb rm` uses the same deletion scope.
 
 <CodeGroup>
 ```rust Rust
@@ -317,6 +317,18 @@ msb rm worker
 ```
 
 </CodeGroup>
+
+For a local sandbox, removal deletes sandbox-owned state while leaving independently managed resources intact:
+
+| Removed | Kept |
+|---------|------|
+| Sandbox record, configuration, status, labels, and run history | Cached OCI images and layers |
+| Managed OCI writable root disk (`upper.ext4`) and its guest filesystem changes | Named volumes and their contents |
+| Captured sandbox logs | Snapshots created from the sandbox |
+| Runtime staging files, including generated scripts | Bind-mounted host files or directories |
+| Root filesystem pin metadata for this sandbox | User-supplied root disk images |
+
+Removing a sandbox does not undo writes made to a named volume, bind mount, or user-supplied disk image. On cloud, removal deletes the remote sandbox resource; the local disk details above do not apply.
 
 ## List and inspect
 

--- a/docs/sdk/go/sandbox.mdx
+++ b/docs/sdk/go/sandbox.mdx
@@ -5,7 +5,7 @@ description: Go SDK - Sandbox API reference
 
 Create and control a microVM sandbox: boot it from an image, run commands, stream logs and metrics, then shut it down. See [Overview](/sandboxes/overview) for configuration examples and [Lifecycle](/sandboxes/lifecycle) for state management. Examples assume the package is imported as `m "github.com/superradcompany/microsandbox/sdk/go"`.
 
-For local sandboxes, call [`EnsureInstalled`](#m-ensureinstalled) once at process startup. It installs the `msb` + `libkrunfw` runtime into `~/.microsandbox/` when needed, is idempotent, and surfaces runtime setup failures before the first sandbox operation. Use [`IsInstalled`](#m-isinstalled) when you only need to check whether the runtime is already present.
+For local runtime installation and verification, see [Runtime setup](/sdk/setup#install-and-verify).
 
 
 ## Functions
@@ -301,87 +301,12 @@ Return a point-in-time [`Metrics`](#metrics) snapshot for every running sandbox,
   </div>
 </div>
 
-#### <span className="msb-recv">m.</span><span className="msb-hn">EnsureInstalled()</span>
+<span id="m-ensureinstalled"></span>
+<span id="m-isinstalled"></span>
+<span id="m-sdkversion"></span>
+<span id="m-runtimeversion"></span>
 
-```go
-func EnsureInstalled(ctx context.Context, opts ...SetupOption) error
-```
-
-<Accordion title="Example">
-
-```go
-if err := m.EnsureInstalled(ctx); err != nil {
-    log.Fatalf("microsandbox setup: %v", err)
-}
-```
-
-</Accordion>
-
-Ensure `msb` + `libkrunfw` are present under `~/.microsandbox/` (`%USERPROFILE%\.microsandbox` on Windows), downloading them from the matching GitHub release if needed. Call this at process startup when the program will create local sandboxes so runtime download/setup failures surface before the first sandbox operation. The Go FFI library is embedded in the Go binary and loads automatically on first use; `EnsureInstalled` only governs the `msb` + `libkrunfw` runtime install. Idempotent; options apply only to the first call.
-
-<p className="msb-label">Parameters</p>
-
-<div className="msb-params">
-  <div className="msb-param">
-    <div className="msb-param-key"><code>ctx</code><span className="msb-type">context.Context</span></div>
-    <div className="msb-param-desc">Cancels an in-flight msb + libkrunfw download.</div>
-  </div>
-  <div className="msb-param">
-    <div className="msb-param-key"><code>opts</code><a className="msb-type" href="#setupoption">...SetupOption</a></div>
-    <div className="msb-param-desc">Install knobs, e.g. <a href="#withskipdownload">WithSkipDownload()</a>.</div>
-  </div>
-</div>
-
-#### <span className="msb-recv">m.</span><span className="msb-hn">IsInstalled()</span>
-
-```go
-func IsInstalled() bool
-```
-
-Report whether `msb` + `libkrunfw` are present on disk at the SDK's pinned version. Use this when you only need to check whether the runtime is already available at the SDK install location. Does **not** dlopen the FFI library, which ships embedded.
-
-<p className="msb-label">Returns</p>
-
-<div className="msb-params">
-  <div className="msb-param">
-    <div className="msb-param-key"><span className="msb-type">bool</span></div>
-    <div className="msb-param-desc"><code>true</code> if the runtime is present at the expected version.</div>
-  </div>
-</div>
-
-#### <span className="msb-recv">m.</span><span className="msb-hn">SDKVersion()</span>
-
-```go
-func SDKVersion() string
-```
-
-Return the microsandbox release version this SDK was compiled against.
-
-<p className="msb-label">Returns</p>
-
-<div className="msb-params">
-  <div className="msb-param">
-    <div className="msb-param-key"><span className="msb-type">string</span></div>
-    <div className="msb-param-desc">Pinned release version for this SDK build.</div>
-  </div>
-</div>
-
-#### <span className="msb-recv">m.</span><span className="msb-hn">RuntimeVersion()</span>
-
-```go
-func RuntimeVersion() (string, error)
-```
-
-Return the version reported by the loaded FFI library. Auto-loads the library on first use; returns an error with `Kind == ErrLibraryNotLoaded` only if loading fails (e.g. unsupported platform or GLIBC mismatch).
-
-<p className="msb-label">Returns</p>
-
-<div className="msb-params">
-  <div className="msb-param">
-    <div className="msb-param-key"><span className="msb-type">string</span></div>
-    <div className="msb-param-desc">FFI library version.</div>
-  </div>
-</div>
+Runtime installation and verification helpers are documented under [Runtime setup](/sdk/setup#install-and-verify). The Go-only version helpers are under [Inspect Go versions](/sdk/setup#inspect-go-versions).
 
 ## Methods
 
@@ -1694,13 +1619,9 @@ Set how long [`Kill`](#sb-kill) waits for stopped-state observation. Default: 5 
   </div>
 </div>
 
-#### <span className="msb-recv"></span><span className="msb-hn">WithSkipDownload()</span>
+<span id="withskipdownload"></span>
 
-```go
-func WithSkipDownload() SetupOption
-```
-
-Prevent [`EnsureInstalled`](#m-ensureinstalled) from fetching the msb + libkrunfw bundle from GitHub. Use when the runtime is already on disk at the install path (e.g. air-gapped CI). The embedded FFI library is unaffected. This is a [`SetupOption`](#setupoption), pass it to `EnsureInstalled`.
+The setup-only `WithSkipDownload()` option is documented under [Runtime setup](/sdk/setup#customize-installation).
 
 ## Patch
 
@@ -2441,12 +2362,6 @@ Package-level factory namespace for [`PatchConfig`](#patchconfig) values. See th
 | [`CopyFile(src, dst, opts)`](#patch-copyfile) | [`PatchConfig`](#patchconfig) | Copy a host file into the rootfs |
 | [`CopyDir(src, dst, opts)`](#patch-copydir) | [`PatchConfig`](#patchconfig) | Copy a host directory into the rootfs |
 
-### SetupOption
+<span id="setupoption"></span>
 
-<p className="msb-backref">Consumed by <a href="#m-ensureinstalled">EnsureInstalled()</a></p>
-
-```go
-type SetupOption func(*setupConfig)
-```
-
-A functional option for [`EnsureInstalled`](#m-ensureinstalled). The only helper is [`WithSkipDownload`](#withskipdownload).
+The setup-only `SetupOption` type is documented under [Runtime setup](/sdk/setup#customize-installation).

--- a/docs/sdk/go/sandbox.mdx
+++ b/docs/sdk/go/sandbox.mdx
@@ -260,7 +260,7 @@ err := m.RemoveSandbox(ctx, "api")
 
 </Accordion>
 
-Delete a stopped sandbox and all its persisted state from disk. Fails if the sandbox is still running, stop it first.
+Delete a stopped sandbox by name. See [Remove](/sandboxes/lifecycle#remove) for the exact local deletion scope and the external resources that are preserved. Fails if the sandbox is still running; stop it first.
 
 <p className="msb-label">Parameters</p>
 

--- a/docs/sdk/overview.mdx
+++ b/docs/sdk/overview.mdx
@@ -26,6 +26,8 @@ go get github.com/superradcompany/microsandbox/sdk/go
 ```
 </CodeGroup>
 
+For explicit runtime installation, verification, custom install locations, and environment overrides, see [Runtime setup](/sdk/setup).
+
 ## Small example
 
 Create a sandbox from a container image, run a command, print the output, and stop it.

--- a/docs/sdk/python/sandbox.mdx
+++ b/docs/sdk/python/sandbox.mdx
@@ -5,6 +5,7 @@ description: Python SDK - Sandbox API reference
 
 Create and control a microVM sandbox: boot it from an image, run commands, stream logs and metrics, then shut it down. See [Overview](/sandboxes/overview) for configuration examples and [Lifecycle](/sandboxes/lifecycle) for state management.
 
+For local runtime installation and verification, see [Runtime setup](/sdk/setup#install-and-verify).
 
 ## Static methods
 

--- a/docs/sdk/python/sandbox.mdx
+++ b/docs/sdk/python/sandbox.mdx
@@ -268,7 +268,7 @@ await Sandbox.remove("api")
 
 </Accordion>
 
-Delete a stopped sandbox and all its state from disk (configuration, logs, runtime directory). Fails if the sandbox is still running; stop it first.
+Delete a stopped sandbox by name. See [Remove](/sandboxes/lifecycle#remove) for the exact local deletion scope and the external resources that are preserved. Fails if the sandbox is still running; stop it first.
 
 <p className="msb-label">Parameters</p>
 

--- a/docs/sdk/rust/sandbox.mdx
+++ b/docs/sdk/rust/sandbox.mdx
@@ -149,7 +149,7 @@ Sandbox::remove("api").await?;
 
 </Accordion>
 
-Delete a stopped sandbox and all its state from disk (configuration, logs, runtime directory). Fails if the sandbox is still running - stop it first.
+Delete a stopped sandbox by name. Locally, this removes the same state as [`sb.remove_persisted()`](#remove-persisted); see [Remove](/sandboxes/lifecycle#remove) for the exact deletion scope. Unlike `remove_persisted()`, this associated function routes through the default backend and also supports cloud sandboxes. Fails if the sandbox is still running—stop it first.
 
 <p className="msb-label">Parameters</p>
 
@@ -636,12 +636,13 @@ async fn remove_persisted(&self) -> MicrosandboxResult<()>
 <Accordion title="Example">
 
 ```rust
+sb.stop().await?;
 sb.remove_persisted().await?;
 ```
 
 </Accordion>
 
-Remove the sandbox and all its persisted state from disk.
+Delete this stopped sandbox's local persisted state. This is the receiver-based form to use when you still hold the `Sandbox` instance; it is local-only and has exactly the same local deletion scope as [`Sandbox::remove(name)`](#remove). It does **not** perform additional cleanup. See [Remove](/sandboxes/lifecycle#remove) for what is deleted and which external resources are preserved.
 
 #### <span className="msb-recv">sb.</span><span className="msb-hn">request_stop()</span>
 

--- a/docs/sdk/rust/sandbox.mdx
+++ b/docs/sdk/rust/sandbox.mdx
@@ -5,6 +5,7 @@ description: Rust SDK - Sandbox API reference
 
 Create and control a microVM sandbox: boot it from an image, run commands, stream logs and metrics, then shut it down. See [Overview](/sandboxes/overview) for configuration examples and [Lifecycle](/sandboxes/lifecycle) for state management.
 
+For local runtime installation and verification, see [Runtime setup](/sdk/setup#install-and-verify).
 
 ## Static methods
 

--- a/docs/sdk/setup.mdx
+++ b/docs/sdk/setup.mdx
@@ -1,0 +1,155 @@
+---
+title: Runtime setup
+description: Install, verify, and configure microsandbox runtime dependencies from every SDK
+icon: "download"
+---
+
+Local sandboxes use the `msb` executable and `libkrunfw` library. Depending on the SDK and installation method, those runtime files may already be bundled or may need to be downloaded. Each SDK exposes helpers that let an application verify the runtime before creating its first sandbox.
+
+The default install root is `~/.microsandbox/` (`%USERPROFILE%\.microsandbox` on Windows). Explicit setup is useful when you want installation failures to surface at process startup or when you are preparing an offline environment.
+
+## Install and verify
+
+Check for the runtime and install it only when needed. These installation helpers are idempotent and reuse a matching installation.
+
+<CodeGroup>
+```rust Rust
+use microsandbox::setup;
+
+if !setup::is_installed() {
+    setup::install().await?;
+}
+```
+
+```typescript TypeScript
+import { install, isInstalled } from "microsandbox";
+
+if (!isInstalled()) {
+  await install();
+}
+```
+
+```python Python
+from microsandbox import install, is_installed
+
+if not is_installed():
+    await install()
+```
+
+```go Go
+import m "github.com/superradcompany/microsandbox/sdk/go"
+
+if !m.IsInstalled() {
+    if err := m.EnsureInstalled(ctx); err != nil {
+        return err
+    }
+}
+```
+</CodeGroup>
+
+| SDK | Install | Check | Behavior |
+|-----|---------|-------|----------|
+| Rust | `setup::install() -> MicrosandboxResult<()>` | `setup::is_installed() -> bool` | Downloads the SDK's pinned runtime and verifies it. |
+| TypeScript | `install(): Promise<void>` | `isInstalled(): boolean` | Downloads the package's pinned runtime and verifies it. |
+| Python | `install() -> None` (async) | `is_installed() -> bool` | Installs and verifies the runtime; release wheels normally bundle matching files. |
+| Go | `EnsureInstalled(ctx, ...SetupOption) error` | `IsInstalled() bool` | Installs `msb` and `libkrunfw`; the Go FFI library is embedded separately. |
+
+## Customize installation
+
+Rust and TypeScript expose builders for custom install roots, versions, verification, and forced downloads. Go exposes `WithSkipDownload()` for pre-provisioned or air-gapped environments. Python's setup helper uses the default installation behavior.
+
+<CodeGroup>
+```rust Rust
+use microsandbox::setup::Setup;
+
+Setup::builder()
+    .base_dir("/opt/microsandbox")
+    .version("0.6.8")
+    .skip_verify(false)
+    .force(true)
+    .build()
+    .install()
+    .await?;
+```
+
+```typescript TypeScript
+import { setup } from "microsandbox";
+
+await setup()
+  .baseDir("/opt/microsandbox")
+  .version("0.6.8")
+  .skipVerify(false)
+  .force(true)
+  .install();
+```
+
+```go Go
+import m "github.com/superradcompany/microsandbox/sdk/go"
+
+// Do not download. Return an error if the runtime was not pre-provisioned.
+if err := m.EnsureInstalled(ctx, m.WithSkipDownload()); err != nil {
+    return err
+}
+```
+</CodeGroup>
+
+| Option | SDKs | Description |
+|--------|------|-------------|
+| Install root | Rust: `base_dir(path)`<br />TypeScript: `baseDir(path)` | Override `~/.microsandbox/`. |
+| Runtime version | Rust: `version(version)`<br />TypeScript: `version(version)` | Install a specific runtime version instead of the SDK's pinned version. |
+| Skip verification | Rust: `skip_verify(enabled)`<br />TypeScript: `skipVerify(enabled)` | Skip post-install verification. |
+| Force download | Rust: `force(enabled)`<br />TypeScript: `force(enabled)` | Download again even when matching files are present. |
+| Skip download | Go: `WithSkipDownload()` | Require the runtime to be present without fetching it. |
+
+<span id="go-with-skip-download"></span>
+<span id="go-setupoption"></span>
+
+In Go, `WithSkipDownload()` returns a `SetupOption`, whose exported type is `func(*setupConfig)`. Options apply only to the first `EnsureInstalled()` call.
+
+## Override runtime paths
+
+The Rust, TypeScript, and Python SDKs can override the process-wide `libkrunfw` path directly. Call the setter before creating a local sandbox.
+
+<CodeGroup>
+```rust Rust
+use microsandbox::set_libkrunfw_path;
+
+set_libkrunfw_path("/opt/microsandbox/lib/libkrunfw.dylib");
+```
+
+```typescript TypeScript
+import { setRuntimeLibkrunfwPath } from "microsandbox";
+
+setRuntimeLibkrunfwPath("/opt/microsandbox/lib/libkrunfw.dylib");
+```
+
+```python Python
+from microsandbox import set_libkrunfw_path
+
+set_libkrunfw_path("/opt/microsandbox/lib/libkrunfw.dylib")
+```
+</CodeGroup>
+
+Environment variables work across the SDKs and take precedence over SDK-provided or configured paths:
+
+| Variable | Purpose |
+|----------|---------|
+| `MSB_PATH` | Override the `msb` executable used by local SDK operations. |
+| `MSB_LIBKRUNFW_PATH` | Override the `libkrunfw` shared library loaded by the process. |
+
+Set these process-wide overrides before creating any local sandbox. They do not belong to an individual sandbox configuration.
+
+## Inspect Go versions
+
+Go also exposes the SDK's pinned release version and the version reported by the loaded FFI library:
+
+```go
+sdkVersion := m.SDKVersion()
+
+runtimeVersion, err := m.RuntimeVersion()
+if err != nil {
+    return err
+}
+```
+
+`SDKVersion() string` does not load the FFI library. `RuntimeVersion() (string, error)` loads it automatically on first use and returns an error if loading fails.

--- a/docs/sdk/typescript/filesystem.mdx
+++ b/docs/sdk/typescript/filesystem.mdx
@@ -8,7 +8,7 @@ Read and write files inside a running sandbox over the same host-guest channel a
 
 ## SandboxFsOps
 
-Filesystem handle for a running sandbox, obtained via [`sandbox.fs()`](/sdk/typescript/sandbox#sandboxfs). Every method is async and returns a `Promise`. Paths are absolute inside the guest.
+Filesystem handle for a running sandbox, obtained via [`sandbox.fs()`](/sdk/typescript/sandbox#sandbox-fs). Every method is async and returns a `Promise`. Paths are absolute inside the guest.
 
 #### <span className="msb-recv">fs.</span><span className="msb-hn">read()</span>
 

--- a/docs/sdk/typescript/sandbox.mdx
+++ b/docs/sdk/typescript/sandbox.mdx
@@ -7,8 +7,17 @@ Create and control a microVM sandbox: boot it from an image, run commands, strea
 
 The TypeScript SDK uses a **builder-only** entry point. Start every new sandbox from `Sandbox.builder(name)` and chain configuration calls before terminating with `.create()`. Use `.detached(true)` before `.create()` for detached/background mode. Sandbox names must be non-empty and no longer than 128 UTF-8 bytes.
 
-`libkrunfw` selection is process-level, not per sandbox. To use a custom library, call `setRuntimeLibkrunfwPath(path)` before creating local sandboxes, set `MSB_LIBKRUNFW_PATH`, or configure `paths.libkrunfw`.
+`libkrunfw` selection is process-level, not per sandbox. See [Runtime setup](/sdk/setup#override-runtime-paths) for installation, verification, and path overrides.
 
+## Functions
+
+#### <span className="msb-hn">allSandboxMetrics()</span>
+
+```typescript
+allSandboxMetrics(): Promise<Record<string, SandboxMetrics>>
+```
+
+Return one [`SandboxMetrics`](#sandboxmetrics) snapshot for every running sandbox, keyed by sandbox name. See [Metrics](/sandboxes/metrics) for a complete example.
 
 ## Static methods
 
@@ -1529,7 +1538,7 @@ Suppress sandbox process log output.
 <Tooltip tip="On microsandbox cloud, plain-HTTP and custom-CA registry options are not available; credential auth still works."><span className="msb-badge-limited">Limited on cloud <Icon icon="circle-info" size={11} /></span></Tooltip>
 
 ```typescript
-registry(configure: (b: RegistryBuilder) => RegistryBuilder): this
+registry(configure: (b: RegistryConfigBuilder) => RegistryConfigBuilder): this
 ```
 
 <Accordion title="Example">
@@ -1537,7 +1546,9 @@ registry(configure: (b: RegistryBuilder) => RegistryBuilder): this
 ```typescript
 const sandbox = await Sandbox.builder("worker")
   .image("registry.internal/app:latest")
-  .registry((r) => r.auth("user", "token"))
+  .registry((r) =>
+    r.auth({ kind: "basic", username: "user", password: "token" }),
+  )
   .create();
 ```
 
@@ -1549,8 +1560,8 @@ Configure the OCI registry connection: authentication, insecure transport, and C
 
 <div className="msb-params">
   <div className="msb-param">
-    <div className="msb-param-key"><code>configure</code><span className="msb-type">(b: RegistryBuilder) =&gt; RegistryBuilder</span></div>
-    <div className="msb-param-desc">Configure the registry.</div>
+    <div className="msb-param-key"><code>configure</code><a className="msb-type" href="#registryconfigbuilder">(b: RegistryConfigBuilder) =&gt; RegistryConfigBuilder</a></div>
+    <div className="msb-param-desc">Configure registry authentication, transport, and CA certificates.</div>
   </div>
 </div>
 
@@ -2189,6 +2200,48 @@ Async iterable creation handle returned by [`createWithPullProgress()`](#createw
 | `[Symbol.asyncIterator]()` | `AsyncIterator<`[`PullProgress`](#pullprogress)`>` | Use with `for await...of` |
 | `awaitSandbox()` | `Promise<`[`Sandbox`](#instance-methods)`>` | Resolve the underlying creation task and return the running sandbox |
 
+### RegistryAuth
+
+Authentication used when pulling images from an OCI registry.
+
+```typescript
+type RegistryAuth =
+  | { kind: "anonymous" }
+  | { kind: "basic"; username: string; password: string };
+```
+
+### RegistryConfigBuilder
+
+Fluent builder for OCI registry connection settings. Obtain it through [`SandboxBuilder.registry()`](#registry); the callback's returned builder is stored in the sandbox configuration.
+
+```typescript
+.registry((r) =>
+  r.auth({ kind: "basic", username: "user", password: "token" })
+    .caCertsPath("/etc/company-registry-ca.pem"),
+)
+```
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `auth(auth)` | `this` | Set [`RegistryAuth`](#registryauth) credentials. |
+| `insecure()` | `this` | Use plain HTTP instead of TLS. |
+| `caCerts(pemData)` | `this` | Add a PEM-encoded CA certificate from a Node.js `Buffer`. May be called repeatedly. |
+| `caCertsPath(path)` | `this` | Read and add a PEM-encoded CA certificate from a filesystem path. |
+| `build()` | [`RegistryConfig`](#registryconfig) | Snapshot the accumulated registry configuration. |
+
+### RegistryConfig
+
+<p className="msb-backref">Built by <a href="#registryconfigbuilder">RegistryConfigBuilder</a> · stored in <a href="#sandboxconfig">SandboxConfig.registry</a></p>
+
+OCI registry connection settings produced by [`RegistryConfigBuilder.build()`](#registryconfigbuilder).
+
+| Field | Type | Description |
+|-------|------|-------------|
+| auth | [`RegistryAuth`](#registryauth)` \| undefined` | Registry authentication, if configured. |
+| insecure | `boolean` | Whether to use plain HTTP instead of TLS. |
+| caCertsCount | `number` | Number of CA certificates added through `caCerts()` or `caCertsPath()`. |
+| caCertsPath | `string \| undefined` | Last CA certificate path passed to `caCertsPath()`, if any. |
+
 ### SandboxConfig
 
 <p className="msb-backref">Returned by <a href="#sandbox-config">config()</a> · <a href="#build">build()</a></p>
@@ -2223,7 +2276,7 @@ Configuration object produced by [`build()`](#build) and returned by [`config()`
 | idleTimeoutSecs | `number \| null` | Stop after idle time |
 | portsTcp | `Array<readonly [number, number]>` | TCP host→guest mappings |
 | portsUdp | `Array<readonly [number, number]>` | UDP host→guest mappings |
-| registry | `RegistryConfig \| null` | Registry connection settings |
+| registry | [`RegistryConfig`](#registryconfig)` \| null` | Registry connection settings |
 | network | `NetworkConfig \| null` | Network configuration |
 | disableNetwork | `boolean` | Disable networking entirely |
 | secrets | `SecretEntry[]` | Secret entries (top-level) |

--- a/docs/sdk/typescript/sandbox.mdx
+++ b/docs/sdk/typescript/sandbox.mdx
@@ -176,7 +176,7 @@ await Sandbox.remove("api");
 
 </Accordion>
 
-Delete a stopped sandbox and all its state from disk (configuration, logs, runtime directory). Fails if the sandbox is still running - stop it first.
+Delete a stopped sandbox by name. See [Remove](/sandboxes/lifecycle#remove) for the exact local deletion scope and the external resources that are preserved. Fails if the sandbox is still running—stop it first.
 
 <p className="msb-label">Parameters</p>
 

--- a/docs/sdk/typescript/secrets.mdx
+++ b/docs/sdk/typescript/secrets.mdx
@@ -271,7 +271,7 @@ Fluent builder for the action taken when a secret placeholder is sent to a disal
 block(): this
 ```
 
-Silently drop a violating request. The guest sees a connection reset. This is the default.
+Silently drop a violating request. The guest sees a connection reset. The default is [`blockAndLog()`](#blockandlog).
 
 #### <span className="msb-recv">.</span><span className="msb-hn">blockAndLog()</span>
 
@@ -586,7 +586,7 @@ type ViolationAction = "block" | "block-and-log" | "block-and-terminate" | "pass
 
 | Value | Builder method | Description |
 |-------|----------------|-------------|
-| `'block'` | [`block()`](#block) | Silently drop the request. The guest sees a connection reset. This is the default. |
-| `'block-and-log'` | [`blockAndLog()`](#blockandlog) | Drop the request and emit a warning log on the host side. |
+| `'block'` | [`block()`](#block) | Silently drop the request. The guest sees a connection reset. |
+| `'block-and-log'` | [`blockAndLog()`](#blockandlog) | Drop the request and emit a warning log on the host side. This is the default. |
 | `'block-and-terminate'` | [`blockAndTerminate()`](#blockandterminate) | Drop the request, log an error, and shut down the entire sandbox. |
 | `'passthrough'` | [`passthroughHost()`](#passthroughhost) / [`passthroughHostPattern()`](#passthroughhostpattern) / [`passthroughAllHosts()`](#passthroughallhosts) | Forward matching hosts with the placeholder unchanged. Non-matching hosts use the base block action. |


### PR DESCRIPTION
## TL;DR

Adds a shared, tabbed runtime setup guide, documents CLI installation and shell completion, clarifies sandbox removal semantics, and resolves the remaining TypeScript documentation drift tracked in #591.

## Description

- document runtime installation and verification in language-switching code groups for Rust, TypeScript, Python, and Go
- organize setup around common workflows instead of per-language API headings
- move setup-specific Go and TypeScript material out of sandbox references while preserving Go deep-link anchors
- add the official Homebrew installation command to the Quickstart and CLI overview
- add tabbed shell-completion installation instructions for Bash, Zsh, Fish, Elvish, and PowerShell
- clarify that Rust's by-name and receiver-based removal APIs have the same local deletion scope
- document exactly which sandbox-owned artifacts are removed and which external resources are preserved
- correct the TypeScript registry builder name, credentials example, and registry types
- document the TypeScript module-level metrics helper
- correct the default secret violation action to `block-and-log`
- fix the broken TypeScript `sandbox.fs()` reference anchor
- Closes #591

## Test Plan

- `cd sdk/node-ts && npm run typecheck`
- `git diff --check`
- parse `docs/docs.json` as JSON
- validate links to headings on the shared Runtime setup page
- validate all SDK removal references against the shared lifecycle scope
- verify balanced Mintlify `CodeGroup` blocks and completion examples for all five supported shells
- verify the Homebrew command matches the README and appears in both primary installation flows
- run a stale-pattern sweep for obsolete TypeScript SDK shapes
