### PR TITLE
docs(networking): group vsock SDK examples in tabs

### DIFF
--- a/docs/networking/vsock.mdx
+++ b/docs/networking/vsock.mdx
@@ -59,6 +59,7 @@ sequenceDiagram
 
 The compact API means stream in every SDK and accepts either platform's local path syntax. Use the explicit datagram variant on macOS or Linux when message boundaries matter.
 
+<CodeGroup>
 ```rust Rust
 let sandbox = Sandbox::builder("worker")
     .image("alpine")
@@ -107,6 +108,7 @@ sandbox = Microsandbox::Sandbox.builder("worker")
   .vsock_dgram("/run/events.sock", 5001)
   .create
 ```
+</CodeGroup>
 
 ## Security model and limits
 


### PR DESCRIPTION
## TL;DR

Groups the virtio-vsock SDK examples into a single tabbed code block so the page matches other multi-language documentation.

## Description

- Wrap the Rust, TypeScript, Python, Go, and Ruby examples in a Mintlify `CodeGroup`.
- Keep the example code and language labels unchanged.

## Test Plan

- `git diff --check`
- Confirm the configured pre-commit checks pass for the docs-only commit.