### PR TITLE
fix(runtime): clear error when a bind-mount host directory is permission-denied

### DIFF
--- a/crates/runtime/lib/vm.rs
+++ b/crates/runtime/lib/vm.rs
@@ -1411,6 +1411,8 @@ fn build_vm(
             .map_err(|e| RuntimeError::Custom(format!("--mount {mount_spec:?}: {e}")))?;
 
         let tag = parsed.tag;
+        // Keep the host path so a mount failure can name the directory.
+        let host_path = parsed.host_path.clone();
         #[cfg(unix)]
         let mount_bind_identity_map =
             bind_identity_map_for_mount(&mut bind_identity_map, parsed.stat_virtualization);
@@ -1428,8 +1430,18 @@ fn build_vm(
             quota_bytes: parsed.quota_bytes,
             ..Default::default()
         };
-        let backend = PassthroughFs::new(cfg)
-            .map_err(|e| RuntimeError::Custom(format!("mount {tag}: {e}")))?;
+        let backend = PassthroughFs::new(cfg).map_err(|e| {
+            // Name the folder on a permission error, usually an OS access restriction.
+            if e.kind() == std::io::ErrorKind::PermissionDenied {
+                RuntimeError::Custom(format!(
+                    "mount {tag}: permission denied reading host folder {} ({e}). \
+                     On macOS, grant access in System Settings > Privacy & Security.",
+                    host_path.display()
+                ))
+            } else {
+                RuntimeError::Custom(format!("mount {tag}: {e}"))
+            }
+        })?;
         builder = builder.fs(move |fs| fs.tag(&tag).custom(Box::new(backend)));
     }
 


### PR DESCRIPTION
When a directory bind mount's host root can't be opened due to a permission error,
`build_vm` surfaced only `mount <tag>: Operation not permitted (os error 1)` — an opaque
internal tag, no path, and it reads like a crash rather than a fixable access problem.

Common on macOS: a process without access to a protected folder (Documents/Desktop/Downloads)
or without Full Disk Access gets EPERM opening the mount root; the same sandbox started from a
context that *does* have access works, which makes the bare errno especially confusing.

Detect `io::ErrorKind::PermissionDenied` from `PassthroughFs::new` and return a message that names
the host folder and says, in plain language, how to grant access. Non-permission errors keep the
existing format. Message-only, cross-platform, no behavior change.

<!-- greptile_comment -->

<sub>Reviews (1): Last reviewed commit: ["fix(runtime): clear error when a bind-mo..."](https://github.com/superradcompany/microsandbox/commit/f718a9f9c14a7d3a03ee85569b3c60a51744823b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53418202)</sub>

<!-- /greptile_comment -->