### PR TITLE
fix(ci): harden pull request runners and caches

### DIFF
--- a/.github/actions/cache-libkrunfw-kernel/action.yml
+++ b/.github/actions/cache-libkrunfw-kernel/action.yml
@@ -1,0 +1,77 @@
+name: Cache libkrunfw kernel source
+description: Download, verify, and cache the kernel source used by libkrunfw.
+
+runs:
+  using: composite
+  steps:
+    - name: Resolve kernel source
+      id: kernel-source
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        kernel_version=$(sed -n 's/^KERNEL_VERSION = //p' vendor/libkrunfw/Makefile)
+        kernel_tarball=$(sed -n 's/^KERNEL_TARBALL = //p' vendor/libkrunfw/Makefile)
+
+        case "${kernel_version}:${kernel_tarball}" in
+          linux-6.12.99:'tarballs/$(KERNEL_VERSION).tar.gz')
+            # Published in kernel.org's signed v6.x sha256sums.asc index.
+            kernel_sha256=194eef900ade82df74ed1d695daa45d03ee4bb415cae4f936a3dbaab2dbbb951
+            ;;
+          *)
+            echo "::error::Add the checksum for ${kernel_version} (${kernel_tarball}) to ${GITHUB_ACTION_PATH}/action.yml"
+            exit 1
+            ;;
+        esac
+
+        kernel_filename="${kernel_version}.tar.gz"
+        kernel_path="vendor/libkrunfw/tarballs/${kernel_filename}"
+        kernel_url="https://cdn.kernel.org/pub/linux/kernel/v6.x/${kernel_filename}"
+
+        {
+          echo "cache-key=libkrunfw-kernel-source-${kernel_version}-${kernel_sha256}"
+          echo "path=${kernel_path}"
+          echo "sha256=${kernel_sha256}"
+          echo "url=${kernel_url}"
+        } >> "${GITHUB_OUTPUT}"
+
+    - name: Restore kernel source
+      id: kernel-source-cache
+      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: ${{ steps.kernel-source.outputs.path }}
+        key: ${{ steps.kernel-source.outputs.cache-key }}
+
+    - name: Download kernel source
+      if: steps.kernel-source-cache.outputs.cache-hit != 'true'
+      shell: bash
+      env:
+        KERNEL_PATH: ${{ steps.kernel-source.outputs.path }}
+        KERNEL_URL: ${{ steps.kernel-source.outputs.url }}
+      run: |
+        set -euo pipefail
+        mkdir -p "$(dirname "${KERNEL_PATH}")"
+        curl \
+          --fail \
+          --location \
+          --http1.1 \
+          --retry 5 \
+          --retry-all-errors \
+          --retry-delay 2 \
+          --continue-at - \
+          --output "${KERNEL_PATH}" \
+          "${KERNEL_URL}"
+
+    - name: Verify kernel source
+      shell: bash
+      env:
+        KERNEL_PATH: ${{ steps.kernel-source.outputs.path }}
+        KERNEL_SHA256: ${{ steps.kernel-source.outputs.sha256 }}
+      run: printf '%s  %s\n' "${KERNEL_SHA256}" "${KERNEL_PATH}" | sha256sum --check --strict -
+
+    - name: Save kernel source
+      if: steps.kernel-source-cache.outputs.cache-hit != 'true'
+      uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: ${{ steps.kernel-source.outputs.path }}
+        key: ${{ steps.kernel-source.outputs.cache-key }}

--- a/.github/workflows/check-platform.yml
+++ b/.github/workflows/check-platform.yml
@@ -70,7 +70,9 @@ jobs:
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: build/libkrunfw*
-          key: libkrunfw-${{ inputs.target }}-${{ hashFiles('vendor/libkrunfw/**') }}
+          # Include the reusable workflow because its inline build recipe and
+          # ABI/version environment also determine the cached output.
+          key: libkrunfw-${{ inputs.target }}-${{ hashFiles('vendor/libkrunfw/**', '.github/workflows/check-platform.yml') }}
 
       - name: Build libkrunfw (Linux)
         if: steps.cache-libkrunfw.outputs.cache-hit != 'true' && inputs.os == 'linux'

--- a/.github/workflows/check-platform.yml
+++ b/.github/workflows/check-platform.yml
@@ -72,7 +72,11 @@ jobs:
           path: build/libkrunfw*
           # Include the reusable workflow because its inline build recipe and
           # ABI/version environment also determine the cached output.
-          key: libkrunfw-${{ inputs.target }}-${{ hashFiles('vendor/libkrunfw/**', '.github/workflows/check-platform.yml') }}
+          key: libkrunfw-${{ inputs.target }}-${{ hashFiles('vendor/libkrunfw/**', '.github/actions/cache-libkrunfw-kernel/action.yml', '.github/workflows/check-platform.yml') }}
+
+      - name: Prepare kernel source (Linux)
+        if: steps.cache-libkrunfw.outputs.cache-hit != 'true' && inputs.os == 'linux'
+        uses: ./.github/actions/cache-libkrunfw-kernel
 
       - name: Build libkrunfw (Linux)
         if: steps.cache-libkrunfw.outputs.cache-hit != 'true' && inputs.os == 'linux'

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -60,7 +60,9 @@ jobs:
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: vendor/libkrunfw/kernel.c
-          key: kernel-c-aarch64-${{ hashFiles('vendor/libkrunfw/**') }}
+          # The build recipe is inline below, so hash this workflow along with
+          # the source to prevent reusing output built with stale flags.
+          key: kernel-c-aarch64-${{ hashFiles('vendor/libkrunfw/**', '.github/workflows/check.yml') }}
 
       - name: Install kernel build deps
         if: steps.cache-kernel.outputs.cache-hit != 'true'
@@ -94,7 +96,9 @@ jobs:
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: vendor/libkrunfw/kernel.c
-          key: kernel-c-x86_64-${{ hashFiles('vendor/libkrunfw/**') }}
+          # The build recipe is inline below, so hash this workflow along with
+          # the source to prevent reusing output built with stale flags.
+          key: kernel-c-x86_64-${{ hashFiles('vendor/libkrunfw/**', '.github/workflows/check.yml') }}
 
       - name: Install kernel build deps
         if: steps.cache-kernel.outputs.cache-hit != 'true'
@@ -225,7 +229,9 @@ jobs:
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: build/libkrunfw*
-          key: libkrunfw-linux-x86_64-${{ hashFiles('vendor/libkrunfw/**') }}
+          # Include the inline build recipe and ABI/version environment in the
+          # key as well as the libkrunfw source.
+          key: libkrunfw-linux-x86_64-${{ hashFiles('vendor/libkrunfw/**', '.github/workflows/check.yml') }}
 
       - name: Build libkrunfw
         if: steps.cache-libkrunfw.outputs.cache-hit != 'true'
@@ -1140,24 +1146,15 @@ jobs:
           export MSB_HOME
           npm test
 
-      # setup-bun downloads a zipped release; unzip isn't preinstalled on
-      # the self-hosted runner.
-      - name: Install unzip
+      # setup-bun downloads a zipped release. The host provisioner installs
+      # unzip so pull-request jobs never need sudo access.
+      - name: Verify unzip is available
         if: matrix.runtime == 'bun'
         run: |
-          if command -v unzip >/dev/null 2>&1; then
-            exit 0
+          if ! command -v unzip >/dev/null 2>&1; then
+            echo "::error::unzip is missing; rerun scripts/ci/provision-runners.sh on the host"
+            exit 1
           fi
-
-          for attempt in {1..10}; do
-            if sudo apt-get update && sudo apt-get install -y unzip; then
-              exit 0
-            fi
-            echo "apt-get install unzip failed on attempt ${attempt}; retrying..."
-            sleep 10
-          done
-
-          exit 1
 
       - if: matrix.runtime == 'bun'
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -62,7 +62,11 @@ jobs:
           path: vendor/libkrunfw/kernel.c
           # The build recipe is inline below, so hash this workflow along with
           # the source to prevent reusing output built with stale flags.
-          key: kernel-c-aarch64-${{ hashFiles('vendor/libkrunfw/**', '.github/workflows/check.yml') }}
+          key: kernel-c-aarch64-${{ hashFiles('vendor/libkrunfw/**', '.github/actions/cache-libkrunfw-kernel/action.yml', '.github/workflows/check.yml') }}
+
+      - name: Prepare kernel source
+        if: steps.cache-kernel.outputs.cache-hit != 'true'
+        uses: ./.github/actions/cache-libkrunfw-kernel
 
       - name: Install kernel build deps
         if: steps.cache-kernel.outputs.cache-hit != 'true'
@@ -98,7 +102,11 @@ jobs:
           path: vendor/libkrunfw/kernel.c
           # The build recipe is inline below, so hash this workflow along with
           # the source to prevent reusing output built with stale flags.
-          key: kernel-c-x86_64-${{ hashFiles('vendor/libkrunfw/**', '.github/workflows/check.yml') }}
+          key: kernel-c-x86_64-${{ hashFiles('vendor/libkrunfw/**', '.github/actions/cache-libkrunfw-kernel/action.yml', '.github/workflows/check.yml') }}
+
+      - name: Prepare kernel source
+        if: steps.cache-kernel.outputs.cache-hit != 'true'
+        uses: ./.github/actions/cache-libkrunfw-kernel
 
       - name: Install kernel build deps
         if: steps.cache-kernel.outputs.cache-hit != 'true'
@@ -231,7 +239,11 @@ jobs:
           path: build/libkrunfw*
           # Include the inline build recipe and ABI/version environment in the
           # key as well as the libkrunfw source.
-          key: libkrunfw-linux-x86_64-${{ hashFiles('vendor/libkrunfw/**', '.github/workflows/check.yml') }}
+          key: libkrunfw-linux-x86_64-${{ hashFiles('vendor/libkrunfw/**', '.github/actions/cache-libkrunfw-kernel/action.yml', '.github/workflows/check.yml') }}
+
+      - name: Prepare kernel source
+        if: steps.cache-libkrunfw.outputs.cache-hit != 'true'
+        uses: ./.github/actions/cache-libkrunfw-kernel
 
       - name: Build libkrunfw
         if: steps.cache-libkrunfw.outputs.cache-hit != 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,9 @@ jobs:
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: vendor/libkrunfw/kernel.c
-          key: kernel-c-aarch64-${{ hashFiles('vendor/libkrunfw/**') }}
+          # The build recipe is inline below, so hash this workflow along with
+          # the source to prevent reusing output built with stale flags.
+          key: kernel-c-aarch64-${{ hashFiles('vendor/libkrunfw/**', '.github/workflows/release.yml') }}
 
       - name: Install kernel build deps
         if: steps.cache-kernel.outputs.cache-hit != 'true'
@@ -68,7 +70,9 @@ jobs:
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: vendor/libkrunfw/kernel.c
-          key: kernel-c-x86_64-${{ hashFiles('vendor/libkrunfw/**') }}
+          # The build recipe is inline below, so hash this workflow along with
+          # the source to prevent reusing output built with stale flags.
+          key: kernel-c-x86_64-${{ hashFiles('vendor/libkrunfw/**', '.github/workflows/release.yml') }}
 
       - name: Install kernel build deps
         if: steps.cache-kernel.outputs.cache-hit != 'true'
@@ -231,7 +235,9 @@ jobs:
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: build/libkrunfw*
-          key: libkrunfw-${{ matrix.target }}-${{ hashFiles('vendor/libkrunfw/**') }}
+          # Include the inline build recipe and ABI/version environment in the
+          # key as well as the libkrunfw source.
+          key: libkrunfw-${{ matrix.target }}-${{ hashFiles('vendor/libkrunfw/**', '.github/workflows/release.yml') }}
 
       - name: Build libkrunfw (Linux)
         if: steps.cache-libkrunfw.outputs.cache-hit != 'true' && matrix.os == 'linux'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,11 @@ jobs:
           path: vendor/libkrunfw/kernel.c
           # The build recipe is inline below, so hash this workflow along with
           # the source to prevent reusing output built with stale flags.
-          key: kernel-c-aarch64-${{ hashFiles('vendor/libkrunfw/**', '.github/workflows/release.yml') }}
+          key: kernel-c-aarch64-${{ hashFiles('vendor/libkrunfw/**', '.github/actions/cache-libkrunfw-kernel/action.yml', '.github/workflows/release.yml') }}
+
+      - name: Prepare kernel source
+        if: steps.cache-kernel.outputs.cache-hit != 'true'
+        uses: ./.github/actions/cache-libkrunfw-kernel
 
       - name: Install kernel build deps
         if: steps.cache-kernel.outputs.cache-hit != 'true'
@@ -72,7 +76,11 @@ jobs:
           path: vendor/libkrunfw/kernel.c
           # The build recipe is inline below, so hash this workflow along with
           # the source to prevent reusing output built with stale flags.
-          key: kernel-c-x86_64-${{ hashFiles('vendor/libkrunfw/**', '.github/workflows/release.yml') }}
+          key: kernel-c-x86_64-${{ hashFiles('vendor/libkrunfw/**', '.github/actions/cache-libkrunfw-kernel/action.yml', '.github/workflows/release.yml') }}
+
+      - name: Prepare kernel source
+        if: steps.cache-kernel.outputs.cache-hit != 'true'
+        uses: ./.github/actions/cache-libkrunfw-kernel
 
       - name: Install kernel build deps
         if: steps.cache-kernel.outputs.cache-hit != 'true'
@@ -237,7 +245,11 @@ jobs:
           path: build/libkrunfw*
           # Include the inline build recipe and ABI/version environment in the
           # key as well as the libkrunfw source.
-          key: libkrunfw-${{ matrix.target }}-${{ hashFiles('vendor/libkrunfw/**', '.github/workflows/release.yml') }}
+          key: libkrunfw-${{ matrix.target }}-${{ hashFiles('vendor/libkrunfw/**', '.github/actions/cache-libkrunfw-kernel/action.yml', '.github/workflows/release.yml') }}
+
+      - name: Prepare kernel source (Linux)
+        if: steps.cache-libkrunfw.outputs.cache-hit != 'true' && matrix.os == 'linux'
+        uses: ./.github/actions/cache-libkrunfw-kernel
 
       - name: Build libkrunfw (Linux)
         if: steps.cache-libkrunfw.outputs.cache-hit != 'true' && matrix.os == 'linux'

--- a/scripts/ci/provision-runners.sh
+++ b/scripts/ci/provision-runners.sh
@@ -40,12 +40,12 @@ trap 'rm -f "${archive_path}"' EXIT
 curl --fail --location --retry 5 --output "${archive_path}" "${RUNNER_URL}"
 printf '%s  %s\n' "${RUNNER_SHA256}" "${archive_path}" | sha256sum --check --status
 
-# Install the only extra package needed by the KVM jobs before dropping to the
-# runner accounts. Pull-request code runs as these users, so they must not have
-# Docker access or any sudo path back to the host's root account.
-if ! command -v unzip >/dev/null 2>&1; then
+# Install the extra packages needed by the KVM jobs before dropping to the
+# runner accounts. Skopeo exports test images without access to the privileged
+# Docker daemon. Pull-request code must not have Docker or sudo access.
+if ! command -v unzip >/dev/null 2>&1 || ! command -v skopeo >/dev/null 2>&1; then
   apt-get update
-  apt-get install -y unzip
+  apt-get install -y skopeo unzip
 fi
 rm -f /etc/sudoers.d/actions-runner-apt
 

--- a/scripts/ci/provision-runners.sh
+++ b/scripts/ci/provision-runners.sh
@@ -4,8 +4,8 @@ set -euo pipefail
 
 # By default, provision eight additional repository-scoped GitHub Actions
 # runners on the existing Ubuntu host, bringing runner01..runner12 online.
-# Each runner gets a distinct Unix user and work tree so concurrent checkouts
-# and per-user ~/.microsandbox state cannot collide.
+# Each runner gets a distinct unprivileged Unix user and work tree so concurrent
+# checkouts and per-user ~/.microsandbox state cannot collide.
 #
 # Run as root with a short-lived repository registration token:
 #   sudo REPOSITORY_URL=https://github.com/OWNER/REPO \
@@ -40,16 +40,49 @@ trap 'rm -f "${archive_path}"' EXIT
 curl --fail --location --retry 5 --output "${archive_path}" "${RUNNER_URL}"
 printf '%s  %s\n' "${RUNNER_SHA256}" "${archive_path}" | sha256sum --check --status
 
-sudoers_tmp=$(mktemp "${TMPDIR:-/tmp}/microsandbox-actions-runners.XXXXXX")
-trap 'rm -f "${archive_path}" "${sudoers_tmp}"' EXIT
+# Install the only extra package needed by the KVM jobs before dropping to the
+# runner accounts. Pull-request code runs as these users, so they must not have
+# Docker access or any sudo path back to the host's root account.
+if ! command -v unzip >/dev/null 2>&1; then
+  apt-get update
+  apt-get install -y unzip
+fi
+rm -f /etc/sudoers.d/actions-runner-apt
 
-# Match the existing runner01..runner04 host policy. Group membership grants
-# KVM and Docker access, while sudo remains restricted to apt-get.
-groupadd --force actions-runner
-printf '%%actions-runner ALL=(root) NOPASSWD: /usr/bin/apt-get\n' > "${sudoers_tmp}"
-chmod 0440 "${sudoers_tmp}"
-visudo -c -f "${sudoers_tmp}"
-install -o root -g root -m 0440 "${sudoers_tmp}" /etc/sudoers.d/actions-runner-apt
+# Revoke the legacy privileges from every runnerNN account, including the
+# original runner01..runner04 users that predate this provisioner.
+while IFS=: read -r existing_user _; do
+  if [[ ${existing_user} != "${RUNNER_USER_PREFIX}"* ]]; then
+    continue
+  fi
+
+  runner_suffix=${existing_user#"${RUNNER_USER_PREFIX}"}
+  if [[ ! ${runner_suffix} =~ ^[0-9]+$ ]]; then
+    continue
+  fi
+
+  privileges_revoked=false
+  for privileged_group in docker actions-runner; do
+    if id -nG "${existing_user}" | tr ' ' '\n' | grep -Fxq "${privileged_group}"; then
+      gpasswd --delete "${existing_user}" "${privileged_group}" >/dev/null
+      privileges_revoked=true
+    fi
+  done
+
+  # A running service retains its old supplementary groups until it restarts.
+  # Restart only services whose account memberships changed.
+  if [[ ${privileges_revoked} == true ]]; then
+    existing_home=$(getent passwd "${existing_user}" | cut -d: -f6)
+    existing_runner_dir="${existing_home}/actions-runner"
+    if [[ -x "${existing_runner_dir}/svc.sh" && -f "${existing_runner_dir}/.service" ]]; then
+      (
+        cd "${existing_runner_dir}"
+        ./svc.sh stop
+        ./svc.sh start
+      )
+    fi
+  fi
+done < <(getent passwd)
 
 for index in $(seq "${RUNNER_FIRST}" "${RUNNER_LAST}"); do
   suffix=$(printf '%02d' "${index}")
@@ -57,9 +90,9 @@ for index in $(seq "${RUNNER_FIRST}" "${RUNNER_LAST}"); do
   runner_name="${RUNNER_PREFIX}${suffix}"
 
   if ! id "${runner_user}" >/dev/null 2>&1; then
-    useradd --create-home --shell /bin/bash --groups kvm,docker,actions-runner "${runner_user}"
+    useradd --create-home --shell /bin/bash --groups kvm "${runner_user}"
   fi
-  usermod --append --groups kvm,docker,actions-runner "${runner_user}"
+  usermod --append --groups kvm "${runner_user}"
 
   runner_home=$(getent passwd "${runner_user}" | cut -d: -f6)
   runner_dir="${runner_home}/actions-runner"

--- a/scripts/ci/provision-runners.sh
+++ b/scripts/ci/provision-runners.sh
@@ -34,11 +34,39 @@ if (( RUNNER_FIRST < 1 || RUNNER_LAST < RUNNER_FIRST )); then
   exit 1
 fi
 
+repository_path=${REPOSITORY_URL#https://github.com/}
+repository_path=${repository_path%.git}
+repository_path=${repository_path%/}
+if [[ ! ${repository_path} =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]]; then
+  echo "unsupported GitHub repository URL: ${REPOSITORY_URL}" >&2
+  exit 1
+fi
+runner_service_scope=${repository_path//\//-}
+
+runner_services_for() {
+  local runner_user=$1
+  local runner_dir=$2
+  local service_name
+
+  while read -r service_name _; do
+    if [[ -z ${service_name} ]]; then
+      continue
+    fi
+
+    if [[ $(systemctl show --property=User --value "${service_name}") == "${runner_user}" ]] &&
+      [[ $(systemctl show --property=WorkingDirectory --value "${service_name}") == "${runner_dir}" ]]; then
+      printf '%s\n' "${service_name}"
+    fi
+  done < <(systemctl list-unit-files --type=service --no-legend 'actions.runner.*.service')
+}
+
 archive_path=$(mktemp "${TMPDIR:-/tmp}/actions-runner.XXXXXX.tar.gz")
-trap 'rm -f "${archive_path}"' EXIT
+unit_template_path=$(mktemp "${TMPDIR:-/tmp}/actions-runner-unit.XXXXXX.service")
+trap 'rm -f "${archive_path}" "${unit_template_path}"' EXIT
 
 curl --fail --location --retry 5 --output "${archive_path}" "${RUNNER_URL}"
 printf '%s  %s\n' "${RUNNER_SHA256}" "${archive_path}" | sha256sum --check --status
+chmod 0644 "${archive_path}"
 
 # Install the extra packages needed by the KVM jobs before dropping to the
 # runner accounts. Skopeo exports test images without access to the privileged
@@ -70,16 +98,18 @@ while IFS=: read -r existing_user _; do
   done
 
   # A running service retains its old supplementary groups until it restarts.
-  # Restart only services whose account memberships changed.
+  # Discover it through root-controlled systemd metadata rather than trusting
+  # the runner-writable svc.sh or .service files.
   if [[ ${privileges_revoked} == true ]]; then
     existing_home=$(getent passwd "${existing_user}" | cut -d: -f6)
     existing_runner_dir="${existing_home}/actions-runner"
-    if [[ -x "${existing_runner_dir}/svc.sh" && -f "${existing_runner_dir}/.service" ]]; then
-      (
-        cd "${existing_runner_dir}"
-        ./svc.sh stop
-        ./svc.sh start
-      )
+    mapfile -t existing_services < <(runner_services_for "${existing_user}" "${existing_runner_dir}")
+    if (( ${#existing_services[@]} > 1 )); then
+      echo "multiple services found for ${existing_user}: ${existing_services[*]}" >&2
+      exit 1
+    fi
+    if (( ${#existing_services[@]} == 1 )); then
+      systemctl restart "${existing_services[0]}"
     fi
   fi
 done < <(getent passwd)
@@ -96,10 +126,13 @@ for index in $(seq "${RUNNER_FIRST}" "${RUNNER_LAST}"); do
 
   runner_home=$(getent passwd "${runner_user}" | cut -d: -f6)
   runner_dir="${runner_home}/actions-runner"
+  if [[ -L ${runner_dir} ]]; then
+    echo "refusing to use symlinked runner directory: ${runner_dir}" >&2
+    exit 1
+  fi
   install -d -o "${runner_user}" -g "${runner_user}" -m 0755 "${runner_dir}"
-  if [[ ! -x "${runner_dir}/config.sh" ]]; then
-    tar -xzf "${archive_path}" -C "${runner_dir}"
-    chown -R "${runner_user}:${runner_user}" "${runner_dir}"
+  if [[ ! -x "${runner_dir}/config.sh" || ! -f "${runner_dir}/.runner" ]]; then
+    runuser -u "${runner_user}" -- tar -xzf "${archive_path}" -C "${runner_dir}"
   fi
 
   if [[ ! -f "${runner_dir}/.runner" ]]; then
@@ -112,26 +145,62 @@ for index in $(seq "${RUNNER_FIRST}" "${RUNNER_LAST}"); do
       --unattended
   fi
 
-  if [[ ! -f "${runner_dir}/.service" ]]; then
-    service_name=$(sed -n 's/^SVC_NAME="\([^"]*\)"/\1/p' "${runner_dir}/svc.sh")
-    if [[ -n "${service_name}" && -f "/etc/systemd/system/${service_name}" ]]; then
-      # Adopt a service left by an interrupted earlier installation. Removing
-      # and reinstalling it recreates runsvc.sh and the local .service marker.
-      (
-        cd "${runner_dir}"
-        ./svc.sh uninstall
-      )
-    fi
-    (
-      cd "${runner_dir}"
-      ./svc.sh install "${runner_user}"
-    )
+  if [[ ! -x "${runner_dir}/runsvc.sh" ]]; then
+    runuser -u "${runner_user}" -- \
+      install -m 0755 "${runner_dir}/bin/runsvc.sh" "${runner_dir}/runsvc.sh"
   fi
 
-  (
-    cd "${runner_dir}"
-    ./svc.sh start
-  )
+  service_name="actions.runner.${runner_service_scope}.${runner_name}.service"
+  unit_path="/etc/systemd/system/${service_name}"
+  mapfile -t runner_services < <(runner_services_for "${runner_user}" "${runner_dir}")
+  if (( ${#runner_services[@]} > 1 )); then
+    echo "multiple services found for ${runner_user}: ${runner_services[*]}" >&2
+    exit 1
+  fi
+  if (( ${#runner_services[@]} == 1 )) && [[ ${runner_services[0]} != "${service_name}" ]]; then
+    echo "unexpected service for ${runner_user}: ${runner_services[0]}" >&2
+    exit 1
+  fi
+  if [[ -L ${unit_path} ]]; then
+    echo "refusing to replace symlinked systemd unit: ${unit_path}" >&2
+    exit 1
+  fi
+
+  cat > "${unit_template_path}" <<EOF
+[Unit]
+Description=GitHub Actions Runner (${runner_service_scope}.${runner_name})
+After=network-online.target
+
+[Service]
+ExecStart=${runner_dir}/runsvc.sh
+User=${runner_user}
+WorkingDirectory=${runner_dir}
+KillMode=process
+KillSignal=SIGTERM
+TimeoutStopSec=5min
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+  unit_changed=false
+  if [[ ! -f ${unit_path} ]] || ! cmp --silent "${unit_template_path}" "${unit_path}"; then
+    install -o root -g root -m 0644 "${unit_template_path}" "${unit_path}"
+    systemctl daemon-reload
+    unit_changed=true
+  else
+    chown root:root "${unit_path}"
+    chmod 0644 "${unit_path}"
+  fi
+
+  printf '%s\n' "${service_name}" |
+    runuser -u "${runner_user}" -- tee "${runner_dir}/.service" >/dev/null
+  systemctl enable "${service_name}"
+  if [[ ${unit_changed} == true ]] && systemctl is-active --quiet "${service_name}"; then
+    systemctl restart "${service_name}"
+  else
+    systemctl start "${service_name}"
+  fi
 
 done
 

--- a/scripts/smoke/cli/image-archive.sh
+++ b/scripts/smoke/cli/image-archive.sh
@@ -4,16 +4,11 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 MSB_BIN="${MSB_BIN:-${ROOT_DIR}/build/msb}"
-IMAGE="${MSB_CLI_SMOKE_DOCKER_IMAGE:-alpine:3.20}"
+IMAGE="${MSB_CLI_SMOKE_DOCKER_IMAGE:-docker.io/library/alpine:3.20}"
 TAG="${MSB_CLI_SMOKE_ARCHIVE_TAG:-msb-archive-smoke:ci}"
 
 if [[ ! -x "$MSB_BIN" ]]; then
   echo "msb binary is not executable: $MSB_BIN" >&2
-  exit 1
-fi
-
-if ! command -v docker >/dev/null 2>&1; then
-  echo "docker is required for image archive smoke tests" >&2
   exit 1
 fi
 
@@ -34,8 +29,19 @@ cleanup() {
 }
 trap cleanup EXIT
 
-docker image inspect "$IMAGE" >/dev/null 2>&1 || docker pull "$IMAGE" >/dev/null
-docker save "$IMAGE" -o "$smoke_root/docker-input.tar"
+# Persistent pull-request runners must not access the root-equivalent Docker
+# socket, so prefer a daemonless export when skopeo is available.
+if command -v skopeo >/dev/null 2>&1; then
+  skopeo copy --retry-times 5 \
+    "docker://${IMAGE}" \
+    "docker-archive:${smoke_root}/docker-input.tar:${TAG}"
+elif command -v docker >/dev/null 2>&1 && docker info >/dev/null 2>&1; then
+  docker image inspect "$IMAGE" >/dev/null 2>&1 || docker pull "$IMAGE" >/dev/null
+  docker save "$IMAGE" -o "$smoke_root/docker-input.tar"
+else
+  echo "skopeo or an accessible Docker daemon is required for image archive smoke tests" >&2
+  exit 1
+fi
 
 "$MSB_BIN" load -i "$smoke_root/docker-input.tar" --tag "$TAG" --quiet
 "$MSB_BIN" save -o "$smoke_root/docker-output.tar" --quiet "$TAG"

--- a/scripts/smoke/cli/image-archive.sh
+++ b/scripts/smoke/cli/image-archive.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 MSB_BIN="${MSB_BIN:-${ROOT_DIR}/build/msb}"
-IMAGE="${MSB_CLI_SMOKE_DOCKER_IMAGE:-docker.io/library/alpine:3.20}"
+IMAGE="${MSB_CLI_SMOKE_DOCKER_IMAGE:-mirror.gcr.io/library/alpine:3.20}"
 TAG="${MSB_CLI_SMOKE_ARCHIVE_TAG:-msb-archive-smoke:ci}"
 
 if [[ ! -x "$MSB_BIN" ]]; then


### PR DESCRIPTION
## TL;DR

Remove host-root escalation paths from persistent KVM runners used by pull-request CI, and make native binary caches sensitive to their build recipes and verified kernel inputs.

## Description

- provision runner accounts with KVM access only, without Docker or passwordless `apt-get`
- revoke legacy `docker` and `actions-runner` memberships from existing `runnerNN` accounts and restart affected services so the change takes effect
- install `unzip` and rootless `skopeo` during host provisioning instead of granting pull-request jobs runtime sudo or Docker access
- export the CLI smoke-test image through skopeo's daemonless Docker archive transport, retaining Docker only as a local-development fallback
- hash each defining workflow and kernel-source action into `kernel.c` and `libkrunfw` cache keys so build recipe changes create fresh native caches
- cache the exact kernel.org source archive by kernel version and published SHA-256
- verify both downloaded and restored kernel archives, with resumable HTTP/1.1 retries for cold downloads
- keep Rust dependency caching unchanged; the pinned cache action excludes workspace crates, so pull-request source is compiled for each run

## Test Plan

- `bash -n scripts/ci/provision-runners.sh scripts/smoke/cli/image-archive.sh`
- `shellcheck scripts/ci/provision-runners.sh scripts/smoke/cli/image-archive.sh`
- `actionlint -ignore 'label "self-hosted-ubuntu-2404-x64" is unknown' -ignore 'shellcheck reported issue' .github/workflows/check.yml .github/workflows/check-platform.yml .github/workflows/release.yml`
- validate the composite action metadata against the pinned libkrunfw kernel version
- `git diff --check`
- rerun `scripts/ci/provision-runners.sh` on the idle runner host and verify `runnerNN` accounts retain `kvm` but not `docker` or `actions-runner` membership
- as `runner02` on the GCloud host, export Alpine with skopeo into a Docker archive and verify its manifest and layer entries
- verify `runner02` still cannot access `/var/run/docker.sock`
- confirm the cold CI run downloads, verifies, and saves the versioned kernel source cache before compiling

<!-- greptile_comment -->

<sub>Reviews (3): Last reviewed commit: ["fix(ci): manage runner services through ..."](https://github.com/superradcompany/microsandbox/commit/6c73ebccbaf2250e2f0b87a69904ac11818b09dc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53504327)</sub>

<!-- /greptile_comment -->