### PR TITLE
feat(ssh): make inactivity timeout configurable

### DIFF
--- a/crates/cli/lib/commands/ssh.rs
+++ b/crates/cli/lib/commands/ssh.rs
@@ -2,10 +2,14 @@
 
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 
 use anyhow::Context;
 use clap::{ArgGroup, Args, Subcommand};
-use microsandbox::sandbox::{DEFAULT_SSH_HOST, DEFAULT_SSH_PORT, SshStdioStream};
+use microsandbox::sandbox::{
+    DEFAULT_SSH_HOST, DEFAULT_SSH_PORT, SshClientOptionsBuilder, SshServerOptionsBuilder,
+    SshStdioStream,
+};
 use russh::keys::PublicKeyBase64;
 use tokio::io::AsyncWriteExt;
 use tokio::net::TcpListener;
@@ -30,6 +34,10 @@ pub struct SshArgs {
     /// Remote command to run inside the sandbox (after --).
     #[arg(last = true)]
     pub remote_command: Vec<String>,
+
+    /// SSH inactivity timeout options.
+    #[command(flatten)]
+    pub inactivity: SshInactivityTimeoutArgs,
 
     /// SSH subcommand.
     #[command(subcommand)]
@@ -62,6 +70,10 @@ pub struct SshConnectArgs {
     /// Remote command to run inside the sandbox (after --).
     #[arg(last = true)]
     pub remote_command: Vec<String>,
+
+    /// SSH inactivity timeout options.
+    #[command(flatten)]
+    pub inactivity: SshInactivityTimeoutArgs,
 }
 
 /// Arguments for `msb ssh serve`.
@@ -81,6 +93,26 @@ pub struct SshServeArgs {
     /// Serve one SSH transport over stdin/stdout.
     #[arg(long)]
     pub stdio: bool,
+
+    /// SSH inactivity timeout options.
+    #[command(flatten)]
+    pub inactivity: SshInactivityTimeoutArgs,
+}
+
+/// Arguments controlling SSH session inactivity timeouts.
+#[derive(Debug, Args)]
+pub struct SshInactivityTimeoutArgs {
+    /// Disconnect after this duration without SSH traffic. Use 0 to disable.
+    #[arg(
+        long,
+        value_name = "DURATION",
+        conflicts_with = "no_inactivity_timeout"
+    )]
+    pub inactivity_timeout: Option<String>,
+
+    /// Disable the SSH session inactivity timeout.
+    #[arg(long)]
+    pub no_inactivity_timeout: bool,
 }
 
 /// Arguments for `msb ssh authorize`.
@@ -119,6 +151,7 @@ pub async fn run(args: SshArgs) -> anyhow::Result<()> {
 }
 
 async fn run_connect(args: SshArgs) -> anyhow::Result<()> {
+    let inactivity_timeout = parse_inactivity_timeout(&args.inactivity)?;
     let mut remote_command = args.remote_command;
     let sandbox = match (args.name.as_ref(), args.sandbox) {
         (None, None)
@@ -131,18 +164,28 @@ async fn run_connect(args: SshArgs) -> anyhow::Result<()> {
         (_, sandbox) => sandbox,
     };
     let name = resolve_sandbox_name(args.name, sandbox)?;
-    connect_to_sandbox(name, remote_command).await
+    connect_to_sandbox(name, remote_command, inactivity_timeout).await
 }
 
 async fn run_connect_args(args: SshConnectArgs) -> anyhow::Result<()> {
+    let inactivity_timeout = parse_inactivity_timeout(&args.inactivity)?;
     let name = resolve_sandbox_name(args.name, args.sandbox)?;
-    connect_to_sandbox(name, args.remote_command).await
+    connect_to_sandbox(name, args.remote_command, inactivity_timeout).await
 }
 
-async fn connect_to_sandbox(name: String, remote_command: Vec<String>) -> anyhow::Result<()> {
+async fn connect_to_sandbox(
+    name: String,
+    remote_command: Vec<String>,
+    inactivity_timeout: Option<Option<Duration>>,
+) -> anyhow::Result<()> {
     let sandbox = super::resolve_and_start(&name, false).await?;
     let result = async {
-        let ssh = sandbox.ssh().open_client().await?;
+        let ssh = sandbox
+            .ssh()
+            .open_client_with(|builder| {
+                apply_client_inactivity_timeout(builder, inactivity_timeout)
+            })
+            .await?;
         if remote_command.is_empty() {
             ssh.attach().await
         } else {
@@ -167,12 +210,18 @@ async fn connect_to_sandbox(name: String, remote_command: Vec<String>) -> anyhow
 }
 
 async fn run_serve(args: SshServeArgs) -> anyhow::Result<()> {
+    let inactivity_timeout = parse_inactivity_timeout(&args.inactivity)?;
     let sandbox = super::resolve_and_start(&args.sandbox, args.stdio).await?;
     let host = args.host.unwrap_or_else(|| DEFAULT_SSH_HOST.to_string());
     let port = args.port.unwrap_or(DEFAULT_SSH_PORT);
 
     let result = async {
-        let server = sandbox.ssh().prepare_server().await?;
+        let server = sandbox
+            .ssh()
+            .prepare_server_with(|builder| {
+                apply_server_inactivity_timeout(builder, inactivity_timeout)
+            })
+            .await?;
         if args.stdio {
             server.serve_connection(SshStdioStream::new()).await
         } else {
@@ -249,6 +298,42 @@ fn is_reserved_name(value: &str) -> bool {
     matches!(value, "serve" | "authorize" | "help")
 }
 
+fn parse_inactivity_timeout(
+    args: &SshInactivityTimeoutArgs,
+) -> anyhow::Result<Option<Option<Duration>>> {
+    if args.no_inactivity_timeout {
+        return Ok(Some(None));
+    }
+    let Some(value) = &args.inactivity_timeout else {
+        return Ok(None);
+    };
+    let timeout = super::common::parse_duration(value)
+        .map_err(|error| anyhow::anyhow!("--inactivity-timeout: {error}"))?;
+    Ok(Some((!timeout.is_zero()).then_some(timeout)))
+}
+
+fn apply_client_inactivity_timeout(
+    builder: SshClientOptionsBuilder,
+    timeout: Option<Option<Duration>>,
+) -> SshClientOptionsBuilder {
+    match timeout {
+        Some(Some(timeout)) => builder.inactivity_timeout(timeout),
+        Some(None) => builder.disable_inactivity_timeout(),
+        None => builder,
+    }
+}
+
+fn apply_server_inactivity_timeout(
+    builder: SshServerOptionsBuilder,
+    timeout: Option<Option<Duration>>,
+) -> SshServerOptionsBuilder {
+    match timeout {
+        Some(Some(timeout)) => builder.inactivity_timeout(timeout),
+        Some(None) => builder.disable_inactivity_timeout(),
+        None => builder,
+    }
+}
+
 fn read_public_key_source(args: SshAuthorizeArgs) -> anyhow::Result<String> {
     if let Some(path) = args.file {
         return std::fs::read_to_string(&path)
@@ -306,4 +391,50 @@ fn set_private_file_permissions(_path: &Path) -> anyhow::Result<()> {
         std::fs::set_permissions(_path, std::fs::Permissions::from_mode(0o600))?;
     }
     Ok(())
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests
+//--------------------------------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn args(timeout: Option<&str>, disabled: bool) -> SshInactivityTimeoutArgs {
+        SshInactivityTimeoutArgs {
+            inactivity_timeout: timeout.map(str::to_string),
+            no_inactivity_timeout: disabled,
+        }
+    }
+
+    #[test]
+    fn inactivity_timeout_inherits_when_unspecified() {
+        assert_eq!(parse_inactivity_timeout(&args(None, false)).unwrap(), None);
+    }
+
+    #[test]
+    fn inactivity_timeout_parses_duration() {
+        assert_eq!(
+            parse_inactivity_timeout(&args(Some("30m"), false)).unwrap(),
+            Some(Some(Duration::from_secs(1800)))
+        );
+    }
+
+    #[test]
+    fn inactivity_timeout_zero_and_disable_flag_turn_it_off() {
+        assert_eq!(
+            parse_inactivity_timeout(&args(Some("0"), false)).unwrap(),
+            Some(None)
+        );
+        assert_eq!(
+            parse_inactivity_timeout(&args(None, true)).unwrap(),
+            Some(None)
+        );
+    }
+
+    #[test]
+    fn inactivity_timeout_rejects_invalid_duration() {
+        assert!(parse_inactivity_timeout(&args(Some("later"), false)).is_err());
+    }
 }

--- a/docs/cli/ssh-commands.mdx
+++ b/docs/cli/ssh-commands.mdx
@@ -21,6 +21,8 @@ msb ssh --name serve -- uptime
 |----------|-------------|
 | `sandbox` | Sandbox name, up to 128 UTF-8 bytes |
 | `--name NAME` | Explicit sandbox name, up to 128 UTF-8 bytes; useful when the name collides with `serve`, `authorize`, or `help` |
+| `--inactivity-timeout DURATION` | Disconnect after this much SSH inactivity; accepts values such as `30s`, `10m`, or `1h`. Use `0` to disable |
+| `--no-inactivity-timeout` | Disable the SSH inactivity timeout |
 | `-- COMMAND...` | Remote command to run through the sandbox shell |
 
 ## msb ssh authorize
@@ -58,6 +60,8 @@ msb ssh serve devbox --stdio
 | `--host HOST` | Listener host. Defaults to `127.0.0.1` |
 | `--port PORT` | Listener port. Defaults to `2222` |
 | `--stdio` | Serve one SSH transport over stdin/stdout for OpenSSH `ProxyCommand` |
+| `--inactivity-timeout DURATION` | Disconnect each connection after this much SSH inactivity. Use `0` to disable |
+| `--no-inactivity-timeout` | Disable the SSH inactivity timeout |
 
 Listener mode accepts ordinary OpenSSH clients:
 
@@ -91,7 +95,11 @@ msb ssh connect devbox -- uname -a
 |----------|-------------|
 | `sandbox` | Sandbox name, up to 128 UTF-8 bytes |
 | `--name NAME` | Explicit sandbox name, up to 128 UTF-8 bytes |
+| `--inactivity-timeout DURATION` | Disconnect after this much SSH inactivity. Use `0` to disable |
+| `--no-inactivity-timeout` | Disable the SSH inactivity timeout |
 | `-- COMMAND...` | Remote command to run through the sandbox shell |
+
+All SSH commands inherit `ssh.inactivity_timeout_secs` from the global configuration when neither timeout flag is present. The built-in default is 10 minutes.
 
 ## SSH state
 

--- a/docs/cli/ssh-commands.mdx
+++ b/docs/cli/ssh-commands.mdx
@@ -21,6 +21,8 @@ msb ssh --name serve -- uptime
 |----------|-------------|
 | `sandbox` | Sandbox name, up to 128 UTF-8 bytes |
 | `--name NAME` | Explicit sandbox name, up to 128 UTF-8 bytes; useful when the name collides with `serve`, `authorize`, or `help` |
+| `--inactivity-timeout DURATION` | Disconnect after this much SSH inactivity; accepts values such as `30s`, `10m`, or `1h`. Use `0` to disable |
+| `--no-inactivity-timeout` | Disable the SSH inactivity timeout |
 | `-- COMMAND...` | Remote command to run through the sandbox shell |
 
 ## msb ssh authorize
@@ -56,6 +58,8 @@ msb ssh serve devbox --stdio
 | `--host HOST` | Listener host. Defaults to `127.0.0.1` |
 | `--port PORT` | Listener port. Defaults to `2222` |
 | `--stdio` | Serve one SSH transport over stdin/stdout for OpenSSH `ProxyCommand` |
+| `--inactivity-timeout DURATION` | Disconnect each connection after this much SSH inactivity. Use `0` to disable |
+| `--no-inactivity-timeout` | Disable the SSH inactivity timeout |
 
 Listener mode accepts ordinary OpenSSH clients:
 
@@ -89,7 +93,11 @@ msb ssh connect devbox -- uname -a
 |----------|-------------|
 | `sandbox` | Sandbox name, up to 128 UTF-8 bytes |
 | `--name NAME` | Explicit sandbox name, up to 128 UTF-8 bytes |
+| `--inactivity-timeout DURATION` | Disconnect after this much SSH inactivity. Use `0` to disable |
+| `--no-inactivity-timeout` | Disable the SSH inactivity timeout |
 | `-- COMMAND...` | Remote command to run through the sandbox shell |
+
+All SSH commands inherit `ssh.inactivity_timeout_secs` from the global configuration when neither timeout flag is present. The built-in default is 10 minutes.
 
 ## SSH state
 

--- a/docs/configuration.mdx
+++ b/docs/configuration.mdx
@@ -79,6 +79,9 @@ microsandbox reads its global configuration from `~/.microsandbox/config.json`. 
       }
     }
   },
+  "ssh": {
+    "inactivity_timeout_secs": 600
+  },
   "metrics": {
     "capacity": 4096
   },
@@ -108,6 +111,7 @@ microsandbox reads its global configuration from `~/.microsandbox/config.json`. 
 | `sandbox_defaults` | [reference](#sandbox_defaults) | Defaults applied to local sandboxes |
 | `runtime` | [reference](#runtime) | Host runtime performance policy |
 | `registries` | [reference](#registries) | Container registry authentication |
+| `ssh` | [reference](#ssh) | Host-side SSH session defaults |
 | `metrics` | [reference](#metrics) | Live metrics shared-memory registry settings |
 | `active_profile` | `null` | Default [backend profile](#profiles) name |
 | `profiles` | [reference](#profiles) | Named [backend profiles](/getting-started/backends) |
@@ -177,6 +181,16 @@ let msb = cfg.resolve_msb_path()?;
 ```
 
 `LocalBackend` has two plain constructors alongside the builder. `LocalBackend::lazy()` is synchronous and defers opening (and migrating) the local sandbox database until the first operation; it is what backend resolution uses when no backend is set explicitly. `LocalBackend::new().await?` opens the database up front, so startup fails fast if the database is unusable.
+
+## `ssh`
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `inactivity_timeout_secs` | `600` | Disconnect an SSH session after this many seconds without SSH traffic. Set to `0` to disable. |
+
+The timeout applies to host-side SSH sessions created by `msb ssh`, `msb ssh serve`, and the local SDK backend. SSH traffic resets the timer. This setting is separate from a sandbox lifecycle idle timeout: disconnecting SSH does not stop the sandbox, and sandbox activity policy does not change the SSH timeout.
+
+Explicit CLI or SDK options override this value. The setting is resolved when a client or server endpoint is prepared, so changing `config.json` does not alter existing connections. Programmatic local backends can override the persisted value with `LocalBackendBuilder::ssh_inactivity_timeout_secs()`.
 
 ## `sandbox_defaults`
 

--- a/docs/configuration.mdx
+++ b/docs/configuration.mdx
@@ -79,6 +79,9 @@ microsandbox reads its global configuration from `~/.microsandbox/config.json`. 
       }
     }
   },
+  "ssh": {
+    "inactivity_timeout_secs": 600
+  },
   "metrics": {
     "capacity": 4096
   },
@@ -108,6 +111,7 @@ microsandbox reads its global configuration from `~/.microsandbox/config.json`. 
 | `sandbox_defaults` | [reference](#sandbox_defaults) | Defaults applied to local sandboxes |
 | `runtime` | [reference](#runtime) | Host runtime performance policy |
 | `registries` | [reference](#registries) | Container registry authentication |
+| `ssh` | [reference](#ssh) | Host-side SSH session defaults |
 | `metrics` | [reference](#metrics) | Live metrics shared-memory registry settings |
 | `active_profile` | `null` | Default backend profile name |
 | `profiles` | `{}` | Named backend profiles |
@@ -175,6 +179,16 @@ let backend = LocalBackend::builder()
 let cfg = backend.config();
 let msb = cfg.resolve_msb_path()?;
 ```
+
+## `ssh`
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `inactivity_timeout_secs` | `600` | Disconnect an SSH session after this many seconds without SSH traffic. Set to `0` to disable. |
+
+The timeout applies to host-side SSH sessions created by `msb ssh`, `msb ssh serve`, and the local SDK backend. SSH traffic resets the timer. This setting is separate from a sandbox lifecycle idle timeout: disconnecting SSH does not stop the sandbox, and sandbox activity policy does not change the SSH timeout.
+
+Explicit CLI or SDK options override this value. The setting is resolved when a client or server endpoint is prepared, so changing `config.json` does not alter existing connections. Programmatic local backends can override the persisted value with `LocalBackendBuilder::ssh_inactivity_timeout_secs()`.
 
 ## `sandbox_defaults`
 

--- a/docs/sandboxes/ssh.mdx
+++ b/docs/sandboxes/ssh.mdx
@@ -13,6 +13,51 @@ There are two ways to connect:
 - **Native sessions** use the built-in microsandbox SSH client. No host `ssh` binary, TCP listener, or authorized key is required, which makes it the quickest path for a shell from `msb` or SSH semantics from the SDK.
 - **External clients** serve the sandbox as an SSH server so standard tools such as `ssh`, `sftp`, and `ProxyCommand` can connect.
 
+## Inactivity timeout
+
+SSH sessions disconnect after 10 minutes without SSH traffic by default. Any SSH input or output resets the timer. This transport timeout is independent of the sandbox lifecycle idle timeout: an SSH disconnect does not stop the sandbox.
+
+Set a global default in `~/.microsandbox/config.json`. Use `0` to disable the timeout:
+
+```json
+{
+  "ssh": {
+    "inactivity_timeout_secs": 0
+  }
+}
+```
+
+Override the global value for one CLI session with `--inactivity-timeout 30m`, or disable it with `--no-inactivity-timeout`. The same overrides are available when opening native clients or preparing server endpoints through an SDK:
+
+<CodeGroup>
+```rust Rust
+use std::time::Duration;
+
+let ssh = sb.ssh()
+    .connect_with(|opts| opts.inactivity_timeout(Duration::from_secs(1800)))
+    .await?;
+
+let persistent = sb.ssh()
+    .connect_with(|opts| opts.disable_inactivity_timeout())
+    .await?;
+```
+
+```typescript TypeScript
+const ssh = await sb.ssh().openClient({ inactivityTimeoutSecs: 1800 });
+const persistent = await sb.ssh().openClient({ inactivityTimeoutSecs: 0 });
+```
+
+```python Python
+ssh = await sb.ssh().open_client(inactivity_timeout=1800)
+persistent = await sb.ssh().open_client(inactivity_timeout=0)
+```
+
+```go Go
+ssh, err := sb.SSH().OpenClient(ctx, m.WithSSHClientInactivityTimeout(30*time.Minute))
+persistent, err := sb.SSH().OpenClient(ctx, m.WithSSHClientInactivityTimeout(0))
+```
+</CodeGroup>
+
 ## Native sessions
 
 Native sessions keep the SSH protocol boundary but do not expose a listener.

--- a/docs/sandboxes/ssh.mdx
+++ b/docs/sandboxes/ssh.mdx
@@ -13,50 +13,9 @@ There are two ways to connect:
 - **Native sessions** use the built-in microsandbox SSH client. No host `ssh` binary, TCP listener, or authorized key is required, which makes it the quickest path for a shell from `msb` or SSH semantics from the SDK.
 - **External clients** serve the sandbox as an SSH server so standard tools such as `ssh`, `sftp`, and `ProxyCommand` can connect.
 
-## Inactivity timeout
-
-SSH sessions disconnect after 10 minutes without SSH traffic by default. Any SSH input or output resets the timer. This transport timeout is independent of the sandbox lifecycle idle timeout: an SSH disconnect does not stop the sandbox.
-
-Set a global default in `~/.microsandbox/config.json`. Use `0` to disable the timeout:
-
-```json
-{
-  "ssh": {
-    "inactivity_timeout_secs": 0
-  }
-}
-```
-
-Override the global value for one CLI session with `--inactivity-timeout 30m`, or disable it with `--no-inactivity-timeout`. The same overrides are available when opening native clients or preparing server endpoints through an SDK:
-
-<CodeGroup>
-```rust Rust
-use std::time::Duration;
-
-let ssh = sb.ssh()
-    .connect_with(|opts| opts.inactivity_timeout(Duration::from_secs(1800)))
-    .await?;
-
-let persistent = sb.ssh()
-    .connect_with(|opts| opts.disable_inactivity_timeout())
-    .await?;
-```
-
-```typescript TypeScript
-const ssh = await sb.ssh().openClient({ inactivityTimeoutSecs: 1800 });
-const persistent = await sb.ssh().openClient({ inactivityTimeoutSecs: 0 });
-```
-
-```python Python
-ssh = await sb.ssh().open_client(inactivity_timeout=1800)
-persistent = await sb.ssh().open_client(inactivity_timeout=0)
-```
-
-```go Go
-ssh, err := sb.SSH().OpenClient(ctx, m.WithSSHClientInactivityTimeout(30*time.Minute))
-persistent, err := sb.SSH().OpenClient(ctx, m.WithSSHClientInactivityTimeout(0))
-```
-</CodeGroup>
+<Note>
+  SSH sessions disconnect after 10 minutes without SSH traffic by default. To change or disable the timeout, see [Configure the inactivity timeout](#configure-the-inactivity-timeout).
+</Note>
 
 ## Native sessions
 
@@ -284,5 +243,50 @@ rsync -av ./src/ devbox.msb:/app/
 ```
 
 Editors that build on OpenSSH, such as VS Code Remote-SSH, connect to the `devbox.msb` host the same way.
+
+## Configure the inactivity timeout
+
+SSH sessions disconnect after 10 minutes without SSH traffic by default. Any SSH input or output resets the timer. This transport timeout is independent of the sandbox lifecycle idle timeout: an SSH disconnect does not stop the sandbox.
+
+Set a global default in `~/.microsandbox/config.json`. Use `0` to disable the timeout:
+
+```json
+{
+  "ssh": {
+    "inactivity_timeout_secs": 0
+  }
+}
+```
+
+Override the global value for one CLI session with `--inactivity-timeout 30m`, or disable it with `--no-inactivity-timeout`. The same overrides are available when opening native clients or preparing server endpoints through an SDK:
+
+<CodeGroup>
+```rust Rust
+use std::time::Duration;
+
+let ssh = sb.ssh()
+    .connect_with(|opts| opts.inactivity_timeout(Duration::from_secs(1800)))
+    .await?;
+
+let persistent = sb.ssh()
+    .connect_with(|opts| opts.disable_inactivity_timeout())
+    .await?;
+```
+
+```typescript TypeScript
+const ssh = await sb.ssh().openClient({ inactivityTimeoutSecs: 1800 });
+const persistent = await sb.ssh().openClient({ inactivityTimeoutSecs: 0 });
+```
+
+```python Python
+ssh = await sb.ssh().open_client(inactivity_timeout=1800)
+persistent = await sb.ssh().open_client(inactivity_timeout=0)
+```
+
+```go Go
+ssh, err := sb.SSH().OpenClient(ctx, m.WithSSHClientInactivityTimeout(30*time.Minute))
+persistent, err := sb.SSH().OpenClient(ctx, m.WithSSHClientInactivityTimeout(0))
+```
+</CodeGroup>
 
 For exact SDK signatures, see the SSH reference for [Rust](/sdk/rust/ssh), [TypeScript](/sdk/typescript/ssh), [Python](/sdk/python/ssh), or [Go](/sdk/go/ssh).

--- a/docs/sandboxes/ssh.mdx
+++ b/docs/sandboxes/ssh.mdx
@@ -13,9 +13,7 @@ There are two ways to connect:
 - **Native sessions** use the built-in microsandbox SSH client. No host `ssh` binary, TCP listener, or authorized key is required, which makes it the quickest path for a shell from `msb` or SSH semantics from the SDK.
 - **External clients** serve the sandbox as an SSH server so standard tools such as `ssh`, `sftp`, and `ProxyCommand` can connect.
 
-<Note>
-  SSH sessions disconnect after 10 minutes without SSH traffic by default. To change or disable the timeout, see [Configure the inactivity timeout](#configure-the-inactivity-timeout).
-</Note>
+SSH sessions disconnect after 10 minutes without traffic by default. [Change or disable the inactivity timeout](#inactivity-timeout).
 
 ## Native sessions
 
@@ -244,7 +242,7 @@ rsync -av ./src/ devbox.msb:/app/
 
 Editors that build on OpenSSH, such as VS Code Remote-SSH, connect to the `devbox.msb` host the same way.
 
-## Configure the inactivity timeout
+## Inactivity timeout
 
 SSH sessions disconnect after 10 minutes without SSH traffic by default. Any SSH input or output resets the timer. This transport timeout is independent of the sandbox lifecycle idle timeout: an SSH disconnect does not stop the sandbox.
 

--- a/docs/sdk/go/ssh.mdx
+++ b/docs/sdk/go/ssh.mdx
@@ -73,7 +73,7 @@ Open a native in-process SSH client to this sandbox. Generates an ephemeral Ed25
   </div>
   <div className="msb-param">
     <div className="msb-param-key"><code>opts</code><a className="msb-type" href="#sshclientoption">...SSHClientOption</a></div>
-    <div className="msb-param-desc">Login user, terminal name, and SFTP toggle.</div>
+    <div className="msb-param-desc">Login user, terminal name, SFTP toggle, and inactivity timeout.</div>
   </div>
 </div>
 
@@ -123,7 +123,7 @@ Prepare a reusable SSH server endpoint for this sandbox. Loads or creates the ho
   </div>
   <div className="msb-param">
     <div className="msb-param-key"><code>opts</code><a className="msb-type" href="#sshserveroption">...SSHServerOption</a></div>
-    <div className="msb-param-desc">Host key, authorized keys, guest user, and SFTP toggle.</div>
+    <div className="msb-param-desc">Host key, authorized keys, guest user, SFTP toggle, and inactivity timeout.</div>
   </div>
 </div>
 
@@ -599,13 +599,14 @@ Close the session (consumes the handle)
 
 <p className="msb-backref">Used by <a href="#ssh-openclient">OpenClient()</a></p>
 
-Functional option for [`OpenClient()`](#ssh-openclient). Defaults: user `root`, terminal from `$TERM` (falling back to `xterm`), SFTP enabled.
+Functional option for [`OpenClient()`](#ssh-openclient). Defaults: user `root`, terminal from `$TERM` (falling back to `xterm`), SFTP enabled, and the global SSH inactivity timeout.
 
 | Option | Description |
 |--------|-------------|
 | WithSSHUser(user) | SSH login user. Default `root` |
 | WithSSHTerm(term) | Terminal name for interactive sessions |
 | WithSSHClientSFTP(enabled) | Enable or disable SFTP on the internal server. Default `true` |
+| WithSSHClientInactivityTimeout(timeout) | Override the internal server inactivity timeout. A zero duration disables it |
 
 ### SSHExecOption
 
@@ -632,7 +633,7 @@ Functional option for [`Attach()`](#c-attach). The default terminal comes from `
 
 <p className="msb-backref">Used by <a href="#ssh-prepareserver">PrepareServer()</a></p>
 
-Functional option for [`PrepareServer()`](#ssh-prepareserver). SFTP is enabled by default; when no authorized-keys path is provided, the default authorized-keys file is loaded.
+Functional option for [`PrepareServer()`](#ssh-prepareserver). SFTP is enabled by default, the inactivity timeout inherits the global SSH setting, and the default authorized-keys file is loaded when no path is provided.
 
 | Option | Description |
 |--------|-------------|
@@ -640,3 +641,4 @@ Functional option for [`PrepareServer()`](#ssh-prepareserver). SFTP is enabled b
 | WithSSHAuthorizedKeysPath(path) | Override the authorized-keys path |
 | WithSSHServerUser(user) | Override the guest user used for SSH exec requests |
 | WithSSHServerSFTP(enabled) | Enable or disable SFTP on the server endpoint. Default `true` |
+| WithSSHServerInactivityTimeout(timeout) | Override the SSH inactivity timeout. A zero duration disables it |

--- a/docs/sdk/go/ssh.mdx
+++ b/docs/sdk/go/ssh.mdx
@@ -66,7 +66,7 @@ Open a native in-process SSH client to this sandbox. Generates an ephemeral Ed25
   </div>
   <div className="msb-param">
     <div className="msb-param-key"><code>opts</code><a className="msb-type" href="#sshclientoption">...SSHClientOption</a></div>
-    <div className="msb-param-desc">Login user, terminal name, and SFTP toggle.</div>
+    <div className="msb-param-desc">Login user, terminal name, SFTP toggle, and inactivity timeout.</div>
   </div>
 </div>
 
@@ -114,7 +114,7 @@ Prepare a reusable SSH server endpoint for this sandbox. Loads or creates the ho
   </div>
   <div className="msb-param">
     <div className="msb-param-key"><code>opts</code><a className="msb-type" href="#sshserveroption">...SSHServerOption</a></div>
-    <div className="msb-param-desc">Host key, authorized keys, guest user, and SFTP toggle.</div>
+    <div className="msb-param-desc">Host key, authorized keys, guest user, SFTP toggle, and inactivity timeout.</div>
   </div>
 </div>
 
@@ -491,13 +491,14 @@ The output from an SSH exec request.
 
 <p className="msb-backref">Used by <a href="#ssh-openclient">OpenClient()</a></p>
 
-Functional option for [`OpenClient()`](#ssh-openclient). Defaults: user `root`, terminal from `$TERM` (falling back to `xterm`), SFTP enabled.
+Functional option for [`OpenClient()`](#ssh-openclient). Defaults: user `root`, terminal from `$TERM` (falling back to `xterm`), SFTP enabled, and the global SSH inactivity timeout.
 
 | Option | Description |
 |--------|-------------|
 | WithSSHUser(user) | SSH login user. Default `root` |
 | WithSSHTerm(term) | Terminal name for interactive sessions |
 | WithSSHClientSFTP(enabled) | Enable or disable SFTP on the internal server. Default `true` |
+| WithSSHClientInactivityTimeout(timeout) | Override the internal server inactivity timeout. A zero duration disables it |
 
 ### SSHExecOption
 
@@ -524,7 +525,7 @@ Functional option for [`Attach()`](#c-attach). The default terminal comes from `
 
 <p className="msb-backref">Used by <a href="#ssh-prepareserver">PrepareServer()</a></p>
 
-Functional option for [`PrepareServer()`](#ssh-prepareserver). SFTP is enabled by default; when no authorized-keys path is provided, the default authorized-keys file is loaded.
+Functional option for [`PrepareServer()`](#ssh-prepareserver). SFTP is enabled by default, the inactivity timeout inherits the global SSH setting, and the default authorized-keys file is loaded when no path is provided.
 
 | Option | Description |
 |--------|-------------|
@@ -532,3 +533,4 @@ Functional option for [`PrepareServer()`](#ssh-prepareserver). SFTP is enabled b
 | WithSSHAuthorizedKeysPath(path) | Override the authorized-keys path |
 | WithSSHServerUser(user) | Override the guest user used for SSH exec requests |
 | WithSSHServerSFTP(enabled) | Enable or disable SFTP on the server endpoint. Default `true` |
+| WithSSHServerInactivityTimeout(timeout) | Override the SSH inactivity timeout. A zero duration disables it |

--- a/docs/sdk/python/ssh.mdx
+++ b/docs/sdk/python/ssh.mdx
@@ -47,6 +47,7 @@ async def open_client(
     user: str = "root",
     term: str | None = None,
     sftp: bool = True,
+    inactivity_timeout: float | None = None,
 ) -> SshClient
 ```
 
@@ -76,6 +77,10 @@ Connect a native in-process SSH client to this sandbox. Generates an ephemeral c
     <div className="msb-param-key"><code>sftp</code><span className="msb-type">bool</span></div>
     <div className="msb-param-desc">Enable or disable SFTP on the internal server. Default <code>True</code>.</div>
   </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>inactivity_timeout</code><span className="msb-type">float | None</span></div>
+    <div className="msb-param-desc">Disconnect after this many seconds without SSH traffic. <code>0</code> disables the timeout; <code>None</code> inherits the global setting.</div>
+  </div>
 </div>
 
 <p className="msb-label">Returns</p>
@@ -98,6 +103,7 @@ async def prepare_server(
     authorized_keys_path: str | os.PathLike[str] | None = None,
     user: str | None = None,
     sftp: bool = True,
+    inactivity_timeout: float | None = None,
 ) -> SshServer
 ```
 
@@ -134,6 +140,10 @@ Prepare a reusable SSH server endpoint for this sandbox. Loads or creates the ho
   <div className="msb-param">
     <div className="msb-param-key"><code>sftp</code><span className="msb-type">bool</span></div>
     <div className="msb-param-desc">Enable or disable SFTP. Default <code>True</code>.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>inactivity_timeout</code><span className="msb-type">float | None</span></div>
+    <div className="msb-param-desc">Disconnect after this many seconds without SSH traffic. <code>0</code> disables the timeout; <code>None</code> inherits the global setting.</div>
   </div>
 </div>
 

--- a/docs/sdk/python/ssh.mdx
+++ b/docs/sdk/python/ssh.mdx
@@ -45,6 +45,7 @@ async def open_client(
     user: str = "root",
     term: str | None = None,
     sftp: bool = True,
+    inactivity_timeout: float | None = None,
 ) -> SshClient
 ```
 
@@ -74,6 +75,10 @@ Connect a native in-process SSH client to this sandbox. Generates an ephemeral c
     <div className="msb-param-key"><code>sftp</code><span className="msb-type">bool</span></div>
     <div className="msb-param-desc">Enable or disable SFTP on the internal server. Default <code>True</code>.</div>
   </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>inactivity_timeout</code><span className="msb-type">float | None</span></div>
+    <div className="msb-param-desc">Disconnect after this many seconds without SSH traffic. <code>0</code> disables the timeout; <code>None</code> inherits the global setting.</div>
+  </div>
 </div>
 
 <p className="msb-label">Returns</p>
@@ -94,6 +99,7 @@ async def prepare_server(
     authorized_keys_path: str | os.PathLike[str] | None = None,
     user: str | None = None,
     sftp: bool = True,
+    inactivity_timeout: float | None = None,
 ) -> SshServer
 ```
 
@@ -130,6 +136,10 @@ Prepare a reusable SSH server endpoint for this sandbox. Loads or creates the ho
   <div className="msb-param">
     <div className="msb-param-key"><code>sftp</code><span className="msb-type">bool</span></div>
     <div className="msb-param-desc">Enable or disable SFTP. Default <code>True</code>.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>inactivity_timeout</code><span className="msb-type">float | None</span></div>
+    <div className="msb-param-desc">Disconnect after this many seconds without SSH traffic. <code>0</code> disables the timeout; <code>None</code> inherits the global setting.</div>
   </div>
 </div>
 

--- a/docs/sdk/rust/ssh.mdx
+++ b/docs/sdk/rust/ssh.mdx
@@ -105,14 +105,14 @@ let client = sb.ssh().connect_with(|opts| opts
 
 </Accordion>
 
-Connect a native in-process SSH client with custom options. The closure configures the login user, terminal name, and whether SFTP is enabled on the internal server.
+Connect a native in-process SSH client with custom options. The closure configures the login user, terminal name, whether SFTP is enabled on the internal server, and the SSH inactivity timeout.
 
 <p className="msb-label">Parameters</p>
 
 <div className="msb-params">
   <div className="msb-param">
     <div className="msb-param-key"><code>f</code><a className="msb-type" href="#sshclientoptionsbuilder">FnOnce(SshClientOptionsBuilder)</a></div>
-    <div className="msb-param-desc">Configure user, terminal, and SFTP support.</div>
+    <div className="msb-param-desc">Configure user, terminal, SFTP support, and the inactivity timeout.</div>
   </div>
 </div>
 
@@ -141,7 +141,7 @@ Alias for [`connect_with`](#ssh-connect_with).
 <div className="msb-params">
   <div className="msb-param">
     <div className="msb-param-key"><code>f</code><a className="msb-type" href="#sshclientoptionsbuilder">FnOnce(SshClientOptionsBuilder)</a></div>
-    <div className="msb-param-desc">Configure user, terminal, and SFTP support.</div>
+    <div className="msb-param-desc">Configure user, terminal, SFTP support, and the inactivity timeout.</div>
   </div>
 </div>
 
@@ -224,14 +224,14 @@ let server = sb.ssh().server_with(|opts| opts
 
 </Accordion>
 
-Prepare a server endpoint with custom host-key, authorization, guest-user, or SFTP options. If no authorized keys are configured, the default authorized-keys file is loaded; an empty key set is an error.
+Prepare a server endpoint with custom host-key, authorization, guest-user, SFTP, or inactivity-timeout options. If no authorized keys are configured, the default authorized-keys file is loaded; an empty key set is an error.
 
 <p className="msb-label">Parameters</p>
 
 <div className="msb-params">
   <div className="msb-param">
     <div className="msb-param-key"><code>f</code><a className="msb-type" href="#sshserveroptionsbuilder">FnOnce(SshServerOptionsBuilder)</a></div>
-    <div className="msb-param-desc">Configure host key, authorized keys, guest user, and SFTP.</div>
+    <div className="msb-param-desc">Configure host key, authorized keys, guest user, SFTP, and the inactivity timeout.</div>
   </div>
 </div>
 
@@ -577,7 +577,7 @@ Default SSH listener port used by the CLI adapter when binding a sandbox SSH end
 
 <p className="msb-backref">Used by <a href="#ssh-connect_with">ssh.connect_with()</a></p>
 
-Builder for SSH client options. Defaults: user `root`, terminal from `$TERM` (falling back to `xterm`), SFTP enabled.
+Builder for SSH client options. Defaults: user `root`, terminal from `$TERM` (falling back to `xterm`), SFTP enabled, and the global SSH inactivity timeout.
 
 
 #### <span className="msb-recv">client_options.</span><span className="msb-hn">user()</span>
@@ -603,6 +603,22 @@ sftp()
 ```
 
 Enable or disable SFTP on the internal server. Default `true`.
+
+#### <span className="msb-recv">client_options.</span><span className="msb-hn">inactivity_timeout()</span>
+
+```rust
+inactivity_timeout(timeout: Duration)
+```
+
+Override the internal server inactivity timeout. `Duration::ZERO` disables it.
+
+#### <span className="msb-recv">client_options.</span><span className="msb-hn">disable_inactivity_timeout()</span>
+
+```rust
+disable_inactivity_timeout()
+```
+
+Disable the internal server inactivity timeout.
 
 #### <span className="msb-recv">client_options.</span><span className="msb-hn">build()</span>
 
@@ -673,7 +689,7 @@ Finalize the options.
 
 <p className="msb-backref">Used by <a href="#ssh-server_with">ssh.server_with()</a></p>
 
-Builder for SSH server options. SFTP is enabled by default; when no authorized keys are provided, the default authorized-keys file is loaded.
+Builder for SSH server options. SFTP is enabled by default; the inactivity timeout inherits the global SSH setting; when no authorized keys are provided, the default authorized-keys file is loaded.
 
 
 #### <span className="msb-recv">server_options.</span><span className="msb-hn">host_key_path()</span>
@@ -723,6 +739,22 @@ sftp()
 ```
 
 Enable or disable SFTP. Default `true`.
+
+#### <span className="msb-recv">server_options.</span><span className="msb-hn">inactivity_timeout()</span>
+
+```rust
+inactivity_timeout(timeout: Duration)
+```
+
+Override the SSH inactivity timeout. `Duration::ZERO` disables it.
+
+#### <span className="msb-recv">server_options.</span><span className="msb-hn">disable_inactivity_timeout()</span>
+
+```rust
+disable_inactivity_timeout()
+```
+
+Disable the SSH inactivity timeout.
 
 #### <span className="msb-recv">server_options.</span><span className="msb-hn">build()</span>
 

--- a/docs/sdk/rust/ssh.mdx
+++ b/docs/sdk/rust/ssh.mdx
@@ -103,14 +103,14 @@ let client = sb.ssh().connect_with(|opts| opts
 
 </Accordion>
 
-Connect a native in-process SSH client with custom options. The closure configures the login user, terminal name, and whether SFTP is enabled on the internal server.
+Connect a native in-process SSH client with custom options. The closure configures the login user, terminal name, whether SFTP is enabled on the internal server, and the SSH inactivity timeout.
 
 <p className="msb-label">Parameters</p>
 
 <div className="msb-params">
   <div className="msb-param">
     <div className="msb-param-key"><code>f</code><a className="msb-type" href="#sshclientoptionsbuilder">FnOnce(SshClientOptionsBuilder)</a></div>
-    <div className="msb-param-desc">Configure user, terminal, and SFTP support.</div>
+    <div className="msb-param-desc">Configure user, terminal, SFTP support, and the inactivity timeout.</div>
   </div>
 </div>
 
@@ -216,14 +216,14 @@ let server = sb.ssh().server_with(|opts| opts
 
 </Accordion>
 
-Prepare a server endpoint with custom host-key, authorization, guest-user, or SFTP options. If no authorized keys are configured, the default authorized-keys file is loaded; an empty key set is an error.
+Prepare a server endpoint with custom host-key, authorization, guest-user, SFTP, or inactivity-timeout options. If no authorized keys are configured, the default authorized-keys file is loaded; an empty key set is an error.
 
 <p className="msb-label">Parameters</p>
 
 <div className="msb-params">
   <div className="msb-param">
     <div className="msb-param-key"><code>f</code><a className="msb-type" href="#sshserveroptionsbuilder">FnOnce(SshServerOptionsBuilder)</a></div>
-    <div className="msb-param-desc">Configure host key, authorized keys, guest user, and SFTP.</div>
+    <div className="msb-param-desc">Configure host key, authorized keys, guest user, SFTP, and the inactivity timeout.</div>
   </div>
 </div>
 
@@ -634,13 +634,15 @@ Ordered duplex stream backed by this process's stdin and stdout. Implements `Asy
 
 <p className="msb-backref">Used by <a href="#ssh-connect_with">ssh.connect_with()</a></p>
 
-Builder for SSH client options. Defaults: user `root`, terminal from `$TERM` (falling back to `xterm`), SFTP enabled.
+Builder for SSH client options. Defaults: user `root`, terminal from `$TERM` (falling back to `xterm`), SFTP enabled, and the global SSH inactivity timeout.
 
 | Method | Parameters | Description |
 |--------|------------|-------------|
 | `user()` | `impl Into<String>` | SSH login user. Default `root`. |
 | `term()` | `impl Into<String>` | Terminal name for interactive sessions. |
 | `sftp()` | `bool` | Enable or disable SFTP on the internal server. Default `true`. |
+| `inactivity_timeout()` | `Duration` | Override the internal server inactivity timeout. `Duration::ZERO` disables it. |
+| `disable_inactivity_timeout()` | | Disable the internal server inactivity timeout. |
 | `build()` | | Finalize the options. |
 
 ### SshExecOptionsBuilder
@@ -670,7 +672,7 @@ Builder for interactive SSH attach options. Default terminal comes from `$TERM` 
 
 <p className="msb-backref">Used by <a href="#ssh-server_with">ssh.server_with()</a></p>
 
-Builder for SSH server options. SFTP is enabled by default; when no authorized keys are provided, the default authorized-keys file is loaded.
+Builder for SSH server options. SFTP is enabled by default; the inactivity timeout inherits the global SSH setting; when no authorized keys are provided, the default authorized-keys file is loaded.
 
 | Method | Parameters | Description |
 |--------|------------|-------------|
@@ -680,4 +682,6 @@ Builder for SSH server options. SFTP is enabled by default; when no authorized k
 | `authorized_key()` | `impl Into<String>` | Add one in-memory authorized public key. |
 | `user()` | `impl Into<String>` | Override the guest user used for exec requests. |
 | `sftp()` | `bool` | Enable or disable SFTP. Default `true`. |
+| `inactivity_timeout()` | `Duration` | Override the SSH inactivity timeout. `Duration::ZERO` disables it. |
+| `disable_inactivity_timeout()` | | Disable the SSH inactivity timeout. |
 | `build()` | | Finalize the options. |

--- a/docs/sdk/typescript/ssh.mdx
+++ b/docs/sdk/typescript/ssh.mdx
@@ -57,7 +57,7 @@ Open a native in-process SSH client connected to the sandbox.
 <div className="msb-params">
   <div className="msb-param">
     <div className="msb-param-key"><code>opts</code><a className="msb-type" href="#sshclientoptions">SshClientOptions</a></div>
-    <div className="msb-param-desc">Optional client options: login user, terminal name, SFTP toggle.</div>
+    <div className="msb-param-desc">Optional client options: login user, terminal name, SFTP toggle, and inactivity timeout.</div>
   </div>
 </div>
 
@@ -94,7 +94,7 @@ Prepare a reusable SSH server endpoint backed by the sandbox.
 <div className="msb-params">
   <div className="msb-param">
     <div className="msb-param-key"><code>opts</code><a className="msb-type" href="#sshserveroptions">SshServerOptions</a></div>
-    <div className="msb-param-desc">Optional server options: host key path, authorized-keys path, guest user, SFTP toggle.</div>
+    <div className="msb-param-desc">Optional server options: host key path, authorized-keys path, guest user, SFTP toggle, and inactivity timeout.</div>
   </div>
 </div>
 
@@ -578,6 +578,7 @@ Options for opening an SSH client. All fields are optional.
 | user | `string` | SSH login user |
 | term | `string` | Terminal name for interactive sessions |
 | sftp | `boolean` | Enable or disable SFTP on the internal server |
+| inactivityTimeoutSecs | `number` | Disconnect after this many whole seconds without SSH traffic. `0` disables the timeout; omitted inherits the global setting |
 
 ### SshExecOptions
 
@@ -612,3 +613,4 @@ Options for preparing an SSH server endpoint. All fields are optional.
 | authorizedKeysPath | `string` | Override the authorized-keys path |
 | user | `string` | Override the guest user used for exec requests |
 | sftp | `boolean` | Enable or disable SFTP |
+| inactivityTimeoutSecs | `number` | Disconnect after this many whole seconds without SSH traffic. `0` disables the timeout; omitted inherits the global setting |

--- a/docs/sdk/typescript/ssh.mdx
+++ b/docs/sdk/typescript/ssh.mdx
@@ -57,7 +57,7 @@ Open a native in-process SSH client connected to the sandbox.
 <div className="msb-params">
   <div className="msb-param">
     <div className="msb-param-key"><code>opts</code><a className="msb-type" href="#sshclientoptions">SshClientOptions</a></div>
-    <div className="msb-param-desc">Optional client options: login user, terminal name, SFTP toggle.</div>
+    <div className="msb-param-desc">Optional client options: login user, terminal name, SFTP toggle, and inactivity timeout.</div>
   </div>
 </div>
 
@@ -92,7 +92,7 @@ Prepare a reusable SSH server endpoint backed by the sandbox.
 <div className="msb-params">
   <div className="msb-param">
     <div className="msb-param-key"><code>opts</code><a className="msb-type" href="#sshserveroptions">SshServerOptions</a></div>
-    <div className="msb-param-desc">Optional server options: host key path, authorized-keys path, guest user, SFTP toggle.</div>
+    <div className="msb-param-desc">Optional server options: host key path, authorized-keys path, guest user, SFTP toggle, and inactivity timeout.</div>
   </div>
 </div>
 
@@ -576,6 +576,7 @@ Options for opening an SSH client. All fields are optional.
 | user | `string` | SSH login user |
 | term | `string` | Terminal name for interactive sessions |
 | sftp | `boolean` | Enable or disable SFTP on the internal server |
+| inactivityTimeoutSecs | `number` | Disconnect after this many seconds without SSH traffic. `0` disables the timeout; omitted inherits the global setting |
 
 ### SshExecOptions
 
@@ -610,3 +611,4 @@ Options for preparing an SSH server endpoint. All fields are optional.
 | authorizedKeysPath | `string` | Override the authorized-keys path |
 | user | `string` | Override the guest user used for exec requests |
 | sftp | `boolean` | Enable or disable SFTP |
+| inactivityTimeoutSecs | `number` | Disconnect after this many seconds without SSH traffic. `0` disables the timeout; omitted inherits the global setting |

--- a/docs/style.css
+++ b/docs/style.css
@@ -101,13 +101,12 @@ h2 + .msb-member-group { margin-top: 1.5rem; }
  * keeping each root type directly navigable. */
 #table-of-contents-content li:has(> .msb-toc-toggle) {
   position: relative;
-  padding-left: 1.35rem;
 }
 #table-of-contents-content .msb-toc-toggle {
   position: absolute;
   z-index: 1;
   top: 0.2rem;
-  left: 0;
+  left: -1.35rem;
   display: grid;
   width: 1.25rem;
   height: 1.25rem;

--- a/sdk/go/internal/ffi/ffi.go
+++ b/sdk/go/internal/ffi/ffi.go
@@ -2480,9 +2480,10 @@ func (s *Sandbox) ExecDefault(ctx context.Context, opts ExecOptions) (*ExecResul
 
 // SSHClientOptions is the FFI wire shape for a native SSH client connection.
 type SSHClientOptions struct {
-	User string `json:"user,omitempty"`
-	Term string `json:"term,omitempty"`
-	SFTP *bool  `json:"sftp,omitempty"`
+	User                  string  `json:"user,omitempty"`
+	Term                  string  `json:"term,omitempty"`
+	SFTP                  *bool   `json:"sftp,omitempty"`
+	InactivityTimeoutSecs *uint64 `json:"inactivity_timeout_secs,omitempty"`
 }
 
 // SSHExecOptions is the FFI wire shape for an SSH exec request.
@@ -2498,10 +2499,11 @@ type SSHAttachOptions struct {
 
 // SSHServerOptions is the FFI wire shape for preparing an SSH server endpoint.
 type SSHServerOptions struct {
-	HostKeyPath        string `json:"host_key_path,omitempty"`
-	AuthorizedKeysPath string `json:"authorized_keys_path,omitempty"`
-	User               string `json:"user,omitempty"`
-	SFTP               *bool  `json:"sftp,omitempty"`
+	HostKeyPath           string  `json:"host_key_path,omitempty"`
+	AuthorizedKeysPath    string  `json:"authorized_keys_path,omitempty"`
+	User                  string  `json:"user,omitempty"`
+	SFTP                  *bool   `json:"sftp,omitempty"`
+	InactivityTimeoutSecs *uint64 `json:"inactivity_timeout_secs,omitempty"`
 }
 
 // SSHOutput is the FFI-decoded output from an SSH exec request.

--- a/sdk/go/internal/ffi/ffi.go
+++ b/sdk/go/internal/ffi/ffi.go
@@ -2459,9 +2459,10 @@ func (s *Sandbox) ExecDefault(ctx context.Context, opts ExecOptions) (*ExecResul
 
 // SSHClientOptions is the FFI wire shape for a native SSH client connection.
 type SSHClientOptions struct {
-	User string `json:"user,omitempty"`
-	Term string `json:"term,omitempty"`
-	SFTP *bool  `json:"sftp,omitempty"`
+	User                  string  `json:"user,omitempty"`
+	Term                  string  `json:"term,omitempty"`
+	SFTP                  *bool   `json:"sftp,omitempty"`
+	InactivityTimeoutSecs *uint64 `json:"inactivity_timeout_secs,omitempty"`
 }
 
 // SSHExecOptions is the FFI wire shape for an SSH exec request.
@@ -2477,10 +2478,11 @@ type SSHAttachOptions struct {
 
 // SSHServerOptions is the FFI wire shape for preparing an SSH server endpoint.
 type SSHServerOptions struct {
-	HostKeyPath        string `json:"host_key_path,omitempty"`
-	AuthorizedKeysPath string `json:"authorized_keys_path,omitempty"`
-	User               string `json:"user,omitempty"`
-	SFTP               *bool  `json:"sftp,omitempty"`
+	HostKeyPath           string  `json:"host_key_path,omitempty"`
+	AuthorizedKeysPath    string  `json:"authorized_keys_path,omitempty"`
+	User                  string  `json:"user,omitempty"`
+	SFTP                  *bool   `json:"sftp,omitempty"`
+	InactivityTimeoutSecs *uint64 `json:"inactivity_timeout_secs,omitempty"`
 }
 
 // SSHOutput is the FFI-decoded output from an SSH exec request.

--- a/sdk/go/native/src/lib.rs
+++ b/sdk/go/native/src/lib.rs
@@ -3283,6 +3283,7 @@ struct SshClientOpts {
     user: Option<String>,
     term: Option<String>,
     sftp: Option<bool>,
+    inactivity_timeout_secs: Option<u64>,
 }
 
 #[derive(serde::Deserialize, Default)]
@@ -3291,6 +3292,7 @@ struct SshServerOpts {
     authorized_keys_path: Option<PathBuf>,
     user: Option<String>,
     sftp: Option<bool>,
+    inactivity_timeout_secs: Option<u64>,
 }
 
 #[derive(serde::Deserialize, Default)]
@@ -3330,6 +3332,9 @@ pub unsafe extern "C" fn msb_sandbox_ssh_connect(
                     }
                     if let Some(sftp) = opts.sftp {
                         builder = builder.sftp(sftp);
+                    }
+                    if let Some(timeout_secs) = opts.inactivity_timeout_secs {
+                        builder = builder.inactivity_timeout(Duration::from_secs(timeout_secs));
                     }
                     builder
                 })
@@ -3373,6 +3378,9 @@ pub unsafe extern "C" fn msb_sandbox_ssh_server(
                     }
                     if let Some(sftp) = opts.sftp {
                         builder = builder.sftp(sftp);
+                    }
+                    if let Some(timeout_secs) = opts.inactivity_timeout_secs {
+                        builder = builder.inactivity_timeout(Duration::from_secs(timeout_secs));
                     }
                     builder
                 })

--- a/sdk/go/native/src/lib.rs
+++ b/sdk/go/native/src/lib.rs
@@ -3218,6 +3218,7 @@ struct SshClientOpts {
     user: Option<String>,
     term: Option<String>,
     sftp: Option<bool>,
+    inactivity_timeout_secs: Option<u64>,
 }
 
 #[derive(serde::Deserialize, Default)]
@@ -3226,6 +3227,7 @@ struct SshServerOpts {
     authorized_keys_path: Option<PathBuf>,
     user: Option<String>,
     sftp: Option<bool>,
+    inactivity_timeout_secs: Option<u64>,
 }
 
 #[derive(serde::Deserialize, Default)]
@@ -3265,6 +3267,9 @@ pub unsafe extern "C" fn msb_sandbox_ssh_connect(
                     }
                     if let Some(sftp) = opts.sftp {
                         builder = builder.sftp(sftp);
+                    }
+                    if let Some(timeout_secs) = opts.inactivity_timeout_secs {
+                        builder = builder.inactivity_timeout(Duration::from_secs(timeout_secs));
                     }
                     builder
                 })
@@ -3308,6 +3313,9 @@ pub unsafe extern "C" fn msb_sandbox_ssh_server(
                     }
                     if let Some(sftp) = opts.sftp {
                         builder = builder.sftp(sftp);
+                    }
+                    if let Some(timeout_secs) = opts.inactivity_timeout_secs {
+                        builder = builder.inactivity_timeout(Duration::from_secs(timeout_secs));
                     }
                     builder
                 })

--- a/sdk/go/ssh.go
+++ b/sdk/go/ssh.go
@@ -2,6 +2,8 @@ package microsandbox
 
 import (
 	"context"
+	"fmt"
+	"time"
 
 	"github.com/superradcompany/microsandbox/sdk/go/internal/ffi"
 )
@@ -20,9 +22,10 @@ func (s *Sandbox) SSH() *SandboxSSHOps {
 type SSHClientOption func(*sshClientConfig)
 
 type sshClientConfig struct {
-	user string
-	term string
-	sftp *bool
+	user              string
+	term              string
+	sftp              *bool
+	inactivityTimeout *time.Duration
 }
 
 // WithSSHUser sets the SSH login user.
@@ -40,6 +43,12 @@ func WithSSHClientSFTP(enabled bool) SSHClientOption {
 	return func(o *sshClientConfig) { o.sftp = &enabled }
 }
 
+// WithSSHClientInactivityTimeout sets the internal SSH server inactivity timeout.
+// A zero duration disables the timeout.
+func WithSSHClientInactivityTimeout(timeout time.Duration) SSHClientOption {
+	return func(o *sshClientConfig) { o.inactivityTimeout = &timeout }
+}
+
 // SSHClient is a native in-process SSH client session.
 type SSHClient struct {
 	inner *ffi.SSHClient
@@ -51,11 +60,16 @@ func (ssh *SandboxSSHOps) OpenClient(ctx context.Context, opts ...SSHClientOptio
 	for _, opt := range opts {
 		opt(&cfg)
 	}
+	inactivityTimeoutSecs, err := sshInactivityTimeoutSeconds(cfg.inactivityTimeout)
+	if err != nil {
+		return nil, err
+	}
 
 	inner, err := ssh.sandbox.inner.SSHConnect(ctx, ffi.SSHClientOptions{
-		User: cfg.user,
-		Term: cfg.term,
-		SFTP: cfg.sftp,
+		User:                  cfg.user,
+		Term:                  cfg.term,
+		SFTP:                  cfg.sftp,
+		InactivityTimeoutSecs: inactivityTimeoutSecs,
 	})
 	if err != nil {
 		return nil, wrapFFI(err)
@@ -217,6 +231,7 @@ type sshServerConfig struct {
 	authorizedKeysPath string
 	user               string
 	sftp               *bool
+	inactivityTimeout  *time.Duration
 }
 
 // WithSSHHostKeyPath overrides the host private key path.
@@ -239,6 +254,12 @@ func WithSSHServerSFTP(enabled bool) SSHServerOption {
 	return func(o *sshServerConfig) { o.sftp = &enabled }
 }
 
+// WithSSHServerInactivityTimeout sets the SSH session inactivity timeout.
+// A zero duration disables the timeout.
+func WithSSHServerInactivityTimeout(timeout time.Duration) SSHServerOption {
+	return func(o *sshServerConfig) { o.inactivityTimeout = &timeout }
+}
+
 // SSHServer is a prepared SSH server endpoint for a sandbox.
 type SSHServer struct {
 	inner *ffi.SSHServer
@@ -250,12 +271,17 @@ func (ssh *SandboxSSHOps) PrepareServer(ctx context.Context, opts ...SSHServerOp
 	for _, opt := range opts {
 		opt(&cfg)
 	}
+	inactivityTimeoutSecs, err := sshInactivityTimeoutSeconds(cfg.inactivityTimeout)
+	if err != nil {
+		return nil, err
+	}
 
 	inner, err := ssh.sandbox.inner.SSHServer(ctx, ffi.SSHServerOptions{
-		HostKeyPath:        cfg.hostKeyPath,
-		AuthorizedKeysPath: cfg.authorizedKeysPath,
-		User:               cfg.user,
-		SFTP:               cfg.sftp,
+		HostKeyPath:           cfg.hostKeyPath,
+		AuthorizedKeysPath:    cfg.authorizedKeysPath,
+		User:                  cfg.user,
+		SFTP:                  cfg.sftp,
+		InactivityTimeoutSecs: inactivityTimeoutSecs,
 	})
 	if err != nil {
 		return nil, wrapFFI(err)
@@ -271,4 +297,15 @@ func (srv *SSHServer) Close(ctx context.Context) error {
 // ServeConnection serves one SSH transport over this process's stdin/stdout.
 func (srv *SSHServer) ServeConnection(ctx context.Context) error {
 	return wrapFFI(srv.inner.ServeConnection(ctx))
+}
+
+func sshInactivityTimeoutSeconds(timeout *time.Duration) (*uint64, error) {
+	if timeout == nil {
+		return nil, nil
+	}
+	if *timeout < 0 {
+		return nil, fmt.Errorf("SSH inactivity timeout must be non-negative")
+	}
+	value := durationSecsCeil(*timeout)
+	return &value, nil
 }

--- a/sdk/go/ssh_test.go
+++ b/sdk/go/ssh_test.go
@@ -1,0 +1,47 @@
+package microsandbox
+
+import (
+	"testing"
+	"time"
+)
+
+func TestSSHInactivityTimeoutSeconds(t *testing.T) {
+	tests := []struct {
+		name    string
+		timeout *time.Duration
+		want    *uint64
+		wantErr bool
+	}{
+		{name: "inherit"},
+		{name: "disabled", timeout: durationPtr(0), want: uint64Ptr(0)},
+		{name: "configured", timeout: durationPtr(30 * time.Second), want: uint64Ptr(30)},
+		{name: "negative", timeout: durationPtr(-time.Second), wantErr: true},
+		{name: "sub-second rounds up", timeout: durationPtr(time.Nanosecond), want: uint64Ptr(1)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := sshInactivityTimeoutSeconds(tt.timeout)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("sshInactivityTimeoutSeconds() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.want == nil {
+				if got != nil {
+					t.Fatalf("sshInactivityTimeoutSeconds() = %v, want nil", *got)
+				}
+				return
+			}
+			if got == nil || *got != *tt.want {
+				t.Fatalf("sshInactivityTimeoutSeconds() = %v, want %v", got, *tt.want)
+			}
+		})
+	}
+}
+
+func durationPtr(value time.Duration) *time.Duration {
+	return &value
+}
+
+func uint64Ptr(value uint64) *uint64 {
+	return &value
+}

--- a/sdk/node-ts/native/index.d.ts
+++ b/sdk/node-ts/native/index.d.ts
@@ -2382,6 +2382,7 @@ export interface SshClientOptions {
   user?: string
   term?: string
   sftp?: boolean
+  inactivityTimeoutSecs?: number
 }
 
 /** Options accepted by `SshClient.exec()`. */
@@ -2402,6 +2403,7 @@ export interface SshServerOptions {
   authorizedKeysPath?: string
   user?: string
   sftp?: boolean
+  inactivityTimeoutSecs?: number
 }
 
 /** Stdin mode for an exec. */

--- a/sdk/node-ts/native/index.d.ts
+++ b/sdk/node-ts/native/index.d.ts
@@ -2335,6 +2335,7 @@ export interface SshClientOptions {
   user?: string
   term?: string
   sftp?: boolean
+  inactivityTimeoutSecs?: number
 }
 
 /** Options accepted by `SshClient.exec()`. */
@@ -2355,6 +2356,7 @@ export interface SshServerOptions {
   authorizedKeysPath?: string
   user?: string
   sftp?: boolean
+  inactivityTimeoutSecs?: number
 }
 
 /** Stdin mode for an exec. */

--- a/sdk/node-ts/native/ssh.rs
+++ b/sdk/node-ts/native/ssh.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+use std::time::Duration;
 
 use napi::bindgen_prelude::*;
 use napi_derive::napi;
@@ -253,6 +254,9 @@ pub fn apply_client_options(
     if let Some(sftp) = options.sftp {
         builder = builder.sftp(sftp);
     }
+    if let Some(timeout_secs) = options.inactivity_timeout_secs {
+        builder = builder.inactivity_timeout(Duration::from_secs(u64::from(timeout_secs)));
+    }
     builder
 }
 
@@ -275,6 +279,9 @@ pub fn apply_server_options(
     }
     if let Some(sftp) = options.sftp {
         builder = builder.sftp(sftp);
+    }
+    if let Some(timeout_secs) = options.inactivity_timeout_secs {
+        builder = builder.inactivity_timeout(Duration::from_secs(u64::from(timeout_secs)));
     }
     builder
 }

--- a/sdk/node-ts/native/types.rs
+++ b/sdk/node-ts/native/types.rs
@@ -175,6 +175,7 @@ pub struct SshClientOptions {
     pub user: Option<String>,
     pub term: Option<String>,
     pub sftp: Option<bool>,
+    pub inactivity_timeout_secs: Option<u32>,
 }
 
 /// Options accepted by `SshClient.exec()`.
@@ -197,6 +198,7 @@ pub struct SshServerOptions {
     pub authorized_keys_path: Option<String>,
     pub user: Option<String>,
     pub sftp: Option<bool>,
+    pub inactivity_timeout_secs: Option<u32>,
 }
 
 /// Filesystem entry metadata returned by `fs.list()`.

--- a/sdk/node-ts/src/internal/napi.ts
+++ b/sdk/node-ts/src/internal/napi.ts
@@ -399,6 +399,7 @@ export interface NapiSshClientOptions {
   user?: string;
   term?: string;
   sftp?: boolean;
+  inactivityTimeoutSecs?: number;
 }
 
 export interface NapiSshExecOptions {
@@ -415,6 +416,7 @@ export interface NapiSshServerOptions {
   authorizedKeysPath?: string;
   user?: string;
   sftp?: boolean;
+  inactivityTimeoutSecs?: number;
 }
 
 export interface NapiSshClient {

--- a/sdk/node-ts/src/internal/napi.ts
+++ b/sdk/node-ts/src/internal/napi.ts
@@ -397,6 +397,7 @@ export interface NapiSshClientOptions {
   user?: string;
   term?: string;
   sftp?: boolean;
+  inactivityTimeoutSecs?: number;
 }
 
 export interface NapiSshExecOptions {
@@ -413,6 +414,7 @@ export interface NapiSshServerOptions {
   authorizedKeysPath?: string;
   user?: string;
   sftp?: boolean;
+  inactivityTimeoutSecs?: number;
 }
 
 export interface NapiSshClient {

--- a/sdk/node-ts/src/ssh.ts
+++ b/sdk/node-ts/src/ssh.ts
@@ -21,6 +21,8 @@ export interface SshClientOptions {
   readonly user?: string;
   readonly term?: string;
   readonly sftp?: boolean;
+  /** Disconnect after this many whole seconds without SSH traffic. Use 0 to disable. */
+  readonly inactivityTimeoutSecs?: number;
 }
 
 export interface SshExecOptions {
@@ -37,6 +39,8 @@ export interface SshServerOptions {
   readonly authorizedKeysPath?: string;
   readonly user?: string;
   readonly sftp?: boolean;
+  /** Disconnect after this many whole seconds without SSH traffic. Use 0 to disable. */
+  readonly inactivityTimeoutSecs?: number;
 }
 
 export class SandboxSshOps {
@@ -167,10 +171,12 @@ export function sshClientOptionsToNapi(
   opts?: SshClientOptions,
 ): NapiSshClientOptions | undefined {
   if (!opts) return undefined;
+  validateInactivityTimeoutSecs(opts.inactivityTimeoutSecs);
   return {
     user: opts.user,
     term: opts.term,
     sftp: opts.sftp,
+    inactivityTimeoutSecs: opts.inactivityTimeoutSecs,
   };
 }
 
@@ -197,12 +203,25 @@ export function sshServerOptionsToNapi(
   opts?: SshServerOptions,
 ): NapiSshServerOptions | undefined {
   if (!opts) return undefined;
+  validateInactivityTimeoutSecs(opts.inactivityTimeoutSecs);
   return {
     hostKeyPath: opts.hostKeyPath,
     authorizedKeysPath: opts.authorizedKeysPath,
     user: opts.user,
     sftp: opts.sftp,
+    inactivityTimeoutSecs: opts.inactivityTimeoutSecs,
   };
+}
+
+function validateInactivityTimeoutSecs(value: number | undefined): void {
+  if (
+    value !== undefined &&
+    (!Number.isSafeInteger(value) || value < 0 || value > 0xffff_ffff)
+  ) {
+    throw new RangeError(
+      "inactivityTimeoutSecs must be an integer between 0 and 4294967295",
+    );
+  }
 }
 
 function sshOutputFromNapi(output: NapiSshOutput): SshOutput {

--- a/sdk/node-ts/src/ssh.ts
+++ b/sdk/node-ts/src/ssh.ts
@@ -21,6 +21,8 @@ export interface SshClientOptions {
   readonly user?: string;
   readonly term?: string;
   readonly sftp?: boolean;
+  /** Disconnect after this many seconds without SSH traffic. Use 0 to disable. */
+  readonly inactivityTimeoutSecs?: number;
 }
 
 export interface SshExecOptions {
@@ -37,6 +39,8 @@ export interface SshServerOptions {
   readonly authorizedKeysPath?: string;
   readonly user?: string;
   readonly sftp?: boolean;
+  /** Disconnect after this many seconds without SSH traffic. Use 0 to disable. */
+  readonly inactivityTimeoutSecs?: number;
 }
 
 export class SandboxSshOps {
@@ -171,6 +175,7 @@ export function sshClientOptionsToNapi(
     user: opts.user,
     term: opts.term,
     sftp: opts.sftp,
+    inactivityTimeoutSecs: opts.inactivityTimeoutSecs,
   };
 }
 
@@ -202,6 +207,7 @@ export function sshServerOptionsToNapi(
     authorizedKeysPath: opts.authorizedKeysPath,
     user: opts.user,
     sftp: opts.sftp,
+    inactivityTimeoutSecs: opts.inactivityTimeoutSecs,
   };
 }
 

--- a/sdk/node-ts/tests/unit/ssh.test.ts
+++ b/sdk/node-ts/tests/unit/ssh.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import {
+  sshClientOptionsToNapi,
+  sshServerOptionsToNapi,
+} from "../../dist/ssh.js";
+
+describe("SSH inactivity timeout options", () => {
+  it("preserves client timeout values, including zero", () => {
+    expect(sshClientOptionsToNapi(undefined)).toBeUndefined();
+    expect(
+      sshClientOptionsToNapi({ inactivityTimeoutSecs: 30 }),
+    ).toMatchObject({ inactivityTimeoutSecs: 30 });
+    expect(
+      sshClientOptionsToNapi({ inactivityTimeoutSecs: 0 }),
+    ).toMatchObject({ inactivityTimeoutSecs: 0 });
+  });
+
+  it("preserves server timeout values, including zero", () => {
+    expect(sshServerOptionsToNapi(undefined)).toBeUndefined();
+    expect(
+      sshServerOptionsToNapi({ inactivityTimeoutSecs: 30 }),
+    ).toMatchObject({ inactivityTimeoutSecs: 30 });
+    expect(
+      sshServerOptionsToNapi({ inactivityTimeoutSecs: 0 }),
+    ).toMatchObject({ inactivityTimeoutSecs: 0 });
+  });
+
+  it("rejects client timeout values outside the native seconds range", () => {
+    for (const inactivityTimeoutSecs of [-1, 1.5, Number.NaN, 0x1_0000_0000]) {
+      expect(() => sshClientOptionsToNapi({ inactivityTimeoutSecs })).toThrow(
+        /integer between 0 and 4294967295/,
+      );
+    }
+  });
+
+  it("rejects invalid server timeout values", () => {
+    expect(() =>
+      sshServerOptionsToNapi({ inactivityTimeoutSecs: Number.POSITIVE_INFINITY }),
+    ).toThrow(/integer between 0 and 4294967295/);
+  });
+});

--- a/sdk/node-ts/tests/unit/ssh.test.ts
+++ b/sdk/node-ts/tests/unit/ssh.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import {
+  sshClientOptionsToNapi,
+  sshServerOptionsToNapi,
+} from "../../dist/ssh.js";
+
+describe("SSH inactivity timeout options", () => {
+  it("preserves client timeout values, including zero", () => {
+    expect(sshClientOptionsToNapi(undefined)).toBeUndefined();
+    expect(
+      sshClientOptionsToNapi({ inactivityTimeoutSecs: 30 }),
+    ).toMatchObject({ inactivityTimeoutSecs: 30 });
+    expect(
+      sshClientOptionsToNapi({ inactivityTimeoutSecs: 0 }),
+    ).toMatchObject({ inactivityTimeoutSecs: 0 });
+  });
+
+  it("preserves server timeout values, including zero", () => {
+    expect(sshServerOptionsToNapi(undefined)).toBeUndefined();
+    expect(
+      sshServerOptionsToNapi({ inactivityTimeoutSecs: 30 }),
+    ).toMatchObject({ inactivityTimeoutSecs: 30 });
+    expect(
+      sshServerOptionsToNapi({ inactivityTimeoutSecs: 0 }),
+    ).toMatchObject({ inactivityTimeoutSecs: 0 });
+  });
+});

--- a/sdk/python/microsandbox/_microsandbox.pyi
+++ b/sdk/python/microsandbox/_microsandbox.pyi
@@ -461,6 +461,7 @@ class SandboxSshOps:
         user: str = "root",
         term: str | None = None,
         sftp: bool = True,
+        inactivity_timeout: float | None = None,
     ) -> SshClient: ...
     async def prepare_server(
         self,
@@ -469,6 +470,7 @@ class SandboxSshOps:
         authorized_keys_path: str | os.PathLike[str] | None = None,
         user: str | None = None,
         sftp: bool = True,
+        inactivity_timeout: float | None = None,
     ) -> SshServer: ...
 
 class SshOutput:

--- a/sdk/python/src/ssh.rs
+++ b/sdk/python/src/ssh.rs
@@ -1,6 +1,8 @@
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::time::Duration;
 
+use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use pyo3::types::PyBytes;
 use tokio::io::AsyncWriteExt;
@@ -64,14 +66,17 @@ impl PySandboxSshOps {
 #[pymethods]
 impl PySandboxSshOps {
     /// Connect a native in-process SSH client to this sandbox.
-    #[pyo3(signature = (*, user = "root".to_string(), term = None, sftp = true))]
+    #[pyo3(signature = (*, user = "root".to_string(), term = None, sftp = true, inactivity_timeout = None))]
     fn open_client<'py>(
         &self,
         py: Python<'py>,
         user: String,
         term: Option<String>,
         sftp: bool,
+        inactivity_timeout: Option<f64>,
     ) -> PyResult<Bound<'py, PyAny>> {
+        let inactivity_timeout =
+            parse_inactivity_timeout(inactivity_timeout).map_err(PyValueError::new_err)?;
         let ssh = Self {
             inner: self.inner.clone(),
         };
@@ -83,6 +88,9 @@ impl PySandboxSshOps {
                     let mut builder = builder.user(user).sftp(sftp);
                     if let Some(term) = term {
                         builder = builder.term(term);
+                    }
+                    if let Some(timeout) = inactivity_timeout {
+                        builder = builder.inactivity_timeout(timeout);
                     }
                     builder
                 })
@@ -99,6 +107,7 @@ impl PySandboxSshOps {
         authorized_keys_path = None,
         user = None,
         sftp = true,
+        inactivity_timeout = None,
     ))]
     fn prepare_server<'py>(
         &self,
@@ -107,7 +116,10 @@ impl PySandboxSshOps {
         authorized_keys_path: Option<PathBuf>,
         user: Option<String>,
         sftp: bool,
+        inactivity_timeout: Option<f64>,
     ) -> PyResult<Bound<'py, PyAny>> {
+        let inactivity_timeout =
+            parse_inactivity_timeout(inactivity_timeout).map_err(PyValueError::new_err)?;
         let ssh = Self {
             inner: self.inner.clone(),
         };
@@ -125,6 +137,9 @@ impl PySandboxSshOps {
                     }
                     if let Some(user) = user {
                         builder = builder.user(user);
+                    }
+                    if let Some(timeout) = inactivity_timeout {
+                        builder = builder.inactivity_timeout(timeout);
                     }
                     builder
                 })
@@ -430,6 +445,15 @@ impl PySshServer {
 // Functions
 //--------------------------------------------------------------------------------------------------
 
+fn parse_inactivity_timeout(timeout: Option<f64>) -> Result<Option<Duration>, &'static str> {
+    match timeout {
+        Some(timeout) => Duration::try_from_secs_f64(timeout)
+            .map(Some)
+            .map_err(|_| "inactivity_timeout must be a non-negative finite duration"),
+        None => Ok(None),
+    }
+}
+
 fn sftp_py_err(error: impl std::fmt::Display) -> PyErr {
     pyo3::exceptions::PyRuntimeError::new_err(format!("SFTP error: {error}"))
 }
@@ -460,5 +484,35 @@ impl PySshServer {
             .map_err(|_| pyo3::exceptions::PyRuntimeError::new_err("SSH server is busy"))?;
         guard.take().ok_or_else(crate::error::consumed)?;
         Ok(())
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests
+//--------------------------------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn inactivity_timeout_parsing_supports_inherit_set_and_disable() {
+        assert_eq!(parse_inactivity_timeout(None).unwrap(), None);
+        assert_eq!(
+            parse_inactivity_timeout(Some(30.5)).unwrap(),
+            Some(Duration::from_secs_f64(30.5))
+        );
+        assert_eq!(
+            parse_inactivity_timeout(Some(0.0)).unwrap(),
+            Some(Duration::ZERO)
+        );
+    }
+
+    #[test]
+    fn inactivity_timeout_rejects_invalid_values() {
+        assert!(parse_inactivity_timeout(Some(-1.0)).is_err());
+        assert!(parse_inactivity_timeout(Some(f64::INFINITY)).is_err());
+        assert!(parse_inactivity_timeout(Some(f64::NAN)).is_err());
+        assert!(parse_inactivity_timeout(Some(f64::MAX)).is_err());
     }
 }

--- a/sdk/python/src/ssh.rs
+++ b/sdk/python/src/ssh.rs
@@ -1,6 +1,8 @@
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::time::Duration;
 
+use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use pyo3::types::PyBytes;
 use tokio::io::AsyncWriteExt;
@@ -64,14 +66,16 @@ impl PySandboxSshOps {
 #[pymethods]
 impl PySandboxSshOps {
     /// Connect a native in-process SSH client to this sandbox.
-    #[pyo3(signature = (*, user = "root".to_string(), term = None, sftp = true))]
+    #[pyo3(signature = (*, user = "root".to_string(), term = None, sftp = true, inactivity_timeout = None))]
     fn open_client<'py>(
         &self,
         py: Python<'py>,
         user: String,
         term: Option<String>,
         sftp: bool,
+        inactivity_timeout: Option<f64>,
     ) -> PyResult<Bound<'py, PyAny>> {
+        let inactivity_timeout = parse_inactivity_timeout(inactivity_timeout)?;
         let ssh = Self {
             inner: self.inner.clone(),
         };
@@ -83,6 +87,9 @@ impl PySandboxSshOps {
                     let mut builder = builder.user(user).sftp(sftp);
                     if let Some(term) = term {
                         builder = builder.term(term);
+                    }
+                    if let Some(timeout) = inactivity_timeout {
+                        builder = builder.inactivity_timeout(timeout);
                     }
                     builder
                 })
@@ -99,6 +106,7 @@ impl PySandboxSshOps {
         authorized_keys_path = None,
         user = None,
         sftp = true,
+        inactivity_timeout = None,
     ))]
     fn prepare_server<'py>(
         &self,
@@ -107,7 +115,9 @@ impl PySandboxSshOps {
         authorized_keys_path: Option<PathBuf>,
         user: Option<String>,
         sftp: bool,
+        inactivity_timeout: Option<f64>,
     ) -> PyResult<Bound<'py, PyAny>> {
+        let inactivity_timeout = parse_inactivity_timeout(inactivity_timeout)?;
         let ssh = Self {
             inner: self.inner.clone(),
         };
@@ -125,6 +135,9 @@ impl PySandboxSshOps {
                     }
                     if let Some(user) = user {
                         builder = builder.user(user);
+                    }
+                    if let Some(timeout) = inactivity_timeout {
+                        builder = builder.inactivity_timeout(timeout);
                     }
                     builder
                 })
@@ -430,6 +443,15 @@ impl PySshServer {
 // Functions
 //--------------------------------------------------------------------------------------------------
 
+fn parse_inactivity_timeout(timeout: Option<f64>) -> PyResult<Option<Duration>> {
+    match timeout {
+        Some(timeout) => Duration::try_from_secs_f64(timeout).map(Some).map_err(|_| {
+            PyValueError::new_err("inactivity_timeout must be a non-negative finite duration")
+        }),
+        None => Ok(None),
+    }
+}
+
 fn sftp_py_err(error: impl std::fmt::Display) -> PyErr {
     pyo3::exceptions::PyRuntimeError::new_err(format!("SFTP error: {error}"))
 }
@@ -460,5 +482,35 @@ impl PySshServer {
             .map_err(|_| pyo3::exceptions::PyRuntimeError::new_err("SSH server is busy"))?;
         guard.take().ok_or_else(crate::error::consumed)?;
         Ok(())
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests
+//--------------------------------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn inactivity_timeout_parsing_supports_inherit_set_and_disable() {
+        assert_eq!(parse_inactivity_timeout(None).unwrap(), None);
+        assert_eq!(
+            parse_inactivity_timeout(Some(30.5)).unwrap(),
+            Some(Duration::from_secs_f64(30.5))
+        );
+        assert_eq!(
+            parse_inactivity_timeout(Some(0.0)).unwrap(),
+            Some(Duration::ZERO)
+        );
+    }
+
+    #[test]
+    fn inactivity_timeout_rejects_invalid_values() {
+        assert!(parse_inactivity_timeout(Some(-1.0)).is_err());
+        assert!(parse_inactivity_timeout(Some(f64::INFINITY)).is_err());
+        assert!(parse_inactivity_timeout(Some(f64::NAN)).is_err());
+        assert!(parse_inactivity_timeout(Some(f64::MAX)).is_err());
     }
 }

--- a/sdk/ruby/README.md
+++ b/sdk/ruby/README.md
@@ -96,6 +96,14 @@ The gem supports sandbox lifecycle operations, collected exec and shell
 output, SSH exec, logs, metrics, guest filesystem operations, local image,
 volume, and snapshot management, and local or cloud backend selection.
 
+SSH exec inherits the global inactivity timeout by default. Override it for a
+single command in seconds, or use `0` to disable it:
+
+```ruby
+output = sandbox.ssh_exec("long-running-agent", inactivity_timeout: 1_800)
+persistent = sandbox.ssh_exec("long-running-agent", inactivity_timeout: 0)
+```
+
 Streaming exec, logs, metrics, and filesystem handles; interactive SSH/SFTP;
 live modification plans; and the complete Rust network and mount builders are
 not currently exposed. Use the Rust SDK when those APIs are required.

--- a/sdk/ruby/ext/microsandbox/src/lib.rs
+++ b/sdk/ruby/ext/microsandbox/src/lib.rs
@@ -1031,10 +1031,22 @@ impl RubySandbox {
         }
         Ok(array)
     }
-    fn ssh_exec(ruby: &Ruby, this: typed_data::Obj<Self>, command: String) -> Result<RHash, Error> {
+    fn ssh_exec(ruby: &Ruby, this: typed_data::Obj<Self>, args: &[Value]) -> Result<RHash, Error> {
+        let parsed = scan_args::<(String,), (), (), (), RHash, ()>(args)?;
+        reject_unknown_keywords(ruby, parsed.keywords, &["inactivity_timeout"])?;
+        let inactivity_timeout = keyword::<f64>(parsed.keywords, "inactivity_timeout")?
+            .map(|seconds| duration(ruby, seconds, "inactivity_timeout"))
+            .transpose()?;
+        let command = parsed.required.0;
         let sb = this.inner_clone()?;
         let output = run(ruby, async move {
-            let client = sb.ssh().connect().await?;
+            let client = sb
+                .ssh()
+                .connect_with(|builder| match inactivity_timeout {
+                    Some(timeout) => builder.inactivity_timeout(timeout),
+                    None => builder,
+                })
+                .await?;
             client.exec(command).await
         })?;
         let hash = current_ruby().hash_new();
@@ -2049,7 +2061,7 @@ fn init(ruby: &Ruby) -> Result<(), Error> {
     sandbox.define_method("touch", method!(RubySandbox::touch, 0))?;
     sandbox.define_method("metrics", method!(RubySandbox::metrics, 0))?;
     sandbox.define_method("logs", method!(RubySandbox::logs, -1))?;
-    sandbox.define_method("ssh_exec", method!(RubySandbox::ssh_exec, 1))?;
+    sandbox.define_method("ssh_exec", method!(RubySandbox::ssh_exec, -1))?;
     // filesystem
     sandbox.define_method("fs_read", method!(RubySandbox::fs_read, 1))?;
     sandbox.define_method("fs_write", method!(RubySandbox::fs_write, 2))?;

--- a/sdk/ruby/test/integration_test.rb
+++ b/sdk/ruby/test/integration_test.rb
@@ -111,6 +111,17 @@ class MicrosandboxIntegrationTest < Test::Unit::TestCase
     sandbox&.stop
   end
 
+  def test_ssh_exec_accepts_inactivity_timeout
+    sandbox = create_sandbox("ssh-timeout")
+
+    output = sandbox.ssh_exec("printf ruby-ssh", inactivity_timeout: 0)
+
+    assert_equal "ruby-ssh", output.fetch("stdout")
+    assert_true output.fetch("success")
+  ensure
+    sandbox&.stop
+  end
+
   def test_assert_eventually_enforces_timeout
     started_at = Process.clock_gettime(Process::CLOCK_MONOTONIC)
 

--- a/sdk/rust/lib/backend/local/mod.rs
+++ b/sdk/rust/lib/backend/local/mod.rs
@@ -93,6 +93,7 @@ pub struct LocalBackendBuilder {
     disable_metrics_sample: Option<bool>,
     ca_certs: Option<Option<PathBuf>>,
     registry_hosts: Option<HashMap<String, RegistryEntry>>,
+    ssh_inactivity_timeout_secs: Option<u64>,
     log_level: Option<microsandbox_runtime::logging::LogLevel>,
     deployment_profile: Option<DeploymentProfile>,
 }
@@ -376,6 +377,14 @@ impl LocalBackendBuilder {
         self
     }
 
+    /// Override the default SSH inactivity timeout in seconds.
+    ///
+    /// Pass `0` to disable the timeout.
+    pub fn ssh_inactivity_timeout_secs(mut self, secs: u64) -> Self {
+        self.ssh_inactivity_timeout_secs = Some(secs);
+        self
+    }
+
     /// Override the runtime log level applied to SDK-spawned sandboxes.
     pub fn log_level(mut self, level: microsandbox_runtime::logging::LogLevel) -> Self {
         self.log_level = Some(level);
@@ -444,6 +453,7 @@ impl LocalBackendBuilder {
             disable_metrics_sample,
             ca_certs,
             registry_hosts,
+            ssh_inactivity_timeout_secs,
             log_level,
             deployment_profile,
         } = self;
@@ -511,6 +521,9 @@ impl LocalBackendBuilder {
         }
         if let Some(v) = registry_hosts {
             base.registries.hosts = v;
+        }
+        if let Some(secs) = ssh_inactivity_timeout_secs {
+            base.ssh.inactivity_timeout_secs = secs;
         }
 
         base
@@ -1305,5 +1318,21 @@ mod tests {
             merged.deployment_profile,
             Some(DeploymentProfile::MultiTenant)
         );
+    }
+
+    #[test]
+    fn builder_ssh_inactivity_timeout_overrides_persisted_default() {
+        let base = LocalConfig {
+            ssh: crate::config::SshConfig {
+                inactivity_timeout_secs: 1800,
+            },
+            ..Default::default()
+        };
+
+        let merged = LocalBackend::builder()
+            .ssh_inactivity_timeout_secs(0)
+            .merge_into(base);
+
+        assert_eq!(merged.ssh.inactivity_timeout_secs, 0);
     }
 }

--- a/sdk/rust/lib/config/mod.rs
+++ b/sdk/rust/lib/config/mod.rs
@@ -48,6 +48,9 @@ pub(crate) const DEFAULT_CONNECT_TIMEOUT_SECS: u64 = 30;
 /// Default sandbox metrics sampling interval in milliseconds.
 pub const DEFAULT_METRICS_SAMPLE_INTERVAL_MS: u64 = 1000;
 
+/// Default SSH session inactivity timeout in seconds.
+pub const DEFAULT_SSH_INACTIVITY_TIMEOUT_SECS: u64 = 600;
+
 /// Default value for `metrics_sample_interval_ms` fields.
 pub fn default_metrics_sample_interval() -> Option<NonZero<u64>> {
     NonZero::new(DEFAULT_METRICS_SAMPLE_INTERVAL_MS)
@@ -172,8 +175,21 @@ pub struct LocalConfig {
     /// Registry authentication configuration.
     pub registries: RegistriesConfig,
 
+    /// SSH session defaults.
+    pub ssh: SshConfig,
+
     /// Live metrics registry configuration.
     pub metrics: MetricsConfig,
+}
+
+/// Default settings for host-side SSH sessions.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct SshConfig {
+    /// Disconnect an SSH session after this many seconds without SSH traffic.
+    ///
+    /// A value of `0` disables the inactivity timeout.
+    pub inactivity_timeout_secs: u64,
 }
 
 /// Live metrics registry configuration.
@@ -720,6 +736,14 @@ impl Default for DatabaseConfig {
             max_connections: DEFAULT_MAX_CONNECTIONS,
             connect_timeout_secs: DEFAULT_CONNECT_TIMEOUT_SECS,
             busy_timeout_secs: microsandbox_db::pool::DEFAULT_BUSY_TIMEOUT_SECS,
+        }
+    }
+}
+
+impl Default for SshConfig {
+    fn default() -> Self {
+        Self {
+            inactivity_timeout_secs: DEFAULT_SSH_INACTIVITY_TIMEOUT_SECS,
         }
     }
 }
@@ -1322,6 +1346,7 @@ mod tests {
         assert_eq!(cfg.database.max_connections, 5);
         assert_eq!(cfg.database.connect_timeout_secs, 30);
         assert_eq!(cfg.database.busy_timeout_secs, 5);
+        assert_eq!(cfg.ssh.inactivity_timeout_secs, 600);
         assert_eq!(
             cfg.runtime.block_writeback,
             BlockWritebackConfig::Auto { pool_mib: None }
@@ -1637,6 +1662,20 @@ mod tests {
         assert_eq!(cfg.database.max_connections, 9);
         assert_eq!(cfg.database.connect_timeout_secs, 7);
         assert_eq!(cfg.database.busy_timeout_secs, 12);
+    }
+
+    #[test]
+    fn test_deserialize_ssh_config() {
+        let json = r#"{"ssh": {"inactivity_timeout_secs": 1800}}"#;
+        let cfg: LocalConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(cfg.ssh.inactivity_timeout_secs, 1800);
+    }
+
+    #[test]
+    fn test_deserialize_ssh_timeout_disabled() {
+        let json = r#"{"ssh": {"inactivity_timeout_secs": 0}}"#;
+        let cfg: LocalConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(cfg.ssh.inactivity_timeout_secs, 0);
     }
 
     #[test]

--- a/sdk/rust/lib/sandbox/ssh.rs
+++ b/sdk/rust/lib/sandbox/ssh.rs
@@ -65,6 +65,7 @@ pub struct SshClientOptions {
     user: String,
     term: String,
     sftp: bool,
+    inactivity_timeout: Option<Option<Duration>>,
 }
 
 /// Builder for [`SshExecOptions`].
@@ -131,6 +132,7 @@ pub struct SshServerOptions {
     authorized_keys: Vec<String>,
     guest_user: Option<String>,
     sftp: bool,
+    inactivity_timeout: Option<Option<Duration>>,
 }
 
 /// Reusable SSH server endpoint for a sandbox.
@@ -259,12 +261,15 @@ impl SandboxSshOps {
         let user = options.user.clone();
         let term = options.term.clone();
         let sftp = options.sftp;
+        let inactivity_timeout = options.inactivity_timeout;
         let server = self
             .server_with(|opts| {
-                opts.host_key(host_key)
+                let opts = opts
+                    .host_key(host_key)
                     .authorized_key(authorized_key)
                     .user(user.clone())
-                    .sftp(sftp)
+                    .sftp(sftp);
+                apply_inactivity_timeout(opts, inactivity_timeout)
             })
             .await?;
 
@@ -344,6 +349,10 @@ impl SandboxSshOps {
     ) -> MicrosandboxResult<SshServer> {
         let options = f(SshServerOptionsBuilder::default()).build();
         let local_backend = self.sandbox.backend().as_local();
+        let inactivity_timeout = resolve_inactivity_timeout(
+            options.inactivity_timeout,
+            local_backend.map(|backend| backend.config()),
+        );
 
         // Explicit/in-memory key material is backend-neutral. Only the
         // convenience defaults live under the local backend's config/runtime
@@ -373,6 +382,7 @@ impl SandboxSshOps {
             auth_rejection_time: Duration::from_secs(3),
             auth_rejection_time_initial: Some(Duration::from_millis(0)),
             keys: vec![host_key],
+            inactivity_timeout,
             ..Default::default()
         });
         let settings = SshSettings {
@@ -404,6 +414,7 @@ impl Default for SshClientOptions {
             user: "root".to_string(),
             term: default_ssh_term(),
             sftp: true,
+            inactivity_timeout: None,
         }
     }
 }
@@ -424,6 +435,21 @@ impl SshClientOptionsBuilder {
     /// Enable or disable SFTP on the internal server used by this client.
     pub fn sftp(mut self, enabled: bool) -> Self {
         self.options.sftp = enabled;
+        self
+    }
+
+    /// Override the inactivity timeout for the internal SSH server.
+    ///
+    /// [`Duration::ZERO`] disables the timeout. If this method is not called,
+    /// the active local backend's global SSH default is used.
+    pub fn inactivity_timeout(mut self, timeout: Duration) -> Self {
+        self.options.inactivity_timeout = Some((!timeout.is_zero()).then_some(timeout));
+        self
+    }
+
+    /// Disable the inactivity timeout for the internal SSH server.
+    pub fn disable_inactivity_timeout(mut self) -> Self {
+        self.options.inactivity_timeout = Some(None);
         self
     }
 
@@ -858,6 +884,7 @@ impl Default for SshServerOptions {
             authorized_keys: Vec::new(),
             guest_user: None,
             sftp: true,
+            inactivity_timeout: None,
         }
     }
 }
@@ -896,6 +923,21 @@ impl SshServerOptionsBuilder {
     /// Enable or disable SFTP.
     pub fn sftp(mut self, enabled: bool) -> Self {
         self.options.sftp = enabled;
+        self
+    }
+
+    /// Override the SSH session inactivity timeout.
+    ///
+    /// [`Duration::ZERO`] disables the timeout. If this method is not called,
+    /// the active local backend's global SSH default is used.
+    pub fn inactivity_timeout(mut self, timeout: Duration) -> Self {
+        self.options.inactivity_timeout = Some((!timeout.is_zero()).then_some(timeout));
+        self
+    }
+
+    /// Disable the SSH session inactivity timeout.
+    pub fn disable_inactivity_timeout(mut self) -> Self {
+        self.options.inactivity_timeout = Some(None);
         self
     }
 
@@ -2489,6 +2531,29 @@ fn status_code(error: MicrosandboxError) -> russh_sftp::protocol::StatusCode {
     }
 }
 
+fn apply_inactivity_timeout(
+    builder: SshServerOptionsBuilder,
+    timeout: Option<Option<Duration>>,
+) -> SshServerOptionsBuilder {
+    match timeout {
+        Some(Some(timeout)) => builder.inactivity_timeout(timeout),
+        Some(None) => builder.disable_inactivity_timeout(),
+        None => builder,
+    }
+}
+
+fn resolve_inactivity_timeout(
+    timeout: Option<Option<Duration>>,
+    local_config: Option<&crate::config::LocalConfig>,
+) -> Option<Duration> {
+    timeout.unwrap_or_else(|| {
+        let secs = local_config
+            .map(|config| config.ssh.inactivity_timeout_secs)
+            .unwrap_or(crate::config::DEFAULT_SSH_INACTIVITY_TIMEOUT_SECS);
+        (secs > 0).then(|| Duration::from_secs(secs))
+    })
+}
+
 fn default_ssh_term() -> String {
     match std::env::var("TERM") {
         Ok(term) if !term.trim().is_empty() && term != "dumb" => term,
@@ -2581,6 +2646,39 @@ mod tests {
         let error = build_authorized_keys(&options, None).unwrap_err();
 
         assert!(matches!(error, MicrosandboxError::Unsupported { .. }));
+    }
+
+    #[test]
+    fn inactivity_timeout_defaults_to_ten_minutes() {
+        assert_eq!(
+            resolve_inactivity_timeout(None, None),
+            Some(Duration::from_secs(600))
+        );
+    }
+
+    #[test]
+    fn inactivity_timeout_uses_global_config() {
+        let mut config = crate::config::LocalConfig::default();
+        config.ssh.inactivity_timeout_secs = 1800;
+
+        assert_eq!(
+            resolve_inactivity_timeout(None, Some(&config)),
+            Some(Duration::from_secs(1800))
+        );
+
+        config.ssh.inactivity_timeout_secs = 0;
+        assert_eq!(resolve_inactivity_timeout(None, Some(&config)), None);
+    }
+
+    #[test]
+    fn inactivity_timeout_per_call_override_wins() {
+        let config = crate::config::LocalConfig::default();
+
+        assert_eq!(
+            resolve_inactivity_timeout(Some(Some(Duration::from_secs(30))), Some(&config)),
+            Some(Duration::from_secs(30))
+        );
+        assert_eq!(resolve_inactivity_timeout(Some(None), Some(&config)), None);
     }
 }
 

--- a/sdk/rust/lib/sandbox/ssh.rs
+++ b/sdk/rust/lib/sandbox/ssh.rs
@@ -61,6 +61,7 @@ pub struct SshClientOptions {
     user: String,
     term: String,
     sftp: bool,
+    inactivity_timeout: Option<Option<Duration>>,
 }
 
 /// Builder for [`SshExecOptions`].
@@ -127,6 +128,7 @@ pub struct SshServerOptions {
     authorized_keys: Vec<String>,
     guest_user: Option<String>,
     sftp: bool,
+    inactivity_timeout: Option<Option<Duration>>,
 }
 
 /// Reusable SSH server endpoint for a sandbox.
@@ -255,12 +257,15 @@ impl SandboxSshOps {
         let user = options.user.clone();
         let term = options.term.clone();
         let sftp = options.sftp;
+        let inactivity_timeout = options.inactivity_timeout;
         let server = self
             .server_with(|opts| {
-                opts.host_key(host_key)
+                let opts = opts
+                    .host_key(host_key)
                     .authorized_key(authorized_key)
                     .user(user.clone())
-                    .sftp(sftp)
+                    .sftp(sftp);
+                apply_inactivity_timeout(opts, inactivity_timeout)
             })
             .await?;
 
@@ -340,6 +345,10 @@ impl SandboxSshOps {
     ) -> MicrosandboxResult<SshServer> {
         let options = f(SshServerOptionsBuilder::default()).build();
         let local_backend = self.sandbox.backend().as_local();
+        let inactivity_timeout = resolve_inactivity_timeout(
+            options.inactivity_timeout,
+            local_backend.map(|backend| backend.config()),
+        );
 
         // Explicit/in-memory key material is backend-neutral. Only the
         // convenience defaults live under the local backend's config/runtime
@@ -369,6 +378,7 @@ impl SandboxSshOps {
             auth_rejection_time: Duration::from_secs(3),
             auth_rejection_time_initial: Some(Duration::from_millis(0)),
             keys: vec![host_key],
+            inactivity_timeout,
             ..Default::default()
         });
         let settings = SshSettings {
@@ -400,6 +410,7 @@ impl Default for SshClientOptions {
             user: "root".to_string(),
             term: default_ssh_term(),
             sftp: true,
+            inactivity_timeout: None,
         }
     }
 }
@@ -420,6 +431,21 @@ impl SshClientOptionsBuilder {
     /// Enable or disable SFTP on the internal server used by this client.
     pub fn sftp(mut self, enabled: bool) -> Self {
         self.options.sftp = enabled;
+        self
+    }
+
+    /// Override the inactivity timeout for the internal SSH server.
+    ///
+    /// [`Duration::ZERO`] disables the timeout. If this method is not called,
+    /// the active local backend's global SSH default is used.
+    pub fn inactivity_timeout(mut self, timeout: Duration) -> Self {
+        self.options.inactivity_timeout = Some((!timeout.is_zero()).then_some(timeout));
+        self
+    }
+
+    /// Disable the inactivity timeout for the internal SSH server.
+    pub fn disable_inactivity_timeout(mut self) -> Self {
+        self.options.inactivity_timeout = Some(None);
         self
     }
 
@@ -853,6 +879,7 @@ impl Default for SshServerOptions {
             authorized_keys: Vec::new(),
             guest_user: None,
             sftp: true,
+            inactivity_timeout: None,
         }
     }
 }
@@ -891,6 +918,21 @@ impl SshServerOptionsBuilder {
     /// Enable or disable SFTP.
     pub fn sftp(mut self, enabled: bool) -> Self {
         self.options.sftp = enabled;
+        self
+    }
+
+    /// Override the SSH session inactivity timeout.
+    ///
+    /// [`Duration::ZERO`] disables the timeout. If this method is not called,
+    /// the active local backend's global SSH default is used.
+    pub fn inactivity_timeout(mut self, timeout: Duration) -> Self {
+        self.options.inactivity_timeout = Some((!timeout.is_zero()).then_some(timeout));
+        self
+    }
+
+    /// Disable the SSH session inactivity timeout.
+    pub fn disable_inactivity_timeout(mut self) -> Self {
+        self.options.inactivity_timeout = Some(None);
         self
     }
 
@@ -2484,6 +2526,29 @@ fn status_code(error: MicrosandboxError) -> russh_sftp::protocol::StatusCode {
     }
 }
 
+fn apply_inactivity_timeout(
+    builder: SshServerOptionsBuilder,
+    timeout: Option<Option<Duration>>,
+) -> SshServerOptionsBuilder {
+    match timeout {
+        Some(Some(timeout)) => builder.inactivity_timeout(timeout),
+        Some(None) => builder.disable_inactivity_timeout(),
+        None => builder,
+    }
+}
+
+fn resolve_inactivity_timeout(
+    timeout: Option<Option<Duration>>,
+    local_config: Option<&crate::config::LocalConfig>,
+) -> Option<Duration> {
+    timeout.unwrap_or_else(|| {
+        let secs = local_config
+            .map(|config| config.ssh.inactivity_timeout_secs)
+            .unwrap_or(crate::config::DEFAULT_SSH_INACTIVITY_TIMEOUT_SECS);
+        (secs > 0).then(|| Duration::from_secs(secs))
+    })
+}
+
 fn default_ssh_term() -> String {
     match std::env::var("TERM") {
         Ok(term) if !term.trim().is_empty() && term != "dumb" => term,
@@ -2576,6 +2641,39 @@ mod tests {
         let error = build_authorized_keys(&options, None).unwrap_err();
 
         assert!(matches!(error, MicrosandboxError::Unsupported { .. }));
+    }
+
+    #[test]
+    fn inactivity_timeout_defaults_to_ten_minutes() {
+        assert_eq!(
+            resolve_inactivity_timeout(None, None),
+            Some(Duration::from_secs(600))
+        );
+    }
+
+    #[test]
+    fn inactivity_timeout_uses_global_config() {
+        let mut config = crate::config::LocalConfig::default();
+        config.ssh.inactivity_timeout_secs = 1800;
+
+        assert_eq!(
+            resolve_inactivity_timeout(None, Some(&config)),
+            Some(Duration::from_secs(1800))
+        );
+
+        config.ssh.inactivity_timeout_secs = 0;
+        assert_eq!(resolve_inactivity_timeout(None, Some(&config)), None);
+    }
+
+    #[test]
+    fn inactivity_timeout_per_call_override_wins() {
+        let config = crate::config::LocalConfig::default();
+
+        assert_eq!(
+            resolve_inactivity_timeout(Some(Some(Duration::from_secs(30))), Some(&config)),
+            Some(Duration::from_secs(30))
+        );
+        assert_eq!(resolve_inactivity_timeout(Some(None), Some(&config)), None);
     }
 }
 


### PR DESCRIPTION
## TL;DR

keep the existing 10-minute ssh inactivity timeout, but make it configurable globally and per session. fixes #1339.

## Description

- own the 600-second default instead of inheriting it from `russh`
- add `ssh.inactivity_timeout_secs` to the global config, with `0` disabling the timeout
- add `--inactivity-timeout` and `--no-inactivity-timeout` to the ssh cli commands
- expose per-session overrides across the rust, typescript, python, and go sdks
- keep the timeout separate from sandbox lifecycle idle timeouts and document the precedence

<!-- greptile_comment -->

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  G[Global SSH timeout] --> R[Resolve effective timeout]
  C[CLI override] --> R
  S[SDK session override] --> R
  R --> E[SSH server endpoint]
  E --> T[Disconnect after inactivity]
```
</details>

<sub>Reviews (6): Last reviewed commit: ["fix(docs): align collapsible table of co..."](https://github.com/superradcompany/microsandbox/commit/e8c6698eae7a9e21b5e36fc3267a771417bee1ff) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53418194)</sub>

<!-- /greptile_comment -->