### PR TITLE
feat(runtime): degrade placement under pressure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4227,9 +4227,9 @@ dependencies = [
 
 [[package]]
 name = "msb_krun"
-version = "0.1.30"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b57b2304dc1cef25b7cdd93be44c6515a97c90e00308b7d35eabc4fe27b02af5"
+checksum = "40e6b83f6cf90f676779409ac026f4429adfd7a11886085a59773ddd3aa8207f"
 dependencies = [
  "crossbeam-channel",
  "kvm-bindings",
@@ -4247,9 +4247,9 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_arch"
-version = "0.1.30"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c0dad7a64ad8861a35d7a2cd93ded468a20e137fcdb40bb31b3038d80b76d61"
+checksum = "929f9765edd9e12cc45e5876998456bf2dfb0d2244d4fe6ddf2fdb5c3dd7e99c"
 dependencies = [
  "kvm-bindings",
  "kvm-ioctls",
@@ -4262,15 +4262,15 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_arch_gen"
-version = "0.1.30"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46f9c70b94c97e1bcef28bdf1178a7a4bcc2a5d881429f9a9ced7811060d0935"
+checksum = "df83bf780774e4e131547a4e17d0ca389e5bbb04cdebcb626880b090cae20f2c"
 
 [[package]]
 name = "msb_krun_cpuid"
-version = "0.1.30"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a503273f4c4e2456c71162b0792754d689968f3a264b447bf46f7bd854982818"
+checksum = "7c569d5d7285ed8f8f80e58454fb3ee213fd2c06ec647cc108a16a2e095558bb"
 dependencies = [
  "kvm-bindings",
  "kvm-ioctls",
@@ -4279,9 +4279,9 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_devices"
-version = "0.1.30"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfefdc7146bf598714637f24cdf41550addc131cc85761b553526df1c571805d"
+checksum = "422da6e72923c2debae8eaeddd2990b924df9042079b51a323b4f3de37ebbdaf"
 dependencies = [
  "bitflags 1.3.2",
  "capng",
@@ -4309,9 +4309,9 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_hvf"
-version = "0.1.30"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "decfbb680a30799333464ac15f1b13532432799249e4af0570cf8c8f68a4ba22"
+checksum = "e5034e7b5ebd4f2f8caefb199f5f18483f8ed0c5cc6afb944b6ed0d127d59aa9"
 dependencies = [
  "crossbeam-channel",
  "libloading 0.8.9",
@@ -4321,9 +4321,9 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_kernel"
-version = "0.1.30"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3313be0d646614d9902e0a35c442adf3a5fc748f693821cf7e3ba42e00f64a3d"
+checksum = "04163d07028500bf08e6247c40c64dd5bae462bbb1997cf6a9613d019976a055"
 dependencies = [
  "msb-vm-memory",
  "msb_krun_utils",
@@ -4331,9 +4331,9 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_polly"
-version = "0.1.30"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aabd0f75484ae953a5f3cf48991c3a4e4dfdfa5f440c2cdb3bc76d6044513acf"
+checksum = "9812193639b368ab800b5f87e18509ad30fd85a2e6a77a05265ffadfed2553d1"
 dependencies = [
  "libc",
  "msb_krun_utils",
@@ -4341,18 +4341,18 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_smbios"
-version = "0.1.30"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20739701381783171489500e10eeb2fb825006711d69000b44def11a0300b758"
+checksum = "8cfd3f05f6447f0ad85f04f688b106eb9f04bb64525fee1183757cf9705070a0"
 dependencies = [
  "msb-vm-memory",
 ]
 
 [[package]]
 name = "msb_krun_utils"
-version = "0.1.30"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f4f682dec7289463f89adfd1df7605a425c069d238265496a99dbff921075a9"
+checksum = "b5ce62484f07792ab43a5ac64baa84435556f56a7633805e15030e990c3b98a3"
 dependencies = [
  "bitflags 1.3.2",
  "crossbeam-channel",
@@ -4366,9 +4366,9 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_vmm"
-version = "0.1.30"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d83ca07ca40186a246ca5fa3464d68b52f939ca85c9434baa36d05aba1389be"
+checksum = "67546eb70fa306e3c7e97f525dac2db44b9cc1642b6684aec4369e3b7f9b3af3"
 dependencies = [
  "bzip2",
  "crossbeam-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,8 +79,8 @@ microsandbox-protocol = { version = "=0.6.8", path = "crates/protocol" }
 microsandbox-runtime = { version = "=0.6.8", path = "crates/runtime", default-features = false }
 microsandbox-utils = { version = "=0.6.8", path = "crates/utils" }
 microsandbox-vsock = { version = "=0.6.8", path = "crates/vsock" }
-msb_krun = "=0.1.30"
-msb_krun_utils = "=0.1.30"
+msb_krun = "=0.1.31"
+msb_krun_utils = "=0.1.31"
 test-macros = { path = "crates/test-macros" }
 test-utils = { path = "crates/test-utils" }
 

--- a/crates/cli/lib/commands/self_cmd.rs
+++ b/crates/cli/lib/commands/self_cmd.rs
@@ -3479,6 +3479,24 @@ mod tests {
         .unwrap();
         Migrator::up(db.inner(), None).await.unwrap();
 
+        // Shared CPU assignment rows downgrade first. Active sandboxes are
+        // prohibited during schema rollback, so the allocation table is empty
+        // and can safely return to its exclusive logical-CPU key.
+        rollback_schema(db.inner(), 1).await.unwrap();
+
+        let rows = db
+            .query_all_raw(Statement::from_sql_and_values(
+                DatabaseBackend::Sqlite,
+                "SELECT version FROM seaql_migrations WHERE version = ?",
+                [schema_metadata::SHARED_CPU_ALLOCATION_MIGRATION_ID.into()],
+            ))
+            .await
+            .unwrap();
+        assert!(
+            rows.is_empty(),
+            "shared CPU allocation should be rolled back"
+        );
+
         // The label rebuild is compatible with older releases, so its down
         // migration only removes the migration record. NUMA memory and
         // writeback state must remain until their own rollback steps.

--- a/crates/db/lib/entity/cpu_allocation_cpu.rs
+++ b/crates/db/lib/entity/cpu_allocation_cpu.rs
@@ -6,18 +6,19 @@ use sea_orm::entity::prelude::*;
 // Types
 //--------------------------------------------------------------------------------------------------
 
-/// One host logical processor reserved by a cooperative allocation.
+/// One guest vCPU assignment coordinated by a host allocation.
 #[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
 #[sea_orm(table_name = "cpu_allocation_cpu")]
 pub struct Model {
-    /// Host logical processor identifier and global conflict key.
-    #[sea_orm(primary_key, auto_increment = false)]
-    pub logical_cpu: i64,
     /// Owning allocation identifier.
+    #[sea_orm(primary_key, auto_increment = false)]
     pub allocation_id: String,
-    /// Possible guest vCPU index, or `None` for policy-only sibling reservations.
-    pub vcpu_index: Option<i32>,
-    /// Reservation role (`assigned` or `smt-reserved`).
+    /// Guest vCPU index within the allocation.
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub vcpu_index: i32,
+    /// Host logical processor selected for this vCPU. Multiple allocations may share it.
+    pub logical_cpu: i64,
+    /// Assignment role: `planned` before the OS acknowledgement, then `assigned` when confirmed.
     pub role: String,
 }
 

--- a/crates/migration/lib/lib.rs
+++ b/crates/migration/lib/lib.rs
@@ -22,6 +22,7 @@ mod m20260723_000001_snapshot_artifact_transition;
 mod m20260803_000001_create_writeback_allocations;
 mod m20260808_000001_create_memory_allocation_nodes;
 mod m20260810_000001_rebuild_sandbox_labels;
+mod m20260813_000001_share_cpu_allocations;
 pub mod schema_metadata;
 
 use sea_orm_migration::prelude::*;
@@ -69,6 +70,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20260803_000001_create_writeback_allocations::Migration),
             Box::new(m20260808_000001_create_memory_allocation_nodes::Migration),
             Box::new(m20260810_000001_rebuild_sandbox_labels::Migration),
+            Box::new(m20260813_000001_share_cpu_allocations::Migration),
         ]
     }
 }

--- a/crates/migration/lib/m20260813_000001_share_cpu_allocations.rs
+++ b/crates/migration/lib/m20260813_000001_share_cpu_allocations.rs
@@ -1,0 +1,222 @@
+//! Migration: Replace exclusive logical-CPU rows with shareable vCPU assignments.
+
+use sea_orm_migration::{prelude::*, sea_orm::ConnectionTrait};
+
+//--------------------------------------------------------------------------------------------------
+// Constants
+//--------------------------------------------------------------------------------------------------
+
+const SHAREABLE_SCHEMA: &str = "
+    CREATE TABLE cpu_allocation_cpu (
+        allocation_id TEXT NOT NULL,
+        vcpu_index INTEGER NOT NULL,
+        logical_cpu INTEGER NOT NULL,
+        role TEXT NOT NULL,
+        PRIMARY KEY (allocation_id, vcpu_index),
+        FOREIGN KEY (allocation_id) REFERENCES cpu_allocation(id) ON DELETE CASCADE
+    );
+";
+
+const EXCLUSIVE_SCHEMA: &str = "
+    CREATE TABLE cpu_allocation_cpu (
+        logical_cpu INTEGER NOT NULL PRIMARY KEY,
+        allocation_id TEXT NOT NULL,
+        vcpu_index INTEGER,
+        role TEXT NOT NULL,
+        FOREIGN KEY (allocation_id) REFERENCES cpu_allocation(id) ON DELETE CASCADE
+    );
+";
+
+const COPY_ASSIGNED_ROWS: &str = "
+    INSERT INTO cpu_allocation_cpu (allocation_id, vcpu_index, logical_cpu, role)
+    SELECT allocation_id, vcpu_index, logical_cpu, 'assigned'
+    FROM cpu_allocation_cpu_previous
+    WHERE vcpu_index IS NOT NULL;
+";
+
+const COPY_EXCLUSIVE_ROWS: &str = "
+    INSERT INTO cpu_allocation_cpu (logical_cpu, allocation_id, vcpu_index, role)
+    SELECT logical_cpu, allocation_id, vcpu_index, role
+    FROM cpu_allocation_cpu_previous;
+";
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+pub struct Migration;
+
+//--------------------------------------------------------------------------------------------------
+// Trait Implementations
+//--------------------------------------------------------------------------------------------------
+
+impl MigrationName for Migration {
+    fn name(&self) -> &str {
+        "m20260813_000001_share_cpu_allocations"
+    }
+}
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        rebuild_assignments(
+            manager,
+            SHAREABLE_SCHEMA,
+            COPY_ASSIGNED_ROWS,
+            "CREATE INDEX idx_cpu_allocation_cpu_logical ON cpu_allocation_cpu(logical_cpu);",
+        )
+        .await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        rebuild_assignments(
+            manager,
+            EXCLUSIVE_SCHEMA,
+            COPY_EXCLUSIVE_ROWS,
+            "CREATE UNIQUE INDEX idx_cpu_allocation_cpu_vcpu \
+             ON cpu_allocation_cpu(allocation_id, vcpu_index);",
+        )
+        .await
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+async fn rebuild_assignments(
+    manager: &SchemaManager<'_>,
+    schema: &'static str,
+    copy: &'static str,
+    index: &'static str,
+) -> Result<(), DbErr> {
+    const SAVEPOINT: &str = "share_cpu_allocations";
+    let connection = manager.get_connection();
+    connection
+        .execute_unprepared(&format!("SAVEPOINT {SAVEPOINT};"))
+        .await?;
+
+    let result = async {
+        connection
+            .execute_unprepared(
+                "ALTER TABLE cpu_allocation_cpu RENAME TO cpu_allocation_cpu_previous;",
+            )
+            .await?;
+        connection.execute_unprepared(schema).await?;
+        connection.execute_unprepared(copy).await?;
+        connection
+            .execute_unprepared("DROP TABLE cpu_allocation_cpu_previous;")
+            .await?;
+        connection.execute_unprepared(index).await?;
+        Ok::<_, DbErr>(())
+    }
+    .await;
+
+    match result {
+        Ok(()) => {
+            connection
+                .execute_unprepared(&format!("RELEASE SAVEPOINT {SAVEPOINT};"))
+                .await?;
+            Ok(())
+        }
+        Err(error) => {
+            let _ = connection
+                .execute_unprepared(&format!("ROLLBACK TO SAVEPOINT {SAVEPOINT};"))
+                .await;
+            let _ = connection
+                .execute_unprepared(&format!("RELEASE SAVEPOINT {SAVEPOINT};"))
+                .await;
+            Err(error)
+        }
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests
+//--------------------------------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use sea_orm_migration::sea_orm::{Database, DatabaseConnection, Statement};
+
+    use super::*;
+
+    async fn exclusive_catalog() -> DatabaseConnection {
+        let db = Database::connect("sqlite::memory:").await.unwrap();
+        db.execute_unprepared(
+            "CREATE TABLE cpu_allocation (id TEXT PRIMARY KEY);
+             CREATE TABLE cpu_allocation_cpu (
+                 logical_cpu INTEGER NOT NULL PRIMARY KEY,
+                 allocation_id TEXT NOT NULL,
+                 vcpu_index INTEGER,
+                 role TEXT NOT NULL,
+                 FOREIGN KEY (allocation_id) REFERENCES cpu_allocation(id) ON DELETE CASCADE
+             );
+             CREATE UNIQUE INDEX idx_cpu_allocation_cpu_vcpu
+                 ON cpu_allocation_cpu(allocation_id, vcpu_index);
+             INSERT INTO cpu_allocation VALUES ('first');
+             INSERT INTO cpu_allocation VALUES ('second');
+             INSERT INTO cpu_allocation_cpu VALUES (0, 'first', 0, 'assigned');
+             INSERT INTO cpu_allocation_cpu VALUES (1, 'first', NULL, 'smt-reserved');",
+        )
+        .await
+        .unwrap();
+        db
+    }
+
+    #[tokio::test]
+    async fn migration_drops_hard_sibling_holds_and_allows_shared_logical_cpus() {
+        let db = exclusive_catalog().await;
+        Migration.up(&SchemaManager::new(&db)).await.unwrap();
+
+        db.execute_unprepared(
+            "INSERT INTO cpu_allocation_cpu
+                (allocation_id, vcpu_index, logical_cpu, role)
+             VALUES ('second', 0, 0, 'assigned');",
+        )
+        .await
+        .unwrap();
+
+        let rows = db
+            .query_all_raw(Statement::from_string(
+                sea_orm::DatabaseBackend::Sqlite,
+                "SELECT allocation_id, vcpu_index, logical_cpu, role
+                 FROM cpu_allocation_cpu ORDER BY allocation_id",
+            ))
+            .await
+            .unwrap();
+        assert_eq!(rows.len(), 2);
+        assert!(
+            rows.iter()
+                .all(|row| row.try_get_by_index::<i64>(2).unwrap() == 0)
+        );
+        assert!(
+            rows.iter()
+                .all(|row| row.try_get_by_index::<String>(3).unwrap() == "assigned")
+        );
+    }
+
+    #[tokio::test]
+    async fn downgrade_restores_the_exclusive_shape_when_allocations_are_stopped() {
+        let db = exclusive_catalog().await;
+        Migration.up(&SchemaManager::new(&db)).await.unwrap();
+        db.execute_unprepared("DELETE FROM cpu_allocation_cpu;")
+            .await
+            .unwrap();
+
+        Migration.down(&SchemaManager::new(&db)).await.unwrap();
+
+        let columns = db
+            .query_all_raw(Statement::from_string(
+                sea_orm::DatabaseBackend::Sqlite,
+                "PRAGMA table_info(cpu_allocation_cpu)",
+            ))
+            .await
+            .unwrap();
+        let logical_cpu = columns
+            .iter()
+            .find(|row| row.try_get_by_index::<String>(1).unwrap() == "logical_cpu")
+            .unwrap();
+        assert_eq!(logical_cpu.try_get_by_index::<i32>(5).unwrap(), 1);
+    }
+}

--- a/crates/migration/lib/schema_metadata.rs
+++ b/crates/migration/lib/schema_metadata.rs
@@ -43,6 +43,9 @@ pub const MEMORY_ALLOCATION_NODES_MIGRATION_ID: &str =
 /// Migration that rebuilds the sandbox label index from persisted configs.
 pub const SANDBOX_LABEL_REBUILD_MIGRATION_ID: &str = "m20260810_000001_rebuild_sandbox_labels";
 
+/// Migration that permits several managed vCPUs to share one host logical processor.
+pub const SHARED_CPU_ALLOCATION_MIGRATION_ID: &str = "m20260813_000001_share_cpu_allocations";
+
 /// Frozen migration baseline for the transitional 0.6.0 release.
 ///
 /// The released 0.6.0 binary predates `msb __schema-baseline --json`, so
@@ -221,6 +224,13 @@ pub const MIGRATION_METADATA: &[MigrationMetadata] = &[
         affects_user_data: false,
         summary: "retain the rebuilt sandbox label index",
     },
+    MigrationMetadata {
+        id: SHARED_CPU_ALLOCATION_MIGRATION_ID,
+        reversible: true,
+        affects_cache: false,
+        affects_user_data: false,
+        summary: "restore exclusive logical CPU allocation rows",
+    },
 ];
 
 //--------------------------------------------------------------------------------------------------
@@ -307,6 +317,7 @@ mod tests {
     #[test]
     fn canonical_applied_prefix_uses_metadata_order() {
         let applied = [
+            SHARED_CPU_ALLOCATION_MIGRATION_ID,
             SANDBOX_LABEL_REBUILD_MIGRATION_ID,
             MEMORY_ALLOCATION_NODES_MIGRATION_ID,
             WRITEBACK_ALLOCATION_MIGRATION_ID,

--- a/crates/runtime/lib/cpu/allocation.rs
+++ b/crates/runtime/lib/cpu/allocation.rs
@@ -5,11 +5,12 @@ use std::fs::File;
 use std::io;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use microsandbox_db::DbWriteConnection;
 use microsandbox_db::entity::{cpu_allocation, cpu_allocation_cpu, memory_allocation_node};
 use microsandbox_utils::process_lock;
+use sea_orm::sea_query::Expr;
 use sea_orm::{ColumnTrait, EntityTrait, QueryFilter, Set};
 
 use super::PlacementRequest;
@@ -21,8 +22,9 @@ use crate::{RuntimeError, RuntimeResult};
 // Constants
 //--------------------------------------------------------------------------------------------------
 
-const MAX_ALLOCATION_ATTEMPTS: usize = 5;
 const PLANNER_LOCK_NAME: &str = "allocator.lock";
+const PLANNER_LOCK_TIMEOUT: Duration = Duration::from_millis(250);
+const PLANNER_LOCK_RETRY_INTERVAL: Duration = Duration::from_millis(2);
 
 //--------------------------------------------------------------------------------------------------
 // Types
@@ -33,14 +35,14 @@ pub(crate) struct AllocationLease {
     lease_path: PathBuf,
     file: File,
     released: AtomicBool,
+    shared: bool,
 }
 
 /// Short-lived cross-process lock covering the allocation snapshot, plan, and catalog commit.
 ///
-/// CPU uniqueness constraints catch colliding CPU plans, but NUMA memory capacity is an aggregate
-/// promise and cannot be expressed as a row-level uniqueness constraint. Holding this lock makes
-/// both resources share one atomic admission boundary. The operating system releases it if the
-/// planner process exits unexpectedly.
+/// CPU load and NUMA memory capacity are aggregate promises that cannot be committed from a stale
+/// snapshot. Holding this lock gives both resources one atomic admission boundary. The operating
+/// system releases it if the planner process exits unexpectedly.
 struct AllocationPlannerLock(File);
 
 struct StaleAllocation {
@@ -55,6 +57,130 @@ struct StaleAllocation {
 //--------------------------------------------------------------------------------------------------
 
 impl AllocationLease {
+    pub(crate) async fn reconcile(
+        &self,
+        db: &DbWriteConnection,
+        report: &msb_krun::PlacementReport,
+    ) -> RuntimeResult<()> {
+        if self.released.load(Ordering::Acquire) {
+            return Ok(());
+        }
+
+        let allocation_id = self.allocation_id.clone();
+        let vcpus = report.vcpus.clone();
+        let memory = report.memory.clone();
+        let shared = self.shared;
+        db.transaction(|transaction| {
+            let allocation_id = allocation_id.clone();
+            let vcpus = vcpus.clone();
+            let memory = memory.clone();
+            async move {
+                let rows = cpu_allocation_cpu::Entity::find()
+                    .filter(cpu_allocation_cpu::Column::AllocationId.eq(allocation_id.clone()))
+                    .all(&transaction)
+                    .await?;
+                if rows.len() != vcpus.len() {
+                    return Err(RuntimeError::Custom(format!(
+                        "placement report has {} vCPUs but allocation {} has {} planned rows",
+                        vcpus.len(),
+                        allocation_id,
+                        rows.len()
+                    )));
+                }
+
+                let mut pinned = 0usize;
+                for result in &vcpus {
+                    let (vcpu_index, reported_cpu) = match result {
+                        msb_krun::VcpuPlacementResult::Pinned {
+                            vcpu_index,
+                            host_cpu,
+                        } => (*vcpu_index, Some(*host_cpu)),
+                        msb_krun::VcpuPlacementResult::Inherited {
+                            vcpu_index,
+                            requested_host_cpu,
+                            ..
+                        } => (*vcpu_index, *requested_host_cpu),
+                    };
+                    let row = rows
+                        .iter()
+                        .find(|row| row.vcpu_index == i32::from(vcpu_index))
+                        .ok_or_else(|| {
+                            RuntimeError::Custom(format!(
+                                "placement report references unplanned vCPU {vcpu_index}"
+                            ))
+                        })?;
+                    if let Some(host_cpu) = reported_cpu {
+                        let reported_key =
+                            ((i64::from(host_cpu.group)) << 16) | i64::from(host_cpu.index);
+                        if row.logical_cpu != reported_key {
+                            return Err(RuntimeError::Custom(format!(
+                                "placement report maps vCPU {vcpu_index} to host CPU {reported_key}, expected {}",
+                                row.logical_cpu
+                            )));
+                        }
+                    }
+
+                    match result {
+                        msb_krun::VcpuPlacementResult::Pinned { .. } => {
+                            pinned += 1;
+                            cpu_allocation_cpu::Entity::update_many()
+                                .col_expr(cpu_allocation_cpu::Column::Role, Expr::value("assigned"))
+                                .filter(
+                                    cpu_allocation_cpu::Column::AllocationId
+                                        .eq(allocation_id.clone()),
+                                )
+                                .filter(
+                                    cpu_allocation_cpu::Column::VcpuIndex
+                                        .eq(i32::from(vcpu_index)),
+                                )
+                                .exec(&transaction)
+                                .await?;
+                        }
+                        msb_krun::VcpuPlacementResult::Inherited { .. } => {
+                            cpu_allocation_cpu::Entity::delete_many()
+                                .filter(
+                                    cpu_allocation_cpu::Column::AllocationId
+                                        .eq(allocation_id.clone()),
+                                )
+                                .filter(
+                                    cpu_allocation_cpu::Column::VcpuIndex
+                                        .eq(i32::from(vcpu_index)),
+                                )
+                                .exec(&transaction)
+                                .await?;
+                        }
+                    }
+                }
+
+                if !matches!(memory, msb_krun::MemoryPlacementResult::Applied) {
+                    memory_allocation_node::Entity::delete_many()
+                        .filter(
+                            memory_allocation_node::Column::AllocationId.eq(allocation_id.clone()),
+                        )
+                        .exec(&transaction)
+                        .await?;
+                }
+
+                let enforcement = match (pinned, vcpus.len(), shared) {
+                    (0, _, _) => "inherited",
+                    (count, total, false) if count == total => "thread-affinity-exclusive",
+                    (count, total, true) if count == total => "thread-affinity-shared",
+                    (_, _, false) => "thread-affinity-partial",
+                    (_, _, true) => "thread-affinity-partial-shared",
+                };
+                cpu_allocation::Entity::update_many()
+                    .col_expr(cpu_allocation::Column::Enforcement, Expr::value(enforcement))
+                    .col_expr(cpu_allocation::Column::State, Expr::value("active"))
+                    .filter(cpu_allocation::Column::Id.eq(allocation_id.clone()))
+                    .exec(&transaction)
+                    .await?;
+
+                Ok::<_, RuntimeError>((transaction, ()))
+            }
+        })
+        .await
+    }
+
     pub(crate) async fn release(&self, db: &DbWriteConnection) -> RuntimeResult<()> {
         if self.released.load(Ordering::Acquire) {
             return Ok(());
@@ -100,7 +226,7 @@ pub(crate) async fn acquire(
 ) -> RuntimeResult<(AllocationLease, ResolvedPlacement, usize)> {
     prepare_lease_dir(lease_dir)?;
     let planner_lock = process_lock::open_lock_file(&lease_dir.join(PLANNER_LOCK_NAME))?;
-    process_lock::lock_exclusive(&planner_lock)?;
+    lock_planner(&planner_lock).await?;
     let _planner_lock = AllocationPlannerLock(planner_lock);
     let allocation_id = format!("{:032x}", rand::random::<u128>());
     let lease_name = format!("{allocation_id}.lock");
@@ -108,187 +234,191 @@ pub(crate) async fn acquire(
     let file = process_lock::create_new_lock_file(&lease_path)?;
     process_lock::lock_exclusive(&file)?;
 
-    for attempt in 0..MAX_ALLOCATION_ATTEMPTS {
-        let snapshot_started = Instant::now();
-        let allocations = match cpu_allocation::Entity::find().all(db).await {
-            Ok(allocations) => allocations,
-            Err(error) => {
-                clean_unpublished_lease(&file, &lease_path);
-                return Err(error.into());
-            }
-        };
-        let cpu_rows = match cpu_allocation_cpu::Entity::find().all(db).await {
-            Ok(cpu_rows) => cpu_rows,
-            Err(error) => {
-                clean_unpublished_lease(&file, &lease_path);
-                return Err(error.into());
-            }
-        };
-        let memory_rows = match memory_allocation_node::Entity::find().all(db).await {
-            Ok(memory_rows) => memory_rows,
-            Err(error) => {
-                clean_unpublished_lease(&file, &lease_path);
-                return Err(error.into());
-            }
-        };
-        let stale = probe_stale_allocations(lease_dir, &allocations);
-        let stale_ids: HashSet<_> = stale.iter().map(|entry| entry.id.as_str()).collect();
-        let occupied = match cpu_rows
-            .iter()
-            .filter(|row| !stale_ids.contains(row.allocation_id.as_str()))
-            .map(|row| {
-                LogicalCpuId::from_catalog_key(row.logical_cpu).map_err(|error| {
-                    RuntimeError::Custom(format!(
-                        "CPU allocation {} contains invalid logical CPU {}: {error}",
-                        row.allocation_id, row.logical_cpu
-                    ))
-                })
-            })
-            .collect::<RuntimeResult<HashSet<_>>>()
-        {
-            Ok(occupied) => occupied,
-            Err(error) => {
-                clean_unpublished_lease(&file, &lease_path);
-                return Err(error);
-            }
-        };
-        let mut reserved_memory_mib = BTreeMap::<u32, u64>::new();
-        for row in memory_rows
-            .iter()
-            .filter(|row| !stale_ids.contains(row.allocation_id.as_str()))
-        {
-            let host_node = u32::try_from(row.host_numa_node).map_err(|_| {
-                RuntimeError::Custom(format!(
-                    "memory allocation {} contains invalid host NUMA node {}",
-                    row.allocation_id, row.host_numa_node
-                ))
-            })?;
-            let max_mib = u64::try_from(row.max_mib).map_err(|_| {
-                RuntimeError::Custom(format!(
-                    "memory allocation {} contains invalid maximum memory {}",
-                    row.allocation_id, row.max_mib
-                ))
-            })?;
-            *reserved_memory_mib.entry(host_node).or_default() += max_mib;
+    let attempt = 0;
+    let snapshot_started = Instant::now();
+    let allocations = match cpu_allocation::Entity::find().all(db).await {
+        Ok(allocations) => allocations,
+        Err(error) => {
+            clean_unpublished_lease(&file, &lease_path);
+            return Err(error.into());
         }
-        let resolved = match planner::plan(topology, &occupied, request, &reserved_memory_mib) {
-            Ok(resolved) => resolved,
+    };
+    let cpu_rows = match cpu_allocation_cpu::Entity::find().all(db).await {
+        Ok(cpu_rows) => cpu_rows,
+        Err(error) => {
+            clean_unpublished_lease(&file, &lease_path);
+            return Err(error.into());
+        }
+    };
+    let memory_rows = match memory_allocation_node::Entity::find().all(db).await {
+        Ok(memory_rows) => memory_rows,
+        Err(error) => {
+            clean_unpublished_lease(&file, &lease_path);
+            return Err(error.into());
+        }
+    };
+    let stale = probe_stale_allocations(lease_dir, &allocations);
+    let stale_ids: HashSet<_> = stale.iter().map(|entry| entry.id.as_str()).collect();
+    let mut loads = BTreeMap::<LogicalCpuId, usize>::new();
+    for row in cpu_rows
+        .iter()
+        .filter(|row| !stale_ids.contains(row.allocation_id.as_str()))
+    {
+        let logical_cpu = match LogicalCpuId::from_catalog_key(row.logical_cpu) {
+            Ok(logical_cpu) => logical_cpu,
             Err(error) => {
                 clean_unpublished_lease(&file, &lease_path);
-                return Err(error);
+                return Err(RuntimeError::Custom(format!(
+                    "CPU allocation {} contains invalid logical CPU {}: {error}",
+                    row.allocation_id, row.logical_cpu
+                )));
             }
         };
+        *loads.entry(logical_cpu).or_default() += 1;
+    }
+    let mut reserved_memory_mib = BTreeMap::<u32, u64>::new();
+    for row in memory_rows
+        .iter()
+        .filter(|row| !stale_ids.contains(row.allocation_id.as_str()))
+    {
+        let host_node = u32::try_from(row.host_numa_node).map_err(|_| {
+            RuntimeError::Custom(format!(
+                "memory allocation {} contains invalid host NUMA node {}",
+                row.allocation_id, row.host_numa_node
+            ))
+        })?;
+        let max_mib = u64::try_from(row.max_mib).map_err(|_| {
+            RuntimeError::Custom(format!(
+                "memory allocation {} contains invalid maximum memory {}",
+                row.allocation_id, row.max_mib
+            ))
+        })?;
+        *reserved_memory_mib.entry(host_node).or_default() += max_mib;
+    }
+    let resolved = match planner::plan(topology, &loads, request, &reserved_memory_mib) {
+        Ok(resolved) => resolved,
+        Err(error) => {
+            clean_unpublished_lease(&file, &lease_path);
+            return Err(error);
+        }
+    };
 
-        let transaction_started = Instant::now();
-        let insert_result = db
-            .transaction(|transaction| {
-                let stale = stale
-                    .iter()
-                    .map(|entry| (entry.id.clone(), entry.lease_name.clone()))
-                    .collect::<Vec<_>>();
-                let allocation_id = allocation_id.clone();
-                let lease_name = lease_name.clone();
-                let topology_fingerprint = topology.fingerprint.clone();
-                let reservations = resolved.reservations.clone();
-                let memory_nodes = resolved
-                    .numa
-                    .as_ref()
-                    .map(|numa| numa.nodes.clone())
-                    .unwrap_or_default();
-                async move {
-                    for (id, expected_lease_name) in stale {
-                        cpu_allocation::Entity::delete_many()
-                            .filter(cpu_allocation::Column::Id.eq(id))
-                            .filter(cpu_allocation::Column::LeaseName.eq(expected_lease_name))
-                            .exec(&transaction)
-                            .await?;
-                    }
+    let transaction_started = Instant::now();
+    let insert_result = db
+        .transaction(|transaction| {
+            let stale = stale
+                .iter()
+                .map(|entry| (entry.id.clone(), entry.lease_name.clone()))
+                .collect::<Vec<_>>();
+            let allocation_id = allocation_id.clone();
+            let lease_name = lease_name.clone();
+            let topology_fingerprint = topology.fingerprint.clone();
+            let reservations = resolved.reservations.clone();
+            let memory_nodes = resolved
+                .numa
+                .as_ref()
+                .map(|numa| numa.nodes.clone())
+                .unwrap_or_default();
+            async move {
+                for (id, expected_lease_name) in stale {
+                    cpu_allocation::Entity::delete_many()
+                        .filter(cpu_allocation::Column::Id.eq(id))
+                        .filter(cpu_allocation::Column::LeaseName.eq(expected_lease_name))
+                        .exec(&transaction)
+                        .await?;
+                }
 
-                    cpu_allocation::Entity::insert(cpu_allocation::ActiveModel {
-                        id: Set(allocation_id.clone()),
-                        run_id: Set(run_id),
-                        requested_policy: Set(request.policy.to_string()),
-                        resolved_policy: Set(resolved.resolved.to_string()),
-                        enforcement: Set("thread-affinity".into()),
-                        topology_fingerprint: Set(topology_fingerprint),
-                        lease_name: Set(lease_name),
-                        state: Set("active".into()),
-                        created_at: Set(chrono::Utc::now().naive_utc()),
+                cpu_allocation::Entity::insert(cpu_allocation::ActiveModel {
+                    id: Set(allocation_id.clone()),
+                    run_id: Set(run_id),
+                    requested_policy: Set(request.policy.to_string()),
+                    resolved_policy: Set(resolved.resolved.to_string()),
+                    enforcement: Set("pending".into()),
+                    topology_fingerprint: Set(topology_fingerprint),
+                    lease_name: Set(lease_name),
+                    state: Set("pending".into()),
+                    created_at: Set(chrono::Utc::now().naive_utc()),
+                })
+                .exec(&transaction)
+                .await?;
+
+                for reservation in reservations {
+                    cpu_allocation_cpu::Entity::insert(cpu_allocation_cpu::ActiveModel {
+                        allocation_id: Set(allocation_id.clone()),
+                        vcpu_index: Set(i32::from(reservation.vcpu_index.ok_or_else(|| {
+                            RuntimeError::Custom(
+                                "CPU assignment is missing its guest vCPU index".into(),
+                            )
+                        })?)),
+                        logical_cpu: Set(reservation.logical_cpu.catalog_key()),
+                        role: Set(reservation.role.into()),
                     })
                     .exec(&transaction)
                     .await?;
-
-                    for reservation in reservations {
-                        cpu_allocation_cpu::Entity::insert(cpu_allocation_cpu::ActiveModel {
-                            logical_cpu: Set(reservation.logical_cpu.catalog_key()),
-                            allocation_id: Set(allocation_id.clone()),
-                            vcpu_index: Set(reservation.vcpu_index.map(i32::from)),
-                            role: Set(reservation.role.into()),
-                        })
-                        .exec(&transaction)
-                        .await?;
-                    }
-                    for node in memory_nodes {
-                        memory_allocation_node::Entity::insert(
-                            memory_allocation_node::ActiveModel {
-                                allocation_id: Set(allocation_id.clone()),
-                                guest_numa_node: Set(i32::from(node.guest_node_id)),
-                                host_numa_node: Set(i32::try_from(node.host_node_id).map_err(
-                                    |_| {
-                                        RuntimeError::Custom(format!(
-                                            "host NUMA node {} exceeds the catalog range",
-                                            node.host_node_id
-                                        ))
-                                    },
-                                )?),
-                                boot_mib: Set(i64::from(node.boot_memory_mib)),
-                                max_mib: Set(i64::from(node.max_memory_mib)),
-                            },
-                        )
-                        .exec(&transaction)
-                        .await?;
-                    }
-                    Ok::<_, RuntimeError>((transaction, ()))
                 }
-            })
-            .await;
+                for node in memory_nodes {
+                    memory_allocation_node::Entity::insert(memory_allocation_node::ActiveModel {
+                        allocation_id: Set(allocation_id.clone()),
+                        guest_numa_node: Set(i32::from(node.guest_node_id)),
+                        host_numa_node: Set(i32::try_from(node.host_node_id).map_err(|_| {
+                            RuntimeError::Custom(format!(
+                                "host NUMA node {} exceeds the catalog range",
+                                node.host_node_id
+                            ))
+                        })?),
+                        boot_mib: Set(i64::from(node.boot_memory_mib)),
+                        max_mib: Set(i64::from(node.max_memory_mib)),
+                    })
+                    .exec(&transaction)
+                    .await?;
+                }
+                Ok::<_, RuntimeError>((transaction, ()))
+            }
+        })
+        .await;
 
-        match insert_result {
-            Ok(()) => {
-                clean_stale_files(stale);
-                tracing::debug!(
-                    attempt,
-                    snapshot_us = snapshot_started.elapsed().as_micros(),
-                    transaction_us = transaction_started.elapsed().as_micros(),
-                    "CPU allocation committed"
-                );
-                return Ok((
-                    AllocationLease {
-                        allocation_id,
-                        lease_path,
-                        file,
-                        released: AtomicBool::new(false),
-                    },
-                    resolved,
-                    attempt,
-                ));
-            }
+    match insert_result {
+        Ok(()) => {
+            clean_stale_files(stale);
+            tracing::debug!(
+                attempt,
+                snapshot_us = snapshot_started.elapsed().as_micros(),
+                transaction_us = transaction_started.elapsed().as_micros(),
+                "CPU allocation committed"
+            );
+            Ok((
+                AllocationLease {
+                    allocation_id,
+                    lease_path,
+                    file,
+                    released: AtomicBool::new(false),
+                    shared: resolved.shared,
+                },
+                resolved,
+                attempt,
+            ))
+        }
+        Err(error) => {
+            clean_unpublished_lease(&file, &lease_path);
             Err(error)
-                if is_cpu_uniqueness_conflict(&error) && attempt + 1 < MAX_ALLOCATION_ATTEMPTS =>
-            {
-                tracing::debug!(attempt, "CPU allocation race lost; re-planning");
-            }
-            Err(error) => {
-                clean_unpublished_lease(&file, &lease_path);
-                return Err(error);
-            }
         }
     }
+}
 
-    clean_unpublished_lease(&file, &lease_path);
-    Err(RuntimeError::Custom(
-        "CPU placement exceeded the bounded allocation retry budget".into(),
-    ))
+async fn lock_planner(file: &File) -> RuntimeResult<()> {
+    let started = Instant::now();
+    loop {
+        if process_lock::try_lock_exclusive(file)? {
+            return Ok(());
+        }
+        if started.elapsed() >= PLANNER_LOCK_TIMEOUT {
+            return Err(RuntimeError::Custom(format!(
+                "CPU placement planner remained busy for {} ms",
+                PLANNER_LOCK_TIMEOUT.as_millis()
+            )));
+        }
+        tokio::time::sleep(PLANNER_LOCK_RETRY_INTERVAL).await;
+    }
 }
 
 fn probe_stale_allocations(
@@ -350,15 +480,6 @@ fn clean_unpublished_lease(file: &File, lease_path: &Path) {
     }
 }
 
-fn is_cpu_uniqueness_conflict(error: &RuntimeError) -> bool {
-    matches!(
-        error,
-        RuntimeError::Database(db_error)
-            if db_error.to_string().contains("cpu_allocation_cpu.logical_cpu")
-                || db_error.to_string().contains("idx_cpu_allocation_cpu_vcpu")
-    )
-}
-
 fn prepare_lease_dir(path: &Path) -> RuntimeResult<()> {
     std::fs::create_dir_all(path)?;
     #[cfg(unix)]
@@ -381,7 +502,20 @@ fn is_valid_lease_name(allocation_id: &str, lease_name: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::is_valid_lease_name;
+    use std::collections::BTreeMap;
+    use std::time::{Duration, Instant};
+
+    use microsandbox_db::DbWriteConnection;
+    use microsandbox_db::entity::{
+        cpu_allocation, cpu_allocation_cpu, memory_allocation_node, run, sandbox,
+    };
+    use microsandbox_migration::{Migrator, MigratorTrait};
+    use microsandbox_types::{CpuPlacement, MemoryPlacement, NumaPlacement, PlacementProfile};
+    use microsandbox_utils::process_lock;
+    use sea_orm::{ActiveModelTrait, EntityTrait, Set};
+
+    use super::{PlacementRequest, acquire, is_valid_lease_name, lock_planner};
+    use crate::cpu::topology::{CpuTopology, HostNumaNode, LogicalCpu, LogicalCpuId};
 
     #[test]
     fn lease_names_are_derived_from_canonical_allocation_ids() {
@@ -393,5 +527,235 @@ mod tests {
             "0123456789abcdef0123456789abcdeg",
             "0123456789abcdef0123456789abcdeg.lock"
         ));
+    }
+
+    #[tokio::test]
+    async fn planner_lock_wait_is_bounded() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("allocator.lock");
+        let held = process_lock::open_lock_file(&path).unwrap();
+        process_lock::lock_exclusive(&held).unwrap();
+        let contender = process_lock::open_lock_file(&path).unwrap();
+
+        let started = Instant::now();
+        let error = lock_planner(&contender).await.unwrap_err();
+
+        assert!(error.to_string().contains("remained busy"));
+        assert!(started.elapsed() < Duration::from_secs(1));
+        process_lock::unlock(&held).unwrap();
+    }
+
+    #[tokio::test]
+    async fn allocations_share_a_logical_cpu_after_exclusive_capacity_is_used() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = DbWriteConnection::open(
+            &dir.path().join("catalog.db"),
+            Duration::from_secs(5),
+            Duration::from_secs(5),
+        )
+        .await
+        .unwrap();
+        Migrator::up(db.inner(), None).await.unwrap();
+        let sandbox_id = sandbox::ActiveModel {
+            name: Set("cpu-sharing-test".into()),
+            config: Set("{}".into()),
+            status: Set(sandbox::SandboxStatus::Running),
+            ephemeral: Set(false),
+            ..Default::default()
+        }
+        .insert(&db)
+        .await
+        .unwrap()
+        .id;
+        let mut run_ids = Vec::new();
+        for _ in 0..2 {
+            run_ids.push(
+                run::ActiveModel {
+                    sandbox_id: Set(sandbox_id),
+                    status: Set(run::RunStatus::Running),
+                    ..Default::default()
+                }
+                .insert(&db)
+                .await
+                .unwrap()
+                .id,
+            );
+        }
+        let topology = CpuTopology {
+            logical_cpus: vec![LogicalCpu {
+                id: LogicalCpuId::new(0),
+                package: 0,
+                die: 0,
+                core: 0,
+                numa_node: 0,
+                performance_class: 0,
+            }],
+            numa_nodes: vec![HostNumaNode {
+                id: 0,
+                package: 0,
+                total_memory_mib: 16_384,
+                available_memory_mib: 16_384,
+                distances: BTreeMap::from([(0, 10)]),
+            }],
+            fingerprint: "single-logical-cpu".into(),
+        };
+        let request = PlacementRequest {
+            policy: CpuPlacement::Auto,
+            max_vcpus: 1,
+            boot_memory_mib: 512,
+            max_memory_mib: 512,
+            profile: None,
+        };
+
+        let first = acquire(
+            &db,
+            run_ids[0],
+            &dir.path().join("leases"),
+            &topology,
+            request,
+        )
+        .await
+        .unwrap();
+        let second = acquire(
+            &db,
+            run_ids[1],
+            &dir.path().join("leases"),
+            &topology,
+            request,
+        )
+        .await
+        .unwrap();
+
+        let rows = cpu_allocation_cpu::Entity::find().all(&db).await.unwrap();
+        assert_eq!(rows.len(), 2);
+        assert!(rows.iter().all(|row| row.logical_cpu == 0));
+        assert!(!first.1.shared);
+        assert!(second.1.shared);
+
+        first.0.release(&db).await.unwrap();
+        second.0.release(&db).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn placement_ack_keeps_successful_pins_and_releases_fallback_capacity() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = DbWriteConnection::open(
+            &dir.path().join("catalog.db"),
+            Duration::from_secs(5),
+            Duration::from_secs(5),
+        )
+        .await
+        .unwrap();
+        Migrator::up(db.inner(), None).await.unwrap();
+        let sandbox_id = sandbox::ActiveModel {
+            name: Set("placement-ack-test".into()),
+            config: Set("{}".into()),
+            status: Set(sandbox::SandboxStatus::Running),
+            ephemeral: Set(false),
+            ..Default::default()
+        }
+        .insert(&db)
+        .await
+        .unwrap()
+        .id;
+        let run_id = run::ActiveModel {
+            sandbox_id: Set(sandbox_id),
+            status: Set(run::RunStatus::Running),
+            ..Default::default()
+        }
+        .insert(&db)
+        .await
+        .unwrap()
+        .id;
+        let topology = CpuTopology {
+            logical_cpus: vec![
+                LogicalCpu {
+                    id: LogicalCpuId::new(0),
+                    package: 0,
+                    die: 0,
+                    core: 0,
+                    numa_node: 0,
+                    performance_class: 0,
+                },
+                LogicalCpu {
+                    id: LogicalCpuId::new(1),
+                    package: 0,
+                    die: 0,
+                    core: 1,
+                    numa_node: 0,
+                    performance_class: 0,
+                },
+            ],
+            numa_nodes: vec![HostNumaNode {
+                id: 0,
+                package: 0,
+                total_memory_mib: 16_384,
+                available_memory_mib: 16_384,
+                distances: BTreeMap::from([(0, 10)]),
+            }],
+            fingerprint: "placement-ack".into(),
+        };
+        let (lease, _, _) = acquire(
+            &db,
+            run_id,
+            &dir.path().join("leases"),
+            &topology,
+            PlacementRequest {
+                policy: CpuPlacement::Auto,
+                max_vcpus: 2,
+                boot_memory_mib: 512,
+                max_memory_mib: 1024,
+                profile: Some(PlacementProfile {
+                    numa: NumaPlacement::PreferSingle,
+                    memory: MemoryPlacement::FollowCpu,
+                }),
+            },
+        )
+        .await
+        .unwrap();
+
+        lease
+            .reconcile(
+                &db,
+                &msb_krun::PlacementReport {
+                    vcpus: vec![
+                        msb_krun::VcpuPlacementResult::Pinned {
+                            vcpu_index: 0,
+                            host_cpu: msb_krun::HostCpuId::new(0),
+                        },
+                        msb_krun::VcpuPlacementResult::Inherited {
+                            vcpu_index: 1,
+                            requested_host_cpu: Some(msb_krun::HostCpuId::new(1)),
+                            reason: Some("injected affinity rejection".into()),
+                        },
+                    ],
+                    memory: msb_krun::MemoryPlacementResult::Fallback {
+                        reason: "partial CPU placement".into(),
+                    },
+                },
+            )
+            .await
+            .unwrap();
+
+        let cpu_rows = cpu_allocation_cpu::Entity::find().all(&db).await.unwrap();
+        assert_eq!(cpu_rows.len(), 1);
+        assert_eq!(cpu_rows[0].vcpu_index, 0);
+        assert_eq!(cpu_rows[0].role, "assigned");
+        assert!(
+            memory_allocation_node::Entity::find()
+                .all(&db)
+                .await
+                .unwrap()
+                .is_empty()
+        );
+        let allocation = cpu_allocation::Entity::find()
+            .one(&db)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(allocation.enforcement, "thread-affinity-partial");
+        assert_eq!(allocation.state, "active");
+
+        lease.release(&db).await.unwrap();
     }
 }

--- a/crates/runtime/lib/cpu/mod.rs
+++ b/crates/runtime/lib/cpu/mod.rs
@@ -38,6 +38,20 @@ pub(crate) struct PlacementRequest {
 //--------------------------------------------------------------------------------------------------
 
 impl CpuPlacementGuard {
+    /// Reconciles tentative coordination rows with placement confirmed by libkrun's startup
+    /// barrier. Successful vCPU pins remain reserved; inherited vCPUs and memory fallbacks stop
+    /// consuming cooperative capacity.
+    pub(crate) async fn reconcile(
+        &self,
+        db: &DbWriteConnection,
+        report: &msb_krun::PlacementReport,
+    ) -> RuntimeResult<()> {
+        if let Some(lease) = &self.lease {
+            lease.reconcile(db, report).await?;
+        }
+        Ok(())
+    }
+
     /// Returns the resolved host processor-group coordinate for every possible vCPU.
     pub(crate) fn vcpu_targets(&self) -> Option<&[LogicalCpuId]> {
         self.resolved
@@ -48,6 +62,14 @@ impl CpuPlacementGuard {
     /// Returns the policy selected by the planner.
     pub fn resolved_policy(&self) -> Option<CpuPlacement> {
         self.resolved.as_ref().map(|resolved| resolved.resolved)
+    }
+
+    /// Returns whether placement enforcement is an explicit launch requirement.
+    pub(crate) fn placement_required(&self) -> bool {
+        self.resolved
+            .as_ref()
+            .and_then(|resolved| resolved.numa.as_ref())
+            .is_some_and(|numa| numa.required)
     }
 
     /// Returns the concrete topology libkrun must realize for this allocation.
@@ -67,14 +89,24 @@ impl CpuPlacementGuard {
                         MemoryPlacement::FollowCpu => {
                             #[cfg(target_os = "linux")]
                             {
-                                msb_krun::HostMemoryPolicy::Bind {
-                                    host_nodes: vec![node.host_node_id],
+                                if numa.required {
+                                    msb_krun::HostMemoryPolicy::Bind {
+                                        host_nodes: vec![node.host_node_id],
+                                    }
+                                } else {
+                                    msb_krun::HostMemoryPolicy::PreferredMany {
+                                        host_nodes: vec![node.host_node_id],
+                                    }
                                 }
                             }
                             #[cfg(target_os = "windows")]
                             {
-                                msb_krun::HostMemoryPolicy::Preferred {
-                                    host_node: node.host_node_id,
+                                if numa.required {
+                                    msb_krun::HostMemoryPolicy::Preferred {
+                                        host_node: node.host_node_id,
+                                    }
+                                } else {
+                                    msb_krun::HostMemoryPolicy::Inherit
                                 }
                             }
                             #[cfg(not(any(target_os = "linux", target_os = "windows")))]
@@ -125,14 +157,57 @@ pub(crate) async fn acquire(
         });
     }
 
+    let strict = request
+        .profile
+        .is_some_and(|profile| matches!(profile.numa, NumaPlacement::StrictSingle));
     let started = Instant::now();
-    let topology = topology::discover()?;
+    let topology = match topology::discover() {
+        Ok(topology) => topology,
+        Err(error) if !strict => {
+            tracing::warn!(
+                requested = %request.policy,
+                %error,
+                "host placement unavailable; inheriting host CPU and memory policy"
+            );
+            return Ok(CpuPlacementGuard {
+                lease: None,
+                resolved: None,
+            });
+        }
+        Err(error) => return Err(error),
+    };
     let (lease, resolved, replans) =
-        allocation::acquire(db, run_id, lease_dir, &topology, request).await?;
+        match allocation::acquire(db, run_id, lease_dir, &topology, request).await {
+            Ok(allocation) => allocation,
+            Err(error) if !strict => {
+                tracing::warn!(
+                    requested = %request.policy,
+                    %error,
+                    "host placement coordination failed; inheriting host CPU and memory policy"
+                );
+                return Ok(CpuPlacementGuard {
+                    lease: None,
+                    resolved: None,
+                });
+            }
+            Err(error) => return Err(error),
+        };
+    let fallback = resolved.fallback.map(|fallback| match fallback {
+        planner::PlacementFallback::PreferSingleCapacity => "prefer-single-capacity",
+        planner::PlacementFallback::FollowCpuCrossNode => "follow-cpu-cross-node",
+        planner::PlacementFallback::FollowCpuMemoryCapacity => "follow-cpu-memory-capacity",
+    });
+    if let Some(reason) = fallback {
+        tracing::warn!(
+            requested = %request.policy,
+            reason,
+            "placement preference could not be honored; inheriting host NUMA and memory policy"
+        );
+    }
     tracing::info!(
         requested = %request.policy,
         resolved = %resolved.resolved,
-        enforcement = "thread-affinity",
+        enforcement = "pending-os-acknowledgement",
         max_vcpus = request.max_vcpus,
         replans,
         elapsed_us = started.elapsed().as_micros(),

--- a/crates/runtime/lib/cpu/planner.rs
+++ b/crates/runtime/lib/cpu/planner.rs
@@ -26,6 +26,15 @@ pub(crate) struct ResolvedPlacement {
     pub(crate) vcpu_targets: Vec<LogicalCpuId>,
     pub(crate) reservations: Vec<CpuReservation>,
     pub(crate) numa: Option<ResolvedNumaPlacement>,
+    pub(crate) shared: bool,
+    pub(crate) fallback: Option<PlacementFallback>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum PlacementFallback {
+    PreferSingleCapacity,
+    FollowCpuCrossNode,
+    FollowCpuMemoryCapacity,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -33,6 +42,7 @@ pub(crate) struct ResolvedNumaPlacement {
     pub(crate) nodes: Vec<ResolvedNumaNode>,
     pub(crate) distances: Vec<(u16, u16, u8)>,
     pub(crate) memory: MemoryPlacement,
+    pub(crate) required: bool,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -50,7 +60,7 @@ pub(crate) struct ResolvedNumaNode {
 
 pub(crate) fn plan(
     topology: &CpuTopology,
-    occupied: &HashSet<LogicalCpuId>,
+    loads: &BTreeMap<LogicalCpuId, usize>,
     request: PlacementRequest,
     reserved_memory_mib: &BTreeMap<u32, u64>,
 ) -> RuntimeResult<ResolvedPlacement> {
@@ -62,7 +72,7 @@ pub(crate) fn plan(
     }
 
     let Some(profile) = request.profile else {
-        return plan_cpu(topology, occupied, request.policy, requested_count);
+        return plan_cpu(topology, loads, request.policy, requested_count);
     };
     if matches!(profile.memory, MemoryPlacement::FollowCpu)
         && matches!(request.policy, CpuPlacement::Inherit)
@@ -98,9 +108,8 @@ pub(crate) fn plan(
             });
             for node in candidates {
                 let reserved = reserved_memory_mib.get(&node.id).copied().unwrap_or(0);
-                if node.available_memory_mib < u64::from(request.boot_memory_mib)
-                    || node.total_memory_mib.saturating_sub(reserved)
-                        < u64::from(request.max_memory_mib)
+                if !node_can_fit_memory(node, reserved, request)
+                    || !node_can_fit_unshared_cpus(topology, loads, node.id, requested_count)
                 {
                     continue;
                 }
@@ -114,7 +123,7 @@ pub(crate) fn plan(
                     numa_nodes: vec![node.clone()],
                     fingerprint: topology.fingerprint.clone(),
                 };
-                let Ok(mut resolved) = plan_cpu(&scoped, occupied, request.policy, requested_count)
+                let Ok(mut resolved) = plan_cpu(&scoped, loads, request.policy, requested_count)
                 else {
                     continue;
                 };
@@ -124,22 +133,24 @@ pub(crate) fn plan(
                     request.boot_memory_mib,
                     request.max_memory_mib,
                     profile.memory,
+                    matches!(profile.numa, NumaPlacement::StrictSingle),
                 ));
                 return Ok(resolved);
             }
 
-            let mode = match profile.numa {
-                NumaPlacement::StrictSingle => "strict_single",
-                NumaPlacement::PreferSingle => "prefer_single",
-                NumaPlacement::Inherit => unreachable!(),
-            };
-            Err(RuntimeError::Custom(format!(
-                "NUMA placement {mode} cannot fit max_cpus={} and max_memory_mib={} on one allowed host node; multi-node guest placement is not enabled yet",
-                request.max_vcpus, request.max_memory_mib
-            )))
+            if matches!(profile.numa, NumaPlacement::StrictSingle) {
+                return Err(RuntimeError::Custom(format!(
+                    "NUMA placement strict_single cannot fit max_cpus={} and max_memory_mib={} on one allowed host node",
+                    request.max_vcpus, request.max_memory_mib
+                )));
+            }
+
+            let mut resolved = plan_cpu(topology, loads, request.policy, requested_count)?;
+            resolved.fallback = Some(PlacementFallback::PreferSingleCapacity);
+            Ok(resolved)
         }
         NumaPlacement::Inherit => {
-            let mut resolved = plan_cpu(topology, occupied, request.policy, requested_count)?;
+            let mut resolved = plan_cpu(topology, loads, request.policy, requested_count)?;
             if matches!(profile.memory, MemoryPlacement::FollowCpu) {
                 let host_nodes = resolved
                     .vcpu_targets
@@ -153,20 +164,34 @@ pub(crate) fn plan(
                     })
                     .collect::<HashSet<_>>();
                 if host_nodes.len() != 1 {
-                    return Err(RuntimeError::Custom(
-                        "follow_cpu memory needs guest NUMA tables when selected CPUs span host nodes; multi-node placement is not enabled yet".into(),
-                    ));
+                    resolved.fallback = Some(PlacementFallback::FollowCpuCrossNode);
+                    return Ok(resolved);
                 }
                 let host_node = *host_nodes.iter().next().ok_or_else(|| {
                     RuntimeError::Custom("resolved CPU placement has no host NUMA node".into())
                 })?;
-                resolved.numa = Some(single_node_numa(
-                    host_node,
-                    request.max_vcpus,
-                    request.boot_memory_mib,
-                    request.max_memory_mib,
-                    profile.memory,
-                ));
+                let node = topology
+                    .numa_nodes
+                    .iter()
+                    .find(|node| node.id == host_node)
+                    .ok_or_else(|| {
+                        RuntimeError::Custom(format!(
+                            "resolved CPU placement references missing host NUMA node {host_node}"
+                        ))
+                    })?;
+                let reserved = reserved_memory_mib.get(&host_node).copied().unwrap_or(0);
+                if node_can_fit_memory(node, reserved, request) {
+                    resolved.numa = Some(single_node_numa(
+                        host_node,
+                        request.max_vcpus,
+                        request.boot_memory_mib,
+                        request.max_memory_mib,
+                        profile.memory,
+                        false,
+                    ));
+                } else {
+                    resolved.fallback = Some(PlacementFallback::FollowCpuMemoryCapacity);
+                }
             }
             Ok(resolved)
         }
@@ -175,11 +200,11 @@ pub(crate) fn plan(
 
 fn plan_cpu(
     topology: &CpuTopology,
-    occupied: &HashSet<LogicalCpuId>,
+    loads: &BTreeMap<LogicalCpuId, usize>,
     requested: CpuPlacement,
     requested_count: usize,
 ) -> RuntimeResult<ResolvedPlacement> {
-    let cores = available_cores(topology, occupied);
+    let cores = core_loads(topology, loads);
     match requested {
         CpuPlacement::Auto => plan_auto(cores, requested_count),
         CpuPlacement::Spread => plan_spread(cores, requested, requested_count),
@@ -196,6 +221,7 @@ fn single_node_numa(
     boot_memory_mib: u32,
     max_memory_mib: u32,
     memory: MemoryPlacement,
+    required: bool,
 ) -> ResolvedNumaPlacement {
     ResolvedNumaPlacement {
         nodes: vec![ResolvedNumaNode {
@@ -207,21 +233,23 @@ fn single_node_numa(
         }],
         distances: vec![(0, 0, 10)],
         memory,
+        required,
     }
 }
 
 #[derive(Debug)]
-struct AvailableCore<'a> {
-    logical: Vec<&'a LogicalCpu>,
-    free: Vec<&'a LogicalCpu>,
-    all_free: bool,
+struct CoreLoad {
+    logical: Vec<LogicalLoad>,
     performance_class: u8,
 }
 
-fn available_cores<'a>(
-    topology: &'a CpuTopology,
-    occupied: &HashSet<LogicalCpuId>,
-) -> Vec<AvailableCore<'a>> {
+#[derive(Debug)]
+struct LogicalLoad {
+    id: LogicalCpuId,
+    assignments: usize,
+}
+
+fn core_loads(topology: &CpuTopology, loads: &BTreeMap<LogicalCpuId, usize>) -> Vec<CoreLoad> {
     let mut grouped: BTreeMap<(i32, i32, i32), Vec<&LogicalCpu>> = BTreeMap::new();
     for cpu in &topology.logical_cpus {
         grouped
@@ -234,17 +262,15 @@ fn available_cores<'a>(
         .into_values()
         .map(|mut logical| {
             logical.sort_by_key(|cpu| cpu.id);
-            let free = logical
-                .iter()
-                .copied()
-                .filter(|cpu| !occupied.contains(&cpu.id))
-                .collect::<Vec<_>>();
-            let all_free = free.len() == logical.len();
-            AvailableCore {
+            CoreLoad {
                 performance_class: logical[0].performance_class,
-                logical,
-                free,
-                all_free,
+                logical: logical
+                    .into_iter()
+                    .map(|cpu| LogicalLoad {
+                        id: cpu.id,
+                        assignments: loads.get(&cpu.id).copied().unwrap_or(0),
+                    })
+                    .collect(),
             }
         })
         .collect::<Vec<_>>();
@@ -253,156 +279,279 @@ fn available_cores<'a>(
 }
 
 /// Plan Auto as one stable spread-then-share strategy.
-///
-/// Pass one uses an untouched physical core. A free sibling beside an existing Auto assignment is
-/// a soft hold only in this pass; pass two may consume it when distinct cores are exhausted.
-fn plan_auto(
-    cores: Vec<AvailableCore<'_>>,
-    requested_count: usize,
-) -> RuntimeResult<ResolvedPlacement> {
+fn plan_auto(mut cores: Vec<CoreLoad>, requested_count: usize) -> RuntimeResult<ResolvedPlacement> {
     let mut selected = Vec::with_capacity(requested_count);
+    let mut shared = false;
 
-    // Prefer one thread from every entirely free physical core. This is the low-contention phase.
-    for core in &cores {
-        if core.all_free {
-            selected.push(core.free[0].id);
+    // Low-contention phase: take one thread from every untouched physical core.
+    for core_index in 0..cores.len() {
+        if core_total(&cores[core_index]) == 0 {
+            select_cpu(&mut cores, core_index, 0, &mut selected, &mut shared);
             if selected.len() == requested_count {
                 break;
             }
         }
     }
 
-    // Density phase: use any remaining free hardware thread, including a derived soft hold beside
-    // an older Auto allocation. Keep core order stable so identical snapshots produce identical
-    // plans and the existing uniqueness constraint can resolve concurrent races predictably.
-    if selected.len() < requested_count {
-        for core in &cores {
-            for cpu in &core.free {
-                if selected.contains(&cpu.id) {
-                    continue;
-                }
-                selected.push(cpu.id);
-                if selected.len() == requested_count {
-                    break;
-                }
-            }
-            if selected.len() == requested_count {
-                break;
-            }
-        }
-    }
-    if selected.len() != requested_count {
-        return insufficient_capacity(CpuPlacement::Auto, requested_count);
+    // Density phase: consume unused SMT siblings, including soft holds beside older Auto work.
+    while selected.len() < requested_count {
+        let candidate = cores.iter().enumerate().find_map(|(core_index, core)| {
+            core.logical
+                .iter()
+                .position(|cpu| cpu.assignments == 0)
+                .map(|logical_index| (core_index, logical_index))
+        });
+        let Some((core_index, logical_index)) = candidate else {
+            break;
+        };
+        select_cpu(
+            &mut cores,
+            core_index,
+            logical_index,
+            &mut selected,
+            &mut shared,
+        );
     }
 
-    let reservations = selected
-        .iter()
-        .enumerate()
-        .map(|(vcpu_index, logical_cpu)| CpuReservation {
-            logical_cpu: *logical_cpu,
-            vcpu_index: Some(vcpu_index as u8),
-            role: "assigned",
-        })
-        .collect();
-    Ok(ResolvedPlacement {
-        requested: CpuPlacement::Auto,
-        resolved: CpuPlacement::Auto,
-        vcpu_targets: selected,
-        reservations,
-        numa: None,
-    })
+    // Pressure phase: share the least-loaded logical CPUs instead of rejecting creation.
+    while selected.len() < requested_count {
+        let (core_index, logical_index) = least_loaded_logical(&cores)?;
+        select_cpu(
+            &mut cores,
+            core_index,
+            logical_index,
+            &mut selected,
+            &mut shared,
+        );
+    }
+
+    Ok(finish_plan(CpuPlacement::Auto, selected, shared))
 }
 
 fn plan_spread(
-    cores: Vec<AvailableCore<'_>>,
+    mut cores: Vec<CoreLoad>,
     requested: CpuPlacement,
     requested_count: usize,
 ) -> RuntimeResult<ResolvedPlacement> {
-    let selected: Vec<_> = cores
-        .into_iter()
-        .filter(|core| core.all_free)
-        .take(requested_count)
-        .collect();
-    if selected.len() != requested_count {
-        return insufficient_capacity(CpuPlacement::Spread, requested_count);
+    let mut selected = Vec::with_capacity(requested_count);
+    let mut shared = false;
+
+    while selected.len() < requested_count {
+        let candidate = cores
+            .iter()
+            .enumerate()
+            .filter(|(_, core)| core.logical.iter().any(|cpu| cpu.assignments == 0))
+            .min_by_key(|(core_index, core)| (core_total(core), *core_index))
+            .map(|(core_index, core)| {
+                let logical_index = core
+                    .logical
+                    .iter()
+                    .position(|cpu| cpu.assignments == 0)
+                    .expect("candidate core has an unused logical CPU");
+                (core_index, logical_index)
+            })
+            .or_else(|| least_loaded_core_logical(&cores));
+        let Some((core_index, logical_index)) = candidate else {
+            return no_host_processors(requested);
+        };
+        select_cpu(
+            &mut cores,
+            core_index,
+            logical_index,
+            &mut selected,
+            &mut shared,
+        );
     }
 
-    let mut vcpu_targets = Vec::with_capacity(requested_count);
-    let mut reservations = Vec::new();
-    for (vcpu_index, core) in selected.into_iter().enumerate() {
-        let assigned = core.logical[0].id;
-        vcpu_targets.push(assigned);
-        for cpu in core.logical {
-            reservations.push(CpuReservation {
-                logical_cpu: cpu.id,
-                vcpu_index: (cpu.id == assigned).then_some(vcpu_index as u8),
-                role: if cpu.id == assigned {
-                    "assigned"
-                } else {
-                    "smt-reserved"
-                },
-            });
-        }
-    }
-
-    Ok(ResolvedPlacement {
-        requested,
-        resolved: CpuPlacement::Spread,
-        vcpu_targets,
-        reservations,
-        numa: None,
-    })
+    Ok(finish_plan(requested, selected, shared))
 }
 
 fn plan_compact(
-    cores: Vec<AvailableCore<'_>>,
+    mut cores: Vec<CoreLoad>,
     requested: CpuPlacement,
     requested_count: usize,
 ) -> RuntimeResult<ResolvedPlacement> {
-    let mut candidates: Vec<_> = cores
-        .into_iter()
-        .map(|core| core.free)
-        .filter(|logical| !logical.is_empty())
-        .collect();
-    candidates.sort_by_key(|logical| std::cmp::Reverse(logical.len()));
-
     let mut selected = Vec::with_capacity(requested_count);
-    for core in candidates {
-        for cpu in core {
-            selected.push(cpu.id);
-            if selected.len() == requested_count {
-                break;
-            }
-        }
-        if selected.len() == requested_count {
+    let mut shared = false;
+
+    // Fill unused siblings on already active cores before opening another physical core.
+    while selected.len() < requested_count {
+        let candidate = cores
+            .iter()
+            .enumerate()
+            .filter(|(_, core)| core.logical.iter().any(|cpu| cpu.assignments == 0))
+            .min_by_key(|(core_index, core)| {
+                (
+                    usize::from(core_total(core) == 0),
+                    std::cmp::Reverse(core_total(core)),
+                    *core_index,
+                )
+            })
+            .map(|(core_index, core)| {
+                let logical_index = core
+                    .logical
+                    .iter()
+                    .position(|cpu| cpu.assignments == 0)
+                    .expect("candidate core has an unused logical CPU");
+                (core_index, logical_index)
+            });
+        let Some((core_index, logical_index)) = candidate else {
             break;
-        }
-    }
-    if selected.len() != requested_count {
-        return insufficient_capacity(CpuPlacement::Compact, requested_count);
+        };
+        select_cpu(
+            &mut cores,
+            core_index,
+            logical_index,
+            &mut selected,
+            &mut shared,
+        );
     }
 
+    // Balance the sharing depth first; compactness is only a tie-breaker under pressure.
+    while selected.len() < requested_count {
+        let candidate = cores
+            .iter()
+            .enumerate()
+            .flat_map(|(core_index, core)| {
+                core.logical
+                    .iter()
+                    .enumerate()
+                    .map(move |(logical_index, cpu)| (core_index, logical_index, cpu))
+            })
+            .min_by_key(|(core_index, logical_index, cpu)| {
+                (
+                    cpu.assignments,
+                    std::cmp::Reverse(core_total(&cores[*core_index])),
+                    *core_index,
+                    *logical_index,
+                )
+            })
+            .map(|(core_index, logical_index, _)| (core_index, logical_index));
+        let Some((core_index, logical_index)) = candidate else {
+            return no_host_processors(requested);
+        };
+        select_cpu(
+            &mut cores,
+            core_index,
+            logical_index,
+            &mut selected,
+            &mut shared,
+        );
+    }
+
+    Ok(finish_plan(requested, selected, shared))
+}
+
+fn finish_plan(
+    requested: CpuPlacement,
+    selected: Vec<LogicalCpuId>,
+    shared: bool,
+) -> ResolvedPlacement {
     let reservations = selected
         .iter()
         .enumerate()
         .map(|(vcpu_index, logical_cpu)| CpuReservation {
             logical_cpu: *logical_cpu,
             vcpu_index: Some(vcpu_index as u8),
-            role: "assigned",
+            role: "planned",
         })
         .collect();
-    Ok(ResolvedPlacement {
+    ResolvedPlacement {
         requested,
-        resolved: CpuPlacement::Compact,
+        resolved: requested,
         vcpu_targets: selected,
         reservations,
         numa: None,
-    })
+        shared,
+        fallback: None,
+    }
 }
 
-fn insufficient_capacity<T>(policy: CpuPlacement, requested_count: usize) -> RuntimeResult<T> {
+fn select_cpu(
+    cores: &mut [CoreLoad],
+    core_index: usize,
+    logical_index: usize,
+    selected: &mut Vec<LogicalCpuId>,
+    shared: &mut bool,
+) {
+    let cpu = &mut cores[core_index].logical[logical_index];
+    *shared |= cpu.assignments > 0;
+    selected.push(cpu.id);
+    cpu.assignments += 1;
+}
+
+fn core_total(core: &CoreLoad) -> usize {
+    core.logical.iter().map(|cpu| cpu.assignments).sum()
+}
+
+fn least_loaded_logical(cores: &[CoreLoad]) -> RuntimeResult<(usize, usize)> {
+    cores
+        .iter()
+        .enumerate()
+        .flat_map(|(core_index, core)| {
+            core.logical
+                .iter()
+                .enumerate()
+                .map(move |(logical_index, cpu)| (core_index, logical_index, cpu))
+        })
+        .min_by_key(|(core_index, logical_index, cpu)| {
+            (
+                cpu.assignments,
+                core_total(&cores[*core_index]),
+                *core_index,
+                *logical_index,
+            )
+        })
+        .map(|(core_index, logical_index, _)| (core_index, logical_index))
+        .ok_or_else(|| {
+            RuntimeError::Custom("managed CPU placement found no host processors".into())
+        })
+}
+
+fn least_loaded_core_logical(cores: &[CoreLoad]) -> Option<(usize, usize)> {
+    let core_index = cores
+        .iter()
+        .enumerate()
+        .min_by_key(|(core_index, core)| (core_total(core), *core_index))?
+        .0;
+    let logical_index = cores[core_index]
+        .logical
+        .iter()
+        .enumerate()
+        .min_by_key(|(logical_index, cpu)| (cpu.assignments, *logical_index))?
+        .0;
+    Some((core_index, logical_index))
+}
+
+fn node_can_fit_memory(
+    node: &super::topology::HostNumaNode,
+    reserved_memory_mib: u64,
+    request: PlacementRequest,
+) -> bool {
+    node.available_memory_mib >= u64::from(request.boot_memory_mib)
+        && node.total_memory_mib.saturating_sub(reserved_memory_mib)
+            >= u64::from(request.max_memory_mib)
+}
+
+fn node_can_fit_unshared_cpus(
+    topology: &CpuTopology,
+    loads: &BTreeMap<LogicalCpuId, usize>,
+    host_node_id: u32,
+    requested_count: usize,
+) -> bool {
+    topology
+        .logical_cpus
+        .iter()
+        .filter(|cpu| cpu.numa_node == host_node_id)
+        .filter(|cpu| loads.get(&cpu.id).copied().unwrap_or(0) == 0)
+        .take(requested_count)
+        .count()
+        == requested_count
+}
+
+fn no_host_processors<T>(policy: CpuPlacement) -> RuntimeResult<T> {
     Err(RuntimeError::Custom(format!(
-        "CPU placement {policy} cannot reserve {requested_count} vCPUs from the allowed host topology"
+        "CPU placement {policy} found no allowed host processors"
     )))
 }
 
@@ -418,13 +567,13 @@ mod tests {
 
     fn plan(
         topology: &CpuTopology,
-        occupied: &HashSet<LogicalCpuId>,
+        loads: &BTreeMap<LogicalCpuId, usize>,
         requested: CpuPlacement,
         max_vcpus: u8,
     ) -> RuntimeResult<ResolvedPlacement> {
         super::plan(
             topology,
-            occupied,
+            loads,
             PlacementRequest {
                 policy: requested,
                 max_vcpus,
@@ -477,8 +626,8 @@ mod tests {
     }
 
     #[test]
-    fn spread_uses_distinct_cores_and_reserves_siblings() {
-        let plan = plan(&topology(), &HashSet::new(), CpuPlacement::Spread, 2).unwrap();
+    fn spread_uses_distinct_cores_without_hard_sibling_holds() {
+        let plan = plan(&topology(), &BTreeMap::new(), CpuPlacement::Spread, 2).unwrap();
 
         assert_eq!(plan.vcpu_targets, vec![id(0), id(1)]);
         assert_eq!(
@@ -486,13 +635,14 @@ mod tests {
                 .iter()
                 .map(|reservation| reservation.logical_cpu)
                 .collect::<Vec<_>>(),
-            vec![id(0), id(6), id(1), id(7)]
+            vec![id(0), id(1)]
         );
+        assert!(!plan.shared);
     }
 
     #[test]
     fn compact_consumes_smt_siblings_first() {
-        let plan = plan(&topology(), &HashSet::new(), CpuPlacement::Compact, 2).unwrap();
+        let plan = plan(&topology(), &BTreeMap::new(), CpuPlacement::Compact, 2).unwrap();
 
         assert_eq!(plan.vcpu_targets, vec![id(0), id(6)]);
         assert_eq!(plan.reservations.len(), 2);
@@ -500,39 +650,70 @@ mod tests {
 
     #[test]
     fn auto_uses_distinct_cores_before_smt_siblings() {
-        let plan = plan(&topology(), &HashSet::new(), CpuPlacement::Auto, 3).unwrap();
+        let plan = plan(&topology(), &BTreeMap::new(), CpuPlacement::Auto, 3).unwrap();
 
         assert_eq!(plan.resolved, CpuPlacement::Auto);
         assert_eq!(plan.vcpu_targets, vec![id(0), id(1), id(2)]);
-        assert!(plan.reservations.iter().all(|row| row.role == "assigned"));
+        assert!(plan.reservations.iter().all(|row| row.role == "planned"));
     }
 
     #[test]
     fn auto_consumes_derived_soft_holds_when_untouched_cores_are_exhausted() {
-        // A previously took CPU 0 and CPU 1 with Auto. Their free siblings are not occupied rows.
-        let occupied = HashSet::from([id(0), id(1)]);
-        let plan = plan(&topology(), &occupied, CpuPlacement::Auto, 2).unwrap();
+        // A previously took CPU 0 and CPU 1 with Auto. Their free siblings remain soft holds.
+        let loads = BTreeMap::from([(id(0), 1), (id(1), 1)]);
+        let plan = plan(&topology(), &loads, CpuPlacement::Auto, 2).unwrap();
 
         assert_eq!(plan.vcpu_targets, vec![id(2), id(6)]);
     }
 
     #[test]
     fn auto_soft_holds_reappear_without_catalog_mutation() {
-        let occupied = HashSet::from([id(0), id(1)]);
+        let loads = BTreeMap::from([(id(0), 1), (id(1), 1)]);
 
-        let first = plan(&topology(), &occupied, CpuPlacement::Auto, 1).unwrap();
-        let after_sibling_user_exits = plan(&topology(), &occupied, CpuPlacement::Auto, 1).unwrap();
+        let first = plan(&topology(), &loads, CpuPlacement::Auto, 1).unwrap();
+        let after_sibling_user_exits = plan(&topology(), &loads, CpuPlacement::Auto, 1).unwrap();
 
         assert_eq!(first.vcpu_targets, vec![id(2)]);
         assert_eq!(after_sibling_user_exits.vcpu_targets, first.vcpu_targets);
     }
 
     #[test]
-    fn spread_does_not_share_a_partially_occupied_core() {
-        let occupied = HashSet::from([id(6)]);
-        let plan = plan(&topology(), &occupied, CpuPlacement::Spread, 2).unwrap();
+    fn spread_preserves_the_widest_available_distribution() {
+        let loads = BTreeMap::from([(id(6), 1)]);
+        let plan = plan(&topology(), &loads, CpuPlacement::Spread, 2).unwrap();
 
         assert_eq!(plan.vcpu_targets, vec![id(1), id(2)]);
+    }
+
+    #[test]
+    fn ordinary_policies_share_after_every_logical_cpu_is_used() {
+        for policy in [
+            CpuPlacement::Auto,
+            CpuPlacement::Spread,
+            CpuPlacement::Compact,
+        ] {
+            let resolved = plan(&topology(), &BTreeMap::new(), policy, 8).unwrap();
+
+            assert_eq!(resolved.vcpu_targets.len(), 8);
+            assert!(resolved.shared, "{policy} should report pressure sharing");
+            assert_eq!(resolved.reservations.len(), 8);
+        }
+    }
+
+    #[test]
+    fn sharing_prefers_the_least_loaded_logical_cpus() {
+        let loads = BTreeMap::from([
+            (id(0), 2),
+            (id(6), 2),
+            (id(1), 1),
+            (id(7), 1),
+            (id(2), 1),
+            (id(8), 1),
+        ]);
+        let resolved = plan(&topology(), &loads, CpuPlacement::Auto, 2).unwrap();
+
+        assert_eq!(resolved.vcpu_targets, vec![id(1), id(2)]);
+        assert!(resolved.shared);
     }
 
     #[test]
@@ -549,7 +730,7 @@ mod tests {
             fingerprint: "heterogeneous".into(),
         };
 
-        let plan = plan(&topology, &HashSet::new(), CpuPlacement::Compact, 1).unwrap();
+        let plan = plan(&topology, &BTreeMap::new(), CpuPlacement::Compact, 1).unwrap();
 
         assert_eq!(plan.vcpu_targets, vec![id(1)]);
     }
@@ -582,7 +763,7 @@ mod tests {
         };
         let resolved = super::plan(
             &topology,
-            &HashSet::new(),
+            &BTreeMap::new(),
             PlacementRequest {
                 policy: CpuPlacement::Auto,
                 max_vcpus: 2,
@@ -600,7 +781,74 @@ mod tests {
                 .iter()
                 .all(|cpu| [id(2), id(8)].contains(cpu))
         );
-        assert_eq!(resolved.numa.unwrap().nodes[0].host_node_id, 1);
+        let numa = resolved.numa.unwrap();
+        assert_eq!(numa.nodes[0].host_node_id, 1);
+        assert!(!numa.required);
+    }
+
+    #[test]
+    fn prefer_single_falls_back_to_inherited_numa_under_memory_pressure() {
+        let profile = PlacementProfile {
+            numa: NumaPlacement::PreferSingle,
+            memory: MemoryPlacement::FollowCpu,
+        };
+        let resolved = super::plan(
+            &topology(),
+            &BTreeMap::new(),
+            PlacementRequest {
+                policy: CpuPlacement::Auto,
+                max_vcpus: 2,
+                boot_memory_mib: 1024,
+                max_memory_mib: 4096,
+                profile: Some(profile),
+            },
+            &BTreeMap::from([(0, 15_000)]),
+        )
+        .unwrap();
+
+        assert!(resolved.numa.is_none());
+        assert_eq!(
+            resolved.fallback,
+            Some(PlacementFallback::PreferSingleCapacity)
+        );
+    }
+
+    #[test]
+    fn follow_cpu_falls_back_when_selected_cpus_span_host_nodes() {
+        let mut topology = topology();
+        topology.numa_nodes.push(HostNumaNode {
+            id: 1,
+            package: 0,
+            total_memory_mib: 16_384,
+            available_memory_mib: 16_384,
+            distances: BTreeMap::from([(0, 12), (1, 10)]),
+        });
+        topology.numa_nodes[0].distances.insert(1, 12);
+        for cpu in &mut topology.logical_cpus {
+            cpu.numa_node = u32::from(cpu.core > 0);
+        }
+        let resolved = super::plan(
+            &topology,
+            &BTreeMap::new(),
+            PlacementRequest {
+                policy: CpuPlacement::Auto,
+                max_vcpus: 2,
+                boot_memory_mib: 1024,
+                max_memory_mib: 4096,
+                profile: Some(PlacementProfile {
+                    numa: NumaPlacement::Inherit,
+                    memory: MemoryPlacement::FollowCpu,
+                }),
+            },
+            &BTreeMap::new(),
+        )
+        .unwrap();
+
+        assert!(resolved.numa.is_none());
+        assert_eq!(
+            resolved.fallback,
+            Some(PlacementFallback::FollowCpuCrossNode)
+        );
     }
 
     #[test]
@@ -611,7 +859,7 @@ mod tests {
         };
         let error = super::plan(
             &topology(),
-            &HashSet::new(),
+            &BTreeMap::new(),
             PlacementRequest {
                 policy: CpuPlacement::Auto,
                 max_vcpus: 2,
@@ -624,5 +872,77 @@ mod tests {
         .unwrap_err();
 
         assert!(error.to_string().contains("strict_single"));
+    }
+
+    #[test]
+    fn strict_single_marks_successful_placement_as_required() {
+        let resolved = super::plan(
+            &topology(),
+            &BTreeMap::new(),
+            PlacementRequest {
+                policy: CpuPlacement::Auto,
+                max_vcpus: 2,
+                boot_memory_mib: 1024,
+                max_memory_mib: 4096,
+                profile: Some(PlacementProfile {
+                    numa: NumaPlacement::StrictSingle,
+                    memory: MemoryPlacement::FollowCpu,
+                }),
+            },
+            &BTreeMap::new(),
+        )
+        .unwrap();
+
+        assert!(resolved.numa.unwrap().required);
+    }
+
+    #[test]
+    fn strict_single_does_not_count_cpu_sharing_as_single_node_capacity() {
+        let error = super::plan(
+            &topology(),
+            &BTreeMap::new(),
+            PlacementRequest {
+                policy: CpuPlacement::Auto,
+                max_vcpus: 8,
+                boot_memory_mib: 512,
+                max_memory_mib: 512,
+                profile: Some(PlacementProfile {
+                    numa: NumaPlacement::StrictSingle,
+                    memory: MemoryPlacement::FollowCpu,
+                }),
+            },
+            &BTreeMap::new(),
+        )
+        .unwrap_err();
+
+        assert!(error.to_string().contains("strict_single"));
+    }
+
+    #[test]
+    fn prefer_single_keeps_cpu_plan_but_inherits_numa_when_unshared_capacity_is_short() {
+        let resolved = super::plan(
+            &topology(),
+            &BTreeMap::new(),
+            PlacementRequest {
+                policy: CpuPlacement::Auto,
+                max_vcpus: 8,
+                boot_memory_mib: 512,
+                max_memory_mib: 512,
+                profile: Some(PlacementProfile {
+                    numa: NumaPlacement::PreferSingle,
+                    memory: MemoryPlacement::FollowCpu,
+                }),
+            },
+            &BTreeMap::new(),
+        )
+        .unwrap();
+
+        assert_eq!(resolved.vcpu_targets.len(), 8);
+        assert!(resolved.shared);
+        assert!(resolved.numa.is_none());
+        assert_eq!(
+            resolved.fallback,
+            Some(PlacementFallback::PreferSingleCapacity)
+        );
     }
 }

--- a/crates/runtime/lib/vm.rs
+++ b/crates/runtime/lib/vm.rs
@@ -704,7 +704,11 @@ fn run(config: Config) -> RuntimeResult<std::convert::Infallible> {
     let exit_metrics_writer = metrics_writer.clone();
     let exit_cpu_guard = Arc::clone(&cpu_guard);
     let exit_writeback_guard = Arc::clone(&writeback_guard);
+    let placement_rt_handle = tokio_rt.handle().clone();
+    let placement_db = db.clone();
+    let placement_cpu_guard = Arc::clone(&cpu_guard);
     let resolved_numa_topology = cpu_guard.numa_topology();
+    let placement_required = cpu_guard.placement_required();
     #[cfg(windows)]
     let _agent_console_pipe_bridge = AgentConsolePipeBridge::spawn(
         agent_console_pipe_name(config.sandbox_id),
@@ -712,6 +716,11 @@ fn run(config: Config) -> RuntimeResult<std::convert::Infallible> {
         tokio_rt.handle(),
     )
     .map_err(|e| RuntimeError::Custom(format!("agent console pipe bridge: {e}")))?;
+    let host_placement = HostPlacement {
+        vcpu_targets: cpu_guard.vcpu_targets(),
+        required: placement_required,
+        numa_topology: resolved_numa_topology,
+    };
     let build_result = build_vm(
         &config,
         console_backend,
@@ -830,9 +839,29 @@ fn run(config: Config) -> RuntimeResult<std::convert::Infallible> {
                 tracing::debug!(error = %err, slot = writer.slot(), "metrics slot release at exit");
             }
         },
+        move |report: &msb_krun::PlacementReport| {
+            let pinned = report
+                .vcpus
+                .iter()
+                .filter(|result| matches!(result, msb_krun::VcpuPlacementResult::Pinned { .. }))
+                .count();
+            if let Err(error) =
+                placement_rt_handle.block_on(placement_cpu_guard.reconcile(&placement_db, report))
+            {
+                // Placement is already effective at the OS boundary. A catalog failure must not
+                // turn an ordinary best-effort policy into a sandbox-creation failure; the
+                // process-held lease remains conservative until exit or stale-lease recovery.
+                tracing::warn!(%error, "record effective host placement");
+            }
+            tracing::info!(
+                pinned_vcpus = pinned,
+                inherited_vcpus = report.vcpus.len().saturating_sub(pinned),
+                memory = ?report.memory,
+                "host placement acknowledged before guest execution"
+            );
+        },
         tokio_rt.handle().clone(),
-        cpu_guard.vcpu_targets(),
-        resolved_numa_topology,
+        host_placement,
         writeback_limit.as_ref(),
     );
     let (
@@ -1349,13 +1378,19 @@ fn is_writeback_limited_disk(format: msb_krun::DiskImageFormat, read_only: bool)
 }
 
 /// Build the `Vm` from config with an exit observer for cleanup.
+struct HostPlacement<'a> {
+    vcpu_targets: Option<&'a [crate::cpu::LogicalCpuId]>,
+    required: bool,
+    numa_topology: Option<msb_krun::NumaTopology>,
+}
+
 fn build_vm(
     config: &Config,
     console_backend: AgentConsoleBackend,
     on_exit: impl Fn(i32) + Send + 'static,
+    on_placement: impl FnOnce(&msb_krun::PlacementReport) + Send + 'static,
     tokio_handle: tokio::runtime::Handle,
-    vcpu_targets: Option<&[crate::cpu::LogicalCpuId]>,
-    numa_topology: Option<msb_krun::NumaTopology>,
+    host_placement: HostPlacement<'_>,
     writeback_limit: Option<&msb_krun::WritebackLimit>,
 ) -> RuntimeResult<VmBuildOutput> {
     let mut exec_env = config.vm.env.clone();
@@ -1376,16 +1411,19 @@ fn build_vm(
                 .max_vcpus(vm.max_cpus.max(vm.vcpus))
                 .max_memory_mib((vm.max_memory_mib.max(vm.memory_mib)) as usize)
                 .balloon_stats_interval(balloon_stats_interval);
-            if let Some(targets) = vcpu_targets {
-                m = m.vcpu_affinity(
-                    targets
-                        .iter()
-                        .copied()
-                        .map(|cpu| msb_krun::HostCpuId::in_group(cpu.group, cpu.index))
-                        .collect(),
-                );
+            if let Some(targets) = host_placement.vcpu_targets {
+                let affinity = targets
+                    .iter()
+                    .copied()
+                    .map(|cpu| msb_krun::HostCpuId::in_group(cpu.group, cpu.index))
+                    .collect();
+                m = if host_placement.required {
+                    m.vcpu_affinity(affinity)
+                } else {
+                    m.try_vcpu_affinity(affinity)
+                };
             }
-            if let Some(topology) = numa_topology {
+            if let Some(topology) = host_placement.numa_topology {
                 m = m.numa_topology(topology);
             }
             #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
@@ -1784,7 +1822,7 @@ fn build_vm(
     }
 
     // Exit observer — runs synchronously before _exit() for DB cleanup.
-    builder = builder.on_exit(on_exit);
+    builder = builder.on_placement(on_placement).on_exit(on_exit);
 
     let vm = builder
         .build()

--- a/docs/configuration.mdx
+++ b/docs/configuration.mdx
@@ -219,9 +219,9 @@ When the root-disk default is flat, plain `msb pull IMAGE` also prepares the reu
 
 ### `runtime.placement_profiles`
 
-Placement profiles let an operator define safe host topology policy once while callers select it by name. `numa.mode` is `prefer_single`, `strict_single`, or `inherit`; `memory.mode` is `follow_cpu` or `inherit`. In this release, both single-node modes fail clearly when `max_cpus` or `max_memory_mib` cannot fit one allowed host NUMA node because multi-node guest placement is not enabled yet.
+Placement profiles let an operator define safe host topology policy once while callers select it by name. `numa.mode` is `prefer_single`, `strict_single`, or `inherit`; `memory.mode` is `follow_cpu` or `inherit`. Multi-node guest placement is not enabled in this release: `prefer_single` falls back to inherited host NUMA behavior when one node cannot fit, while `strict_single` fails clearly because it is an explicit guarantee.
 
-`follow_cpu` requires managed CPU placement (`auto`, `spread`, or `compact`). Linux binds guest RAM to the selected node and admits the configured maximum against host-node capacity. Windows requests preferred-node allocation and checks current boot-time availability, but Windows does not expose equivalent per-node total capacity for a hard future-growth promise. macOS accepts only an inherited no-op profile because it has no equivalent hard-affinity API.
+`follow_cpu` requires managed CPU placement (`auto`, `spread`, or `compact`). Linux prefers the selected node for ordinary profiles and allows memory to spill elsewhere under pressure; `strict_single` uses a required binding instead. If CPUs span nodes, capacity is already insufficient, or the kernel rejects a best-effort affinity or memory-policy syscall, an ordinary profile starts with inherited memory placement. Windows keeps ordinary memory inherited because its preferred-node allocation cannot be undone if a later vCPU affinity attempt falls back; `strict_single` can still request required preferred-node allocation. Windows checks current boot-time availability, but does not expose equivalent per-node total capacity for a hard future-growth promise. macOS inherits ordinary CPU and memory scheduling for non-strict profiles because it has no equivalent hard-affinity API.
 
 ### `runtime.block_writeback`
 

--- a/docs/optimization/overview.mdx
+++ b/docs/optimization/overview.mdx
@@ -63,7 +63,7 @@ There is no universal fastest profile. The following is a reasonable starting po
 }
 ```
 
-`cpu_placement: auto` is intentionally not a portable macOS default: managed placement is unsupported on macOS because the operating system does not expose an equivalent public hard-affinity API. Use `inherit` on macOS. Keep `thp: madvise` unless a representative workload and density test justify another policy. On Linux, the default writeback `auto` policy gives an idle disk the measured 1.5 GiB window that kept the unchanged OVH customer disk suite at containment-off throughput. When more writable disks join than the pool can support at that maximum, all live VMMs reduce their targets to a fair share and apply write pressure instead of rejecting the new sandbox. On macOS and Windows, unconfigured `auto` is a no-op because this controller governs Linux host page-cache writeback. Use `fixed` when a different per-disk maximum is justified by measurement.
+`cpu_placement: auto` is intentionally not a portable macOS performance default: macOS inherits ordinary scheduling because the operating system does not expose an equivalent public hard-affinity API. Keep `thp: madvise` unless a representative workload and density test justify another policy. On Linux, the default writeback `auto` policy gives an idle disk the measured 1.5 GiB window that kept the unchanged OVH customer disk suite at containment-off throughput. When more writable disks join than the pool can support at that maximum, all live VMMs reduce their targets to a fair share and apply write pressure instead of rejecting the new sandbox. On macOS and Windows, unconfigured writeback `auto` is a no-op because this controller governs Linux host page-cache writeback. Use `fixed` when a different per-disk maximum is justified by measurement.
 
 ## Storage layout: layered or flat
 
@@ -106,16 +106,16 @@ Reflink optimizes provisioning rather than promising faster steady-state writes.
 
 ## CPU placement
 
-`inherit` performs no topology discovery, central allocation, lease creation, or affinity call. It is the lowest-complexity choice when an external orchestrator already constrains the Microsandbox process. Managed `auto`, `spread`, and `compact` policies coordinate through the allocation catalog associated with one `MSB_HOME` and apply hard affinity to libkrun vCPU threads.
+`inherit` performs no topology discovery, central allocation, lease creation, or affinity call. It is the lowest-complexity choice when an external orchestrator already constrains the Microsandbox process. Managed `auto`, `spread`, and `compact` policies coordinate through the allocation catalog associated with one `MSB_HOME` and ask libkrun to pin its vCPU threads. Ordinary placement is best effort at the host boundary: if the operating system rejects an affinity or NUMA-memory call after planning, the VM starts under inherited scheduling or memory placement. An explicit `strict_single` profile keeps required enforcement and fails instead.
 
 | Policy | Use when | Tradeoff |
 | --- | --- | --- |
 | `inherit` | The host scheduler or an external orchestrator owns placement | No cooperative isolation from other Microsandbox vCPUs |
-| `auto` | A general dedicated host should choose between spread and compact | Result depends on topology and requested `max_cpus` |
-| `spread` | Throughput benefits from distinct physical cores and avoiding SMT siblings | Consumes more physical cores and can reduce packing density |
-| `compact` | Cache locality and host packing matter more than avoiding SMT siblings | Sibling contention can hurt compute-heavy workloads |
+| `auto` | General dedicated hosts | Spreads first, uses SMT siblings next, then shares the least-loaded logical CPUs |
+| `spread` | Throughput benefits from the widest physical-core distribution | Preserves that distribution under pressure, then shares balanced logical CPUs |
+| `compact` | Cache locality and host packing matter more than avoiding SMT siblings | Packs exclusive work first, then balances sharing depth to avoid one unbounded hotspot |
 
-Managed placement reserves for `max_cpus`, including vCPUs that are offline at boot. It does not pin VMM device workers, isolate unrelated host processes, or promise dedicated physical cores. Named placement profiles can additionally request NUMA-local guest memory. All cooperating processes must use the same machine-wide `MSB_HOME` if the allocation catalog is expected to coordinate the whole host. See [CPU placement](/sandboxes/cpu-placement) for the complete guarantees and platform behavior.
+Managed placement accounts for `max_cpus`, including vCPUs that are offline at boot. When exclusive logical processors run out, ordinary policies continue by pinning several vCPU threads to the same logical processor and letting the host scheduler time-slice them. It does not pin VMM device workers, isolate unrelated host processes, or promise dedicated physical cores. Named placement profiles can additionally request NUMA-local guest memory. All cooperating processes must use the same machine-wide `MSB_HOME` if the allocation catalog is expected to coordinate the whole host. See [CPU placement](/sandboxes/cpu-placement) for the complete guarantees and platform behavior.
 
 ## Guest transparent huge pages
 

--- a/docs/sandboxes/cpu-placement.mdx
+++ b/docs/sandboxes/cpu-placement.mdx
@@ -11,11 +11,11 @@ Microsandbox normally inherits the CPU scheduling and affinity constraints of th
 | Policy | Behavior |
 | --- | --- |
 | `inherit` | Default. Performs no topology discovery, allocation work, lease creation, or affinity calls. |
-| `auto` | Uses `spread` when the requested maximum vCPU count fits on distinct physical cores while leaving one core outside the allocation; otherwise uses `compact`. |
-| `spread` | Assigns each vCPU to a different physical core before using SMT siblings. SMT siblings of selected cores are reserved from other cooperating `spread` sandboxes. |
-| `compact` | Assigns SMT siblings first to minimize the number of physical cores used. |
+| `auto` | Uses untouched physical cores first, then unused SMT siblings, then fairly shares logical CPUs under pressure. |
+| `spread` | Preserves the widest practical distribution across physical cores, then SMT siblings, then shared logical CPUs. |
+| `compact` | Fills SMT siblings and minimizes the physical cores used while exclusive capacity remains, then shares logical CPUs without creating a single unbounded hotspot. |
 
-Managed placement reserves enough host targets for `max_cpus`, including guest CPUs that are offline at boot. Explicit managed policies fail when the host cannot enforce them or has insufficient cooperative capacity; they never silently fall back to `inherit`.
+Managed placement accounts for `max_cpus`, including guest CPUs that are offline at boot. Ordinary policies do not reject creation when cooperative CPU capacity is exhausted: multiple vCPU threads may be pinned to the same logical CPU and the host scheduler time-slices them. Runtime logs distinguish exclusive from shared placement. If topology discovery or cooperative coordination is unavailable, ordinary policies visibly fall back to `inherit`; `strict_single` remains fail-closed.
 
 <CodeGroup>
 ```bash CLI
@@ -126,16 +126,16 @@ sb, err := m.CreateSandbox(ctx, "worker",
 ```
 </CodeGroup>
 
-Planning uses `max_cpus` and `max_memory_mib`, not just the boot values. On Linux, this keeps later live growth inside the reserved node. In this release, multi-node guest placement is intentionally disabled: `prefer_single` and `strict_single` both return a capacity error rather than silently splitting a sandbox. Linux binds guest RAM to the chosen node. Windows uses the actual processor-to-NUMA-node mapping and requests preferred-node allocation; it checks current boot-time availability, but the operating system does not expose equivalent per-node total capacity for a hard future-growth promise. `inherit` leaves host memory policy unchanged.
+Planning uses `max_cpus` and `max_memory_mib`, not just the boot values. A sandbox fits one node only when that node has enough currently unassigned logical CPUs for every possible vCPU, enough current memory for boot, and enough cooperative total memory for its configured maximum. CPU time-sharing never counts as strict single-node capacity. Multi-node guest placement is not enabled in this release: `prefer_single` keeps the best ordinary CPU plan but falls back to inherited host NUMA and memory behavior when one node cannot fit, while `strict_single` returns a capacity error. `follow_cpu` similarly falls back to inherited memory placement if selected CPUs span nodes or the node lacks the requested memory capacity, unless it is paired with `strict_single`. Ordinary Linux placement uses a soft multi-node preference so memory can spill under pressure; `strict_single` uses a required binding. Windows uses the actual processor-to-NUMA-node mapping, but keeps ordinary memory inherited because preferred-node allocation cannot be undone after a later partial CPU fallback. A Windows `strict_single` profile can use required preferred-node allocation. `inherit` leaves host memory policy unchanged.
 
 ## Scope and guarantees
 
-Managed placement applies hard affinity to libkrun's vCPU threads before they enter guest execution: Linux uses the process affinity mask and `sched_setaffinity`, while Windows uses the calling runtime thread's processor-group affinity and `SetThreadGroupAffinity`. On heterogeneous Windows processors, the planner prefers the higher-performance core class reported by Windows. Placement does not isolate unrelated host processes, pin VMM or device-worker threads, or promise dedicated cores. Guest RAM remains under the normal host policy unless a selected placement profile uses `memory.mode: follow_cpu`.
+Managed placement asks libkrun to apply affinity to its vCPU threads before they enter guest execution: Linux uses the process affinity mask and `sched_setaffinity`, while Windows uses the calling runtime thread's processor-group affinity and `SetThreadGroupAffinity`. Every vCPU waits behind a startup barrier while libkrun reports what the operating system actually applied. For ordinary policies, successful pins remain in force and only rejected vCPUs inherit scheduler placement; Microsandbox removes their tentative catalog reservations before the guest runs. Any partial CPU result also returns ordinary `follow_cpu` memory to inherited policy. A `strict_single` profile keeps required enforcement and fails before guest execution instead. On heterogeneous Windows processors, the planner prefers the higher-performance core class reported by Windows. Placement does not isolate unrelated host processes, pin VMM or device-worker threads, or promise dedicated cores.
 
 Windows planning currently stays within the runtime thread's inherited primary processor group. Processor-group coordinates are preserved in the allocation catalog and libkrun affinity map, but one runtime process does not spread a sandbox across multiple Windows processor groups. This is immaterial on hosts with at most 64 logical processors and avoids expanding an affinity boundary inherited from the caller.
 
 Coordination is local to one Microsandbox catalog and lease directory. Sandboxes using different `MSB_HOME` values do not share reservations. Provider deployments that need machine-wide cooperative placement should configure one machine-wide allocation domain.
 
-On macOS, `inherit` remains available. `auto`, `spread`, and `compact` return an unsupported-platform error because Apple does not expose an equivalent public hard-affinity API; Microsandbox does not claim enforcement that was not applied.
+On macOS, `auto`, `spread`, and `compact` visibly resolve to inherited scheduling because Apple does not expose an equivalent public hard-affinity API. A profile using `strict_single` still fails because its locality guarantee cannot be enforced.
 
 See [Performance optimization](/optimization/overview#cpu-placement) for workload selection guidance and the interaction with host topology, THP, and interrupt acceleration.

--- a/packages/microsandbox-types/rust/lib/domain.rs
+++ b/packages/microsandbox-types/rust/lib/domain.rs
@@ -849,13 +849,13 @@ pub enum CpuPlacement {
     #[default]
     Inherit,
 
-    /// Select a managed placement policy from the available host topology.
+    /// Spread across cores, then use SMT siblings, then share logical processors under pressure.
     Auto,
 
-    /// Prefer distinct physical cores before assigning SMT siblings.
+    /// Preserve the widest practical distribution, sharing logical processors when necessary.
     Spread,
 
-    /// Prefer SMT siblings and minimize the number of physical cores used.
+    /// Prefer SMT siblings and fewer physical cores, then share balanced logical processors.
     Compact,
 }
 
@@ -865,7 +865,7 @@ pub enum CpuPlacement {
 #[cfg_attr(feature = "ts", derive(ts_rs::TS))]
 #[serde(tag = "mode", rename_all = "snake_case", deny_unknown_fields)]
 pub enum NumaPlacement {
-    /// Prefer one host NUMA node. Multi-node expansion is not enabled yet.
+    /// Prefer one host NUMA node, falling back to inherited host placement when it cannot fit.
     PreferSingle,
     /// Require maximum CPU and memory capacity to fit one host NUMA node.
     StrictSingle,
@@ -879,7 +879,7 @@ pub enum NumaPlacement {
 #[cfg_attr(feature = "ts", derive(ts_rs::TS))]
 #[serde(tag = "mode", rename_all = "snake_case", deny_unknown_fields)]
 pub enum MemoryPlacement {
-    /// Back guest RAM from the host nodes selected for its vCPUs.
+    /// Back guest RAM from the selected CPU node when enforceable, otherwise inherit host policy.
     FollowCpu,
     /// Preserve the operating system's ordinary memory policy.
     Inherit,


### PR DESCRIPTION
## TL;DR

Makes ordinary CPU and NUMA placement launch-safe under pressure. `auto`, `spread`, and `compact` share logical CPUs when exclusive capacity runs out; `prefer_single` keeps the CPU plan and drops NUMA locality when one node cannot truly fit; only `strict_single` remains fail-closed. Tentative catalog rows are reconciled with libkrun's actual pre-execution placement report.

## Description

- Change ordinary CPU planning to preserve each policy's shape through exclusive CPUs, SMT siblings, and balanced logical-CPU sharing instead of rejecting sandbox creation.
- Replace exclusive logical-CPU rows with per-allocation/per-vCPU assignments and coordinate planning from assignment load counts.
- Define true one-node fit as enough unassigned logical CPUs for `max_cpus`, enough available boot memory, and enough cooperative total memory for `max_memory_mib`; time-sharing cannot satisfy `strict_single`.
- Make `prefer_single` and ordinary `follow_cpu` visibly fall back to inherited NUMA/memory placement when locality cannot be guaranteed while preserving the resolved CPU targets.
- Commit CPU and memory reservations as tentative, then reconcile them while libkrun keeps every vCPU paused: confirmed pins remain, rejected vCPU rows are removed, and non-applied memory promises are removed.
- Keep catalog reconciliation failure non-fatal for ordinary placement; the process-held lease remains conservative until exit or stale-lease recovery.
- Update configuration, optimization, and CPU-placement docs to explain sharing, strict guarantees, the acknowledgement barrier, and platform behavior.

## Examples

### Ordinary pressure does not reject creation

Consider one NUMA node with two physical cores and SMT enabled:

```text
physical core 0: CPU 0, CPU 2
physical core 1: CPU 1, CPU 3
```

Three two-vCPU sandboxes using `cpu_placement = auto` are planned like this:

```text
Sandbox A: CPU 0 + CPU 1   untouched physical cores
Sandbox B: CPU 2 + CPU 3   unused SMT siblings
Sandbox C: CPU 0 + CPU 1   least-loaded logical CPUs; scheduler sharing
```

Sandbox C still starts. If it requested `prefer_single`, the CPU plan remains, but NUMA and `follow_cpu` memory locality become inherited because two currently unassigned logical CPUs are no longer available. With `strict_single`, that same request fails because strict mode is an explicit capacity guarantee.

### Partial OS enforcement keeps useful pins

Suppose a sandbox tentatively plans both CPU and memory locality:

```text
planned
  vCPU 0 -> CPU 0
  vCPU 1 -> CPU 1
  memory -> NUMA node 0

libkrun reports before guest execution
  vCPU 0 -> pinned
  vCPU 1 -> inherited (OS rejected affinity)
  memory -> inherited

reconciled catalog
  keep   vCPU 0 -> CPU 0
  remove vCPU 1 -> CPU 1
  remove NUMA node 0 memory promise
```

The successful pin is not thrown away just because another pin failed, and the catalog never continues claiming memory locality that is no longer true.

Uses the effective placement API merged in [libkrun PR #111](https://github.com/superradcompany/libkrun/pull/111) and published in `msb_krun` 0.1.31.

## Test Plan

- [x] `cargo fmt --all -- --check`
- [x] `MSB_AGENTD_PATH=/usr/bin/true cargo check -p microsandbox-runtime` against the exact local source from [libkrun PR #111](https://github.com/superradcompany/libkrun/pull/111)
- [x] `MSB_AGENTD_PATH=/usr/bin/true cargo test -p microsandbox-runtime cpu:: --lib` against the exact local source from [libkrun PR #111](https://github.com/superradcompany/libkrun/pull/111) (22 passed)
- [x] Placement acknowledgement integration test: preserves one successful pin, removes one rejected vCPU reservation, and removes the fallback NUMA memory promise
- [x] Planner tests: ordinary pressure sharing, balanced load, true strict-single capacity, and prefer-single NUMA fallback
- [x] Refresh `Cargo.lock` and run `MSB_AGENTD_PATH=/usr/bin/true cargo check -p microsandbox-runtime --locked` against published `msb_krun = 0.1.31`
- [x] Run `MSB_AGENTD_PATH=/usr/bin/true cargo test -p microsandbox-runtime cpu:: --lib --locked` against published `msb_krun = 0.1.31` (22 passed)
- [ ] Full CI matrix (running on the pushed lockfile fix)
