### PR TITLE
feat(config): configure deployment profile from config.json

### DIFF
--- a/docs/configuration.mdx
+++ b/docs/configuration.mdx
@@ -11,6 +11,7 @@ microsandbox reads its global configuration from `~/.microsandbox/config.json`. 
 {
   "home": "/custom/path/.microsandbox",
   "log_level": "info",
+  "deployment_profile": "multi-tenant",
   "database": {
     "url": "sqlite:///tmp/msb.db",
     "max_connections": 10,
@@ -94,6 +95,7 @@ microsandbox reads its global configuration from `~/.microsandbox/config.json`. 
 |-------|---------|-------------|
 | `home` | `~/.microsandbox` | Root directory for all microsandbox data |
 | `log_level` | `null` (silent) | Log level for sandbox processes: `error`, `warn`, `info`, `debug`, `trace` |
+| `deployment_profile` | `null` | Authoritative local host-runtime isolation profile: `single-tenant` or `multi-tenant` |
 | `database` | [reference](#database) | Database connection settings |
 | `paths` | [reference](#paths) | Path overrides for binaries and directories |
 | `sandbox_defaults` | [reference](#sandbox_defaults) | Defaults applied to local sandboxes |
@@ -102,6 +104,20 @@ microsandbox reads its global configuration from `~/.microsandbox/config.json`. 
 | `metrics` | [reference](#metrics) | Live metrics shared-memory registry settings |
 | `active_profile` | `null` | Default backend profile name |
 | `profiles` | `{}` | Named backend profiles |
+
+## `deployment_profile`
+
+Set `deployment_profile` when the local host must enforce one deployment policy for every sandbox:
+
+```json
+{
+  "deployment_profile": "multi-tenant"
+}
+```
+
+`single-tenant` preserves the network configuration requested by each sandbox. `multi-tenant` applies the host-runtime isolation floor for shared infrastructure. The configured value is authoritative on create and restart, so a per-sandbox CLI or SDK option cannot weaken or replace it. A programmatic `LocalBackendBuilder::deployment_profile()` override takes precedence over the file. When the field is absent or `null`, each sandbox selects its own profile and defaults to `single-tenant`.
+
+The parser also accepts the internal wire spellings `single_tenant` and `multi_tenant` for compatibility, but the kebab-case values above are canonical in this human-edited file. Managed cloud backends ignore this local setting because the hosting platform chooses their effective deployment profile.
 
 ## `database`
 

--- a/docs/networking/overview.mdx
+++ b/docs/networking/overview.mdx
@@ -92,7 +92,7 @@ msb create python --name shared-worker --deployment-profile multi-tenant
 ```
 </CodeGroup>
 
-An embedding host can set an authoritative profile on `LocalBackend`; that operator choice overrides the sandbox request on create and restart. Managed cloud create requests intentionally do not carry a deployment profile—the hosting driver selects it.
+An operator can set an authoritative profile with the top-level `deployment_profile` field in `~/.microsandbox/config.json` or programmatically on `LocalBackend`. That operator choice overrides the sandbox request on create and restart. Managed cloud create requests intentionally do not carry a deployment profile—the hosting driver selects it.
 
 ## High-level profiles
 

--- a/sdk/rust/lib/backend/local/mod.rs
+++ b/sdk/rust/lib/backend/local/mod.rs
@@ -128,11 +128,12 @@ impl LocalBackend {
         selection_source: BackendSelectionSource,
         profile: Option<String>,
     ) -> Self {
-        let config = Arc::new(load_persisted_config_or_default().unwrap_or_default());
+        let config = load_persisted_config_or_default().unwrap_or_default();
+        let deployment_profile = config.deployment_profile;
         Self {
-            config,
+            config: Arc::new(config),
             db: OnceCell::new(),
-            deployment_profile: None,
+            deployment_profile,
             selection_source,
             profile,
         }
@@ -410,8 +411,8 @@ impl LocalBackendBuilder {
     /// sandbox state.
     pub fn build_lazy(self) -> LocalBackend {
         let persisted = load_persisted_config_or_default().unwrap_or_default();
-        let deployment_profile = self.deployment_profile;
         let config = self.merge_into(persisted);
+        let deployment_profile = config.deployment_profile;
         LocalBackend {
             config: Arc::new(config),
             db: OnceCell::new(),
@@ -444,7 +445,7 @@ impl LocalBackendBuilder {
             ca_certs,
             registry_hosts,
             log_level,
-            deployment_profile: _,
+            deployment_profile,
         } = self;
 
         if let Some(home) = home {
@@ -452,6 +453,9 @@ impl LocalBackendBuilder {
         }
         if let Some(level) = log_level {
             base.log_level = Some(level);
+        }
+        if let Some(profile) = deployment_profile {
+            base.deployment_profile = Some(profile);
         }
 
         if let Some(v) = max_connections {
@@ -1233,6 +1237,7 @@ mod tests {
         // wrote to ~/.microsandbox/config.json.
         let base = LocalConfig {
             log_level: Some(microsandbox_runtime::logging::LogLevel::Debug),
+            deployment_profile: Some(DeploymentProfile::MultiTenant),
             database: DatabaseConfig {
                 url: None,
                 max_connections: 9,
@@ -1276,6 +1281,27 @@ mod tests {
         assert_eq!(
             merged.log_level,
             Some(microsandbox_runtime::logging::LogLevel::Debug)
+        );
+        assert_eq!(
+            merged.deployment_profile,
+            Some(DeploymentProfile::MultiTenant)
+        );
+    }
+
+    #[test]
+    fn builder_deployment_profile_overrides_persisted_policy() {
+        let base = LocalConfig {
+            deployment_profile: Some(DeploymentProfile::SingleTenant),
+            ..Default::default()
+        };
+
+        let merged = LocalBackend::builder()
+            .deployment_profile(DeploymentProfile::MultiTenant)
+            .merge_into(base);
+
+        assert_eq!(
+            merged.deployment_profile,
+            Some(DeploymentProfile::MultiTenant)
         );
     }
 }

--- a/sdk/rust/lib/config/mod.rs
+++ b/sdk/rust/lib/config/mod.rs
@@ -21,7 +21,7 @@ use std::{
 use docker_credential::{CredentialRetrievalError, DockerCredential};
 use microsandbox_image::RegistryAuth;
 use microsandbox_runtime::logging::LogLevel;
-use microsandbox_types::{CpuPlacement, RootDisk, TransparentHugePagePolicy};
+use microsandbox_types::{CpuPlacement, DeploymentProfile, RootDisk, TransparentHugePagePolicy};
 use serde::{Deserialize, Serialize};
 
 use crate::error::Operation;
@@ -62,6 +62,40 @@ pub(crate) mod metrics_interval_serde {
 
     pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<Option<NonZero<u64>>, D::Error> {
         Ok(NonZero::new(u64::deserialize(d)?))
+    }
+}
+
+/// Serde adapter for the human-facing deployment profile names used in `config.json`.
+///
+/// Sandbox wire data uses snake_case, while the CLI and SDKs expose kebab-case
+/// names. Accepting both forms keeps existing serialized values readable and
+/// gives the hand-edited global config one canonical spelling.
+mod deployment_profile_serde {
+    use microsandbox_types::DeploymentProfile;
+    use serde::{Deserialize, Deserializer, Serializer, de::Error as _};
+
+    pub fn serialize<S: Serializer>(
+        profile: &Option<DeploymentProfile>,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error> {
+        match profile {
+            Some(DeploymentProfile::SingleTenant) => serializer.serialize_some("single-tenant"),
+            Some(DeploymentProfile::MultiTenant) => serializer.serialize_some("multi-tenant"),
+            None => serializer.serialize_none(),
+        }
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<Option<DeploymentProfile>, D::Error> {
+        match Option::<String>::deserialize(deserializer)?.as_deref() {
+            Some("single-tenant" | "single_tenant") => Ok(Some(DeploymentProfile::SingleTenant)),
+            Some("multi-tenant" | "multi_tenant") => Ok(Some(DeploymentProfile::MultiTenant)),
+            Some(other) => Err(D::Error::custom(format!(
+                "unknown deployment profile {other:?}; expected `single-tenant` or `multi-tenant`"
+            ))),
+            None => Ok(None),
+        }
     }
 }
 
@@ -108,6 +142,18 @@ pub struct LocalConfig {
     /// `None` means sandbox runtime processes are silent unless overridden
     /// per-sandbox.
     pub log_level: Option<LogLevel>,
+
+    /// Authoritative host-runtime isolation profile for local sandboxes.
+    ///
+    /// When set, this operator policy overrides the profile requested by an
+    /// individual sandbox on create and restart. `None` preserves per-sandbox
+    /// selection and its built-in `single-tenant` default.
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "deployment_profile_serde"
+    )]
+    pub deployment_profile: Option<DeploymentProfile>,
 
     /// Database configuration.
     pub database: DatabaseConfig,
@@ -1240,6 +1286,7 @@ mod tests {
             NonZero::new(DEFAULT_METRICS_SAMPLE_INTERVAL_MS)
         );
         assert_eq!(cfg.log_level, None);
+        assert_eq!(cfg.deployment_profile, None);
         assert_eq!(cfg.database.max_connections, 5);
         assert_eq!(cfg.database.connect_timeout_secs, 30);
         assert_eq!(cfg.database.busy_timeout_secs, 5);
@@ -1270,6 +1317,33 @@ mod tests {
         let cfg: LocalConfig = serde_json::from_str(json).unwrap();
         assert_eq!(cfg.sandbox_defaults.cpus, 4);
         assert_eq!(cfg.sandbox_defaults.memory_mib, 512);
+    }
+
+    #[test]
+    fn test_deployment_profile_uses_human_facing_config_values() {
+        let cfg: LocalConfig =
+            serde_json::from_str(r#"{"deployment_profile":"multi-tenant"}"#).unwrap();
+        assert_eq!(cfg.deployment_profile, Some(DeploymentProfile::MultiTenant));
+
+        let json = serde_json::to_value(cfg).unwrap();
+        assert_eq!(json["deployment_profile"], "multi-tenant");
+    }
+
+    #[test]
+    fn test_deployment_profile_accepts_snake_case_wire_values() {
+        let cfg: LocalConfig =
+            serde_json::from_str(r#"{"deployment_profile":"single_tenant"}"#).unwrap();
+        assert_eq!(
+            cfg.deployment_profile,
+            Some(DeploymentProfile::SingleTenant)
+        );
+    }
+
+    #[test]
+    fn test_deployment_profile_rejects_unknown_values() {
+        let error =
+            serde_json::from_str::<LocalConfig>(r#"{"deployment_profile":"shared"}"#).unwrap_err();
+        assert!(error.to_string().contains("unknown deployment profile"));
     }
 
     #[test]


### PR DESCRIPTION
## TL;DR
Let local host operators enforce `single-tenant` or `multi-tenant` deployment policy for every sandbox from the global config file.

## Description
- Add an optional top-level `deployment_profile` field to `LocalConfig`, using `single-tenant` and `multi-tenant` as the canonical human-facing values while accepting snake_case wire values for compatibility.
- Apply the configured profile as authoritative host policy for ambient and explicitly built local backends on sandbox create and restart, with programmatic backend configuration retaining highest precedence.
- Preserve existing behavior when the field is absent or null, so sandboxes keep their requested profile and default to `single-tenant`.
- Document the local-only scope, precedence, accepted spellings, and the narrow Rust source compatibility impact for exhaustive `LocalConfig` struct literals.
- Configure a shared local host with:

```json
{
  "deployment_profile": "multi-tenant"
}
```

## Test Plan
- [x] `cargo fmt --all -- --check` exits 0
- [x] `cargo clippy -p microsandbox --lib -- -D warnings` exits 0
- [x] `cargo test -p microsandbox --lib` passes with 535 passed and 3 platform-specific ignored tests
- [x] `cargo test -p microsandbox-cli --lib` passes all 270 tests
