### PR TITLE
docs(docker): add flat root setup

### DIFF
--- a/docs/recipes/docker/docker-in-sandbox.mdx
+++ b/docs/recipes/docker/docker-in-sandbox.mdx
@@ -36,6 +36,8 @@ This command does three things:
 
 ## Simpler local setup with a flat root disk
 
+<Tooltip tip="Flat root disks are not available on microsandbox cloud."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
+
 For a simpler local setup, use a flat root disk instead of a separate named volume. A flat root mounts ext4 directly, so Docker's overlay storage is not nested on the default sandbox OverlayFS.
 
 ```sh
@@ -52,7 +54,7 @@ msb run --name docker-demo --replace \
   docker:dind
 ```
 
-This stores Docker's images, containers, and build cache on the sandbox's root disk. The data persists when the sandbox stops and starts, but unlike a named volume, it does not survive removing or replacing the sandbox. The `10G` capacity covers the entire root filesystem, including Docker's data. Flat root disks are available for local sandboxes only.
+This stores Docker's images, containers, and build cache on the sandbox's root disk. The data persists when the sandbox stops and starts, but unlike a named volume, it does not survive removing or replacing the sandbox. The `10G` capacity covers the entire root filesystem, including Docker's data.
 
 ## Run a container
 

--- a/docs/recipes/docker/docker-in-sandbox.mdx
+++ b/docs/recipes/docker/docker-in-sandbox.mdx
@@ -34,6 +34,26 @@ This command does three things:
 
 `--mount-named docker-data:/var/lib/docker:kind=disk,size=10G` is idempotent. If `docker-data` does not exist, the CLI creates it before starting the sandbox. If it already exists with compatible disk settings, the same command reuses it, so pulled images and created containers can survive `msb rm docker-demo`.
 
+## Simpler local setup with a flat root disk
+
+For a simpler local setup, use a flat root disk instead of a separate named volume. A flat root mounts ext4 directly, so Docker's overlay storage is not nested on the default sandbox OverlayFS.
+
+```sh
+msb run --name docker-demo --replace \
+  --memory 2G \
+  --root-disk flat:10G \
+  --script start='dockerd >/tmp/dockerd.log 2>&1 &
+  timeout 60 sh -c "until docker info>/dev/null 2>&1;do sleep 1;done" || {
+    cat /tmp/dockerd.log
+    false
+  }
+  exec sh' \
+  --entrypoint start \
+  docker:dind
+```
+
+This stores Docker's images, containers, and build cache on the sandbox's root disk. The data persists when the sandbox stops and starts, but unlike a named volume, it does not survive removing or replacing the sandbox. The `10G` capacity covers the entire root filesystem, including Docker's data. Flat root disks are available for local sandboxes only.
+
 ## Run a container
 
 From the sandbox shell, run a nested Ubuntu container:
@@ -59,6 +79,8 @@ msb volume rm docker-data
 ```
 
 Remove `docker-data` only when you no longer need the images, containers, and build cache stored by the nested daemon.
+
+If you used the flat-root alternative, skip `msb volume rm docker-data`; removing the sandbox also removes its Docker data.
 
 ## Details
 


### PR DESCRIPTION
## TL;DR
Add a simpler local Docker-in-sandbox command that uses a flat root disk and explain how its data lifecycle differs from the named-volume setup.

## Description
- Add a `flat:10G` Docker-in-sandbox example that avoids nesting Docker's overlay storage on the default sandbox OverlayFS.
- Clarify that Docker data on the flat root survives sandbox stop and start cycles but not replacement or removal.
- Explain that the flat-root capacity covers the whole root filesystem and that flat roots are local-only.
- Update cleanup guidance for readers who choose the flat-root setup.

## Test Plan
- [x] `git diff origin/main..HEAD --check` exits 0
- [x] `jq empty docs/docs.json` exits 0
- [ ] Mintlify preview renders the new section and command correctly (runs in the docs preview)

<!-- greptile_comment -->

<sub>Reviews (2): Last reviewed commit: ["docs(docker): use local-only badge"](https://github.com/superradcompany/microsandbox/commit/7ae812ae4f336bc1ddbb7109933be98c86ddd4da) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53526977)</sub>

<!-- /greptile_comment -->