### PR TITLE
perf(agent): add generation-8 raw bulk transport

### DIFF
--- a/crates/agentd/lib/agent.rs
+++ b/crates/agentd/lib/agent.rs
@@ -823,6 +823,10 @@ async fn handle_message(
                     }
                 }
             }
+            // Cancellation owns the correlation through its ordinary terminal response. This
+            // gives SDK dispatch a precise point at which it may retire the route while any raw
+            // records admitted before cancellation are still being discarded.
+            encode_bulk_terminal_failure(msg.id, cancel.kind, cancel.message, out_buf)?;
         }
 
         MessageType::BulkAccepted => {
@@ -1220,6 +1224,37 @@ fn encode_bulk_tcp_failure(id: u32, error: String, out_buf: &mut Vec<u8>) -> Age
         out_buf,
     )?;
     encode_tcp_failed(id, error, out_buf)
+}
+
+/// Emit the operation family's existing terminal failure without recursively sending a cancel.
+fn encode_bulk_terminal_failure(
+    id: u32,
+    kind: BulkKind,
+    error: String,
+    out_buf: &mut Vec<u8>,
+) -> AgentdResult<()> {
+    match kind {
+        BulkKind::Filesystem => {
+            let response = Message::with_payload(
+                MessageType::FsResponse,
+                id,
+                &FsResponse {
+                    ok: false,
+                    error: Some(error),
+                    data: None,
+                },
+            )
+            .map_err(|error| {
+                AgentdError::ExecSession(format!("encode filesystem terminal failure: {error}"))
+            })?;
+            codec::encode_to_buf(&response, out_buf).map_err(|error| {
+                AgentdError::ExecSession(format!(
+                    "encode filesystem terminal failure frame: {error}"
+                ))
+            })
+        }
+        BulkKind::Tcp => encode_tcp_failed(id, error, out_buf),
+    }
 }
 
 fn encode_bulk_cancel(
@@ -1777,5 +1812,27 @@ mod tests {
 
         assert_eq!(activity.activity_seq, 0);
         assert_eq!(activity.counters.guest_messages, 0);
+    }
+
+    #[test]
+    fn bulk_cancellation_uses_each_operations_existing_terminal_type() {
+        for (kind, expected) in [
+            (BulkKind::Filesystem, MessageType::FsResponse),
+            (BulkKind::Tcp, MessageType::TcpFailed),
+        ] {
+            let mut encoded = Vec::new();
+            encode_bulk_terminal_failure(17, kind, "cancelled".into(), &mut encoded).unwrap();
+            let mut bytes = BytesMut::from(encoded.as_slice());
+            let frame = codec::try_decode_frame_from_bytes(&mut bytes)
+                .unwrap()
+                .expect("terminal frame");
+            let DecodedFrame::Control(message) = frame else {
+                panic!("cancellation terminal must be control");
+            };
+            assert_eq!(message.id, 17);
+            assert_eq!(message.t, expected);
+            assert_eq!(message.flags, microsandbox_protocol::message::FLAG_TERMINAL);
+            assert!(bytes.is_empty());
+        }
     }
 }

--- a/crates/agentd/lib/agent.rs
+++ b/crates/agentd/lib/agent.rs
@@ -16,7 +16,11 @@ use tokio::time::{self, Duration};
 
 use microsandbox_protocol::HANDOFF_POWEROFF_TIMEOUT;
 use microsandbox_protocol::bootstrap::GuestBootstrap;
-use microsandbox_protocol::codec::{self, MAX_FRAME_SIZE};
+use microsandbox_protocol::bulk::{
+    BULK_PROTOCOL_VERSION, BulkCancel, BulkCancelReason, BulkCredit, BulkFinish, BulkFlow,
+    BulkKind, BulkRecord,
+};
+use microsandbox_protocol::codec::{self, DecodedFrame, MAX_FRAME_SIZE};
 use microsandbox_protocol::core::{
     ClockSync, CoreError, CoreErrorKind, InitAck, InitResolved, Ping, Pong, Ready,
     RelayClientDisconnected, ResolvedUser, Touch, Touched,
@@ -25,7 +29,7 @@ use microsandbox_protocol::exec::{
     ExecExited, ExecFailed, ExecFailureKind, ExecRequest, ExecResize, ExecSignal, ExecStarted,
     ExecStderr, ExecStdin, ExecStdinError, ExecStdout,
 };
-use microsandbox_protocol::fs::{FsData, FsRequest};
+use microsandbox_protocol::fs::{FsData, FsRequest, FsResponse};
 use microsandbox_protocol::heartbeat::{ActivityCounters, Heartbeat};
 use microsandbox_protocol::message::{Message, MessageType};
 use microsandbox_protocol::tcp::{TcpClose, TcpConnect, TcpData, TcpEof, TcpFailed};
@@ -253,9 +257,22 @@ pub async fn run(
                             // message-level failures are reported on the same
                             // correlation ID with `core.error`; unrecoverable
                             // frame-level failures still close the agent loop.
-                            while let Some(msg) = codec::try_decode_from_bytes(&mut serial_in_buf)
+                            while let Some(frame) = codec::try_decode_frame_from_bytes(&mut serial_in_buf)
                                 .map_err(|e| AgentdError::ExecSession(format!("decode frame: {e}")))?
                             {
+                                let DecodedFrame::Control(msg) = frame else {
+                                    let DecodedFrame::Bulk(record) = frame else {
+                                        unreachable!();
+                                    };
+                                    handle_bulk_record(
+                                        record,
+                                        &mut state,
+                                        &mut activity,
+                                        &mut serial_out_buf,
+                                    ).await?;
+                                    publish_heartbeat_snapshot(&heartbeat_tx, &state, &activity);
+                                    continue;
+                                };
                                 if msg.flags != msg.t.flags() {
                                     let out_before = serial_out_buf.len();
                                     encode_core_error_if_supported(
@@ -366,6 +383,13 @@ pub async fn run(
                         }
                         write_all_async_fd(&async_port, &output.frame).await?;
                     }
+                    SessionOutput::Bulk(output) => {
+                        apply_raw_activity(output.activity, &mut activity);
+                        if !serial_out_buf.is_empty() {
+                            flush_write_buf(&async_port, &mut serial_out_buf).await?;
+                        }
+                        write_bulk_record_async_fd(&async_port, &output.record).await?;
+                    }
                 }
                 publish_heartbeat_snapshot(&heartbeat_tx, &state, &activity);
 
@@ -460,6 +484,74 @@ pub fn report_init_context(
 //--------------------------------------------------------------------------------------------------
 
 /// Handles a single incoming message from the host.
+async fn handle_bulk_record(
+    record: BulkRecord,
+    state: &mut AgentState,
+    activity: &mut ActivityTracker,
+    out_buf: &mut Vec<u8>,
+) -> AgentdResult<()> {
+    activity.record_host_message();
+    match record.kind {
+        BulkKind::Filesystem => {
+            if record.flow != BulkFlow::HostToGuest {
+                encode_bulk_fs_failure(
+                    record.id,
+                    "host sent a filesystem record in the guest-to-host flow".into(),
+                    out_buf,
+                )?;
+                if let Some(session) = state.read_sessions.remove(&record.id) {
+                    session.abort();
+                }
+                state.write_sessions.remove(&record.id);
+                return Ok(());
+            }
+
+            let result = match state.write_sessions.get_mut(&record.id) {
+                Some(session) => {
+                    fs::handle_fs_bulk_record(record.id, &record, session, out_buf).await
+                }
+                None => Err(format!("unknown filesystem write session: {}", record.id)),
+            };
+            match result {
+                Ok(true) => {
+                    state.write_sessions.remove(&record.id);
+                }
+                Ok(false) => activity.add_fs_bytes(record.payload.len()),
+                Err(error) => {
+                    state.write_sessions.remove(&record.id);
+                    encode_bulk_fs_failure(record.id, error, out_buf)?;
+                }
+            }
+        }
+        BulkKind::Tcp => {
+            if record.flow != BulkFlow::HostToGuest {
+                encode_bulk_tcp_failure(
+                    record.id,
+                    "host sent a TCP record in the guest-to-host flow".into(),
+                    out_buf,
+                )?;
+                if let Some(session) = state.tcp_sessions.remove(&record.id) {
+                    session.close();
+                }
+                return Ok(());
+            }
+            let result = match state.tcp_sessions.get(&record.id) {
+                Some(session) => session.write_bulk(record.clone()).await,
+                None => Err(format!("unknown TCP session: {}", record.id)),
+            };
+            if let Err(error) = result {
+                encode_bulk_tcp_failure(record.id, error, out_buf)?;
+                if let Some(session) = state.tcp_sessions.remove(&record.id) {
+                    session.close();
+                }
+            } else {
+                activity.add_tcp_bytes(record.payload.len());
+            }
+        }
+    }
+    Ok(())
+}
+
 async fn handle_message(
     msg: Message,
     state: &mut AgentState,
@@ -594,7 +686,9 @@ async fn handle_message(
             let Some(req) = decode_payload_or_core_error::<FsRequest>(&msg, out_buf)? else {
                 return Ok(());
             };
-            match fs::handle_fs_request(msg.id, req, &mut state.fs, out_buf, session_tx).await {
+            match fs::handle_fs_request(msg.id, msg.v, req, &mut state.fs, out_buf, session_tx)
+                .await
+            {
                 Ok(Some(FsStreamSession::Read(rs))) => {
                     state.read_sessions.insert(msg.id, rs);
                 }
@@ -641,10 +735,119 @@ async fn handle_message(
             }
         }
 
+        MessageType::BulkCredit => {
+            let Some(credit) = decode_payload_or_core_error::<BulkCredit>(&msg, out_buf)? else {
+                return Ok(());
+            };
+            match credit.kind {
+                BulkKind::Filesystem => {
+                    let result = state
+                        .read_sessions
+                        .get(&msg.id)
+                        .ok_or_else(|| format!("unknown filesystem read session: {}", msg.id))
+                        .and_then(|session| session.apply_credit(credit));
+                    if let Err(error) = result {
+                        if let Some(session) = state.read_sessions.remove(&msg.id) {
+                            session.abort();
+                        }
+                        encode_bulk_fs_failure(msg.id, error, out_buf)?;
+                    }
+                }
+                BulkKind::Tcp => {
+                    let result = match state.tcp_sessions.get(&msg.id) {
+                        Some(session) => session.apply_credit(credit).await,
+                        None => Err(format!("unknown TCP session: {}", msg.id)),
+                    };
+                    if let Err(error) = result {
+                        encode_bulk_tcp_failure(msg.id, error, out_buf)?;
+                        if let Some(session) = state.tcp_sessions.remove(&msg.id) {
+                            session.close();
+                        }
+                    }
+                }
+            }
+        }
+
+        MessageType::BulkFinish => {
+            let Some(finish) = decode_payload_or_core_error::<BulkFinish>(&msg, out_buf)? else {
+                return Ok(());
+            };
+            match finish.kind {
+                BulkKind::Filesystem => {
+                    let result = match state.write_sessions.get_mut(&msg.id) {
+                        Some(session) => {
+                            fs::handle_fs_bulk_finish(msg.id, finish, session, out_buf).await
+                        }
+                        None => Err(format!("unknown filesystem write session: {}", msg.id)),
+                    };
+                    match result {
+                        Ok(true) => {
+                            state.write_sessions.remove(&msg.id);
+                        }
+                        Ok(false) => {}
+                        Err(error) => {
+                            state.write_sessions.remove(&msg.id);
+                            encode_bulk_fs_failure(msg.id, error, out_buf)?;
+                        }
+                    }
+                }
+                BulkKind::Tcp => {
+                    let result = match state.tcp_sessions.get(&msg.id) {
+                        Some(session) => session.finish_bulk(finish).await,
+                        None => Err(format!("unknown TCP session: {}", msg.id)),
+                    };
+                    if let Err(error) = result {
+                        encode_bulk_tcp_failure(msg.id, error, out_buf)?;
+                        if let Some(session) = state.tcp_sessions.remove(&msg.id) {
+                            session.close();
+                        }
+                    }
+                }
+            }
+        }
+
+        MessageType::BulkCancel => {
+            let Some(cancel) = decode_payload_or_core_error::<BulkCancel>(&msg, out_buf)? else {
+                return Ok(());
+            };
+            match cancel.kind {
+                BulkKind::Filesystem => {
+                    state.write_sessions.remove(&msg.id);
+                    if let Some(session) = state.read_sessions.remove(&msg.id) {
+                        session.abort();
+                    }
+                }
+                BulkKind::Tcp => {
+                    if let Some(session) = state.tcp_sessions.remove(&msg.id) {
+                        session.close();
+                    }
+                }
+            }
+        }
+
+        MessageType::BulkAccepted => {
+            encode_core_error_if_supported(
+                &msg,
+                msg.id,
+                CoreErrorKind::UnsupportedMessageType,
+                "host cannot accept a guest-initiated bulk offer".into(),
+                Some(msg.t.as_str().to_string()),
+                out_buf,
+            )?;
+        }
+
         MessageType::TcpConnect => {
             let Some(req) = decode_payload_or_core_error::<TcpConnect>(&msg, out_buf)? else {
                 return Ok(());
             };
+            if req.bulk.is_some() && msg.v < BULK_PROTOCOL_VERSION {
+                encode_tcp_failed(
+                    msg.id,
+                    format!("raw bulk offer requires protocol generation {BULK_PROTOCOL_VERSION}"),
+                    out_buf,
+                )?;
+                return Ok(());
+            }
             // The connect runs inside the session task; the agent loop never
             // blocks on it. Success or failure arrives later as a tcp frame.
             let session = TcpSession::open(msg.id, req, session_tx);
@@ -986,6 +1189,60 @@ fn encode_tcp_failed(id: u32, error: String, out_buf: &mut Vec<u8>) -> AgentdRes
     Ok(())
 }
 
+fn encode_bulk_fs_failure(id: u32, error: String, out_buf: &mut Vec<u8>) -> AgentdResult<()> {
+    encode_bulk_cancel(
+        id,
+        BulkKind::Filesystem,
+        BulkCancelReason::ProtocolState,
+        error.clone(),
+        out_buf,
+    )?;
+    let response = Message::with_payload(
+        MessageType::FsResponse,
+        id,
+        &FsResponse {
+            ok: false,
+            error: Some(error),
+            data: None,
+        },
+    )
+    .map_err(|error| AgentdError::ExecSession(format!("encode fs failure: {error}")))?;
+    codec::encode_to_buf(&response, out_buf)
+        .map_err(|error| AgentdError::ExecSession(format!("encode fs failure frame: {error}")))
+}
+
+fn encode_bulk_tcp_failure(id: u32, error: String, out_buf: &mut Vec<u8>) -> AgentdResult<()> {
+    encode_bulk_cancel(
+        id,
+        BulkKind::Tcp,
+        BulkCancelReason::ProtocolState,
+        error.clone(),
+        out_buf,
+    )?;
+    encode_tcp_failed(id, error, out_buf)
+}
+
+fn encode_bulk_cancel(
+    id: u32,
+    kind: BulkKind,
+    reason: BulkCancelReason,
+    message: String,
+    out_buf: &mut Vec<u8>,
+) -> AgentdResult<()> {
+    let cancel = Message::with_payload(
+        MessageType::BulkCancel,
+        id,
+        &BulkCancel {
+            kind,
+            reason,
+            message,
+        },
+    )
+    .map_err(|error| AgentdError::ExecSession(format!("encode bulk cancel: {error}")))?;
+    codec::encode_to_buf(&cancel, out_buf)
+        .map_err(|error| AgentdError::ExecSession(format!("encode bulk cancel frame: {error}")))
+}
+
 fn encode_core_error_if_supported(
     source: &Message,
     id: u32,
@@ -1257,6 +1514,47 @@ async fn write_all_async_fd(fd: &AsyncFd<std::fs::File>, buf: &[u8]) -> AgentdRe
     Ok(())
 }
 
+/// Writes a raw bulk header and payload with cursor-safe `writev` calls.
+async fn write_bulk_record_async_fd(
+    fd: &AsyncFd<std::fs::File>,
+    record: &BulkRecord,
+) -> AgentdResult<()> {
+    let header = codec::encode_bulk_header(record)
+        .map_err(|error| AgentdError::ExecSession(format!("encode bulk header: {error}")))?;
+    let mut header_offset = 0;
+    let mut payload_offset = 0;
+
+    while header_offset < header.len() || payload_offset < record.payload.len() {
+        let mut guard = fd.writable().await?;
+        let result = guard.try_io(|inner| {
+            write_vectored_to_fd(
+                inner.get_ref().as_raw_fd(),
+                &header[header_offset..],
+                &record.payload[payload_offset..],
+            )
+        });
+        let written = match result {
+            Ok(Ok(0)) => {
+                return Err(std::io::Error::from(std::io::ErrorKind::WriteZero).into());
+            }
+            Ok(Ok(written)) => written,
+            Ok(Err(error)) if error.kind() == std::io::ErrorKind::Interrupted => continue,
+            Ok(Err(error)) => return Err(error.into()),
+            Err(_would_block) => continue,
+        };
+
+        let header_remaining = header.len() - header_offset;
+        if written < header_remaining {
+            header_offset += written;
+        } else {
+            header_offset = header.len();
+            payload_offset += written - header_remaining;
+        }
+    }
+
+    Ok(())
+}
+
 /// Writes to a raw fd (non-blocking).
 fn write_to_fd(fd: i32, buf: &[u8]) -> std::io::Result<usize> {
     let n = unsafe { libc::write(fd, buf.as_ptr() as *const libc::c_void, buf.len()) };
@@ -1264,6 +1562,30 @@ fn write_to_fd(fd: i32, buf: &[u8]) -> std::io::Result<usize> {
         Err(std::io::Error::last_os_error())
     } else {
         Ok(n as usize)
+    }
+}
+
+fn write_vectored_to_fd(fd: i32, header: &[u8], payload: &[u8]) -> std::io::Result<usize> {
+    if header.is_empty() {
+        return write_to_fd(fd, payload);
+    }
+
+    let vectors = [
+        libc::iovec {
+            iov_base: header.as_ptr().cast_mut().cast(),
+            iov_len: header.len(),
+        },
+        libc::iovec {
+            iov_base: payload.as_ptr().cast_mut().cast(),
+            iov_len: payload.len(),
+        },
+    ];
+    let vector_count = if payload.is_empty() { 1 } else { 2 };
+    let written = unsafe { libc::writev(fd, vectors.as_ptr(), vector_count) };
+    if written < 0 {
+        Err(std::io::Error::last_os_error())
+    } else {
+        Ok(written as usize)
     }
 }
 

--- a/crates/agentd/lib/agent.rs
+++ b/crates/agentd/lib/agent.rs
@@ -1723,10 +1723,24 @@ mod tests {
     fn bootstrap_rejects_older_protocol_generation() {
         let mut message =
             Message::with_payload(MessageType::Bootstrap, 0, &GuestBootstrap::default()).unwrap();
-        message.v = PROTOCOL_VERSION - 1;
+        let min_version = MessageType::Bootstrap.min_protocol_version();
+        assert!(min_version > 0);
+        message.v = min_version - 1;
 
         let error = decode_bootstrap_message(message).unwrap_err();
         assert!(error.to_string().contains("or newer"));
+    }
+
+    #[test]
+    fn bootstrap_accepts_minimum_supported_protocol_generation() {
+        let mut message =
+            Message::with_payload(MessageType::Bootstrap, 0, &GuestBootstrap::default()).unwrap();
+        message.v = MessageType::Bootstrap.min_protocol_version();
+
+        assert_eq!(
+            decode_bootstrap_message(message).unwrap(),
+            GuestBootstrap::default()
+        );
     }
 
     #[test]

--- a/crates/agentd/lib/fs.rs
+++ b/crates/agentd/lib/fs.rs
@@ -11,19 +11,27 @@ use std::os::unix::fs::{MetadataExt, PermissionsExt};
 use std::path::Path;
 use std::sync::Arc;
 
+use bytes::Bytes;
 use microsandbox_protocol::AGENT_RELAY_ID_RANGE_STEP;
+use microsandbox_protocol::bulk::{
+    BULK_FLOW_MASK_GUEST_TO_HOST, BULK_FLOW_MASK_HOST_TO_GUEST, BULK_PROTOCOL_VERSION,
+    BulkAccepted, BulkCredit, BulkFinish, BulkFlow, BulkKind, BulkOffer, BulkReceiveState,
+    BulkRecord, BulkSendState, DEFAULT_BULK_WINDOW,
+};
 use microsandbox_protocol::codec;
 use microsandbox_protocol::fs::{
     FS_CHUNK_SIZE, FsData, FsEntryInfo, FsOp, FsOpenOptions, FsRequest, FsResponse, FsResponseData,
     FsSetAttrs,
 };
 use microsandbox_protocol::message::{Message, MessageType};
+use serde::Serialize;
 use tokio::io::{AsyncReadExt, AsyncSeekExt, AsyncWriteExt};
-use tokio::sync::Mutex;
+use tokio::sync::{Mutex, watch};
 use tokio::task::JoinHandle;
 
 use crate::session::{
-    RawActivity, RawSessionCompletion, RawSessionOutput, SessionOutput, SessionOutputSender,
+    BulkSessionOutput, RawActivity, RawSessionCompletion, RawSessionOutput, SessionOutput,
+    SessionOutputSender,
 };
 
 //--------------------------------------------------------------------------------------------------
@@ -56,6 +64,7 @@ pub struct FsWriteSession {
     append: bool,
     expected_len: Option<u64>,
     written: u64,
+    bulk: Option<BulkReceiveState>,
 }
 
 /// Tracks an in-progress streaming read operation.
@@ -63,6 +72,7 @@ pub struct FsReadSession {
     owner_id: u32,
     handle: u64,
     task: JoinHandle<()>,
+    credit_tx: Option<watch::Sender<Option<BulkCredit>>>,
 }
 
 /// A filesystem stream session started by a request.
@@ -268,6 +278,23 @@ impl FsReadSession {
     pub fn abort(self) {
         self.task.abort();
     }
+
+    /// Delivers the latest absolute credit update to a generation-8 read task.
+    pub fn apply_credit(&self, credit: BulkCredit) -> Result<(), String> {
+        let Some(tx) = &self.credit_tx else {
+            return Err("filesystem read session is not using raw bulk".into());
+        };
+        if credit.kind != BulkKind::Filesystem || credit.flow != BulkFlow::GuestToHost {
+            return Err("filesystem read received credit for another kind or flow".into());
+        }
+        tx.send_replace(Some(credit));
+        Ok(())
+    }
+
+    /// Whether this read session negotiated generation-8 raw bulk.
+    pub fn is_bulk(&self) -> bool {
+        self.credit_tx.is_some()
+    }
 }
 
 impl FsWriteSession {
@@ -279,6 +306,11 @@ impl FsWriteSession {
     /// Filesystem handle being written.
     pub fn handle(&self) -> u64 {
         self.handle
+    }
+
+    /// Whether this write session negotiated generation-8 raw bulk.
+    pub fn is_bulk(&self) -> bool {
+        self.bulk.is_some()
     }
 }
 
@@ -301,12 +333,33 @@ fn same_relay_client(left: u32, right: u32) -> bool {
 /// Handles an incoming `FsRequest` message.
 pub async fn handle_fs_request(
     id: u32,
+    protocol_version: u8,
     req: FsRequest,
     state: &mut FsState,
     out_buf: &mut Vec<u8>,
     session_tx: &SessionOutputSender,
 ) -> Result<Option<FsStreamSession>, String> {
-    match req.op {
+    let FsRequest { op, bulk } = req;
+    if bulk.is_some() && protocol_version < BULK_PROTOCOL_VERSION {
+        encode_response(
+            id,
+            error_response(format!(
+                "raw bulk offer requires protocol generation {BULK_PROTOCOL_VERSION}"
+            )),
+            out_buf,
+        )?;
+        return Ok(None);
+    }
+    if bulk.is_some() && !matches!(&op, FsOp::Read { .. } | FsOp::Write { .. }) {
+        encode_response(
+            id,
+            error_response("raw bulk is only valid for streaming reads and writes".into()),
+            out_buf,
+        )?;
+        return Ok(None);
+    }
+
+    match op {
         FsOp::RealPath { path } => {
             let resp = handle_realpath(&path).await;
             encode_response(id, resp, out_buf)?;
@@ -391,13 +444,36 @@ pub async fn handle_fs_request(
         } => match state.file(id, handle, true, false) {
             Ok((file, _, _)) => {
                 let tx = session_tx.clone();
-                let task = tokio::spawn(async move {
-                    handle_read_stream(id, file, offset, len, &tx).await;
-                });
+                let (task, credit_tx) = match bulk {
+                    Some(offer) => {
+                        let accepted = accept_fs_read_offer(offer)?;
+                        encode_control(MessageType::BulkAccepted, id, &accepted, out_buf)?;
+                        let sender = BulkSendState::new(
+                            BulkKind::Filesystem,
+                            BulkFlow::GuestToHost,
+                            accepted.max_record_payload,
+                            accepted.guest_to_host_credit_limit,
+                        )
+                        .map_err(|error| format!("accept read bulk state: {error}"))?;
+                        let (credit_tx, credit_rx) = watch::channel(None);
+                        let task = tokio::spawn(async move {
+                            handle_bulk_read_stream(id, file, offset, len, sender, credit_rx, &tx)
+                                .await;
+                        });
+                        (task, Some(credit_tx))
+                    }
+                    None => {
+                        let task = tokio::spawn(async move {
+                            handle_read_stream(id, file, offset, len, &tx).await;
+                        });
+                        (task, None)
+                    }
+                };
                 Ok(Some(FsStreamSession::Read(FsReadSession {
                     owner_id: id,
                     handle,
                     task,
+                    credit_tx,
                 })))
             }
             Err(e) => {
@@ -410,15 +486,35 @@ pub async fn handle_fs_request(
             offset,
             len,
         } => match state.file(id, handle, false, true) {
-            Ok((file, append, _)) => Ok(Some(FsStreamSession::Write(FsWriteSession {
-                owner_id: id,
-                handle,
-                file,
-                offset,
-                append,
-                expected_len: len,
-                written: 0,
-            }))),
+            Ok((file, append, _)) => {
+                let bulk = match bulk {
+                    Some(offer) => {
+                        let accepted = accept_fs_write_offer(offer)?;
+                        encode_control(MessageType::BulkAccepted, id, &accepted, out_buf)?;
+                        Some(
+                            BulkReceiveState::new(
+                                BulkKind::Filesystem,
+                                BulkFlow::HostToGuest,
+                                accepted.max_record_payload,
+                                accepted.host_to_guest_credit_limit,
+                                DEFAULT_BULK_WINDOW,
+                            )
+                            .map_err(|error| format!("accept write bulk state: {error}"))?,
+                        )
+                    }
+                    None => None,
+                };
+                Ok(Some(FsStreamSession::Write(FsWriteSession {
+                    owner_id: id,
+                    handle,
+                    file,
+                    offset,
+                    append,
+                    expected_len: len,
+                    written: 0,
+                    bulk,
+                })))
+            }
             Err(e) => {
                 encode_response(id, error_response(format!("write: {e}")), out_buf)?;
                 Ok(None)
@@ -452,6 +548,14 @@ pub async fn handle_fs_data(
     session: &mut FsWriteSession,
     out_buf: &mut Vec<u8>,
 ) -> Result<bool, String> {
+    if session.bulk.is_some() {
+        encode_response(
+            id,
+            error_response("CBOR filesystem data is invalid after raw bulk acceptance".into()),
+            out_buf,
+        )?;
+        return Ok(true);
+    }
     if data.data.is_empty() {
         if let Some(expected) = session.expected_len
             && session.written != expected
@@ -499,6 +603,94 @@ pub async fn handle_fs_data(
         session.written = session.written.saturating_add(data.data.len() as u64);
         Ok(false)
     }
+}
+
+/// Handles one generation-8 raw record for a filesystem write correlation.
+pub async fn handle_fs_bulk_record(
+    id: u32,
+    record: &BulkRecord,
+    session: &mut FsWriteSession,
+    out_buf: &mut Vec<u8>,
+) -> Result<bool, String> {
+    let Some(receiver) = session.bulk.as_mut() else {
+        return Err("raw bulk record sent to a generation-6 filesystem write".into());
+    };
+    let end = receiver
+        .accept_record(record)
+        .map_err(|error| format!("invalid filesystem bulk record: {error}"))?;
+
+    if let Some(expected) = session.expected_len
+        && end > expected
+    {
+        encode_response(
+            id,
+            error_response(format!(
+                "write length mismatch: expected {expected}, received at least {end}"
+            )),
+            out_buf,
+        )?;
+        return Ok(true);
+    }
+
+    let mut file = session.file.lock().await;
+    if !session.append
+        && let Err(error) = file.seek(std::io::SeekFrom::Start(session.offset)).await
+    {
+        encode_response(id, error_response(format!("seek: {error}")), out_buf)?;
+        return Ok(true);
+    }
+    if let Err(error) = file.write_all(&record.payload).await {
+        encode_response(id, error_response(format!("write: {error}")), out_buf)?;
+        return Ok(true);
+    }
+    drop(file);
+
+    session.offset = session.offset.saturating_add(record.payload.len() as u64);
+    session.written = end;
+    if let Some(credit) = receiver
+        .consume(end)
+        .map_err(|error| format!("advance filesystem bulk credit: {error}"))?
+    {
+        encode_control(MessageType::BulkCredit, id, &credit, out_buf)?;
+    }
+    Ok(false)
+}
+
+/// Handles the exact end marker for a generation-8 filesystem write.
+pub async fn handle_fs_bulk_finish(
+    id: u32,
+    finish: BulkFinish,
+    session: &mut FsWriteSession,
+    out_buf: &mut Vec<u8>,
+) -> Result<bool, String> {
+    let Some(receiver) = session.bulk.as_mut() else {
+        return Err("bulk finish sent to a generation-6 filesystem write".into());
+    };
+    receiver
+        .accept_finish(finish)
+        .map_err(|error| format!("invalid filesystem bulk finish: {error}"))?;
+
+    if let Some(expected) = session.expected_len
+        && session.written != expected
+    {
+        encode_response(
+            id,
+            error_response(format!(
+                "write length mismatch: expected {expected}, wrote {}",
+                session.written
+            )),
+            out_buf,
+        )?;
+        return Ok(true);
+    }
+
+    let mut file = session.file.lock().await;
+    if let Err(error) = file.flush().await {
+        encode_response(id, error_response(format!("flush: {error}")), out_buf)?;
+        return Ok(true);
+    }
+    encode_response(id, ok_response(None), out_buf)?;
+    Ok(true)
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -746,6 +938,155 @@ async fn handle_rename(src: &str, dst: &str) -> FsResponse {
     }
 }
 
+fn accept_fs_read_offer(offer: BulkOffer) -> Result<BulkAccepted, String> {
+    let offer = offer
+        .validate()
+        .map_err(|error| format!("invalid filesystem read bulk offer: {error}"))?;
+    if offer.guest_to_host_credit_limit == 0 {
+        return Err("filesystem read bulk offer must grant guest-to-host credit".into());
+    }
+    Ok(BulkAccepted {
+        kind: BulkKind::Filesystem,
+        flows: BULK_FLOW_MASK_GUEST_TO_HOST,
+        format: offer.format,
+        max_record_payload: offer
+            .max_record_payload
+            .min(microsandbox_protocol::bulk::DEFAULT_BULK_RECORD_PAYLOAD),
+        host_to_guest_credit_limit: 0,
+        guest_to_host_credit_limit: offer.guest_to_host_credit_limit,
+    })
+}
+
+fn accept_fs_write_offer(offer: BulkOffer) -> Result<BulkAccepted, String> {
+    let offer = offer
+        .validate()
+        .map_err(|error| format!("invalid filesystem write bulk offer: {error}"))?;
+    if offer.guest_to_host_credit_limit != 0 {
+        return Err("filesystem write bulk offer must not grant guest-to-host credit".into());
+    }
+    Ok(BulkAccepted {
+        kind: BulkKind::Filesystem,
+        flows: BULK_FLOW_MASK_HOST_TO_GUEST,
+        format: offer.format,
+        max_record_payload: offer
+            .max_record_payload
+            .min(microsandbox_protocol::bulk::DEFAULT_BULK_RECORD_PAYLOAD),
+        host_to_guest_credit_limit: DEFAULT_BULK_WINDOW,
+        guest_to_host_credit_limit: 0,
+    })
+}
+
+async fn handle_bulk_read_stream(
+    id: u32,
+    file: Arc<Mutex<tokio::fs::File>>,
+    offset: u64,
+    len: Option<u64>,
+    mut sender: BulkSendState,
+    mut credit_rx: watch::Receiver<Option<BulkCredit>>,
+    tx: &SessionOutputSender,
+) {
+    let mut file = file.lock().await;
+    if let Err(error) = file.seek(std::io::SeekFrom::Start(offset)).await {
+        send_raw_response(id, false, Some(format!("seek: {error}")), None, tx).await;
+        return;
+    }
+
+    let mut remaining = len;
+    loop {
+        if remaining == Some(0) {
+            break;
+        }
+        while sender.available_credit() == 0 {
+            if credit_rx.changed().await.is_err() {
+                return;
+            }
+            let Some(credit) = *credit_rx.borrow_and_update() else {
+                continue;
+            };
+            if let Err(error) = sender.apply_credit(credit) {
+                send_raw_response(
+                    id,
+                    false,
+                    Some(format!("invalid filesystem bulk credit: {error}")),
+                    None,
+                    tx,
+                )
+                .await;
+                return;
+            }
+        }
+
+        let read_len = sender
+            .available_credit()
+            .min(sender.max_record_payload() as u64)
+            .min(remaining.unwrap_or(u64::MAX)) as usize;
+        let Some(permit) = tx.reserve(read_len).await else {
+            return;
+        };
+        let mut payload = vec![0u8; read_len];
+        match file.read(&mut payload).await {
+            Ok(0) => break,
+            Ok(read) => {
+                payload.truncate(read);
+                if let Some(remaining) = &mut remaining {
+                    *remaining = remaining.saturating_sub(read as u64);
+                }
+                let record_offset = match sender.admit(read) {
+                    Ok(offset) => offset,
+                    Err(error) => {
+                        send_raw_response(
+                            id,
+                            false,
+                            Some(format!("admit filesystem bulk record: {error}")),
+                            None,
+                            tx,
+                        )
+                        .await;
+                        return;
+                    }
+                };
+                let record = BulkRecord {
+                    id,
+                    kind: BulkKind::Filesystem,
+                    flow: BulkFlow::GuestToHost,
+                    offset: record_offset,
+                    payload: Bytes::from(payload),
+                };
+                let output = BulkSessionOutput::new(record, RawActivity::fs_bytes(read));
+                if !tx
+                    .send_reserved(id, SessionOutput::Bulk(output), permit)
+                    .await
+                {
+                    return;
+                }
+            }
+            Err(error) => {
+                send_raw_response(id, false, Some(format!("read: {error}")), None, tx).await;
+                return;
+            }
+        }
+    }
+
+    let finish = match sender.finish() {
+        Ok(finish) => finish,
+        Err(error) => {
+            send_raw_response(
+                id,
+                false,
+                Some(format!("finish filesystem bulk read: {error}")),
+                None,
+                tx,
+            )
+            .await;
+            return;
+        }
+    };
+    if !send_raw_control(id, MessageType::BulkFinish, &finish, None, tx).await {
+        return;
+    }
+    send_raw_response(id, true, None, None, tx).await;
+}
+
 async fn handle_read_stream(
     id: u32,
     file: Arc<Mutex<tokio::fs::File>>,
@@ -991,6 +1332,41 @@ fn encode_response(id: u32, resp: FsResponse, out_buf: &mut Vec<u8>) -> Result<(
     Ok(())
 }
 
+fn encode_control<T: Serialize>(
+    message_type: MessageType,
+    id: u32,
+    payload: &T,
+    out_buf: &mut Vec<u8>,
+) -> Result<(), String> {
+    let message = Message::with_payload(message_type, id, payload)
+        .map_err(|error| format!("encode {}: {error}", message_type.as_str()))?;
+    codec::encode_to_buf(&message, out_buf)
+        .map_err(|error| format!("encode {} frame: {error}", message_type.as_str()))
+}
+
+async fn send_raw_control<T: Serialize>(
+    id: u32,
+    message_type: MessageType,
+    payload: &T,
+    completion: Option<RawSessionCompletion>,
+    tx: &SessionOutputSender,
+) -> bool {
+    let mut frame = Vec::new();
+    if let Err(error) = encode_control(message_type, id, payload, &mut frame) {
+        eprintln!("failed to {error}");
+        return false;
+    }
+    tx.send(
+        id,
+        SessionOutput::Raw(RawSessionOutput::new(
+            frame,
+            RawActivity::guest_message(),
+            completion,
+        )),
+    )
+    .await
+}
+
 async fn send_raw_response(
     id: u32,
     ok: bool,
@@ -1126,4 +1502,149 @@ fn unknown_entry_info(path: &str) -> FsEntryInfo {
 fn cstring_path(path: impl AsRef<Path>) -> Result<CString, String> {
     CString::new(path.as_ref().as_os_str().as_bytes())
         .map_err(|e| format!("path contains NUL: {e}"))
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests
+//--------------------------------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    use super::*;
+
+    #[tokio::test]
+    async fn raw_bulk_write_requires_exact_offsets_and_finish_length() {
+        let path = test_path("bulk-write");
+        let file = tokio::fs::File::create(&path).await.unwrap();
+        let mut session = FsWriteSession {
+            owner_id: 1,
+            handle: 1,
+            file: Arc::new(Mutex::new(file)),
+            offset: 0,
+            append: false,
+            expected_len: Some(7),
+            written: 0,
+            bulk: Some(
+                BulkReceiveState::new(
+                    BulkKind::Filesystem,
+                    BulkFlow::HostToGuest,
+                    microsandbox_protocol::bulk::DEFAULT_BULK_RECORD_PAYLOAD,
+                    DEFAULT_BULK_WINDOW,
+                    DEFAULT_BULK_WINDOW,
+                )
+                .unwrap(),
+            ),
+        };
+        let mut out = Vec::new();
+
+        let wrong_offset = BulkRecord {
+            id: 1,
+            kind: BulkKind::Filesystem,
+            flow: BulkFlow::HostToGuest,
+            offset: 1,
+            payload: Bytes::from_static(b"ignored"),
+        };
+        assert!(
+            handle_fs_bulk_record(1, &wrong_offset, &mut session, &mut out)
+                .await
+                .unwrap_err()
+                .contains("does not match expected")
+        );
+
+        let record = BulkRecord {
+            offset: 0,
+            ..wrong_offset
+        };
+        assert!(
+            !handle_fs_bulk_record(1, &record, &mut session, &mut out)
+                .await
+                .unwrap()
+        );
+        assert!(
+            handle_fs_bulk_finish(
+                1,
+                BulkFinish {
+                    kind: BulkKind::Filesystem,
+                    flow: BulkFlow::HostToGuest,
+                    final_offset: 7,
+                },
+                &mut session,
+                &mut out,
+            )
+            .await
+            .unwrap()
+        );
+        drop(session);
+
+        let response = codec::try_decode_from_buf(&mut out).unwrap().unwrap();
+        assert_eq!(response.t, MessageType::FsResponse);
+        assert!(response.payload::<FsResponse>().unwrap().ok);
+        assert_eq!(tokio::fs::read(&path).await.unwrap(), b"ignored");
+        tokio::fs::remove_file(path).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn raw_bulk_read_emits_payload_exact_finish_then_terminal_response() {
+        let path = test_path("bulk-read");
+        tokio::fs::write(&path, b"raw-read-payload").await.unwrap();
+        let file = tokio::fs::File::open(&path).await.unwrap();
+        let sender = BulkSendState::new(
+            BulkKind::Filesystem,
+            BulkFlow::GuestToHost,
+            microsandbox_protocol::bulk::DEFAULT_BULK_RECORD_PAYLOAD,
+            DEFAULT_BULK_WINDOW,
+        )
+        .unwrap();
+        let (_credit_tx, credit_rx) = watch::channel(None);
+        let (session_tx, mut session_rx) = SessionOutputSender::channel();
+
+        handle_bulk_read_stream(
+            2,
+            Arc::new(Mutex::new(file)),
+            0,
+            None,
+            sender,
+            credit_rx,
+            &session_tx,
+        )
+        .await;
+
+        let first = session_rx.recv().await.unwrap();
+        let SessionOutput::Bulk(first) = first.output else {
+            panic!("expected raw filesystem record");
+        };
+        assert_eq!(first.record.offset, 0);
+        assert_eq!(
+            first.record.payload,
+            Bytes::from_static(b"raw-read-payload")
+        );
+
+        let finish = decode_raw_output(session_rx.recv().await.unwrap().output);
+        assert_eq!(finish.t, MessageType::BulkFinish);
+        let finish: BulkFinish = finish.payload().unwrap();
+        assert_eq!(finish.final_offset, b"raw-read-payload".len() as u64);
+        let response = decode_raw_output(session_rx.recv().await.unwrap().output);
+        assert_eq!(response.t, MessageType::FsResponse);
+        assert!(response.payload::<FsResponse>().unwrap().ok);
+        tokio::fs::remove_file(path).await.unwrap();
+    }
+
+    fn decode_raw_output(output: SessionOutput) -> Message {
+        let SessionOutput::Raw(mut output) = output else {
+            panic!("expected raw control frame");
+        };
+        codec::try_decode_from_buf(&mut output.frame)
+            .unwrap()
+            .unwrap()
+    }
+
+    fn test_path(name: &str) -> std::path::PathBuf {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        std::env::temp_dir().join(format!("msb-agentd-{name}-{}-{unique}", std::process::id()))
+    }
 }

--- a/crates/agentd/lib/session.rs
+++ b/crates/agentd/lib/session.rs
@@ -13,6 +13,7 @@ use nix::sys::signal::Signal;
 use tokio::io::AsyncReadExt;
 use tokio::sync::{Semaphore, mpsc};
 
+use microsandbox_protocol::bulk::BulkRecord;
 use microsandbox_protocol::exec::{ExecFailed, ExecFailureKind, ExecRequest};
 
 use crate::config::SecurityProfile;
@@ -155,6 +156,9 @@ pub enum SessionOutput {
 
     /// Pre-encoded frame bytes to write directly to the serial output buffer.
     Raw(RawSessionOutput),
+
+    /// Generation-8 raw bulk record whose payload remains separately owned.
+    Bulk(BulkSessionOutput),
 }
 
 /// One queued session event and the data-budget capacity owned by its buffer.
@@ -189,6 +193,15 @@ pub struct RawSessionOutput {
 
     /// Session table entry completed by the frame, if any.
     pub completion: Option<RawSessionCompletion>,
+}
+
+/// Raw bulk output plus activity metadata known by its producer.
+pub struct BulkSessionOutput {
+    /// Validated record whose payload is written with the fixed header via `writev`.
+    pub record: BulkRecord,
+
+    /// Activity represented by the record.
+    pub activity: RawActivity,
 }
 
 /// Activity represented by a pre-encoded session frame.
@@ -279,11 +292,19 @@ impl RawSessionOutput {
     }
 }
 
+impl BulkSessionOutput {
+    /// Creates a raw bulk output event.
+    pub fn new(record: BulkRecord, activity: RawActivity) -> Self {
+        Self { record, activity }
+    }
+}
+
 impl SessionOutput {
     /// Bytes retained by this event that count against bulk output capacity.
     fn budget_bytes(&self) -> usize {
         let allocation = match self {
             Self::Stdout(data) | Self::Stderr(data) => data.capacity(),
+            Self::Bulk(output) => output.record.payload.len(),
             Self::Raw(output)
                 if output.activity.fs_bytes != 0 || output.activity.tcp_bytes != 0 =>
             {
@@ -1552,7 +1573,7 @@ mod tests {
                 match envelope.output {
                     SessionOutput::Stdout(data) => stdout.extend_from_slice(&data),
                     SessionOutput::Exited(code) => panic!("session exited early with {code}"),
-                    SessionOutput::Stderr(_) | SessionOutput::Raw(_) => {}
+                    SessionOutput::Stderr(_) | SessionOutput::Raw(_) | SessionOutput::Bulk(_) => {}
                 }
             }
         })
@@ -1889,7 +1910,7 @@ mod tests {
                         exit = Some(code);
                         break;
                     }
-                    SessionOutput::Stderr(_) | SessionOutput::Raw(_) => {}
+                    SessionOutput::Stderr(_) | SessionOutput::Raw(_) | SessionOutput::Bulk(_) => {}
                 }
             }
         })

--- a/crates/agentd/lib/tcp.rs
+++ b/crates/agentd/lib/tcp.rs
@@ -5,11 +5,17 @@
 
 use std::time::Duration;
 
+use bytes::Bytes;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpStream;
 use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
 
+use microsandbox_protocol::bulk::{
+    BULK_FLOW_MASK_GUEST_TO_HOST, BULK_FLOW_MASK_HOST_TO_GUEST, BulkAccepted, BulkCredit,
+    BulkFinish, BulkFlow, BulkKind, BulkOffer, BulkReceiveState, BulkRecord, BulkSendState,
+    DEFAULT_BULK_RECORD_PAYLOAD, DEFAULT_BULK_WINDOW,
+};
 use microsandbox_protocol::codec;
 use microsandbox_protocol::message::{Message, MessageType};
 use microsandbox_protocol::tcp::{TcpClosed, TcpConnect, TcpConnected, TcpData, TcpEof, TcpFailed};
@@ -17,8 +23,8 @@ use microsandbox_protocol::tcp::{TcpClosed, TcpConnect, TcpConnected, TcpData, T
 #[cfg(test)]
 use crate::session::SessionOutputEnvelope;
 use crate::session::{
-    RawActivity, RawSessionCompletion, RawSessionOutput, SessionOutput, SessionOutputPermit,
-    SessionOutputSender,
+    BulkSessionOutput, RawActivity, RawSessionCompletion, RawSessionOutput, SessionOutput,
+    SessionOutputPermit, SessionOutputSender,
 };
 
 //--------------------------------------------------------------------------------------------------
@@ -54,11 +60,20 @@ pub struct TcpSession {
     owner_id: u32,
     commands: mpsc::Sender<TcpCommand>,
     task: JoinHandle<()>,
+    bulk: bool,
 }
 
 enum TcpCommand {
     Data(Vec<u8>),
     Eof,
+    BulkRecord(BulkRecord),
+    BulkCredit(BulkCredit),
+    BulkFinish(BulkFinish),
+}
+
+struct TcpBulkState {
+    send: BulkSendState,
+    receive: BulkReceiveState,
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -76,6 +91,9 @@ impl TcpSession {
     /// Awaits queue space when the per-session relay is behind, so a stalled
     /// destination backpressures the caller instead of growing memory.
     pub async fn write_data(&self, data: Vec<u8>) -> Result<(), String> {
+        if self.bulk {
+            return Err("CBOR TCP data is invalid after raw bulk acceptance".into());
+        }
         self.commands
             .send(TcpCommand::Data(data))
             .await
@@ -87,10 +105,51 @@ impl TcpSession {
     /// Ordered after any queued data, so the destination sees the write shutdown
     /// only once it has received everything sent before it.
     pub async fn close_write(&self) -> Result<(), String> {
+        if self.bulk {
+            return Err("CBOR TCP EOF is invalid after raw bulk acceptance".into());
+        }
         self.commands
             .send(TcpCommand::Eof)
             .await
             .map_err(|_| "TCP session is closed".to_string())
+    }
+
+    /// Queue one host-to-guest raw bulk record.
+    pub async fn write_bulk(&self, record: BulkRecord) -> Result<(), String> {
+        if !self.bulk {
+            return Err("raw bulk record sent to a generation-6 TCP stream".into());
+        }
+        self.commands
+            .send(TcpCommand::BulkRecord(record))
+            .await
+            .map_err(|_| "TCP session is closed".to_string())
+    }
+
+    /// Deliver an absolute guest-to-host credit update.
+    pub async fn apply_credit(&self, credit: BulkCredit) -> Result<(), String> {
+        if !self.bulk {
+            return Err("bulk credit sent to a generation-6 TCP stream".into());
+        }
+        self.commands
+            .send(TcpCommand::BulkCredit(credit))
+            .await
+            .map_err(|_| "TCP session is closed".to_string())
+    }
+
+    /// Queue the exact host-to-guest half-close marker.
+    pub async fn finish_bulk(&self, finish: BulkFinish) -> Result<(), String> {
+        if !self.bulk {
+            return Err("bulk finish sent to a generation-6 TCP stream".into());
+        }
+        self.commands
+            .send(TcpCommand::BulkFinish(finish))
+            .await
+            .map_err(|_| "TCP session is closed".to_string())
+    }
+
+    /// Whether this TCP session negotiated generation-8 raw bulk.
+    pub fn is_bulk(&self) -> bool {
+        self.bulk
     }
 
     /// Tear down the TCP session.
@@ -117,6 +176,7 @@ impl TcpSession {
     /// either reply by id. The returned session is live immediately, with
     /// commands queued until the connect completes.
     pub fn open(id: u32, req: TcpConnect, session_tx: &SessionOutputSender) -> Self {
+        let bulk = req.bulk.is_some();
         let (commands_tx, commands_rx) = mpsc::channel(TCP_COMMAND_CAPACITY);
         let output_tx = session_tx.clone();
         let task = tokio::spawn(async move {
@@ -127,6 +187,7 @@ impl TcpSession {
             owner_id: id,
             commands: commands_tx,
             task,
+            bulk,
         }
     }
 }
@@ -147,7 +208,8 @@ async fn connect_and_relay(
     commands: mpsc::Receiver<TcpCommand>,
     tx: SessionOutputSender,
 ) {
-    let connect = TcpStream::connect((req.host.as_str(), req.port));
+    let TcpConnect { host, port, bulk } = req;
+    let connect = TcpStream::connect((host.as_str(), port));
     let stream = match tokio::time::timeout(TCP_CONNECT_TIMEOUT, connect).await {
         Ok(Ok(stream)) => stream,
         Ok(Err(e)) => {
@@ -155,7 +217,7 @@ async fn connect_and_relay(
                 id,
                 MessageType::TcpFailed,
                 &TcpFailed {
-                    error: format!("connect {}:{}: {e}", req.host, req.port),
+                    error: format!("connect {host}:{port}: {e}"),
                 },
                 RawActivity::guest_message(),
                 Some(RawSessionCompletion::Tcp),
@@ -169,7 +231,7 @@ async fn connect_and_relay(
                 id,
                 MessageType::TcpFailed,
                 &TcpFailed {
-                    error: format!("connect {}:{} timed out", req.host, req.port),
+                    error: format!("connect {host}:{port} timed out"),
                 },
                 RawActivity::guest_message(),
                 Some(RawSessionCompletion::Tcp),
@@ -193,7 +255,83 @@ async fn connect_and_relay(
         return;
     }
 
-    relay_tcp_session(id, stream, commands, tx).await;
+    let bulk = match bulk {
+        Some(offer) => {
+            let accepted = match accept_tcp_offer(offer) {
+                Ok(accepted) => accepted,
+                Err(error) => {
+                    send_raw_tcp_message(
+                        id,
+                        MessageType::TcpFailed,
+                        &TcpFailed { error },
+                        RawActivity::guest_message(),
+                        Some(RawSessionCompletion::Tcp),
+                        &tx,
+                    )
+                    .await;
+                    return;
+                }
+            };
+            if !send_raw_tcp_message(
+                id,
+                MessageType::BulkAccepted,
+                &accepted,
+                RawActivity::guest_message(),
+                None,
+                &tx,
+            )
+            .await
+            {
+                return;
+            }
+            let send = match BulkSendState::new(
+                BulkKind::Tcp,
+                BulkFlow::GuestToHost,
+                accepted.max_record_payload,
+                accepted.guest_to_host_credit_limit,
+            ) {
+                Ok(send) => send,
+                Err(error) => {
+                    eprintln!("failed to create TCP bulk send state for {id}: {error}");
+                    return;
+                }
+            };
+            let receive = match BulkReceiveState::new(
+                BulkKind::Tcp,
+                BulkFlow::HostToGuest,
+                accepted.max_record_payload,
+                accepted.host_to_guest_credit_limit,
+                DEFAULT_BULK_WINDOW,
+            ) {
+                Ok(receive) => receive,
+                Err(error) => {
+                    eprintln!("failed to create TCP bulk receive state for {id}: {error}");
+                    return;
+                }
+            };
+            Some(TcpBulkState { send, receive })
+        }
+        None => None,
+    };
+
+    relay_tcp_session(id, stream, commands, tx, bulk).await;
+}
+
+fn accept_tcp_offer(offer: BulkOffer) -> Result<BulkAccepted, String> {
+    let offer = offer
+        .validate()
+        .map_err(|error| format!("invalid TCP bulk offer: {error}"))?;
+    if offer.guest_to_host_credit_limit == 0 {
+        return Err("TCP bulk offer must grant guest-to-host credit".into());
+    }
+    Ok(BulkAccepted {
+        kind: BulkKind::Tcp,
+        flows: BULK_FLOW_MASK_HOST_TO_GUEST | BULK_FLOW_MASK_GUEST_TO_HOST,
+        format: offer.format,
+        max_record_payload: offer.max_record_payload.min(DEFAULT_BULK_RECORD_PAYLOAD),
+        host_to_guest_credit_limit: DEFAULT_BULK_WINDOW,
+        guest_to_host_credit_limit: offer.guest_to_host_credit_limit,
+    })
 }
 
 async fn relay_tcp_session(
@@ -201,37 +339,99 @@ async fn relay_tcp_session(
     mut stream: TcpStream,
     mut commands: mpsc::Receiver<TcpCommand>,
     tx: SessionOutputSender,
+    mut bulk: Option<TcpBulkState>,
 ) {
-    let mut read_buf = vec![0u8; TCP_CHUNK_SIZE];
+    let read_capacity = bulk.as_ref().map_or(TCP_CHUNK_SIZE, |state| {
+        state.send.max_record_payload() as usize
+    });
+    let mut read_buf = vec![0u8; read_capacity];
     let mut terminal_sent = false;
     // The destination half-closed its write side. We stop reading but keep the
     // loop alive so host->destination data still flows until the host closes.
     let mut read_eof = false;
 
     loop {
+        let read_limit = bulk.as_ref().map_or(TCP_CHUNK_SIZE, |state| {
+            state
+                .send
+                .available_credit()
+                .min(state.send.max_record_payload() as u64) as usize
+        });
         tokio::select! {
-            read = stream.read(&mut read_buf), if !read_eof => {
+            read = stream.read(&mut read_buf[..read_limit]), if !read_eof && read_limit != 0 => {
                 match read {
                     Ok(0) => {
-                        send_raw_tcp_message(
-                            id,
-                            MessageType::TcpEof,
-                            &TcpEof {},
-                            RawActivity::guest_message(),
-                            None,
-                            &tx,
-                        )
-                        .await;
+                        if let Some(state) = bulk.as_mut() {
+                            match state.send.finish() {
+                                Ok(finish) => {
+                                    send_raw_tcp_message(
+                                        id,
+                                        MessageType::BulkFinish,
+                                        &finish,
+                                        RawActivity::guest_message(),
+                                        None,
+                                        &tx,
+                                    )
+                                    .await;
+                                }
+                                Err(error) => {
+                                    eprintln!("failed to finish TCP bulk receive flow {id}: {error}");
+                                    break;
+                                }
+                            }
+                        } else {
+                            send_raw_tcp_message(
+                                id,
+                                MessageType::TcpEof,
+                                &TcpEof {},
+                                RawActivity::guest_message(),
+                                None,
+                                &tx,
+                            )
+                            .await;
+                        }
                         read_eof = true;
                     }
                     Ok(n) => {
-                        let Some(permit) = tx.reserve(TCP_OUTPUT_RESERVATION).await else {
-                            break;
-                        };
-                        let data = read_buf[..n].to_vec();
-                        if !send_raw_tcp_data(id, data, n, permit, &tx).await
-                        {
-                            break;
+                        if let Some(state) = bulk.as_mut() {
+                            let offset = match state.send.admit(n) {
+                                Ok(offset) => offset,
+                                Err(error) => {
+                                    eprintln!("failed to admit TCP bulk record {id}: {error}");
+                                    break;
+                                }
+                            };
+                            let Some(permit) = tx.reserve(n).await else {
+                                break;
+                            };
+                            let record = BulkRecord {
+                                id,
+                                kind: BulkKind::Tcp,
+                                flow: BulkFlow::GuestToHost,
+                                offset,
+                                payload: Bytes::copy_from_slice(&read_buf[..n]),
+                            };
+                            if !tx
+                                .send_reserved(
+                                    id,
+                                    SessionOutput::Bulk(BulkSessionOutput::new(
+                                        record,
+                                        RawActivity::tcp_bytes(n),
+                                    )),
+                                    permit,
+                                )
+                                .await
+                            {
+                                break;
+                            }
+                        } else {
+                            let Some(permit) = tx.reserve(TCP_OUTPUT_RESERVATION).await else {
+                                break;
+                            };
+                            let data = read_buf[..n].to_vec();
+                            if !send_raw_tcp_data(id, data, n, permit, &tx).await {
+                                break;
+                            }
                         }
                     }
                     Err(e) => {
@@ -253,6 +453,15 @@ async fn relay_tcp_session(
             command = commands.recv() => {
                 match command {
                     Some(TcpCommand::Data(data)) => {
+                        if bulk.is_some() {
+                            terminal_sent = send_tcp_failure(
+                                id,
+                                "CBOR TCP data received after raw bulk acceptance".into(),
+                                &tx,
+                            )
+                            .await;
+                            break;
+                        }
                         if let Err(e) = stream.write_all(&data).await {
                             terminal_sent = send_raw_tcp_message(
                                 id,
@@ -269,6 +478,15 @@ async fn relay_tcp_session(
                         }
                     }
                     Some(TcpCommand::Eof) => {
+                        if bulk.is_some() {
+                            terminal_sent = send_tcp_failure(
+                                id,
+                                "CBOR TCP EOF received after raw bulk acceptance".into(),
+                                &tx,
+                            )
+                            .await;
+                            break;
+                        }
                         if let Err(e) = stream.shutdown().await {
                             terminal_sent = send_raw_tcp_message(
                                 id,
@@ -287,6 +505,113 @@ async fn relay_tcp_session(
                     None => {
                         break;
                     }
+                    Some(TcpCommand::BulkRecord(record)) => {
+                        let Some(state) = bulk.as_mut() else {
+                            terminal_sent = send_tcp_failure(
+                                id,
+                                "raw bulk record received on a generation-6 TCP stream".into(),
+                                &tx,
+                            )
+                            .await;
+                            break;
+                        };
+                        let end = match state.receive.accept_record(&record) {
+                            Ok(end) => end,
+                            Err(error) => {
+                                terminal_sent = send_tcp_failure(
+                                    id,
+                                    format!("invalid TCP bulk record: {error}"),
+                                    &tx,
+                                )
+                                .await;
+                                break;
+                            }
+                        };
+                        if let Err(error) = stream.write_all(&record.payload).await {
+                            terminal_sent = send_tcp_failure(
+                                id,
+                                format!("write TCP stream: {error}"),
+                                &tx,
+                            )
+                            .await;
+                            break;
+                        }
+                        match state.receive.consume(end) {
+                            Ok(Some(credit)) => {
+                                if !send_raw_tcp_message(
+                                    id,
+                                    MessageType::BulkCredit,
+                                    &credit,
+                                    RawActivity::guest_message(),
+                                    None,
+                                    &tx,
+                                )
+                                .await
+                                {
+                                    break;
+                                }
+                            }
+                            Ok(None) => {}
+                            Err(error) => {
+                                terminal_sent = send_tcp_failure(
+                                    id,
+                                    format!("advance TCP bulk credit: {error}"),
+                                    &tx,
+                                )
+                                .await;
+                                break;
+                            }
+                        }
+                    }
+                    Some(TcpCommand::BulkCredit(credit)) => {
+                        let Some(state) = bulk.as_mut() else {
+                            terminal_sent = send_tcp_failure(
+                                id,
+                                "bulk credit received on a generation-6 TCP stream".into(),
+                                &tx,
+                            )
+                            .await;
+                            break;
+                        };
+                        if let Err(error) = state.send.apply_credit(credit) {
+                            terminal_sent = send_tcp_failure(
+                                id,
+                                format!("invalid TCP bulk credit: {error}"),
+                                &tx,
+                            )
+                            .await;
+                            break;
+                        }
+                    }
+                    Some(TcpCommand::BulkFinish(finish)) => {
+                        let Some(state) = bulk.as_mut() else {
+                            terminal_sent = send_tcp_failure(
+                                id,
+                                "bulk finish received on a generation-6 TCP stream".into(),
+                                &tx,
+                            )
+                            .await;
+                            break;
+                        };
+                        if let Err(error) = state.receive.accept_finish(finish) {
+                            terminal_sent = send_tcp_failure(
+                                id,
+                                format!("invalid TCP bulk finish: {error}"),
+                                &tx,
+                            )
+                            .await;
+                            break;
+                        }
+                        if let Err(error) = stream.shutdown().await {
+                            terminal_sent = send_tcp_failure(
+                                id,
+                                format!("shutdown TCP stream: {error}"),
+                                &tx,
+                            )
+                            .await;
+                            break;
+                        }
+                    }
                 }
             }
         }
@@ -303,6 +628,18 @@ async fn relay_tcp_session(
         )
         .await;
     }
+}
+
+async fn send_tcp_failure(id: u32, error: String, tx: &SessionOutputSender) -> bool {
+    send_raw_tcp_message(
+        id,
+        MessageType::TcpFailed,
+        &TcpFailed { error },
+        RawActivity::guest_message(),
+        Some(RawSessionCompletion::Tcp),
+        tx,
+    )
+    .await
 }
 
 fn encode_tcp_message<T: serde::Serialize>(
@@ -391,6 +728,7 @@ mod tests {
             TcpConnect {
                 host: "127.0.0.1".to_string(),
                 port: 0,
+                bulk: None,
             },
             &session_tx,
         );
@@ -420,6 +758,7 @@ mod tests {
             TcpConnect {
                 host: "127.0.0.1".to_string(),
                 port,
+                bulk: None,
             },
             &session_tx,
         );
@@ -455,6 +794,7 @@ mod tests {
             TcpConnect {
                 host: "127.0.0.1".to_string(),
                 port,
+                bulk: None,
             },
             &session_tx,
         );
@@ -485,6 +825,78 @@ mod tests {
         accept_task.await.unwrap();
     }
 
+    #[tokio::test]
+    async fn raw_bulk_tcp_relays_both_directions_and_exact_half_closes() {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let (session_tx, mut session_rx) = SessionOutputSender::channel();
+        let (got_tx, got_rx) = tokio::sync::oneshot::channel();
+        let accept_task = tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            socket.write_all(b"from-destination").await.unwrap();
+            socket.shutdown().await.unwrap();
+            let mut received = Vec::new();
+            socket.read_to_end(&mut received).await.unwrap();
+            got_tx.send(received).unwrap();
+        });
+
+        let session = TcpSession::open(
+            13,
+            TcpConnect {
+                host: "127.0.0.1".to_string(),
+                port,
+                bulk: Some(BulkOffer::tcp()),
+            },
+            &session_tx,
+        );
+        assert_eq!(
+            recv_message(&mut session_rx).await.t,
+            MessageType::TcpConnected
+        );
+        assert_eq!(
+            recv_message(&mut session_rx).await.t,
+            MessageType::BulkAccepted
+        );
+
+        let host_payload = Bytes::from_static(b"from-host");
+        session
+            .write_bulk(BulkRecord {
+                id: 13,
+                kind: BulkKind::Tcp,
+                flow: BulkFlow::HostToGuest,
+                offset: 0,
+                payload: host_payload.clone(),
+            })
+            .await
+            .unwrap();
+        session
+            .finish_bulk(BulkFinish {
+                kind: BulkKind::Tcp,
+                flow: BulkFlow::HostToGuest,
+                final_offset: host_payload.len() as u64,
+            })
+            .await
+            .unwrap();
+
+        let record = recv_bulk(&mut session_rx).await;
+        assert_eq!(record.flow, BulkFlow::GuestToHost);
+        assert_eq!(record.offset, 0);
+        assert_eq!(record.payload, Bytes::from_static(b"from-destination"));
+        let finish = recv_message(&mut session_rx).await;
+        assert_eq!(finish.t, MessageType::BulkFinish);
+        let finish: BulkFinish = finish.payload().unwrap();
+        assert_eq!(finish.final_offset, b"from-destination".len() as u64);
+
+        let received = tokio::time::timeout(Duration::from_secs(1), got_rx)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(received, host_payload);
+        session.close();
+        wait_finished(&session).await;
+        accept_task.await.unwrap();
+    }
+
     async fn wait_finished(session: &TcpSession) {
         tokio::time::timeout(Duration::from_secs(1), async {
             while !session.is_finished() {
@@ -505,5 +917,13 @@ mod tests {
             panic!("expected SessionOutput::Raw frame");
         };
         decode_one_message(&mut output.frame)
+    }
+
+    async fn recv_bulk(rx: &mut mpsc::Receiver<SessionOutputEnvelope>) -> BulkRecord {
+        let envelope = rx.recv().await.unwrap();
+        let SessionOutput::Bulk(output) = envelope.output else {
+            panic!("expected SessionOutput::Bulk record");
+        };
+        output.record
     }
 }

--- a/crates/protocol/VERSIONING.md
+++ b/crates/protocol/VERSIONING.md
@@ -154,11 +154,9 @@ mid-session.
 These are the promises that make all of the above hold together:
 
 1. **One version number** (the generation), agreed once at the handshake.
-2. **The message container never changes shape.** All evolution goes inside the message, not into
-   its framing.
+2. **The binary frame header never changes shape.** A negotiated generation may add a body format selected by an exclusive flag, but old peers are never sent that format.
 3. **New fields are always optional**, so old and new can ignore or default what they don't know.
-4. **New kinds of message are only ever added, never removed or redefined**, and each records the
-   generation it arrived in.
+4. **New kinds of message and body format are only ever added, never removed or redefined**, and each records the generation it arrived in.
 5. **The host checks the agreed version before sending** anything new, so unsupported features
    fail cleanly and alone.
 6. **The newer side speaks the older format.** The old runtime is never asked to learn anything.
@@ -188,13 +186,23 @@ whole protocol up front.
 
 ## Implementation details (for contributors changing the protocol)
 
-The wire layout, in two nested layers:
+The stable wire header and ordinary control body are:
 
 ```
-[ length ][ id ][ flags ]          <- fixed binary header, read first, never changes shape
-CBOR { v, t, p }                   <- the envelope: version, message type, payload bytes
-            p = CBOR { ...fields }  <- the payload for that message type (ExecRequest, etc.)
+[ length ][ id ][ flags ][ body ]  <- fixed binary header, read first, never changes shape
+body = CBOR { v, t, p }            <- ordinary control envelope
+              p = CBOR { ... }     <- payload for that message type
 ```
+
+Generation 8 adds one negotiated data-body alternative without changing the header:
+
+```
+flags = FLAG_BULK                  <- exclusive; no lifecycle flag may be combined with it
+body = [ kind ][ flow ][ 0 ][ offset ][ opaque payload ]
+       u8     u8     u16   u64 BE    1..negotiated maximum bytes
+```
+
+Filesystem reads/writes and TCP streams first negotiate this format through CBOR control messages. A host connected to a generation-7 or older runtime never offers raw bulk and continues using the CBOR data messages. The relay validates the universal length and exclusive flag shape, routes on the unchanged correlation ID, and does not interpret bulk kind, flow, offsets, credits, or payload.
 
 - **`v`** is the generation, echoed onto each message. Same number negotiated at the handshake;
   not a per-message version. Don't gate behavior by reading it per message.
@@ -221,15 +229,10 @@ sandbox echoed in its ready frame)`. Every typed send checks `min_protocol_versi
 - **Codec vs. gate.** `AgentProtocol` (Current / LegacyV1) selects the wire _codec_ (the container
   format). `negotiated_version` drives the _capability gate_. These are the two consumers of the
   one generation number.
-- **The binary header** `[length][id][flags]` is immutable. The relay routes on `id`/`flags`
-  without parsing the CBOR, and it bridges a host and guest that may be different generations, so
-  changing the header would force the relay to translate. Keep all change inside the CBOR body.
-- **`flags`** is a 1-byte field (3 of 8 bits used) carrying lifecycle hints the relay needs without
-  decoding CBOR. New bits are append-only and must be safe for an old relay to ignore. Anything
-  that isn't safe to ignore belongs behind the capability gate, not a flag bit.
-- **A real format break** (kind 3) means forking the codec per `AgentProtocol` generation and
-  carrying the old one until a support horizon (see `TODO(upgrade-0.6)`), keeping the binary header
-  fixed so the relay stays format-agnostic.
+- **The binary header** `[length][id][flags]` is immutable. The relay routes on `id`/`flags` without parsing the body, and it bridges a host and guest that may be different generations, so changing the header would force the relay to translate.
+- **`flags`** is a 1-byte field (4 of 8 bits used) carrying either lifecycle hints or the exclusive generation-8 raw-body discriminator. New bits are append-only, must define whether combination is legal, and must be withheld from peers below their capability generation.
+- **Generation-8 raw bulk is an additive, gated body format.** `FLAG_BULK` is never combined with lifecycle flags; opening offers and acceptance messages establish the permitted operation kind, flow mask, record limit, and initial absolute credits before any raw record may appear.
+- **A real format break** (kind 3) now means changing the immutable header or changing an existing body's interpretation. That requires forking the codec per `AgentProtocol` generation and carrying the old one until a support horizon (see `TODO(upgrade-0.6)`).
 
 ### Tests that keep this honest
 

--- a/crates/protocol/lib/bulk.rs
+++ b/crates/protocol/lib/bulk.rs
@@ -1,0 +1,766 @@
+//! Generation-8 raw bulk records, control payloads, and flow state.
+
+use bytes::Bytes;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use thiserror::Error;
+
+//--------------------------------------------------------------------------------------------------
+// Constants
+//--------------------------------------------------------------------------------------------------
+
+/// Generation that introduced raw bulk records.
+pub const BULK_PROTOCOL_VERSION: u8 = 8;
+
+/// First and only bulk record format in generation 8.
+pub const BULK_FORMAT_RAW_V1: u8 = 1;
+
+/// Bytes in the raw record body before its payload.
+pub const BULK_HEADER_SIZE: usize = 12;
+
+/// Default raw-record payload selected by generation-8 peers.
+pub const DEFAULT_BULK_RECORD_PAYLOAD: u32 = 256 * 1024;
+
+/// Smallest record payload a peer may negotiate.
+pub const MIN_BULK_RECORD_PAYLOAD: u32 = 16 * 1024;
+
+/// Largest record payload generation 8 permits.
+pub const MAX_BULK_RECORD_PAYLOAD: u32 = 1024 * 1024;
+
+/// Default receive window granted to one bulk flow.
+pub const DEFAULT_BULK_WINDOW: u64 = 8 * 1024 * 1024;
+
+/// Largest receive window generation 8 permits.
+pub const MAX_BULK_WINDOW: u64 = 32 * 1024 * 1024;
+
+/// Flow-mask bit for host-to-guest data.
+pub const BULK_FLOW_MASK_HOST_TO_GUEST: u8 = 0b01;
+
+/// Flow-mask bit for guest-to-host data.
+pub const BULK_FLOW_MASK_GUEST_TO_HOST: u8 = 0b10;
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// Operation family carried by a raw bulk record.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum BulkKind {
+    /// Filesystem read or write bytes.
+    Filesystem = 1,
+
+    /// TCP stream bytes.
+    Tcp = 2,
+}
+
+/// Physical direction of a raw bulk flow across the VM boundary.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum BulkFlow {
+    /// Host or SDK to guest or agentd.
+    HostToGuest = 1,
+
+    /// Guest or agentd to host or SDK.
+    GuestToHost = 2,
+}
+
+/// A generation-8 raw record after fixed-header validation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BulkRecord {
+    /// Correlation that owns this record.
+    pub id: u32,
+
+    /// Operation family.
+    pub kind: BulkKind,
+
+    /// Physical data direction.
+    pub flow: BulkFlow,
+
+    /// Zero-based stream offset of the first payload byte.
+    pub offset: u64,
+
+    /// Opaque payload bytes.
+    pub payload: Bytes,
+}
+
+/// Optional raw-bulk offer on a generation-8 opening request.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BulkOffer {
+    /// Bulk record format. Generation 8 requires `1`.
+    pub format: u8,
+
+    /// Largest payload this host accepts in one raw record.
+    pub max_record_payload: u32,
+
+    /// Initial absolute guest-to-host exclusive send limit.
+    pub guest_to_host_credit_limit: u64,
+}
+
+/// Guest acceptance of one offered bulk correlation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BulkAccepted {
+    /// Accepted operation family.
+    pub kind: BulkKind,
+
+    /// Enabled-flow mask.
+    pub flows: u8,
+
+    /// Accepted record format.
+    pub format: u8,
+
+    /// Effective maximum record payload.
+    pub max_record_payload: u32,
+
+    /// Initial absolute host-to-guest exclusive send limit.
+    pub host_to_guest_credit_limit: u64,
+
+    /// Exact host grant accepted for guest-to-host data.
+    pub guest_to_host_credit_limit: u64,
+}
+
+/// Absolute credit update from a flow receiver.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BulkCredit {
+    /// Operation family.
+    pub kind: BulkKind,
+
+    /// Flow whose sender receives credit.
+    pub flow: BulkFlow,
+
+    /// Bytes for which the receiver has accepted responsibility.
+    pub consumed_offset: u64,
+
+    /// Absolute exclusive byte offset the sender may reach.
+    pub credit_limit: u64,
+}
+
+/// Exact end offset for one flow.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BulkFinish {
+    /// Operation family.
+    pub kind: BulkKind,
+
+    /// Flow that reached EOF or half-close.
+    pub flow: BulkFlow,
+
+    /// Exact final byte offset.
+    pub final_offset: u64,
+}
+
+/// Reason one peer cancelled an entire bulk correlation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum BulkCancelReason {
+    /// Local caller dropped or cancelled the operation.
+    CallerCancelled = 1,
+
+    /// Destination file or socket I/O failed.
+    DestinationIo = 2,
+
+    /// A configured resource limit was reached.
+    ResourceLimit = 3,
+
+    /// The underlying transport failed.
+    TransportFailure = 4,
+
+    /// The peer violated the correlation state machine.
+    ProtocolState = 5,
+}
+
+/// Best-effort request to stop an entire bulk correlation.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BulkCancel {
+    /// Operation family.
+    pub kind: BulkKind,
+
+    /// Stable cancellation reason.
+    pub reason: BulkCancelReason,
+
+    /// Human-readable diagnostic without payload data.
+    pub message: String,
+}
+
+/// Sender-side absolute-offset and credit state for one flow.
+#[derive(Debug, Clone)]
+pub struct BulkSendState {
+    kind: BulkKind,
+    flow: BulkFlow,
+    max_record_payload: u32,
+    next_offset: u64,
+    consumed_offset: u64,
+    credit_limit: u64,
+    finished: bool,
+}
+
+/// Receiver-side exact-offset and replenishment state for one flow.
+#[derive(Debug, Clone)]
+pub struct BulkReceiveState {
+    kind: BulkKind,
+    flow: BulkFlow,
+    max_record_payload: u32,
+    window: u64,
+    next_expected_offset: u64,
+    consumed_offset: u64,
+    credit_limit: u64,
+    finished: bool,
+}
+
+/// Validation failure in generation-8 bulk state.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum BulkStateError {
+    /// Unsupported record format.
+    #[error("unsupported bulk format {0}")]
+    UnsupportedFormat(u8),
+
+    /// Negotiated record limit is outside generation-8 bounds.
+    #[error("invalid maximum bulk record payload {0}")]
+    InvalidRecordLimit(u32),
+
+    /// A raw record payload is empty or exceeds the negotiated limit.
+    #[error("invalid bulk record payload length {length} (max {max})")]
+    InvalidPayloadLength {
+        /// Actual payload length.
+        length: usize,
+        /// Negotiated maximum.
+        max: u32,
+    },
+
+    /// The record or control belongs to another operation family or flow.
+    #[error("bulk kind or flow does not match the correlation")]
+    FlowMismatch,
+
+    /// Offset arithmetic overflowed `u64`.
+    #[error("bulk offset overflow")]
+    OffsetOverflow,
+
+    /// A sender tried to exceed the absolute receive credit.
+    #[error("bulk record end {end} exceeds credit limit {limit}")]
+    CreditExceeded {
+        /// Proposed exclusive record end.
+        end: u64,
+        /// Current exclusive credit limit.
+        limit: u64,
+    },
+
+    /// Credit state regressed or violated the negotiated window.
+    #[error("invalid bulk credit: {0}")]
+    InvalidCredit(String),
+
+    /// A record did not start at the exact expected stream offset.
+    #[error("bulk record offset {actual} does not match expected {expected}")]
+    OffsetMismatch {
+        /// Required offset.
+        expected: u64,
+        /// Received offset.
+        actual: u64,
+    },
+
+    /// A finish marker did not match the exact admitted offset.
+    #[error("bulk finish offset {actual} does not match expected {expected}")]
+    FinishMismatch {
+        /// Required final offset.
+        expected: u64,
+        /// Received final offset.
+        actual: u64,
+    },
+
+    /// Data or control arrived after this flow finished.
+    #[error("bulk flow is already finished")]
+    AlreadyFinished,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Methods
+//--------------------------------------------------------------------------------------------------
+
+impl BulkKind {
+    /// Parse a generation-8 wire value.
+    pub fn from_wire(value: u8) -> Option<Self> {
+        match value {
+            1 => Some(Self::Filesystem),
+            2 => Some(Self::Tcp),
+            _ => None,
+        }
+    }
+}
+
+impl BulkFlow {
+    /// Parse a generation-8 wire value.
+    pub fn from_wire(value: u8) -> Option<Self> {
+        match value {
+            1 => Some(Self::HostToGuest),
+            2 => Some(Self::GuestToHost),
+            _ => None,
+        }
+    }
+
+    /// Return this flow's bit in [`BulkAccepted::flows`].
+    pub fn mask(self) -> u8 {
+        match self {
+            Self::HostToGuest => BULK_FLOW_MASK_HOST_TO_GUEST,
+            Self::GuestToHost => BULK_FLOW_MASK_GUEST_TO_HOST,
+        }
+    }
+}
+
+impl BulkOffer {
+    /// Build the default offer for a filesystem read.
+    pub fn filesystem_read() -> Self {
+        Self::new(DEFAULT_BULK_WINDOW)
+    }
+
+    /// Build the default offer for a filesystem write.
+    pub fn filesystem_write() -> Self {
+        Self::new(0)
+    }
+
+    /// Build the default bidirectional TCP offer.
+    pub fn tcp() -> Self {
+        Self::new(DEFAULT_BULK_WINDOW)
+    }
+
+    /// Validate generation-8 offer limits.
+    pub fn validate(self) -> Result<Self, BulkStateError> {
+        validate_record_limit(self.max_record_payload)?;
+        if self.format != BULK_FORMAT_RAW_V1 {
+            return Err(BulkStateError::UnsupportedFormat(self.format));
+        }
+        if self.guest_to_host_credit_limit > MAX_BULK_WINDOW {
+            return Err(BulkStateError::InvalidCredit(format!(
+                "initial guest-to-host limit {} exceeds {}",
+                self.guest_to_host_credit_limit, MAX_BULK_WINDOW
+            )));
+        }
+        Ok(self)
+    }
+
+    fn new(guest_to_host_credit_limit: u64) -> Self {
+        Self {
+            format: BULK_FORMAT_RAW_V1,
+            max_record_payload: DEFAULT_BULK_RECORD_PAYLOAD,
+            guest_to_host_credit_limit,
+        }
+    }
+}
+
+impl BulkAccepted {
+    /// Validate an acceptance against the opening offer and required operation shape.
+    pub fn validate_against(
+        self,
+        offer: BulkOffer,
+        kind: BulkKind,
+        flows: u8,
+    ) -> Result<Self, BulkStateError> {
+        let offer = offer.validate()?;
+        validate_record_limit(self.max_record_payload)?;
+        if self.kind != kind || self.flows != flows || self.flows & !0b11 != 0 {
+            return Err(BulkStateError::FlowMismatch);
+        }
+        if self.format != BULK_FORMAT_RAW_V1 {
+            return Err(BulkStateError::UnsupportedFormat(self.format));
+        }
+        if self.max_record_payload > offer.max_record_payload {
+            return Err(BulkStateError::InvalidRecordLimit(self.max_record_payload));
+        }
+        if self.guest_to_host_credit_limit != offer.guest_to_host_credit_limit {
+            return Err(BulkStateError::InvalidCredit(
+                "guest-to-host grant was not echoed exactly".into(),
+            ));
+        }
+        if self.host_to_guest_credit_limit > MAX_BULK_WINDOW {
+            return Err(BulkStateError::InvalidCredit(
+                "host-to-guest grant exceeds the generation-8 window".into(),
+            ));
+        }
+        let host_to_guest = self.flows & BULK_FLOW_MASK_HOST_TO_GUEST != 0;
+        let guest_to_host = self.flows & BULK_FLOW_MASK_GUEST_TO_HOST != 0;
+        if host_to_guest != (self.host_to_guest_credit_limit != 0) {
+            return Err(BulkStateError::InvalidCredit(
+                "host-to-guest credit must be nonzero exactly when that flow is enabled".into(),
+            ));
+        }
+        if guest_to_host != (self.guest_to_host_credit_limit != 0) {
+            return Err(BulkStateError::InvalidCredit(
+                "guest-to-host credit must be nonzero exactly when that flow is enabled".into(),
+            ));
+        }
+        Ok(self)
+    }
+}
+
+impl BulkSendState {
+    /// Create one sender flow from negotiated limits.
+    pub fn new(
+        kind: BulkKind,
+        flow: BulkFlow,
+        max_record_payload: u32,
+        credit_limit: u64,
+    ) -> Result<Self, BulkStateError> {
+        validate_record_limit(max_record_payload)?;
+        if credit_limit > MAX_BULK_WINDOW {
+            return Err(BulkStateError::InvalidCredit(
+                "initial credit exceeds the generation-8 window".into(),
+            ));
+        }
+        Ok(Self {
+            kind,
+            flow,
+            max_record_payload,
+            next_offset: 0,
+            consumed_offset: 0,
+            credit_limit,
+            finished: false,
+        })
+    }
+
+    /// Return the next byte offset this sender will assign.
+    pub fn next_offset(&self) -> u64 {
+        self.next_offset
+    }
+
+    /// Return the currently admitted exclusive limit.
+    pub fn credit_limit(&self) -> u64 {
+        self.credit_limit
+    }
+
+    /// Return the maximum payload negotiated for this flow.
+    pub fn max_record_payload(&self) -> u32 {
+        self.max_record_payload
+    }
+
+    /// Return bytes the sender may currently admit without another credit update.
+    pub fn available_credit(&self) -> u64 {
+        self.credit_limit.saturating_sub(self.next_offset)
+    }
+
+    /// Admit a payload and advance the ordered sender cursor.
+    pub fn admit(&mut self, payload_len: usize) -> Result<u64, BulkStateError> {
+        if self.finished {
+            return Err(BulkStateError::AlreadyFinished);
+        }
+        validate_payload_len(payload_len, self.max_record_payload)?;
+        let end = self
+            .next_offset
+            .checked_add(payload_len as u64)
+            .ok_or(BulkStateError::OffsetOverflow)?;
+        if end > self.credit_limit {
+            return Err(BulkStateError::CreditExceeded {
+                end,
+                limit: self.credit_limit,
+            });
+        }
+        let offset = self.next_offset;
+        self.next_offset = end;
+        Ok(offset)
+    }
+
+    /// Apply one idempotent absolute credit update.
+    pub fn apply_credit(&mut self, credit: BulkCredit) -> Result<bool, BulkStateError> {
+        if credit.kind != self.kind || credit.flow != self.flow {
+            return Err(BulkStateError::FlowMismatch);
+        }
+        if credit.consumed_offset > self.next_offset {
+            return Err(BulkStateError::InvalidCredit(
+                "peer consumed bytes the sender has not admitted".into(),
+            ));
+        }
+        if credit.credit_limit < credit.consumed_offset
+            || credit.credit_limit - credit.consumed_offset > MAX_BULK_WINDOW
+        {
+            return Err(BulkStateError::InvalidCredit(
+                "credit limit is outside the allowed absolute window".into(),
+            ));
+        }
+
+        if credit.consumed_offset <= self.consumed_offset
+            && credit.credit_limit <= self.credit_limit
+        {
+            return Ok(false);
+        }
+        if credit.consumed_offset < self.consumed_offset
+            || credit.credit_limit < self.credit_limit
+            || credit.credit_limit < self.next_offset
+        {
+            return Err(BulkStateError::InvalidCredit(
+                "credit fields advanced inconsistently".into(),
+            ));
+        }
+
+        self.consumed_offset = credit.consumed_offset;
+        self.credit_limit = credit.credit_limit;
+        Ok(true)
+    }
+
+    /// Finish this sender at its exact current offset.
+    pub fn finish(&mut self) -> Result<BulkFinish, BulkStateError> {
+        if self.finished {
+            return Err(BulkStateError::AlreadyFinished);
+        }
+        self.finished = true;
+        Ok(BulkFinish {
+            kind: self.kind,
+            flow: self.flow,
+            final_offset: self.next_offset,
+        })
+    }
+}
+
+impl BulkReceiveState {
+    /// Create one receiver flow and its initial absolute grant.
+    pub fn new(
+        kind: BulkKind,
+        flow: BulkFlow,
+        max_record_payload: u32,
+        credit_limit: u64,
+        window: u64,
+    ) -> Result<Self, BulkStateError> {
+        validate_record_limit(max_record_payload)?;
+        if window == 0 || window > MAX_BULK_WINDOW || credit_limit > window {
+            return Err(BulkStateError::InvalidCredit(
+                "invalid initial receive window".into(),
+            ));
+        }
+        Ok(Self {
+            kind,
+            flow,
+            max_record_payload,
+            window,
+            next_expected_offset: 0,
+            consumed_offset: 0,
+            credit_limit,
+            finished: false,
+        })
+    }
+
+    /// Return the next exact record offset.
+    pub fn next_expected_offset(&self) -> u64 {
+        self.next_expected_offset
+    }
+
+    /// Return the current absolute receive credit limit.
+    pub fn credit_limit(&self) -> u64 {
+        self.credit_limit
+    }
+
+    /// Validate and admit a record before its destination consumes the payload.
+    pub fn accept_record(&mut self, record: &BulkRecord) -> Result<u64, BulkStateError> {
+        if self.finished {
+            return Err(BulkStateError::AlreadyFinished);
+        }
+        if record.kind != self.kind || record.flow != self.flow {
+            return Err(BulkStateError::FlowMismatch);
+        }
+        validate_payload_len(record.payload.len(), self.max_record_payload)?;
+        if record.offset != self.next_expected_offset {
+            return Err(BulkStateError::OffsetMismatch {
+                expected: self.next_expected_offset,
+                actual: record.offset,
+            });
+        }
+        let end = record
+            .offset
+            .checked_add(record.payload.len() as u64)
+            .ok_or(BulkStateError::OffsetOverflow)?;
+        if end > self.credit_limit {
+            return Err(BulkStateError::CreditExceeded {
+                end,
+                limit: self.credit_limit,
+            });
+        }
+        self.next_expected_offset = end;
+        Ok(end)
+    }
+
+    /// Mark admitted bytes consumed and return a replenishment when half the window remains.
+    pub fn consume(&mut self, consumed_offset: u64) -> Result<Option<BulkCredit>, BulkStateError> {
+        if consumed_offset < self.consumed_offset || consumed_offset > self.next_expected_offset {
+            return Err(BulkStateError::InvalidCredit(
+                "consumed offset is outside admitted bytes".into(),
+            ));
+        }
+        self.consumed_offset = consumed_offset;
+        if self.credit_limit - self.consumed_offset > self.window / 2 {
+            return Ok(None);
+        }
+        let next_limit = self
+            .consumed_offset
+            .checked_add(self.window)
+            .ok_or(BulkStateError::OffsetOverflow)?;
+        if next_limit <= self.credit_limit {
+            return Ok(None);
+        }
+        self.credit_limit = next_limit;
+        Ok(Some(BulkCredit {
+            kind: self.kind,
+            flow: self.flow,
+            consumed_offset: self.consumed_offset,
+            credit_limit: self.credit_limit,
+        }))
+    }
+
+    /// Accept an exact finish after all earlier records.
+    pub fn accept_finish(&mut self, finish: BulkFinish) -> Result<(), BulkStateError> {
+        if self.finished {
+            return Err(BulkStateError::AlreadyFinished);
+        }
+        if finish.kind != self.kind || finish.flow != self.flow {
+            return Err(BulkStateError::FlowMismatch);
+        }
+        if finish.final_offset != self.next_expected_offset {
+            return Err(BulkStateError::FinishMismatch {
+                expected: self.next_expected_offset,
+                actual: finish.final_offset,
+            });
+        }
+        self.finished = true;
+        Ok(())
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Trait Implementations
+//--------------------------------------------------------------------------------------------------
+
+macro_rules! impl_wire_enum {
+    ($type:ty, $parse:path) => {
+        impl Serialize for $type {
+            fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+            where
+                S: Serializer,
+            {
+                serializer.serialize_u8(*self as u8)
+            }
+        }
+
+        impl<'de> Deserialize<'de> for $type {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: Deserializer<'de>,
+            {
+                let value = u8::deserialize(deserializer)?;
+                $parse(value).ok_or_else(|| serde::de::Error::custom("unknown bulk enum value"))
+            }
+        }
+    };
+}
+
+impl_wire_enum!(BulkKind, BulkKind::from_wire);
+impl_wire_enum!(BulkFlow, BulkFlow::from_wire);
+
+impl Serialize for BulkCancelReason {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_u8(*self as u8)
+    }
+}
+
+impl<'de> Deserialize<'de> for BulkCancelReason {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = u8::deserialize(deserializer)?;
+        match value {
+            1 => Ok(Self::CallerCancelled),
+            2 => Ok(Self::DestinationIo),
+            3 => Ok(Self::ResourceLimit),
+            4 => Ok(Self::TransportFailure),
+            5 => Ok(Self::ProtocolState),
+            _ => Err(serde::de::Error::custom("unknown bulk cancel reason")),
+        }
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+fn validate_record_limit(limit: u32) -> Result<(), BulkStateError> {
+    if !(MIN_BULK_RECORD_PAYLOAD..=MAX_BULK_RECORD_PAYLOAD).contains(&limit) {
+        return Err(BulkStateError::InvalidRecordLimit(limit));
+    }
+    Ok(())
+}
+
+fn validate_payload_len(length: usize, max: u32) -> Result<(), BulkStateError> {
+    if length == 0 || length > max as usize {
+        return Err(BulkStateError::InvalidPayloadLength { length, max });
+    }
+    Ok(())
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests
+//--------------------------------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sender_stops_at_exact_credit_and_accepts_absolute_replenishment() {
+        let mut sender = BulkSendState::new(
+            BulkKind::Filesystem,
+            BulkFlow::GuestToHost,
+            MIN_BULK_RECORD_PAYLOAD,
+            MIN_BULK_RECORD_PAYLOAD as u64,
+        )
+        .unwrap();
+        assert_eq!(sender.admit(MIN_BULK_RECORD_PAYLOAD as usize).unwrap(), 0);
+        assert!(matches!(
+            sender.admit(1),
+            Err(BulkStateError::CreditExceeded { .. })
+        ));
+
+        assert!(
+            sender
+                .apply_credit(BulkCredit {
+                    kind: BulkKind::Filesystem,
+                    flow: BulkFlow::GuestToHost,
+                    consumed_offset: MIN_BULK_RECORD_PAYLOAD as u64,
+                    credit_limit: 2 * MIN_BULK_RECORD_PAYLOAD as u64,
+                })
+                .unwrap()
+        );
+        assert_eq!(
+            sender.admit(MIN_BULK_RECORD_PAYLOAD as usize).unwrap(),
+            MIN_BULK_RECORD_PAYLOAD as u64
+        );
+    }
+
+    #[test]
+    fn receiver_rejects_gap_and_replenishes_at_half_window() {
+        let window = 2 * MIN_BULK_RECORD_PAYLOAD as u64;
+        let mut receiver = BulkReceiveState::new(
+            BulkKind::Tcp,
+            BulkFlow::HostToGuest,
+            MIN_BULK_RECORD_PAYLOAD,
+            window,
+            window,
+        )
+        .unwrap();
+        let gap = BulkRecord {
+            id: 4,
+            kind: BulkKind::Tcp,
+            flow: BulkFlow::HostToGuest,
+            offset: 1,
+            payload: Bytes::from_static(b"x"),
+        };
+        assert!(matches!(
+            receiver.accept_record(&gap),
+            Err(BulkStateError::OffsetMismatch { .. })
+        ));
+
+        let record = BulkRecord {
+            offset: 0,
+            payload: Bytes::from(vec![0; MIN_BULK_RECORD_PAYLOAD as usize]),
+            ..gap
+        };
+        let end = receiver.accept_record(&record).unwrap();
+        let credit = receiver.consume(end).unwrap().unwrap();
+        assert_eq!(credit.consumed_offset, MIN_BULK_RECORD_PAYLOAD as u64);
+        assert_eq!(credit.credit_limit, 3 * MIN_BULK_RECORD_PAYLOAD as u64);
+    }
+}

--- a/crates/protocol/lib/codec.rs
+++ b/crates/protocol/lib/codec.rs
@@ -1,18 +1,20 @@
 //! Length-prefixed frame codec for reading and writing protocol messages.
 //!
-//! Wire format: `[len: u32 BE][id: u32 BE][flags: u8][CBOR(v, t, p)]`
+//! Wire format: `[len: u32 BE][id: u32 BE][flags: u8][body]`.
+//! Control bodies are CBOR; generation-8 bulk bodies use a fixed raw header.
 //!
 //! The correlation ID and flags sit in a fixed-position binary header so that
 //! relay intermediaries can route frames without CBOR parsing.
 
 use std::io::IoSlice;
 
-use bytes::{Buf, BytesMut};
+use bytes::{Buf, Bytes, BytesMut};
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 
 use crate::{
+    bulk::{BULK_HEADER_SIZE, BulkFlow, BulkKind, BulkRecord, MAX_BULK_RECORD_PAYLOAD},
     error::{ProtocolError, ProtocolResult},
-    message::{FRAME_HEADER_SIZE, Message},
+    message::{FLAG_BULK, FRAME_HEADER_SIZE, Message},
 };
 
 //--------------------------------------------------------------------------------------------------
@@ -22,19 +24,18 @@ use crate::{
 /// Maximum allowed frame size (4 MiB).
 ///
 /// This covers everything after the 4-byte length prefix:
-/// `id (4) + flags (1) + CBOR payload`.
+/// `id (4) + flags (1) + control or raw body`.
 pub const MAX_FRAME_SIZE: u32 = 4 * 1024 * 1024;
 
 //--------------------------------------------------------------------------------------------------
 // Types
 //--------------------------------------------------------------------------------------------------
 
-/// A frame with the binary header parsed but the CBOR body left untouched.
+/// A frame with the binary header parsed but the body left untouched.
 ///
 /// Used by routers, relays, and FFI consumers that want to handle framing
-/// without paying for CBOR (de)serialization. The [`body`](Self::body) field
-/// contains the exact CBOR-encoded `Message` body bytes — `v`, `t`, `p` —
-/// the same bytes that follow the binary header on the wire.
+/// without interpreting the control or raw data body. The [`body`](Self::body)
+/// field contains the exact bytes that follow the binary header on the wire.
 #[derive(Debug, Clone)]
 pub struct RawFrame {
     /// Correlation ID. Same as [`Message::id`].
@@ -43,8 +44,18 @@ pub struct RawFrame {
     /// Frame flags. Same as [`Message::flags`].
     pub flags: u8,
 
-    /// Raw CBOR bytes of the message body (`v`, `t`, `p`). Not decoded.
+    /// Raw body bytes. `flags` determines whether these are CBOR control bytes or raw bulk bytes.
     pub body: Vec<u8>,
+}
+
+/// One fully validated control message or raw bulk record.
+#[derive(Debug, Clone)]
+pub enum DecodedFrame {
+    /// CBOR control-plane message.
+    Control(Message),
+
+    /// Generation-8 data-plane record.
+    Bulk(BulkRecord),
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -190,36 +201,71 @@ pub async fn write_raw_frame<W: AsyncWrite + Unpin>(
     Ok(())
 }
 
+/// Writes a generation-8 raw bulk record without copying its payload.
+pub async fn write_bulk_record<W: AsyncWrite + Unpin>(
+    writer: &mut W,
+    record: &BulkRecord,
+) -> ProtocolResult<()> {
+    let header = encode_bulk_header(record)?;
+    write_vectored_all(writer, &header, &record.payload).await?;
+    writer.flush().await?;
+    Ok(())
+}
+
+/// Encodes a generation-8 raw bulk record into a contiguous byte buffer.
+pub fn encode_bulk_to_buf(record: &BulkRecord, buf: &mut Vec<u8>) -> ProtocolResult<()> {
+    let header = encode_bulk_header(record)?;
+    buf.reserve(header.len() + record.payload.len());
+    buf.extend_from_slice(&header);
+    buf.extend_from_slice(&record.payload);
+    Ok(())
+}
+
+/// Decodes and validates a raw frame as a generation-8 bulk record.
+pub fn raw_frame_to_bulk(frame: RawFrame, max_payload: u32) -> ProtocolResult<BulkRecord> {
+    if frame.flags != FLAG_BULK {
+        return Err(invalid_bulk("bulk flag must be set exclusively"));
+    }
+    decode_bulk_body(frame.id, Bytes::from(frame.body), max_payload)
+}
+
+/// Decodes one complete control or generation-8 bulk frame from a cursor-based buffer.
+pub fn try_decode_frame_from_bytes(buf: &mut BytesMut) -> ProtocolResult<Option<DecodedFrame>> {
+    let Some((frame_len, total)) = complete_frame_len(buf)? else {
+        return Ok(None);
+    };
+
+    let flags = buf[8];
+    if flags & FLAG_BULK == 0 {
+        let message = decode_message_frame(&buf[..total])?;
+        buf.advance(total);
+        return Ok(Some(DecodedFrame::Control(message)));
+    }
+    if flags != FLAG_BULK {
+        return Err(invalid_bulk(
+            "bulk flag cannot be combined with control flags",
+        ));
+    }
+    if frame_len < FRAME_HEADER_SIZE + BULK_HEADER_SIZE + 1 {
+        return Err(invalid_bulk("bulk record has no payload"));
+    }
+
+    let frame = buf.split_to(total).freeze();
+    let id = u32::from_be_bytes(frame[4..8].try_into().unwrap());
+    let body = frame.slice(4 + FRAME_HEADER_SIZE..);
+    let record = decode_bulk_body(id, body, MAX_BULK_RECORD_PAYLOAD)?;
+    Ok(Some(DecodedFrame::Bulk(record)))
+}
+
 /// Decode one complete typed frame from a cursor-based buffer without front-draining it.
 pub fn try_decode_from_bytes(buf: &mut BytesMut) -> ProtocolResult<Option<Message>> {
-    if buf.len() < 4 {
-        return Ok(None);
+    match try_decode_frame_from_bytes(buf)? {
+        Some(DecodedFrame::Control(message)) => Ok(Some(message)),
+        Some(DecodedFrame::Bulk(_)) => Err(invalid_bulk(
+            "raw bulk record passed to the control-message decoder",
+        )),
+        None => Ok(None),
     }
-
-    let frame_len = u32::from_be_bytes(buf[..4].try_into().unwrap());
-    if frame_len > MAX_FRAME_SIZE {
-        return Err(ProtocolError::FrameTooLarge {
-            size: frame_len,
-            max: MAX_FRAME_SIZE,
-        });
-    }
-
-    let frame_len = frame_len as usize;
-    if frame_len < FRAME_HEADER_SIZE {
-        return Err(ProtocolError::FrameTooShort {
-            size: frame_len as u32,
-            min: FRAME_HEADER_SIZE as u32,
-        });
-    }
-
-    let total = 4 + frame_len;
-    if buf.len() < total {
-        return Ok(None);
-    }
-
-    let message = decode_message_frame(&buf[..total])?;
-    buf.advance(total);
-    Ok(Some(message))
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -344,6 +390,113 @@ pub fn decode_message_frame(frame: &[u8]) -> ProtocolResult<Message> {
     msg.id = u32::from_be_bytes([frame[4], frame[5], frame[6], frame[7]]);
     msg.flags = frame[8];
     Ok(msg)
+}
+
+/// Encodes the fixed outer and generation-8 bulk headers, leaving the payload separate.
+pub fn encode_bulk_header(
+    record: &BulkRecord,
+) -> ProtocolResult<[u8; 4 + FRAME_HEADER_SIZE + BULK_HEADER_SIZE]> {
+    let payload_len = record.payload.len();
+    if payload_len == 0 || payload_len > MAX_BULK_RECORD_PAYLOAD as usize {
+        return Err(invalid_bulk(format!(
+            "payload length {payload_len} is outside 1..={MAX_BULK_RECORD_PAYLOAD}"
+        )));
+    }
+    record
+        .offset
+        .checked_add(payload_len as u64)
+        .ok_or_else(|| invalid_bulk("record end offset overflows u64"))?;
+
+    let frame_len = FRAME_HEADER_SIZE + BULK_HEADER_SIZE + payload_len;
+    let frame_len = u32::try_from(frame_len).map_err(|_| ProtocolError::FrameTooLarge {
+        size: u32::MAX,
+        max: MAX_FRAME_SIZE,
+    })?;
+    if frame_len > MAX_FRAME_SIZE {
+        return Err(ProtocolError::FrameTooLarge {
+            size: frame_len,
+            max: MAX_FRAME_SIZE,
+        });
+    }
+
+    let mut header = [0u8; 4 + FRAME_HEADER_SIZE + BULK_HEADER_SIZE];
+    header[..4].copy_from_slice(&frame_len.to_be_bytes());
+    header[4..8].copy_from_slice(&record.id.to_be_bytes());
+    header[8] = FLAG_BULK;
+    header[9] = record.kind as u8;
+    header[10] = record.flow as u8;
+    // Bytes 11..13 are reserved and deliberately remain zero.
+    header[13..21].copy_from_slice(&record.offset.to_be_bytes());
+    Ok(header)
+}
+
+fn decode_bulk_body(id: u32, body: Bytes, max_payload: u32) -> ProtocolResult<BulkRecord> {
+    if max_payload == 0 || max_payload > MAX_BULK_RECORD_PAYLOAD {
+        return Err(invalid_bulk(format!(
+            "invalid decoder payload limit {max_payload}"
+        )));
+    }
+    if body.len() < BULK_HEADER_SIZE + 1 {
+        return Err(invalid_bulk("bulk record has no payload"));
+    }
+    if body[2] != 0 || body[3] != 0 {
+        return Err(invalid_bulk("reserved bulk header bytes must be zero"));
+    }
+
+    let kind = BulkKind::from_wire(body[0])
+        .ok_or_else(|| invalid_bulk(format!("unknown bulk kind {}", body[0])))?;
+    let flow = BulkFlow::from_wire(body[1])
+        .ok_or_else(|| invalid_bulk(format!("unknown bulk flow {}", body[1])))?;
+    let offset = u64::from_be_bytes(body[4..12].try_into().unwrap());
+    let payload = body.slice(BULK_HEADER_SIZE..);
+    if payload.len() > max_payload as usize {
+        return Err(invalid_bulk(format!(
+            "payload length {} exceeds negotiated maximum {max_payload}",
+            payload.len()
+        )));
+    }
+    offset
+        .checked_add(payload.len() as u64)
+        .ok_or_else(|| invalid_bulk("record end offset overflows u64"))?;
+
+    Ok(BulkRecord {
+        id,
+        kind,
+        flow,
+        offset,
+        payload,
+    })
+}
+
+fn complete_frame_len(buf: &BytesMut) -> ProtocolResult<Option<(usize, usize)>> {
+    if buf.len() < 4 {
+        return Ok(None);
+    }
+
+    let frame_len = u32::from_be_bytes(buf[..4].try_into().unwrap());
+    if frame_len > MAX_FRAME_SIZE {
+        return Err(ProtocolError::FrameTooLarge {
+            size: frame_len,
+            max: MAX_FRAME_SIZE,
+        });
+    }
+    if frame_len < FRAME_HEADER_SIZE as u32 {
+        return Err(ProtocolError::FrameTooShort {
+            size: frame_len,
+            min: FRAME_HEADER_SIZE as u32,
+        });
+    }
+
+    let frame_len = frame_len as usize;
+    let total = 4 + frame_len;
+    if buf.len() < total {
+        return Ok(None);
+    }
+    Ok(Some((frame_len, total)))
+}
+
+fn invalid_bulk(message: impl Into<String>) -> ProtocolError {
+    ProtocolError::InvalidBulkFrame(message.into())
 }
 
 async fn write_vectored_all<W: AsyncWrite + Unpin>(
@@ -599,6 +752,149 @@ mod tests {
         assert_eq!(decoded.id, frame.id);
         assert_eq!(decoded.flags, frame.flags);
         assert_eq!(decoded.body, frame.body);
+    }
+
+    #[test]
+    fn smallest_bulk_record_has_exact_wire_layout() {
+        let record = BulkRecord {
+            id: 0x0102_0304,
+            kind: BulkKind::Filesystem,
+            flow: BulkFlow::HostToGuest,
+            offset: 0x0102_0304_0506_0708,
+            payload: Bytes::from_static(&[0xFF]),
+        };
+        let mut encoded = Vec::new();
+        encode_bulk_to_buf(&record, &mut encoded).unwrap();
+
+        assert_eq!(
+            encoded,
+            vec![
+                0x00, 0x00, 0x00, 0x12, // frame length: 5 + 12 + 1
+                0x01, 0x02, 0x03, 0x04, // correlation ID
+                0x08, // FLAG_BULK
+                0x01, // filesystem
+                0x01, // host to guest
+                0x00, 0x00, // reserved
+                0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, // offset
+                0xFF, // opaque payload
+            ]
+        );
+    }
+
+    #[test]
+    fn largest_bulk_record_roundtrips_without_payload_copy() {
+        let record = BulkRecord {
+            id: 81,
+            kind: BulkKind::Tcp,
+            flow: BulkFlow::GuestToHost,
+            offset: 7,
+            payload: Bytes::from(vec![0xA5; MAX_BULK_RECORD_PAYLOAD as usize]),
+        };
+        let mut encoded = Vec::new();
+        encode_bulk_to_buf(&record, &mut encoded).unwrap();
+        let mut cursor = BytesMut::from(encoded.as_slice());
+
+        let Some(DecodedFrame::Bulk(decoded)) = try_decode_frame_from_bytes(&mut cursor).unwrap()
+        else {
+            panic!("expected bulk record");
+        };
+        assert_eq!(decoded, record);
+        assert!(cursor.is_empty());
+    }
+
+    #[test]
+    fn bulk_payload_is_opaque_even_when_it_looks_like_cbor() {
+        let payload = Bytes::from_static(&[0xA3, 0x61, b'v', 0x07, 0x61, b't', 0xF6]);
+        let record = BulkRecord {
+            id: 3,
+            kind: BulkKind::Filesystem,
+            flow: BulkFlow::GuestToHost,
+            offset: 0,
+            payload: payload.clone(),
+        };
+        let mut encoded = Vec::new();
+        encode_bulk_to_buf(&record, &mut encoded).unwrap();
+        let mut cursor = BytesMut::from(encoded.as_slice());
+
+        let Some(DecodedFrame::Bulk(decoded)) = try_decode_frame_from_bytes(&mut cursor).unwrap()
+        else {
+            panic!("expected bulk record");
+        };
+        assert_eq!(decoded.payload, payload);
+    }
+
+    #[test]
+    fn bulk_decoder_accepts_every_frame_fragment_boundary() {
+        let record = BulkRecord {
+            id: 34,
+            kind: BulkKind::Tcp,
+            flow: BulkFlow::HostToGuest,
+            offset: 99,
+            payload: Bytes::from(vec![0x73; 128]),
+        };
+        let mut encoded = Vec::new();
+        encode_bulk_to_buf(&record, &mut encoded).unwrap();
+
+        for split in 0..=encoded.len() {
+            let mut cursor = BytesMut::from(&encoded[..split]);
+            let first = try_decode_frame_from_bytes(&mut cursor).unwrap();
+            if split < encoded.len() {
+                assert!(first.is_none(), "decoded incomplete frame at split {split}");
+                cursor.extend_from_slice(&encoded[split..]);
+            }
+            let decoded = first
+                .or_else(|| try_decode_frame_from_bytes(&mut cursor).unwrap())
+                .unwrap();
+            assert!(matches!(decoded, DecodedFrame::Bulk(ref value) if value == &record));
+            assert!(cursor.is_empty());
+        }
+    }
+
+    #[test]
+    fn bulk_decoder_rejects_malformed_wire_shapes() {
+        let record = BulkRecord {
+            id: 5,
+            kind: BulkKind::Filesystem,
+            flow: BulkFlow::HostToGuest,
+            offset: 0,
+            payload: Bytes::from_static(b"x"),
+        };
+        let mut valid = Vec::new();
+        encode_bulk_to_buf(&record, &mut valid).unwrap();
+
+        for (index, value) in [(8, FLAG_BULK | FLAG_TERMINAL), (9, 0), (10, 3), (11, 1)] {
+            let mut malformed = valid.clone();
+            malformed[index] = value;
+            let error =
+                try_decode_frame_from_bytes(&mut BytesMut::from(malformed.as_slice())).unwrap_err();
+            assert!(matches!(error, ProtocolError::InvalidBulkFrame(_)));
+        }
+
+        let mut no_payload = valid;
+        no_payload.truncate(4 + FRAME_HEADER_SIZE + BULK_HEADER_SIZE);
+        no_payload[..4]
+            .copy_from_slice(&((FRAME_HEADER_SIZE + BULK_HEADER_SIZE) as u32).to_be_bytes());
+        let error =
+            try_decode_frame_from_bytes(&mut BytesMut::from(no_payload.as_slice())).unwrap_err();
+        assert!(matches!(error, ProtocolError::InvalidBulkFrame(_)));
+    }
+
+    #[tokio::test]
+    async fn bulk_vectored_writer_handles_one_byte_short_writes() {
+        let record = BulkRecord {
+            id: 91,
+            kind: BulkKind::Tcp,
+            flow: BulkFlow::GuestToHost,
+            offset: 42,
+            payload: Bytes::from(vec![0xCD; 257]),
+        };
+        let mut expected = Vec::new();
+        encode_bulk_to_buf(&record, &mut expected).unwrap();
+
+        let mut writer = OneByteWriter::default();
+        write_bulk_record(&mut writer, &record).await.unwrap();
+
+        assert_eq!(writer.bytes, expected);
     }
 
     #[test]

--- a/crates/protocol/lib/error.rs
+++ b/crates/protocol/lib/error.rs
@@ -42,6 +42,10 @@ pub enum ProtocolError {
         min: u32,
     },
 
+    /// A generation-8 raw bulk record violates its universal wire shape.
+    #[error("invalid bulk frame: {0}")]
+    InvalidBulkFrame(String),
+
     /// Unexpected end of stream.
     #[error("unexpected end of stream")]
     UnexpectedEof,

--- a/crates/protocol/lib/fs.rs
+++ b/crates/protocol/lib/fs.rs
@@ -2,6 +2,8 @@
 
 use serde::{Deserialize, Serialize};
 
+use crate::bulk::BulkOffer;
+
 //--------------------------------------------------------------------------------------------------
 // Constants
 //--------------------------------------------------------------------------------------------------
@@ -229,6 +231,10 @@ pub struct FsOpenOptions {
 pub struct FsRequest {
     /// The operation to perform.
     pub op: FsOp,
+
+    /// Generation-8 raw-bulk offer for streaming reads and writes.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub bulk: Option<BulkOffer>,
 }
 
 /// Metadata about a filesystem entry (wire format).

--- a/crates/protocol/lib/lib.rs
+++ b/crates/protocol/lib/lib.rs
@@ -432,6 +432,7 @@ pub const GUEST_TLS_HOST_CAS_PATH: &str = "/.msb/tls/host-cas.pem";
 //--------------------------------------------------------------------------------------------------
 
 pub mod bootstrap;
+pub mod bulk;
 pub mod codec;
 pub mod core;
 pub mod exec;

--- a/crates/protocol/lib/message.rs
+++ b/crates/protocol/lib/message.rs
@@ -9,7 +9,7 @@ use crate::error::ProtocolResult;
 //--------------------------------------------------------------------------------------------------
 
 /// Current protocol version.
-pub const PROTOCOL_VERSION: u8 = 7;
+pub const PROTOCOL_VERSION: u8 = 8;
 
 /// Frame flag: this is the last message for the given correlation ID.
 ///
@@ -27,8 +27,11 @@ pub const FLAG_SESSION_START: u8 = 0b0000_0010;
 /// drain escalation (SIGTERM → SIGKILL) if the guest doesn't exit voluntarily.
 pub const FLAG_SHUTDOWN: u8 = 0b0000_0100;
 
+/// Frame flag: the body is a generation-8 raw bulk record rather than CBOR.
+pub const FLAG_BULK: u8 = 0b0000_1000;
+
 /// Size of the frame header fields that sit between the length prefix and the
-/// CBOR payload: `[id: u32 BE][flags: u8]` = 5 bytes.
+/// control or raw body: `[id: u32 BE][flags: u8]` = 5 bytes.
 pub const FRAME_HEADER_SIZE: usize = 5;
 
 //--------------------------------------------------------------------------------------------------
@@ -137,6 +140,22 @@ pub enum MessageType {
     /// Peer reports a recoverable protocol-level error.
     #[strum(serialize = "core.error")]
     CoreError,
+
+    /// Guest accepts the raw-bulk offer on an opening operation.
+    #[strum(serialize = "core.bulk.accepted")]
+    BulkAccepted,
+
+    /// Receiver grants an absolute send limit for one bulk flow.
+    #[strum(serialize = "core.bulk.credit")]
+    BulkCredit,
+
+    /// Sender declares the exact final offset of one bulk flow.
+    #[strum(serialize = "core.bulk.finish")]
+    BulkFinish,
+
+    /// Peer asks to stop an entire bulk correlation.
+    #[strum(serialize = "core.bulk.cancel")]
+    BulkCancel,
 
     /// Host requests command execution.
     #[strum(serialize = "core.exec.request")]
@@ -329,6 +348,7 @@ impl MessageType {
             Self::CoreError => 5,
             Self::Ping | Self::Pong | Self::Touch | Self::Touched => 6,
             Self::Bootstrap => 7,
+            Self::BulkAccepted | Self::BulkCredit | Self::BulkFinish | Self::BulkCancel => 8,
             Self::TcpConnect
             | Self::TcpConnected
             | Self::TcpData
@@ -416,6 +436,10 @@ mod tests {
             (MessageType::Touch, "core.touch"),
             (MessageType::Touched, "core.touched"),
             (MessageType::CoreError, "core.error"),
+            (MessageType::BulkAccepted, "core.bulk.accepted"),
+            (MessageType::BulkCredit, "core.bulk.credit"),
+            (MessageType::BulkFinish, "core.bulk.finish"),
+            (MessageType::BulkCancel, "core.bulk.cancel"),
             (MessageType::ExecRequest, "core.exec.request"),
             (MessageType::ExecStarted, "core.exec.started"),
             (MessageType::ExecStdin, "core.exec.stdin"),
@@ -459,6 +483,10 @@ mod tests {
             MessageType::Touch,
             MessageType::Touched,
             MessageType::CoreError,
+            MessageType::BulkAccepted,
+            MessageType::BulkCredit,
+            MessageType::BulkFinish,
+            MessageType::BulkCancel,
             MessageType::ExecRequest,
             MessageType::ExecStarted,
             MessageType::ExecStdin,
@@ -529,6 +557,10 @@ mod tests {
         assert_eq!(MessageType::ClockSync.flags(), 0);
         assert_eq!(MessageType::Ping.flags(), 0);
         assert_eq!(MessageType::Touch.flags(), 0);
+        assert_eq!(MessageType::BulkAccepted.flags(), 0);
+        assert_eq!(MessageType::BulkCredit.flags(), 0);
+        assert_eq!(MessageType::BulkFinish.flags(), 0);
+        assert_eq!(MessageType::BulkCancel.flags(), 0);
         assert_eq!(MessageType::ExecStarted.flags(), 0);
         assert_eq!(MessageType::ExecStdin.flags(), 0);
         assert_eq!(MessageType::ExecStdout.flags(), 0);
@@ -593,7 +625,11 @@ mod tests {
         assert!(MessageType::Ping.is_available_at(PROTOCOL_VERSION));
         // Bootstrap is internal to generation-7 host/agent boot.
         assert!(!MessageType::Bootstrap.is_available_at(6));
-        assert!(MessageType::Bootstrap.is_available_at(PROTOCOL_VERSION));
+        assert!(MessageType::Bootstrap.is_available_at(7));
+        // Raw bulk controls are generation-8 only. A bootstrap-capable
+        // generation-7 peer must remain on the framed compatibility path.
+        assert!(!MessageType::BulkAccepted.is_available_at(7));
+        assert!(MessageType::BulkAccepted.is_available_at(8));
     }
 
     #[test]
@@ -642,6 +678,14 @@ mod tests {
         }
 
         assert_eq!(MessageType::Bootstrap.min_protocol_version(), 7);
+        for mt in [
+            MessageType::BulkAccepted,
+            MessageType::BulkCredit,
+            MessageType::BulkFinish,
+            MessageType::BulkCancel,
+        ] {
+            assert_eq!(mt.min_protocol_version(), 8, "{mt:?} should require gen 8");
+        }
 
         // Every current type must be sendable to a current peer.
         assert!(MessageType::FsRequest.min_protocol_version() <= PROTOCOL_VERSION);

--- a/crates/protocol/lib/tcp.rs
+++ b/crates/protocol/lib/tcp.rs
@@ -2,6 +2,8 @@
 
 use serde::{Deserialize, Serialize};
 
+use crate::bulk::BulkOffer;
+
 //--------------------------------------------------------------------------------------------------
 // Types
 //--------------------------------------------------------------------------------------------------
@@ -14,6 +16,10 @@ pub struct TcpConnect {
 
     /// Destination TCP port.
     pub port: u16,
+
+    /// Generation-8 bidirectional raw-bulk offer.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub bulk: Option<BulkOffer>,
 }
 
 /// Confirmation that a TCP connection was opened.
@@ -60,6 +66,7 @@ mod tests {
         let connect = TcpConnect {
             host: "127.0.0.1".to_string(),
             port: 8080,
+            bulk: None,
         };
         let mut buf = Vec::new();
         ciborium::into_writer(&connect, &mut buf).unwrap();

--- a/crates/protocol/schema/gen-8.json
+++ b/crates/protocol/schema/gen-8.json
@@ -1,0 +1,166 @@
+{
+  "bulk": {
+    "default_record_payload": 262144,
+    "default_window": 8388608,
+    "format_raw_v1": 1,
+    "header_size": 12,
+    "max_record_payload": 1048576,
+    "max_window": 33554432,
+    "min_record_payload": 16384
+  },
+  "frame": {
+    "flag_bulk": 8,
+    "flag_session_start": 2,
+    "flag_shutdown": 4,
+    "flag_terminal": 1,
+    "header_size": 5,
+    "max_frame_size": 4194304
+  },
+  "message_types": [
+    {
+      "introduced_in": 1,
+      "wire": "core.ready"
+    },
+    {
+      "introduced_in": 1,
+      "wire": "core.init.resolved"
+    },
+    {
+      "introduced_in": 1,
+      "wire": "core.init.ack"
+    },
+    {
+      "introduced_in": 1,
+      "wire": "core.shutdown"
+    },
+    {
+      "introduced_in": 1,
+      "wire": "core.relay.client.disconnected"
+    },
+    {
+      "introduced_in": 1,
+      "wire": "core.clock.sync"
+    },
+    {
+      "introduced_in": 6,
+      "wire": "core.ping"
+    },
+    {
+      "introduced_in": 6,
+      "wire": "core.pong"
+    },
+    {
+      "introduced_in": 6,
+      "wire": "core.touch"
+    },
+    {
+      "introduced_in": 6,
+      "wire": "core.touched"
+    },
+    {
+      "introduced_in": 5,
+      "wire": "core.error"
+    },
+    {
+      "introduced_in": 8,
+      "wire": "core.bulk.accepted"
+    },
+    {
+      "introduced_in": 8,
+      "wire": "core.bulk.credit"
+    },
+    {
+      "introduced_in": 8,
+      "wire": "core.bulk.finish"
+    },
+    {
+      "introduced_in": 8,
+      "wire": "core.bulk.cancel"
+    },
+    {
+      "introduced_in": 1,
+      "wire": "core.exec.request"
+    },
+    {
+      "introduced_in": 1,
+      "wire": "core.exec.started"
+    },
+    {
+      "introduced_in": 1,
+      "wire": "core.exec.stdin"
+    },
+    {
+      "introduced_in": 1,
+      "wire": "core.exec.stdin.error"
+    },
+    {
+      "introduced_in": 1,
+      "wire": "core.exec.stdout"
+    },
+    {
+      "introduced_in": 1,
+      "wire": "core.exec.stderr"
+    },
+    {
+      "introduced_in": 1,
+      "wire": "core.exec.exited"
+    },
+    {
+      "introduced_in": 1,
+      "wire": "core.exec.failed"
+    },
+    {
+      "introduced_in": 1,
+      "wire": "core.exec.resize"
+    },
+    {
+      "introduced_in": 1,
+      "wire": "core.exec.signal"
+    },
+    {
+      "introduced_in": 2,
+      "wire": "core.fs.request"
+    },
+    {
+      "introduced_in": 2,
+      "wire": "core.fs.response"
+    },
+    {
+      "introduced_in": 2,
+      "wire": "core.fs.data"
+    },
+    {
+      "introduced_in": 4,
+      "wire": "core.tcp.connect"
+    },
+    {
+      "introduced_in": 4,
+      "wire": "core.tcp.connected"
+    },
+    {
+      "introduced_in": 4,
+      "wire": "core.tcp.data"
+    },
+    {
+      "introduced_in": 4,
+      "wire": "core.tcp.eof"
+    },
+    {
+      "introduced_in": 4,
+      "wire": "core.tcp.close"
+    },
+    {
+      "introduced_in": 4,
+      "wire": "core.tcp.closed"
+    },
+    {
+      "introduced_in": 4,
+      "wire": "core.tcp.failed"
+    },
+    {
+      "introduced_in": 7,
+      "wire": "core.bootstrap"
+    }
+  ],
+  "protocol_version": 8
+}

--- a/crates/protocol/tests/schema_snapshot.rs
+++ b/crates/protocol/tests/schema_snapshot.rs
@@ -18,10 +18,14 @@
 use std::{collections::HashSet, fs};
 
 use microsandbox_protocol::{
+    bulk::{
+        BULK_FORMAT_RAW_V1, BULK_HEADER_SIZE, DEFAULT_BULK_RECORD_PAYLOAD, DEFAULT_BULK_WINDOW,
+        MAX_BULK_RECORD_PAYLOAD, MAX_BULK_WINDOW, MIN_BULK_RECORD_PAYLOAD,
+    },
     codec::MAX_FRAME_SIZE,
     message::{
-        FLAG_SESSION_START, FLAG_SHUTDOWN, FLAG_TERMINAL, FRAME_HEADER_SIZE, MessageType,
-        PROTOCOL_VERSION,
+        FLAG_BULK, FLAG_SESSION_START, FLAG_SHUTDOWN, FLAG_TERMINAL, FRAME_HEADER_SIZE,
+        MessageType, PROTOCOL_VERSION,
     },
 };
 use serde_json::{Value, json};
@@ -46,6 +50,16 @@ fn render_surface() -> String {
             "flag_terminal": FLAG_TERMINAL,
             "flag_session_start": FLAG_SESSION_START,
             "flag_shutdown": FLAG_SHUTDOWN,
+            "flag_bulk": FLAG_BULK,
+        },
+        "bulk": {
+            "format_raw_v1": BULK_FORMAT_RAW_V1,
+            "header_size": BULK_HEADER_SIZE,
+            "min_record_payload": MIN_BULK_RECORD_PAYLOAD,
+            "default_record_payload": DEFAULT_BULK_RECORD_PAYLOAD,
+            "max_record_payload": MAX_BULK_RECORD_PAYLOAD,
+            "default_window": DEFAULT_BULK_WINDOW,
+            "max_window": MAX_BULK_WINDOW,
         },
         "message_types": message_types,
     });

--- a/crates/runtime/lib/runner/relay.rs
+++ b/crates/runtime/lib/runner/relay.rs
@@ -22,7 +22,8 @@ use microsandbox_protocol::codec::{self, MAX_FRAME_SIZE};
 use microsandbox_protocol::core::{InitAck, InitResolved, RelayClientDisconnected};
 use microsandbox_protocol::exec::{ExecRequest, ExecSignal, ExecStderr, ExecStdout};
 use microsandbox_protocol::message::{
-    FLAG_SESSION_START, FLAG_SHUTDOWN, FLAG_TERMINAL, FRAME_HEADER_SIZE, Message, MessageType,
+    FLAG_BULK, FLAG_SESSION_START, FLAG_SHUTDOWN, FLAG_TERMINAL, FRAME_HEADER_SIZE, Message,
+    MessageType,
 };
 use microsandbox_protocol::{AGENT_RELAY_ID_RANGE_STEP, AGENT_RELAY_MAX_CLIENTS};
 #[cfg(unix)]
@@ -996,6 +997,14 @@ async fn ring_reader_task(
         }
 
         for frame in frames.drain(..) {
+            if !has_valid_frame_flags(frame.flags) {
+                tracing::warn!(
+                    flags = frame.flags,
+                    id = frame.id,
+                    "agent relay: dropping guest frame with invalid flag combination"
+                );
+                continue;
+            }
             let client_slot = frame.id / AGENT_RELAY_ID_RANGE_STEP;
             let client_slot = client_slot.min(AGENT_RELAY_MAX_CLIENTS - 1);
 
@@ -1005,7 +1014,9 @@ async fn ring_reader_task(
             // when a log writer is attached. The CBOR decode is only
             // done when there is a writer, so the no-capture path is
             // unchanged.
-            if let Some(writer) = log_writer.as_ref() {
+            if frame.flags != FLAG_BULK
+                && let Some(writer) = log_writer.as_ref()
+            {
                 tap_frame_into_log(&frame, writer, &session_registry);
             }
 
@@ -1137,6 +1148,15 @@ async fn client_reader_task(
                 break;
             }
         };
+
+        if !has_valid_frame_flags(frame.flags) {
+            tracing::warn!(
+                flags = frame.flags,
+                id = frame.id,
+                "agent relay: client slot={slot} sent an invalid flag combination"
+            );
+            break;
+        }
 
         // Track session starts for disconnect cleanup.
         let is_session_start = (frame.flags & FLAG_SESSION_START) != 0;
@@ -1300,6 +1320,14 @@ fn is_client_frame_allowed(id: u32, flags: u8, id_start: u32, id_end_exclusive: 
     is_shutdown_control || (id >= id_start && id < id_end_exclusive)
 }
 
+/// Validate the complete generation-8 flag byte without interpreting an opaque frame body.
+fn has_valid_frame_flags(flags: u8) -> bool {
+    matches!(
+        flags,
+        0 | FLAG_TERMINAL | FLAG_SESSION_START | FLAG_SHUTDOWN | FLAG_BULK
+    )
+}
+
 //--------------------------------------------------------------------------------------------------
 // Tests
 //--------------------------------------------------------------------------------------------------
@@ -1364,6 +1392,13 @@ mod tests {
     #[test]
     fn client_frame_validation_allows_shutdown_control_id_zero() {
         assert!(is_client_frame_allowed(0, FLAG_SHUTDOWN, 10, 20));
+    }
+
+    #[test]
+    fn raw_bulk_flag_is_exclusive() {
+        assert!(has_valid_frame_flags(FLAG_BULK));
+        assert!(!has_valid_frame_flags(FLAG_BULK | FLAG_TERMINAL));
+        assert!(!has_valid_frame_flags(0x80));
     }
 
     #[tokio::test]

--- a/packages/agent-client/rust/README.md
+++ b/packages/agent-client/rust/README.md
@@ -29,13 +29,13 @@ The high-level `microsandbox` SDK enables `uds` explicitly because local sandbox
 
 ## Protocol Model
 
-The agent protocol is a length-prefixed binary frame:
+The agent protocol uses a stable length-prefixed binary frame header:
 
 ```text
-[len: u32 BE][id: u32 BE][flags: u8][CBOR Message body]
+[len: u32 BE][id: u32 BE][flags: u8][body]
 ```
 
-The CBOR `Message` body contains:
+Ordinary control frames carry a CBOR `Message` body:
 
 ```text
 { v, t, p }
@@ -44,6 +44,8 @@ The CBOR `Message` body contains:
 - `v`: protocol generation.
 - `t`: wire message type such as `core.exec.request`.
 - `p`: CBOR-encoded payload for that message type.
+
+Generation 8 adds an opt-in raw data body for negotiated filesystem and TCP streams. `FLAG_BULK` is exclusive, and its body is `[kind: u8][flow: u8][reserved: u16 = 0][offset: u64 BE][payload]`. The relay continues to route solely on the stable header; endpoints validate kind, direction, exact offset, negotiated record size, and absolute credit.
 
 `AgentClient` owns `id` allocation from the relay-assigned range. Callers choose message types and payloads; the client computes flags, gates unsupported message types against the negotiated protocol generation, frames messages, and routes responses by correlation ID.
 
@@ -83,6 +85,7 @@ async fn example() -> Result<(), Box<dyn std::error::Error>> {
                     path: "/etc/os-release".to_string(),
                     follow_symlink: true,
                 },
+                bulk: None,
             },
         )
         .await?;
@@ -129,6 +132,8 @@ client.request(MessageType::FsRequest, &payload).await?;
 client.stream(MessageType::ExecRequest, &payload).await?;
 client.send(id, MessageType::ExecStdin, &payload).await?;
 ```
+
+Negotiated bulk streams use `stream_frames` to receive control messages and raw records on the same correlation, `send_bulk` for owned raw payloads, and `cancel_bulk` to stop the peer and release local dispatch state. These methods reject peers older than generation 8 before raw bytes are sent.
 
 Raw APIs move complete CBOR message envelope bodies while still letting the client own frame headers, ID allocation, and response routing:
 

--- a/packages/agent-client/rust/lib/client.rs
+++ b/packages/agent-client/rust/lib/client.rs
@@ -31,15 +31,17 @@ use std::sync::{Arc, atomic::AtomicU32};
 #[cfg(feature = "stream")]
 use std::time::Duration;
 
+use microsandbox_protocol::message::FLAG_BULK;
 #[cfg(feature = "stream")]
 use microsandbox_protocol::message::FLAG_TERMINAL;
-#[cfg(feature = "stream")]
-use microsandbox_protocol::{codec::MAX_FRAME_SIZE, message::FRAME_HEADER_SIZE};
 use microsandbox_protocol::{
+    bulk::{BULK_PROTOCOL_VERSION, BulkCancel, BulkRecord, MAX_BULK_RECORD_PAYLOAD},
     codec::{self, RawFrame},
     core::Ready,
     message::{Message, MessageType, PROTOCOL_VERSION},
 };
+#[cfg(feature = "stream")]
+use microsandbox_protocol::{codec::MAX_FRAME_SIZE, message::FRAME_HEADER_SIZE};
 use serde::Serialize;
 #[cfg(feature = "stream")]
 use tokio::io::{AsyncRead, AsyncWrite};
@@ -95,6 +97,16 @@ pub enum AgentProtocol {
     LegacyV1,
 }
 
+/// One decoded frame from a generation-aware streaming correlation.
+#[derive(Debug, Clone)]
+pub enum AgentFrame {
+    /// CBOR control-plane message.
+    Control(Message),
+
+    /// Generation-8 raw bulk record.
+    Bulk(BulkRecord),
+}
+
 /// Client for communicating with agentd through the agent relay.
 ///
 /// See the module-level docs for an overview of the two API tiers.
@@ -138,8 +150,14 @@ struct AgentHandshake {
 
 #[cfg_attr(not(feature = "stream"), allow(dead_code))]
 struct WriterCommand {
-    frame: RawFrame,
+    frame: WriterFrame,
     ack: oneshot::Sender<AgentClientResult<()>>,
+}
+
+#[cfg_attr(not(feature = "stream"), allow(dead_code))]
+enum WriterFrame {
+    Control(RawFrame),
+    Bulk(BulkRecord),
 }
 
 #[cfg(feature = "stream")]
@@ -352,6 +370,11 @@ impl AgentClient {
         self.write_frame(id, flags, body).await
     }
 
+    /// Remove a streaming correlation from local dispatch after its peer has been told to stop.
+    pub async fn forget_stream(&self, id: u32) {
+        self.pending.lock().await.remove(&id);
+    }
+
     /// The cached `core.ready` handshake frame body bytes (CBOR-encoded).
     ///
     /// Useful for bindings that want to deserialize the ready payload with
@@ -449,6 +472,22 @@ impl AgentClient {
         Ok((id, rx))
     }
 
+    /// Opens a streaming typed session that can receive both control messages and raw bulk data.
+    pub async fn stream_frames<T: Serialize>(
+        &self,
+        t: MessageType,
+        payload: &T,
+    ) -> AgentClientResult<(u32, mpsc::Receiver<AgentFrame>)> {
+        self.ensure_version_compat(t)?;
+        let flags = t.flags();
+        let body = encode_message_body(self.protocol.version(), t, payload)?;
+        let (id, raw_rx) = self.stream_raw(flags, body).await?;
+
+        let (tx, rx) = mpsc::channel(STREAM_QUEUE_CAPACITY);
+        tokio::spawn(decode_frame_stream_task(raw_rx, tx));
+        Ok((id, rx))
+    }
+
     /// Send a follow-up typed message on an existing correlation id.
     pub async fn send<T: Serialize>(
         &self,
@@ -460,6 +499,34 @@ impl AgentClient {
         let flags = t.flags();
         let body = encode_message_body(self.protocol.version(), t, payload)?;
         self.write_frame_owned(id, flags, body).await
+    }
+
+    /// Sends one generation-8 raw bulk record on an existing correlation.
+    pub async fn send_bulk(&self, record: BulkRecord) -> AgentClientResult<()> {
+        if self.negotiated_version < BULK_PROTOCOL_VERSION {
+            return Err(AgentClientError::UnsupportedOperation {
+                msg_type: "raw bulk record",
+                needs: BULK_PROTOCOL_VERSION,
+                peer: self.negotiated_version,
+            });
+        }
+
+        let (ack, written) = oneshot::channel();
+        self.writer
+            .send(WriterCommand {
+                frame: WriterFrame::Bulk(record),
+                ack,
+            })
+            .await
+            .map_err(|_| AgentClientError::Closed)?;
+        written.await.map_err(|_| AgentClientError::Closed)?
+    }
+
+    /// Cancel an entire raw-bulk correlation and release its local dispatch slot.
+    pub async fn cancel_bulk(&self, id: u32, cancel: &BulkCancel) -> AgentClientResult<()> {
+        let result = self.send(id, MessageType::BulkCancel, cancel).await;
+        self.forget_stream(id).await;
+        result
     }
 
     /// Decode the cached handshake `core.ready` payload.
@@ -510,7 +577,7 @@ impl AgentClient {
         let (ack, written) = oneshot::channel();
         self.writer
             .send(WriterCommand {
-                frame: RawFrame { id, flags, body },
+                frame: WriterFrame::Control(RawFrame { id, flags, body }),
                 ack,
             })
             .await
@@ -760,7 +827,11 @@ where
     W: tokio::io::AsyncWrite + Unpin,
 {
     while let Some(command) = rx.recv().await {
-        if let Err(e) = codec::write_raw_frame(&mut writer, &command.frame).await {
+        let result = match &command.frame {
+            WriterFrame::Control(frame) => codec::write_raw_frame(&mut writer, frame).await,
+            WriterFrame::Bulk(record) => codec::write_bulk_record(&mut writer, record).await,
+        };
+        if let Err(e) = result {
             tracing::debug!("agent client: stream writer error: {e}");
             let _ = command.ack.send(Err(AgentClientError::Protocol(e)));
             break;
@@ -821,6 +892,10 @@ async fn dispatch_frame(
 /// Translate a stream of raw frames into typed messages.
 async fn decode_stream_task(mut raw_rx: mpsc::Receiver<RawFrame>, tx: mpsc::Sender<Message>) {
     while let Some(frame) = raw_rx.recv().await {
+        if frame.flags & FLAG_BULK != 0 {
+            tracing::warn!("agent client: raw bulk record reached a control-only stream");
+            break;
+        }
         match codec::raw_frame_to_message(frame) {
             Ok(msg) => {
                 if tx.send(msg).await.is_err() {
@@ -830,6 +905,32 @@ async fn decode_stream_task(mut raw_rx: mpsc::Receiver<RawFrame>, tx: mpsc::Send
             Err(e) => {
                 tracing::warn!("agent client: failed to decode frame in stream: {e}");
                 // Continue — single malformed frame shouldn't kill the stream.
+            }
+        }
+    }
+}
+
+/// Translates raw relay frames into generation-aware control or bulk items.
+async fn decode_frame_stream_task(
+    mut raw_rx: mpsc::Receiver<RawFrame>,
+    tx: mpsc::Sender<AgentFrame>,
+) {
+    while let Some(frame) = raw_rx.recv().await {
+        let decoded = if frame.flags & FLAG_BULK != 0 {
+            codec::raw_frame_to_bulk(frame, MAX_BULK_RECORD_PAYLOAD).map(AgentFrame::Bulk)
+        } else {
+            codec::raw_frame_to_message(frame).map(AgentFrame::Control)
+        };
+
+        match decoded {
+            Ok(frame) => {
+                if tx.send(frame).await.is_err() {
+                    break;
+                }
+            }
+            Err(error) => {
+                tracing::warn!("agent client: failed to decode frame in bulk stream: {error}");
+                break;
             }
         }
     }
@@ -846,6 +947,17 @@ fn encode_message_body<T: Serialize>(
     let mut body = Vec::new();
     ciborium::into_writer(&msg, &mut body).map_err(microsandbox_protocol::ProtocolError::from)?;
     Ok(body)
+}
+
+//--------------------------------------------------------------------------------------------------
+// Trait Implementations
+//--------------------------------------------------------------------------------------------------
+
+impl Drop for AgentClient {
+    fn drop(&mut self) {
+        self.reader_handle.abort();
+        self.writer_handle.abort();
+    }
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -1059,10 +1171,11 @@ mod tests {
 
     #[test]
     fn version_compat_across_generations() {
-        use MessageType::{ExecRequest, FsRequest};
+        use MessageType::{BulkAccepted, ExecRequest, FsRequest};
         // (message type, peer generation, expected allowed). Generation 1 is the
         // pre-0.5 legacy runtime (no filesystem); generation 2 introduced the
-        // Fs* types; generation 6 is current.
+        // Fs* types; generation 7 added bootstrap without raw bulk; generation 8
+        // introduced the raw-bulk control messages.
         let cases = [
             (ExecRequest, 1, true),
             (ExecRequest, 2, true),
@@ -1070,6 +1183,8 @@ mod tests {
             (FsRequest, 1, false),
             (FsRequest, 2, true),
             (FsRequest, 3, true),
+            (BulkAccepted, 7, false),
+            (BulkAccepted, 8, true),
         ];
         for (t, generation, allowed) in cases {
             assert_eq!(
@@ -1255,15 +1370,138 @@ mod tests {
         let exit: ExecExited = second.payload().unwrap();
         assert_eq!(exit.code, 0);
     }
-}
 
-//--------------------------------------------------------------------------------------------------
-// Trait Implementations
-//--------------------------------------------------------------------------------------------------
+    #[cfg(feature = "stream")]
+    #[tokio::test]
+    async fn connect_stream_carries_bidirectional_raw_bulk_records() {
+        use microsandbox_protocol::bulk::{
+            BULK_FLOW_MASK_GUEST_TO_HOST, BULK_FLOW_MASK_HOST_TO_GUEST, BulkAccepted, BulkFinish,
+            BulkFlow, BulkKind, BulkOffer, DEFAULT_BULK_RECORD_PAYLOAD, DEFAULT_BULK_WINDOW,
+        };
+        use microsandbox_protocol::tcp::{TcpClosed, TcpConnect, TcpConnected};
+        use tokio::io::AsyncWriteExt;
 
-impl Drop for AgentClient {
-    fn drop(&mut self) {
-        self.reader_handle.abort();
-        self.writer_handle.abort();
+        let (client_io, mut server_io) = tokio::io::duplex(1024 * 1024);
+        let ready = Ready {
+            agent_version: "bulk-stream-test".to_string(),
+            ..Default::default()
+        };
+        let ready_msg = Message::with_payload(MessageType::Ready, 0, &ready).unwrap();
+
+        let server = tokio::spawn(async move {
+            server_io.write_all(&1u32.to_be_bytes()).await.unwrap();
+            server_io.write_all(&1024u32.to_be_bytes()).await.unwrap();
+            codec::write_message(&mut server_io, &ready_msg)
+                .await
+                .unwrap();
+
+            let opening = codec::read_raw_frame(&mut server_io).await.unwrap();
+            let opening_id = opening.id;
+            let opening = codec::raw_frame_to_message(opening).unwrap();
+            assert_eq!(opening.t, MessageType::TcpConnect);
+            let connected =
+                Message::with_payload(MessageType::TcpConnected, opening_id, &TcpConnected {})
+                    .unwrap();
+            codec::write_message(&mut server_io, &connected)
+                .await
+                .unwrap();
+            let accepted = Message::with_payload(
+                MessageType::BulkAccepted,
+                opening_id,
+                &BulkAccepted {
+                    kind: BulkKind::Tcp,
+                    flows: BULK_FLOW_MASK_HOST_TO_GUEST | BULK_FLOW_MASK_GUEST_TO_HOST,
+                    format: 1,
+                    max_record_payload: DEFAULT_BULK_RECORD_PAYLOAD,
+                    host_to_guest_credit_limit: DEFAULT_BULK_WINDOW,
+                    guest_to_host_credit_limit: DEFAULT_BULK_WINDOW,
+                },
+            )
+            .unwrap();
+            codec::write_message(&mut server_io, &accepted)
+                .await
+                .unwrap();
+
+            let inbound = codec::read_raw_frame(&mut server_io).await.unwrap();
+            let inbound = codec::raw_frame_to_bulk(inbound, DEFAULT_BULK_RECORD_PAYLOAD).unwrap();
+            assert_eq!(inbound.id, opening_id);
+            assert_eq!(inbound.flow, BulkFlow::HostToGuest);
+            assert_eq!(inbound.payload.as_ref(), b"host-to-guest");
+
+            codec::write_bulk_record(
+                &mut server_io,
+                &BulkRecord {
+                    id: opening_id,
+                    kind: BulkKind::Tcp,
+                    flow: BulkFlow::GuestToHost,
+                    offset: 0,
+                    payload: b"guest-to-host".as_slice().into(),
+                },
+            )
+            .await
+            .unwrap();
+            let finish = Message::with_payload(
+                MessageType::BulkFinish,
+                opening_id,
+                &BulkFinish {
+                    kind: BulkKind::Tcp,
+                    flow: BulkFlow::GuestToHost,
+                    final_offset: 13,
+                },
+            )
+            .unwrap();
+            codec::write_message(&mut server_io, &finish).await.unwrap();
+            let closed =
+                Message::with_payload(MessageType::TcpClosed, opening_id, &TcpClosed {}).unwrap();
+            codec::write_message(&mut server_io, &closed).await.unwrap();
+        });
+
+        let client = AgentClient::connect_stream_with_deadline(
+            client_io,
+            Instant::now() + Duration::from_secs(1),
+        )
+        .await
+        .unwrap();
+        let offer = BulkOffer::tcp();
+        let (id, mut rx) = client
+            .stream_frames(
+                MessageType::TcpConnect,
+                &TcpConnect {
+                    host: "example.test".into(),
+                    port: 80,
+                    bulk: Some(offer),
+                },
+            )
+            .await
+            .unwrap();
+        assert!(
+            matches!(rx.recv().await, Some(AgentFrame::Control(message)) if message.t == MessageType::TcpConnected)
+        );
+        assert!(
+            matches!(rx.recv().await, Some(AgentFrame::Control(message)) if message.t == MessageType::BulkAccepted)
+        );
+
+        client
+            .send_bulk(BulkRecord {
+                id,
+                kind: BulkKind::Tcp,
+                flow: BulkFlow::HostToGuest,
+                offset: 0,
+                payload: b"host-to-guest".as_slice().into(),
+            })
+            .await
+            .unwrap();
+        let Some(AgentFrame::Bulk(record)) = rx.recv().await else {
+            panic!("expected raw bulk record");
+        };
+        assert_eq!(record.payload.as_ref(), b"guest-to-host");
+        assert!(
+            matches!(rx.recv().await, Some(AgentFrame::Control(message)) if message.t == MessageType::BulkFinish)
+        );
+        assert!(
+            matches!(rx.recv().await, Some(AgentFrame::Control(message)) if message.t == MessageType::TcpClosed)
+        );
+
+        server.await.unwrap();
     }
 }

--- a/packages/agent-client/rust/lib/client.rs
+++ b/packages/agent-client/rust/lib/client.rs
@@ -115,7 +115,7 @@ pub struct AgentClient {
     writer: mpsc::Sender<WriterCommand>,
     /// Next correlation ID to allocate (starts at `id_min`).
     next_id: AtomicU32,
-    /// Lower bound (inclusive) of the assigned ID range, used for wrap-around.
+    /// Lower bound (inclusive) of the assigned ID range.
     id_min: u32,
     /// Upper bound (exclusive) of the assigned ID range.
     id_max: u32,
@@ -127,7 +127,7 @@ pub struct AgentClient {
     /// which selects the wire codec; see `VERSIONING.md`.
     negotiated_version: u8,
     /// Pending response channels keyed by correlation ID.
-    pending: Arc<Mutex<HashMap<u32, mpsc::Sender<RawFrame>>>>,
+    pending: Arc<Mutex<HashMap<u32, CorrelationRoute>>>,
     /// Background reader task handle.
     reader_handle: JoinHandle<()>,
     /// Background writer task handle.
@@ -158,6 +158,18 @@ struct WriterCommand {
 enum WriterFrame {
     Control(RawFrame),
     Bulk(BulkRecord),
+}
+
+/// Local dispatch state retained through the terminal result of a cancellation.
+struct CorrelationRoute {
+    tx: mpsc::Sender<RawFrame>,
+    state: CorrelationState,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum CorrelationState {
+    Active,
+    Cancelling,
 }
 
 #[cfg(feature = "stream")]
@@ -283,7 +295,7 @@ impl AgentClient {
             );
         }
 
-        let pending: Arc<Mutex<HashMap<u32, mpsc::Sender<RawFrame>>>> =
+        let pending: Arc<Mutex<HashMap<u32, CorrelationRoute>>> =
             Arc::new(Mutex::new(HashMap::new()));
 
         let (writer_tx, writer_rx) = mpsc::channel(WRITER_QUEUE_CAPACITY);
@@ -522,11 +534,12 @@ impl AgentClient {
         written.await.map_err(|_| AgentClientError::Closed)?
     }
 
-    /// Cancel an entire raw-bulk correlation and release its local dispatch slot.
+    /// Cancel an entire raw-bulk correlation and retain its route through terminal cleanup.
     pub async fn cancel_bulk(&self, id: u32, cancel: &BulkCancel) -> AgentClientResult<()> {
-        let result = self.send(id, MessageType::BulkCancel, cancel).await;
-        self.forget_stream(id).await;
-        result
+        if let Some(route) = self.pending.lock().await.get_mut(&id) {
+            route.state = CorrelationState::Cancelling;
+        }
+        self.send(id, MessageType::BulkCancel, cancel).await
     }
 
     /// Decode the cached handshake `core.ready` payload.
@@ -542,29 +555,33 @@ impl AgentClient {
 impl AgentClient {
     /// Reserve a unique correlation ID from the relay-assigned range.
     ///
-    /// Wraps around within the assigned range and skips IDs that still have an
-    /// active pending request or stream.
+    /// IDs are single-use for this connection. Exhaustion requires reconnecting for a fresh range
+    /// incarnation; wrap-around could relabel late raw records as a new operation.
     async fn reserve_id(&self, tx: mpsc::Sender<RawFrame>) -> AgentClientResult<u32> {
-        let mut pending = self.pending.lock().await;
-        let attempts = usable_id_count(self.id_min, self.id_max);
-        for _ in 0..attempts {
-            let id = self
-                .next_id
-                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-            if self.next_id.load(std::sync::atomic::Ordering::Relaxed) >= self.id_max {
-                self.next_id.store(
-                    first_request_id(self.id_min),
-                    std::sync::atomic::Ordering::Relaxed,
-                );
-            }
-            if id == 0 || id < self.id_min || id >= self.id_max || pending.contains_key(&id) {
-                continue;
-            }
-            pending.insert(id, tx);
-            return Ok(id);
+        let id = self
+            .next_id
+            .fetch_update(
+                std::sync::atomic::Ordering::Relaxed,
+                std::sync::atomic::Ordering::Relaxed,
+                |next| (next < self.id_max).then_some(next.saturating_add(1)),
+            )
+            .map_err(|_| AgentClientError::IdRangeExhausted)?;
+        if id == 0 || id < self.id_min {
+            return Err(AgentClientError::IdRangeExhausted);
         }
 
-        Err(AgentClientError::IdRangeExhausted)
+        let replaced = self.pending.lock().await.insert(
+            id,
+            CorrelationRoute {
+                tx,
+                state: CorrelationState::Active,
+            },
+        );
+        debug_assert!(
+            replaced.is_none(),
+            "single-use correlation was already routed"
+        );
+        Ok(id)
     }
 
     /// Write a single framed message to the socket.
@@ -843,7 +860,7 @@ where
 /// Background task that reads frames from the relay and dispatches them to
 /// pending channels by correlation ID. Operates on raw frames — no CBOR.
 #[cfg(feature = "stream")]
-async fn reader_loop<R>(mut reader: R, pending: Arc<Mutex<HashMap<u32, mpsc::Sender<RawFrame>>>>)
+async fn reader_loop<R>(mut reader: R, pending: Arc<Mutex<HashMap<u32, CorrelationRoute>>>)
 where
     R: tokio::io::AsyncRead + Unpin,
 {
@@ -865,19 +882,20 @@ where
 }
 
 #[cfg(feature = "stream")]
-async fn dispatch_frame(
-    frame: RawFrame,
-    pending: &Arc<Mutex<HashMap<u32, mpsc::Sender<RawFrame>>>>,
-) {
+async fn dispatch_frame(frame: RawFrame, pending: &Arc<Mutex<HashMap<u32, CorrelationRoute>>>) {
     let id = frame.id;
     let is_terminal = (frame.flags & FLAG_TERMINAL) != 0;
 
     let tx = {
         let mut map = pending.lock().await;
-        let Some(tx) = map.get(&id).cloned() else {
+        let Some(route) = map.get(&id) else {
             tracing::trace!("agent client: no pending handler for id={id}");
             return;
         };
+        if route.state == CorrelationState::Cancelling && frame.flags == FLAG_BULK {
+            return;
+        }
+        let tx = route.tx.clone();
         if is_terminal {
             map.remove(&id);
         }
@@ -1373,6 +1391,41 @@ mod tests {
 
     #[cfg(feature = "stream")]
     #[tokio::test]
+    async fn correlation_ids_are_single_use_until_reconnect() {
+        use microsandbox_protocol::core::{Ping, Pong};
+        use tokio::io::AsyncWriteExt;
+
+        let (client_io, mut server_io) = tokio::io::duplex(64 * 1024);
+        let ready_msg = Message::with_payload(MessageType::Ready, 0, &Ready::default()).unwrap();
+        let server = tokio::spawn(async move {
+            server_io.write_all(&1u32.to_be_bytes()).await.unwrap();
+            server_io.write_all(&3u32.to_be_bytes()).await.unwrap();
+            codec::write_message(&mut server_io, &ready_msg)
+                .await
+                .unwrap();
+            for expected_id in 1..3 {
+                let request = codec::read_raw_frame(&mut server_io).await.unwrap();
+                assert_eq!(request.id, expected_id);
+                let response =
+                    Message::with_payload(MessageType::Pong, request.id, &Pong {}).unwrap();
+                codec::write_message(&mut server_io, &response)
+                    .await
+                    .unwrap();
+            }
+        });
+
+        let client = AgentClient::connect_stream(client_io).await.unwrap();
+        client.request(MessageType::Ping, &Ping {}).await.unwrap();
+        client.request(MessageType::Ping, &Ping {}).await.unwrap();
+        assert!(matches!(
+            client.request(MessageType::Ping, &Ping {}).await,
+            Err(AgentClientError::IdRangeExhausted)
+        ));
+        server.await.unwrap();
+    }
+
+    #[cfg(feature = "stream")]
+    #[tokio::test]
     async fn connect_stream_carries_bidirectional_raw_bulk_records() {
         use microsandbox_protocol::bulk::{
             BULK_FLOW_MASK_GUEST_TO_HOST, BULK_FLOW_MASK_HOST_TO_GUEST, BulkAccepted, BulkFinish,
@@ -1502,6 +1555,115 @@ mod tests {
             matches!(rx.recv().await, Some(AgentFrame::Control(message)) if message.t == MessageType::TcpClosed)
         );
 
+        server.await.unwrap();
+    }
+
+    #[cfg(feature = "stream")]
+    #[tokio::test]
+    async fn bulk_cancel_discards_late_raw_but_retains_terminal_route() {
+        use microsandbox_protocol::bulk::{
+            BULK_FLOW_MASK_GUEST_TO_HOST, BulkAccepted, BulkCancelReason, BulkFlow, BulkKind,
+            BulkOffer, DEFAULT_BULK_RECORD_PAYLOAD, DEFAULT_BULK_WINDOW,
+        };
+        use microsandbox_protocol::tcp::{TcpClosed, TcpConnect, TcpConnected};
+        use tokio::io::AsyncWriteExt;
+
+        let (client_io, mut server_io) = tokio::io::duplex(1024 * 1024);
+        let (late_sent, late_observed) = tokio::sync::oneshot::channel();
+        let (send_terminal, terminal_allowed) = tokio::sync::oneshot::channel();
+        let ready_msg = Message::with_payload(MessageType::Ready, 0, &Ready::default()).unwrap();
+        let server = tokio::spawn(async move {
+            server_io.write_all(&1u32.to_be_bytes()).await.unwrap();
+            server_io.write_all(&1024u32.to_be_bytes()).await.unwrap();
+            codec::write_message(&mut server_io, &ready_msg)
+                .await
+                .unwrap();
+
+            let opening = codec::read_raw_frame(&mut server_io).await.unwrap();
+            let id = opening.id;
+            let connected =
+                Message::with_payload(MessageType::TcpConnected, id, &TcpConnected {}).unwrap();
+            codec::write_message(&mut server_io, &connected)
+                .await
+                .unwrap();
+            let accepted = Message::with_payload(
+                MessageType::BulkAccepted,
+                id,
+                &BulkAccepted {
+                    kind: BulkKind::Tcp,
+                    flows: BULK_FLOW_MASK_GUEST_TO_HOST,
+                    format: 1,
+                    max_record_payload: DEFAULT_BULK_RECORD_PAYLOAD,
+                    host_to_guest_credit_limit: 0,
+                    guest_to_host_credit_limit: DEFAULT_BULK_WINDOW,
+                },
+            )
+            .unwrap();
+            codec::write_message(&mut server_io, &accepted)
+                .await
+                .unwrap();
+
+            let cancel = codec::read_raw_frame(&mut server_io).await.unwrap();
+            assert_eq!(cancel.id, id);
+            assert_eq!(
+                codec::raw_frame_to_message(cancel).unwrap().t,
+                MessageType::BulkCancel
+            );
+            codec::write_bulk_record(
+                &mut server_io,
+                &BulkRecord {
+                    id,
+                    kind: BulkKind::Tcp,
+                    flow: BulkFlow::GuestToHost,
+                    offset: 0,
+                    payload: b"late".as_slice().into(),
+                },
+            )
+            .await
+            .unwrap();
+            let _ = late_sent.send(());
+            let _ = terminal_allowed.await;
+            let closed = Message::with_payload(MessageType::TcpClosed, id, &TcpClosed {}).unwrap();
+            codec::write_message(&mut server_io, &closed).await.unwrap();
+        });
+
+        let client = AgentClient::connect_stream(client_io).await.unwrap();
+        let (id, mut frames) = client
+            .stream_frames(
+                MessageType::TcpConnect,
+                &TcpConnect {
+                    host: "example.test".into(),
+                    port: 80,
+                    bulk: Some(BulkOffer::tcp()),
+                },
+            )
+            .await
+            .unwrap();
+        assert!(
+            matches!(frames.recv().await, Some(AgentFrame::Control(message)) if message.t == MessageType::TcpConnected)
+        );
+        assert!(
+            matches!(frames.recv().await, Some(AgentFrame::Control(message)) if message.t == MessageType::BulkAccepted)
+        );
+
+        client
+            .cancel_bulk(
+                id,
+                &BulkCancel {
+                    kind: BulkKind::Tcp,
+                    reason: BulkCancelReason::CallerCancelled,
+                    message: "test cancellation".into(),
+                },
+            )
+            .await
+            .unwrap();
+        late_observed.await.unwrap();
+        assert!(client.pending.lock().await.contains_key(&id));
+        let _ = send_terminal.send(());
+        assert!(
+            matches!(frames.recv().await, Some(AgentFrame::Control(message)) if message.t == MessageType::TcpClosed)
+        );
+        assert!(!client.pending.lock().await.contains_key(&id));
         server.await.unwrap();
     }
 }

--- a/packages/agent-client/rust/lib/lib.rs
+++ b/packages/agent-client/rust/lib/lib.rs
@@ -32,7 +32,7 @@ pub mod transports {
 // Re-Exports
 //--------------------------------------------------------------------------------------------------
 
-pub use client::{AgentClient, AgentProtocol};
+pub use client::{AgentClient, AgentFrame, AgentProtocol};
 pub use error::{AgentClientError, AgentClientResult};
 pub use message::{EncodedMessage, IntoOutboundMessage, OutboundMessage, TypedMessage};
 pub use stream::AgentStream;

--- a/packages/agent-client/typescript/src/client.ts
+++ b/packages/agent-client/typescript/src/client.ts
@@ -250,19 +250,12 @@ export class AgentClient {
   }
 
   private reserveId(queue: Pending): number {
-    const attempts = usableIdCount(this.idMin, this.idMax);
-    for (let i = 0; i < attempts; i += 1) {
+    // Correlation IDs are single-use for one relay range ownership period. Wrapping could let a
+    // delayed raw record from an old operation enter a new operation with the same numeric ID.
+    if (this.nextId < this.idMax) {
       const id = this.nextId;
       this.nextId += 1;
-      if (this.nextId >= this.idMax) this.nextId = Math.max(1, this.idMin);
-      if (
-        id !== 0 &&
-        id >= this.idMin &&
-        id < this.idMax &&
-        !this.pending.has(id)
-      ) {
-        return id;
-      }
+      return id;
     }
     queue.close(new Error("agent correlation id range exhausted"));
     throw new Error("agent correlation id range exhausted");

--- a/packages/agent-client/typescript/tests/client.test.ts
+++ b/packages/agent-client/typescript/tests/client.test.ts
@@ -63,6 +63,30 @@ describe("AgentClient over a Unix socket relay", () => {
     await client.close();
   });
 
+  it("does not reuse a correlation id after its request completes", async () => {
+    const relay = await startRelay(async (socket) => {
+      await writeHandshake(socket, 1, 3);
+      for (const expectedId of [1, 2]) {
+        const request = await readFrame(socket);
+        expect(request.id).toBe(expectedId);
+        await writeFrame(socket, {
+          id: request.id,
+          flags: FLAG_TERMINAL,
+          body: encodeEnvelope("core.fs.response", { ok: true }),
+        });
+      }
+    });
+
+    const client = await connectUnix(relay.path);
+    const request = typedMessage("core.fs.request", { op: { ping: true } });
+    await expect(client.request(request)).resolves.toBeDefined();
+    await expect(client.request(request)).resolves.toBeDefined();
+    await expect(client.request(request)).rejects.toThrow(
+      "correlation id range exhausted",
+    );
+    await client.close();
+  });
+
   it("routes stream frames and allows follow-up sends", async () => {
     const relay = await startRelay(async (socket) => {
       await writeHandshake(socket, 10, 1024);

--- a/sdk/rust/lib/sandbox/fs.rs
+++ b/sdk/rust/lib/sandbox/fs.rs
@@ -10,11 +10,16 @@
 use std::{path::Path, sync::Arc};
 
 use bytes::Bytes;
+use microsandbox_agent_client::AgentFrame;
 use microsandbox_protocol::{
-    fs::{FsData, FsEntryInfo, FsResponse},
+    bulk::{
+        BulkAccepted, BulkCancel, BulkCancelReason, BulkCredit, BulkFinish, BulkFlow, BulkKind,
+        BulkOffer, BulkReceiveState, BulkRecord, BulkSendState,
+    },
+    fs::{FS_CHUNK_SIZE, FsData, FsEntryInfo, FsResponse},
     message::{Message, MessageType},
 };
-use tokio::sync::mpsc;
+use tokio::sync::{Mutex, mpsc};
 
 use crate::{
     MicrosandboxError, MicrosandboxResult,
@@ -120,7 +125,8 @@ pub struct FsMetadata {
 
 /// A streaming reader for file data from the sandbox.
 pub struct FsReadStream {
-    rx: mpsc::Receiver<Message>,
+    id: u32,
+    rx: mpsc::Receiver<AgentFrame>,
     // Holds the per-call agent client alive for the duration of the stream.
     // Without this the AgentClient's reader task would be dropped after
     // `fs_read_stream` returns and `rx` would receive nothing.
@@ -128,14 +134,28 @@ pub struct FsReadStream {
     close_handle: Option<FsHandle>,
     /// Set only after a terminal `FsResponse`; channel closure alone is an error.
     finished: bool,
+    bulk: Option<BulkReceiveState>,
+    bulk_finish_seen: bool,
 }
 
 /// A streaming writer for file data to the sandbox.
 pub struct FsWriteSink {
     id: u32,
     client: Arc<AgentClient>,
-    rx: mpsc::Receiver<Message>,
+    protocol: Mutex<Option<FsWriteProtocol>>,
     close_handle: Option<FsHandle>,
+    finished: bool,
+    bulk_active: bool,
+}
+
+enum FsWriteProtocol {
+    Legacy {
+        rx: mpsc::Receiver<AgentFrame>,
+    },
+    Bulk {
+        rx: mpsc::Receiver<AgentFrame>,
+        sender: BulkSendState,
+    },
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -530,15 +550,20 @@ impl<'a> SandboxFsOps<'a> {
 impl FsReadStream {
     /// Construct a read stream that closes an owned handle at EOF.
     pub(crate) fn with_client_and_close(
-        rx: mpsc::Receiver<Message>,
+        id: u32,
+        rx: mpsc::Receiver<AgentFrame>,
         client: Arc<AgentClient>,
         close_handle: Option<FsHandle>,
+        bulk: Option<BulkReceiveState>,
     ) -> Self {
         Self {
+            id,
             rx,
             client: Some(client),
             close_handle,
             finished: false,
+            bulk,
+            bulk_finish_seen: false,
         }
     }
 
@@ -551,27 +576,89 @@ impl FsReadStream {
             return Ok(None);
         }
 
-        while let Some(msg) = self.rx.recv().await {
-            match msg.t {
-                MessageType::FsData => {
-                    let chunk: FsData = msg.payload()?;
-                    if !chunk.data.is_empty() {
-                        return Ok(Some(Bytes::from(chunk.data)));
+        while let Some(frame) = self.rx.recv().await {
+            match frame {
+                AgentFrame::Bulk(record) => {
+                    let Some(receiver) = self.bulk.as_mut() else {
+                        return self
+                            .fail("raw bulk data arrived without filesystem negotiation")
+                            .await;
+                    };
+                    let end = receiver.accept_record(&record).map_err(|error| {
+                        MicrosandboxError::SandboxFsOps(format!(
+                            "invalid filesystem bulk record: {error}"
+                        ))
+                    })?;
+                    let payload = record.payload;
+                    if let Some(credit) = receiver.consume(end).map_err(|error| {
+                        MicrosandboxError::SandboxFsOps(format!(
+                            "advance filesystem bulk credit: {error}"
+                        ))
+                    })? {
+                        let client = self.client.as_ref().ok_or_else(|| {
+                            MicrosandboxError::SandboxFsOps(
+                                "filesystem stream client closed".into(),
+                            )
+                        })?;
+                        client
+                            .send(self.id, MessageType::BulkCredit, &credit)
+                            .await?;
                     }
+                    return Ok(Some(payload));
                 }
-                MessageType::FsResponse => {
-                    let resp: FsResponse = msg.payload()?;
-                    let close_result = self.close_owned_handle().await;
-                    self.finished = true;
-                    if !resp.ok {
-                        return Err(MicrosandboxError::SandboxFsOps(
-                            resp.error.unwrap_or_else(|| "unknown error".into()),
-                        ));
+                AgentFrame::Control(msg) => match msg.t {
+                    MessageType::FsData => {
+                        if self.bulk.is_some() {
+                            return self
+                                .fail("CBOR filesystem data arrived after raw bulk acceptance")
+                                .await;
+                        }
+                        let chunk: FsData = msg.payload()?;
+                        if !chunk.data.is_empty() {
+                            return Ok(Some(Bytes::from(chunk.data)));
+                        }
                     }
-                    close_result?;
-                    return Ok(None);
-                }
-                _ => {}
+                    MessageType::BulkFinish => {
+                        let finish: BulkFinish = msg.payload()?;
+                        let Some(receiver) = self.bulk.as_mut() else {
+                            return self.fail("bulk finish arrived without negotiation").await;
+                        };
+                        receiver.accept_finish(finish).map_err(|error| {
+                            MicrosandboxError::SandboxFsOps(format!(
+                                "invalid filesystem bulk finish: {error}"
+                            ))
+                        })?;
+                        self.bulk_finish_seen = true;
+                    }
+                    MessageType::BulkCancel => {
+                        let cancel: BulkCancel = msg.payload()?;
+                        return self
+                            .fail(&format!(
+                                "filesystem bulk transfer cancelled: {}",
+                                cancel.message
+                            ))
+                            .await;
+                    }
+                    MessageType::FsResponse => {
+                        let resp: FsResponse = msg.payload()?;
+                        let close_result = self.close_owned_handle().await;
+                        self.finished = true;
+                        if !resp.ok {
+                            return Err(MicrosandboxError::SandboxFsOps(
+                                resp.error.unwrap_or_else(|| "unknown error".into()),
+                            ));
+                        }
+                        if self.bulk.is_some() && !self.bulk_finish_seen {
+                            return Err(MicrosandboxError::SandboxFsOps(
+                                "filesystem bulk read completed without an exact finish marker"
+                                    .into(),
+                            ));
+                        }
+                        close_result?;
+                        return Ok(None);
+                    }
+                    _ => {}
+                },
             }
         }
         self.close_owned_handle().await?;
@@ -595,6 +682,12 @@ impl FsReadStream {
         }
         Ok(())
     }
+
+    async fn fail(&mut self, message: &str) -> MicrosandboxResult<Option<Bytes>> {
+        let _ = self.close_owned_handle().await;
+        self.finished = true;
+        Err(MicrosandboxError::SandboxFsOps(message.into()))
+    }
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -606,14 +699,22 @@ impl FsWriteSink {
     pub(crate) fn new(
         id: u32,
         client: Arc<AgentClient>,
-        rx: mpsc::Receiver<Message>,
+        rx: mpsc::Receiver<AgentFrame>,
         close_handle: Option<FsHandle>,
+        bulk: Option<BulkSendState>,
     ) -> Self {
+        let bulk_active = bulk.is_some();
+        let protocol = match bulk {
+            Some(sender) => FsWriteProtocol::Bulk { rx, sender },
+            None => FsWriteProtocol::Legacy { rx },
+        };
         Self {
             id,
             client,
-            rx,
+            protocol: Mutex::new(Some(protocol)),
             close_handle,
+            finished: false,
+            bulk_active,
         }
     }
 
@@ -624,11 +725,53 @@ impl FsWriteSink {
 
     /// Write an already-owned chunk without cloning it at the SDK stream boundary.
     async fn write_owned(&self, data: Vec<u8>) -> MicrosandboxResult<()> {
-        let fs_data = FsData { data };
-        self.client
-            .send(self.id, MessageType::FsData, &fs_data)
-            .await
-            .map_err(Into::into)
+        let mut protocol = self.protocol.lock().await;
+        let protocol = protocol.as_mut().ok_or_else(|| {
+            MicrosandboxError::SandboxFsOps("filesystem write stream is already closed".into())
+        })?;
+        match protocol {
+            FsWriteProtocol::Legacy { .. } => {
+                // Keep generation-6 writes below the bounded CBOR frame limit even when a
+                // streaming caller supplies a much larger chunk.
+                for chunk in data.chunks(FS_CHUNK_SIZE) {
+                    let fs_data = FsData {
+                        data: chunk.to_vec(),
+                    };
+                    self.client
+                        .send(self.id, MessageType::FsData, &fs_data)
+                        .await?;
+                }
+                Ok(())
+            }
+            FsWriteProtocol::Bulk { rx, sender } => {
+                let mut remaining = Bytes::from(data);
+                while !remaining.is_empty() {
+                    while sender.available_credit() == 0 {
+                        apply_next_fs_write_credit(rx, sender).await?;
+                    }
+                    let chunk_len = remaining
+                        .len()
+                        .min(sender.max_record_payload() as usize)
+                        .min(sender.available_credit() as usize);
+                    let payload = remaining.split_to(chunk_len);
+                    let offset = sender.admit(chunk_len).map_err(|error| {
+                        MicrosandboxError::SandboxFsOps(format!(
+                            "admit filesystem bulk write: {error}"
+                        ))
+                    })?;
+                    self.client
+                        .send_bulk(BulkRecord {
+                            id: self.id,
+                            kind: BulkKind::Filesystem,
+                            flow: BulkFlow::HostToGuest,
+                            offset,
+                            payload,
+                        })
+                        .await?;
+                }
+                Ok(())
+            }
+        }
     }
 
     /// Close the write stream (sends EOF) and wait for confirmation.
@@ -636,24 +779,85 @@ impl FsWriteSink {
     /// This must be called to finalize the write operation. Returns an
     /// error if the guest reports a write failure.
     pub async fn close(mut self) -> MicrosandboxResult<()> {
-        let eof = FsData { data: Vec::new() };
-        self.client.send(self.id, MessageType::FsData, &eof).await?;
-
-        // Wait for the terminal FsResponse from the guest.
-        let result = wait_for_ok_response(&mut self.rx).await;
+        let protocol = self.protocol.get_mut().take().ok_or_else(|| {
+            MicrosandboxError::SandboxFsOps("filesystem write stream is already closed".into())
+        })?;
+        let result = match protocol {
+            FsWriteProtocol::Legacy { mut rx } => {
+                let eof = FsData { data: Vec::new() };
+                self.client.send(self.id, MessageType::FsData, &eof).await?;
+                wait_for_ok_frame_response(&mut rx).await
+            }
+            FsWriteProtocol::Bulk { mut rx, mut sender } => {
+                let finish = sender.finish().map_err(|error| {
+                    MicrosandboxError::SandboxFsOps(format!(
+                        "finish filesystem bulk write: {error}"
+                    ))
+                })?;
+                self.client
+                    .send(self.id, MessageType::BulkFinish, &finish)
+                    .await?;
+                wait_for_ok_frame_response(&mut rx).await
+            }
+        };
         let close_result = if let Some(handle) = self.close_handle.take() {
             agent::close_handle(&self.client, handle).await
         } else {
             Ok(())
         };
+        self.finished = true;
+        self.bulk_active = false;
         result?;
         close_result
     }
 }
 
 //--------------------------------------------------------------------------------------------------
+// Trait Implementations
+//--------------------------------------------------------------------------------------------------
+
+impl Drop for FsReadStream {
+    fn drop(&mut self) {
+        if self.finished || self.bulk.is_none() {
+            return;
+        }
+        let Some(client) = self.client.take() else {
+            return;
+        };
+        spawn_fs_bulk_cancel(self.id, client, self.close_handle.take());
+    }
+}
+
+impl Drop for FsWriteSink {
+    fn drop(&mut self) {
+        if self.finished || !self.bulk_active {
+            return;
+        }
+        spawn_fs_bulk_cancel(self.id, Arc::clone(&self.client), self.close_handle.take());
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
 // Functions
 //--------------------------------------------------------------------------------------------------
+
+/// Best-effort cancellation keeps a dropped SDK stream from draining or retaining guest work.
+fn spawn_fs_bulk_cancel(id: u32, client: Arc<AgentClient>, close_handle: Option<FsHandle>) {
+    let Ok(runtime) = tokio::runtime::Handle::try_current() else {
+        return;
+    };
+    runtime.spawn(async move {
+        let cancel = BulkCancel {
+            kind: BulkKind::Filesystem,
+            reason: BulkCancelReason::CallerCancelled,
+            message: "host filesystem stream was dropped".into(),
+        };
+        let _ = client.cancel_bulk(id, &cancel).await;
+        if let Some(handle) = close_handle {
+            let _ = agent::close_handle(&client, handle).await;
+        }
+    });
+}
 
 /// Parse a kind string from the wire protocol into an `FsEntryKind`.
 fn parse_kind(s: &str) -> FsEntryKind {
@@ -712,14 +916,113 @@ fn check_response(msg: Message) -> MicrosandboxResult<()> {
 }
 
 /// Wait for and check a terminal `FsResponse` from a subscription channel.
-async fn wait_for_ok_response(rx: &mut mpsc::Receiver<Message>) -> MicrosandboxResult<()> {
-    while let Some(msg) = rx.recv().await {
-        if msg.t == MessageType::FsResponse {
-            return check_response(msg);
+async fn wait_for_ok_frame_response(rx: &mut mpsc::Receiver<AgentFrame>) -> MicrosandboxResult<()> {
+    while let Some(frame) = rx.recv().await {
+        match frame {
+            AgentFrame::Control(message) if message.t == MessageType::FsResponse => {
+                return check_response(message);
+            }
+            AgentFrame::Control(message) if message.t == MessageType::BulkCancel => {
+                let cancel: BulkCancel = message.payload()?;
+                return Err(MicrosandboxError::SandboxFsOps(format!(
+                    "filesystem bulk transfer cancelled: {}",
+                    cancel.message
+                )));
+            }
+            AgentFrame::Control(_) => {}
+            AgentFrame::Bulk(_) => {
+                return Err(MicrosandboxError::SandboxFsOps(
+                    "unexpected raw bulk data on a filesystem write".into(),
+                ));
+            }
         }
     }
     Err(MicrosandboxError::SandboxFsOps(
         "channel closed before response".into(),
+    ))
+}
+
+async fn apply_next_fs_write_credit(
+    rx: &mut mpsc::Receiver<AgentFrame>,
+    sender: &mut BulkSendState,
+) -> MicrosandboxResult<()> {
+    while let Some(frame) = rx.recv().await {
+        match frame {
+            AgentFrame::Control(message) if message.t == MessageType::BulkCredit => {
+                let credit: BulkCredit = message.payload()?;
+                sender.apply_credit(credit).map_err(|error| {
+                    MicrosandboxError::SandboxFsOps(format!(
+                        "invalid filesystem bulk credit: {error}"
+                    ))
+                })?;
+                return Ok(());
+            }
+            AgentFrame::Control(message) if message.t == MessageType::BulkCancel => {
+                let cancel: BulkCancel = message.payload()?;
+                return Err(MicrosandboxError::SandboxFsOps(format!(
+                    "filesystem bulk transfer cancelled: {}",
+                    cancel.message
+                )));
+            }
+            AgentFrame::Control(message) if message.t == MessageType::FsResponse => {
+                check_response(message)?;
+                return Err(MicrosandboxError::SandboxFsOps(
+                    "filesystem write completed before its finish marker".into(),
+                ));
+            }
+            AgentFrame::Control(_) => {}
+            AgentFrame::Bulk(_) => {
+                return Err(MicrosandboxError::SandboxFsOps(
+                    "unexpected raw bulk data on a filesystem write".into(),
+                ));
+            }
+        }
+    }
+    Err(MicrosandboxError::SandboxFsOps(
+        "filesystem write closed while waiting for credit".into(),
+    ))
+}
+
+async fn receive_fs_bulk_acceptance(
+    rx: &mut mpsc::Receiver<AgentFrame>,
+    offer: BulkOffer,
+    flows: u8,
+) -> MicrosandboxResult<BulkAccepted> {
+    while let Some(frame) = rx.recv().await {
+        match frame {
+            AgentFrame::Control(message) if message.t == MessageType::BulkAccepted => {
+                let accepted: BulkAccepted = message.payload()?;
+                return accepted
+                    .validate_against(offer, BulkKind::Filesystem, flows)
+                    .map_err(|error| {
+                        MicrosandboxError::SandboxFsOps(format!(
+                            "invalid filesystem bulk acceptance: {error}"
+                        ))
+                    });
+            }
+            AgentFrame::Control(message) if message.t == MessageType::FsResponse => {
+                check_response(message)?;
+                return Err(MicrosandboxError::SandboxFsOps(
+                    "filesystem stream completed before bulk acceptance".into(),
+                ));
+            }
+            AgentFrame::Control(message) if message.t == MessageType::BulkCancel => {
+                let cancel: BulkCancel = message.payload()?;
+                return Err(MicrosandboxError::SandboxFsOps(format!(
+                    "filesystem bulk negotiation cancelled: {}",
+                    cancel.message
+                )));
+            }
+            AgentFrame::Control(_) => {}
+            AgentFrame::Bulk(_) => {
+                return Err(MicrosandboxError::SandboxFsOps(
+                    "filesystem bulk data arrived before acceptance".into(),
+                ));
+            }
+        }
+    }
+    Err(MicrosandboxError::SandboxFsOps(
+        "filesystem stream closed before bulk acceptance".into(),
     ))
 }
 
@@ -756,9 +1059,12 @@ pub(crate) mod agent {
 
     use bytes::Bytes;
     use microsandbox_protocol::{
+        bulk::{
+            BULK_FLOW_MASK_GUEST_TO_HOST, BULK_FLOW_MASK_HOST_TO_GUEST, BulkFlow, BulkKind,
+            BulkOffer, BulkReceiveState, BulkSendState,
+        },
         fs::{
-            FS_CHUNK_SIZE, FsData, FsOp, FsOpenOptions, FsRequest, FsResponse, FsResponseData,
-            FsSetAttrs,
+            FS_CHUNK_SIZE, FsOp, FsOpenOptions, FsRequest, FsResponse, FsResponseData, FsSetAttrs,
         },
         message::MessageType,
     };
@@ -768,7 +1074,7 @@ pub(crate) mod agent {
 
     use super::{
         FsEntry, FsHandle, FsMetadata, FsReadStream, FsWriteSink, check_response,
-        entry_info_to_fs_entry, entry_info_to_metadata, wait_for_ok_response,
+        entry_info_to_fs_entry, entry_info_to_metadata, receive_fs_bulk_acceptance,
     };
 
     /// Open a fresh agent connection for the named sandbox.
@@ -797,6 +1103,7 @@ pub(crate) mod agent {
                 path: path.to_string(),
                 options,
             },
+            bulk: None,
         };
         let resp_msg = client.request(MessageType::FsRequest, &req).await?;
         let resp: FsResponse = resp_msg.payload()?;
@@ -818,6 +1125,7 @@ pub(crate) mod agent {
             op: FsOp::OpenDir {
                 path: path.to_string(),
             },
+            bulk: None,
         };
         let resp_msg = client.request(MessageType::FsRequest, &req).await?;
         let resp: FsResponse = resp_msg.payload()?;
@@ -840,6 +1148,7 @@ pub(crate) mod agent {
     ) -> MicrosandboxResult<()> {
         let req = FsRequest {
             op: FsOp::CloseHandle { handle },
+            bulk: None,
         };
         let resp_msg = client.request(MessageType::FsRequest, &req).await?;
         check_response(resp_msg)
@@ -870,15 +1179,42 @@ pub(crate) mod agent {
                 offset,
                 len,
             },
+            bulk: client
+                .supports(MessageType::BulkAccepted)
+                .then(BulkOffer::filesystem_read),
         };
-        let (_id, rx) = client.stream(MessageType::FsRequest, &req).await?;
+        let (id, mut rx) = client.stream_frames(MessageType::FsRequest, &req).await?;
+        let bulk = match req.bulk {
+            Some(offer) => {
+                let accepted =
+                    receive_fs_bulk_acceptance(&mut rx, offer, BULK_FLOW_MASK_GUEST_TO_HOST)
+                        .await?;
+                Some(
+                    BulkReceiveState::new(
+                        BulkKind::Filesystem,
+                        BulkFlow::GuestToHost,
+                        accepted.max_record_payload,
+                        accepted.guest_to_host_credit_limit,
+                        offer.guest_to_host_credit_limit,
+                    )
+                    .map_err(|error| {
+                        MicrosandboxError::SandboxFsOps(format!(
+                            "create filesystem bulk read state: {error}"
+                        ))
+                    })?,
+                )
+            }
+            None => None,
+        };
 
         // The stream must retain the same relay client while the handle is in
         // use; agentd rejects handle operations from a different client range.
         Ok(FsReadStream::with_client_and_close(
+            id,
             rx,
             client,
             close_handle,
+            bulk,
         ))
     }
 
@@ -909,9 +1245,33 @@ pub(crate) mod agent {
                 offset,
                 len,
             },
+            bulk: client
+                .supports(MessageType::BulkAccepted)
+                .then(BulkOffer::filesystem_write),
         };
-        let (id, rx) = client.stream(MessageType::FsRequest, &req).await?;
-        Ok(FsWriteSink::new(id, client, rx, close_handle))
+        let (id, mut rx) = client.stream_frames(MessageType::FsRequest, &req).await?;
+        let bulk = match req.bulk {
+            Some(offer) => {
+                let accepted =
+                    receive_fs_bulk_acceptance(&mut rx, offer, BULK_FLOW_MASK_HOST_TO_GUEST)
+                        .await?;
+                Some(
+                    BulkSendState::new(
+                        BulkKind::Filesystem,
+                        BulkFlow::HostToGuest,
+                        accepted.max_record_payload,
+                        accepted.host_to_guest_credit_limit,
+                    )
+                    .map_err(|error| {
+                        MicrosandboxError::SandboxFsOps(format!(
+                            "create filesystem bulk write state: {error}"
+                        ))
+                    })?,
+                )
+            }
+            None => None,
+        };
+        Ok(FsWriteSink::new(id, client, rx, close_handle, bulk))
     }
 
     pub(crate) async fn read_dir_handle(
@@ -921,6 +1281,7 @@ pub(crate) mod agent {
     ) -> MicrosandboxResult<Vec<FsEntry>> {
         let req = FsRequest {
             op: FsOp::ReadDir { handle, limit },
+            bulk: None,
         };
         let resp_msg = client.request(MessageType::FsRequest, &req).await?;
         let resp: FsResponse = resp_msg.payload()?;
@@ -945,6 +1306,7 @@ pub(crate) mod agent {
     ) -> MicrosandboxResult<FsMetadata> {
         let req = FsRequest {
             op: FsOp::FStat { handle },
+            bulk: None,
         };
         let resp_msg = client.request(MessageType::FsRequest, &req).await?;
         let resp: FsResponse = resp_msg.payload()?;
@@ -970,6 +1332,7 @@ pub(crate) mod agent {
     ) -> MicrosandboxResult<()> {
         let req = FsRequest {
             op: FsOp::FSetStat { handle, attrs },
+            bulk: None,
         };
         let resp_msg = client.request(MessageType::FsRequest, &req).await?;
         check_response(resp_msg)
@@ -980,40 +1343,13 @@ pub(crate) mod agent {
         name: &str,
         path: &str,
     ) -> MicrosandboxResult<Bytes> {
-        let client = connect_agent(backend, name).await?;
+        let client = Arc::new(connect_agent(backend, name).await?);
         let handle = open_file(&client, path, super::read_only_open_options()).await?;
-
-        let req = FsRequest {
-            op: FsOp::Read {
-                handle,
-                offset: 0,
-                len: None,
-            },
-        };
-        let (_id, mut rx) = client.stream(MessageType::FsRequest, &req).await?;
-
+        let mut stream = read_handle_stream(client, handle, 0, None, Some(handle)).await?;
         let mut data = Vec::new();
-        while let Some(msg) = rx.recv().await {
-            match msg.t {
-                MessageType::FsData => {
-                    let chunk: FsData = msg.payload()?;
-                    data.extend_from_slice(&chunk.data);
-                }
-                MessageType::FsResponse => {
-                    let resp: FsResponse = msg.payload()?;
-                    if !resp.ok {
-                        return Err(MicrosandboxError::SandboxFsOps(
-                            resp.error.unwrap_or_else(|| "unknown error".into()),
-                        ));
-                    }
-                    break;
-                }
-                _ => {}
-            }
+        while let Some(chunk) = stream.recv().await? {
+            data.extend_from_slice(&chunk);
         }
-
-        let close_result = close_handle(&client, handle).await;
-        close_result?;
         Ok(Bytes::from(data))
     }
 
@@ -1025,22 +1361,7 @@ pub(crate) mod agent {
         let client = Arc::new(connect_agent(backend, name).await?);
         let handle = open_file(&client, path, super::read_only_open_options()).await?;
 
-        let req = FsRequest {
-            op: FsOp::Read {
-                handle,
-                offset: 0,
-                len: None,
-            },
-        };
-        let (_id, rx) = client.stream(MessageType::FsRequest, &req).await?;
-
-        // Pin the AgentClient alive inside the stream and close the
-        // auto-opened file handle once the guest sends the terminal response.
-        Ok(FsReadStream::with_client_and_close(
-            rx,
-            client,
-            Some(handle),
-        ))
+        read_handle_stream(client, handle, 0, None, Some(handle)).await
     }
 
     pub(crate) async fn write(
@@ -1049,31 +1370,14 @@ pub(crate) mod agent {
         path: &str,
         data: Vec<u8>,
     ) -> MicrosandboxResult<()> {
-        let client = connect_agent(backend, name).await?;
+        let client = Arc::new(connect_agent(backend, name).await?);
         let handle = open_file(&client, path, super::write_open_options()).await?;
-
-        let req = FsRequest {
-            op: FsOp::Write {
-                handle,
-                offset: 0,
-                len: Some(data.len() as u64),
-            },
-        };
-        let (id, mut rx) = client.stream(MessageType::FsRequest, &req).await?;
-
+        let sink =
+            write_handle_stream(client, handle, 0, Some(data.len() as u64), Some(handle)).await?;
         for chunk in data.chunks(FS_CHUNK_SIZE) {
-            let fs_data = FsData {
-                data: chunk.to_vec(),
-            };
-            client.send(id, MessageType::FsData, &fs_data).await?;
+            sink.write(chunk).await?;
         }
-
-        let eof = FsData { data: Vec::new() };
-        client.send(id, MessageType::FsData, &eof).await?;
-
-        let result = wait_for_ok_response(&mut rx).await;
-        let _ = close_handle(&client, handle).await;
-        result
+        sink.close().await
     }
 
     pub(crate) async fn write_stream(
@@ -1084,16 +1388,7 @@ pub(crate) mod agent {
         let client = Arc::new(connect_agent(backend, name).await?);
         let handle = open_file(&client, path, super::write_open_options()).await?;
 
-        let req = FsRequest {
-            op: FsOp::Write {
-                handle,
-                offset: 0,
-                len: None,
-            },
-        };
-        let (id, rx) = client.stream(MessageType::FsRequest, &req).await?;
-
-        Ok(FsWriteSink::new(id, client, rx, Some(handle)))
+        write_handle_stream(client, handle, 0, None, Some(handle)).await
     }
 
     pub(crate) async fn list(
@@ -1106,6 +1401,7 @@ pub(crate) mod agent {
             op: FsOp::List {
                 path: path.to_string(),
             },
+            bulk: None,
         };
         let resp_msg = client.request(MessageType::FsRequest, &req).await?;
         let resp: FsResponse = resp_msg.payload()?;
@@ -1135,6 +1431,7 @@ pub(crate) mod agent {
                 path: path.to_string(),
                 mode: None,
             },
+            bulk: None,
         };
         let resp_msg = client.request(MessageType::FsRequest, &req).await?;
         check_response(resp_msg)
@@ -1155,6 +1452,7 @@ pub(crate) mod agent {
             op: FsOp::Remove {
                 path: path.to_string(),
             },
+            bulk: None,
         };
         let resp_msg = client.request(MessageType::FsRequest, &req).await?;
         check_response(resp_msg)
@@ -1172,6 +1470,7 @@ pub(crate) mod agent {
                 path: path.to_string(),
                 recursive,
             },
+            bulk: None,
         };
         let resp_msg = client.request(MessageType::FsRequest, &req).await?;
         check_response(resp_msg)
@@ -1189,6 +1488,7 @@ pub(crate) mod agent {
                 src: from.to_string(),
                 dst: to.to_string(),
             },
+            bulk: None,
         };
         let resp_msg = client.request(MessageType::FsRequest, &req).await?;
         check_response(resp_msg)
@@ -1206,6 +1506,7 @@ pub(crate) mod agent {
                 src: from.to_string(),
                 dst: to.to_string(),
             },
+            bulk: None,
         };
         let resp_msg = client.request(MessageType::FsRequest, &req).await?;
         check_response(resp_msg)
@@ -1231,6 +1532,7 @@ pub(crate) mod agent {
                 path: path.to_string(),
                 follow_symlink,
             },
+            bulk: None,
         };
         let resp_msg = client.request(MessageType::FsRequest, &req).await?;
         let resp: FsResponse = resp_msg.payload()?;
@@ -1263,6 +1565,7 @@ pub(crate) mod agent {
                 follow_symlink,
                 attrs,
             },
+            bulk: None,
         };
         let resp_msg = client.request(MessageType::FsRequest, &req).await?;
         check_response(resp_msg)
@@ -1278,6 +1581,7 @@ pub(crate) mod agent {
             op: FsOp::ReadLink {
                 path: path.to_string(),
             },
+            bulk: None,
         };
         let resp_msg = client.request(MessageType::FsRequest, &req).await?;
         let resp: FsResponse = resp_msg.payload()?;
@@ -1308,6 +1612,7 @@ pub(crate) mod agent {
                 target: target.to_string(),
                 link_path: link_path.to_string(),
             },
+            bulk: None,
         };
         let resp_msg = client.request(MessageType::FsRequest, &req).await?;
         check_response(resp_msg)
@@ -1323,6 +1628,7 @@ pub(crate) mod agent {
             op: FsOp::RealPath {
                 path: path.to_string(),
             },
+            bulk: None,
         };
         let resp_msg = client.request(MessageType::FsRequest, &req).await?;
         let resp: FsResponse = resp_msg.payload()?;
@@ -1640,10 +1946,13 @@ mod tests {
         let (tx, rx) = mpsc::channel(1);
         drop(tx);
         let mut stream = FsReadStream {
+            id: 1,
             rx,
             client: None,
             close_handle: None,
             finished: false,
+            bulk: None,
+            bulk_finish_seen: false,
         };
 
         let error = stream.recv().await.unwrap_err();
@@ -1662,15 +1971,20 @@ mod tests {
             error: None,
             data: None,
         };
-        tx.send(Message::with_payload(MessageType::FsResponse, 1, &response).unwrap())
-            .await
-            .unwrap();
+        tx.send(AgentFrame::Control(
+            Message::with_payload(MessageType::FsResponse, 1, &response).unwrap(),
+        ))
+        .await
+        .unwrap();
         drop(tx);
         let mut stream = FsReadStream {
+            id: 1,
             rx,
             client: None,
             close_handle: None,
             finished: false,
+            bulk: None,
+            bulk_finish_seen: false,
         };
 
         assert!(stream.recv().await.unwrap().is_none());

--- a/sdk/rust/lib/sandbox/ssh.rs
+++ b/sdk/rust/lib/sandbox/ssh.rs
@@ -17,14 +17,15 @@ use bytes::Bytes;
 use microsandbox_agent_client::AgentFrame;
 use microsandbox_protocol::{
     bulk::{
-        BULK_FLOW_MASK_GUEST_TO_HOST, BULK_FLOW_MASK_HOST_TO_GUEST, BulkCancel, BulkCredit,
-        BulkFinish, BulkFlow, BulkKind, BulkOffer, BulkReceiveState, BulkRecord, BulkSendState,
+        BULK_FLOW_MASK_GUEST_TO_HOST, BULK_FLOW_MASK_HOST_TO_GUEST, BulkCancel, BulkCancelReason,
+        BulkCredit, BulkFinish, BulkFlow, BulkKind, BulkOffer, BulkReceiveState, BulkRecord,
+        BulkSendState,
     },
     fs::{
         FS_CHUNK_SIZE, FsEntryInfo, FsOp, FsOpenOptions, FsRequest, FsResponse, FsResponseData,
         FsSetAttrs,
     },
-    message::{Message, MessageType},
+    message::MessageType,
     tcp::{TcpClose, TcpClosed, TcpConnect, TcpConnected, TcpData, TcpEof, TcpFailed},
 };
 use microsandbox_types::EnvVar;
@@ -1672,11 +1673,27 @@ impl russh::server::Handler for SshSession {
     ) -> Result<(), Self::Error> {
         match self.channels.remove(&channel) {
             Some(ChannelState::Tcp {
-                id, client, relay, ..
+                id,
+                client,
+                bulk,
+                relay,
             }) => {
                 relay.abort();
-                let _ = client.send(id, MessageType::TcpClose, &TcpClose {}).await;
-                client.forget_stream(id).await;
+                if bulk.is_some() {
+                    let _ = client
+                        .cancel_bulk(
+                            id,
+                            &BulkCancel {
+                                kind: BulkKind::Tcp,
+                                reason: BulkCancelReason::CallerCancelled,
+                                message: "SSH direct-tcpip channel was closed".into(),
+                            },
+                        )
+                        .await;
+                } else {
+                    let _ = client.send(id, MessageType::TcpClose, &TcpClose {}).await;
+                    client.forget_stream(id).await;
+                }
             }
             Some(ChannelState::Exec { control, stdin }) => {
                 if let Some(stdin) = stdin {

--- a/sdk/rust/lib/sandbox/ssh.rs
+++ b/sdk/rust/lib/sandbox/ssh.rs
@@ -6,15 +6,23 @@ use std::io::Write;
 use std::os::fd::AsRawFd;
 use std::path::{Path, PathBuf};
 use std::pin::Pin;
-use std::sync::Arc;
+use std::sync::{
+    Arc,
+    atomic::{AtomicBool, Ordering},
+};
 use std::task::{Context, Poll};
 use std::time::Duration;
 
 use bytes::Bytes;
+use microsandbox_agent_client::AgentFrame;
 use microsandbox_protocol::{
+    bulk::{
+        BULK_FLOW_MASK_GUEST_TO_HOST, BULK_FLOW_MASK_HOST_TO_GUEST, BulkCancel, BulkCredit,
+        BulkFinish, BulkFlow, BulkKind, BulkOffer, BulkReceiveState, BulkRecord, BulkSendState,
+    },
     fs::{
-        FS_CHUNK_SIZE, FsData, FsEntryInfo, FsOp, FsOpenOptions, FsRequest, FsResponse,
-        FsResponseData, FsSetAttrs,
+        FS_CHUNK_SIZE, FsEntryInfo, FsOp, FsOpenOptions, FsRequest, FsResponse, FsResponseData,
+        FsSetAttrs,
     },
     message::{Message, MessageType},
     tcp::{TcpClose, TcpClosed, TcpConnect, TcpConnected, TcpData, TcpEof, TcpFailed},
@@ -25,6 +33,7 @@ use russh::keys::{Algorithm, PrivateKey, PrivateKeyWithHashAlg, PublicKeyBase64,
 use russh::server::{Auth, ChannelOpenHandle, Msg, Session};
 use russh::{Channel, ChannelId, ChannelMsg, ChannelOpenFailure, Sig};
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+use tokio::sync::{Mutex, Notify};
 
 use super::attach;
 #[cfg(windows)]
@@ -180,12 +189,22 @@ enum ChannelState {
     Tcp {
         id: u32,
         client: Arc<AgentClient>,
+        bulk: Option<Arc<TcpBulkSender>>,
         /// Guest-to-SSH relay task. It is aborted on channel/session teardown
         /// so a dropped SSH connection does not leave a stream reader behind.
         relay: tokio::task::JoinHandle<()>,
     },
     Sftp,
 }
+
+/// Host-to-guest credit state shared by SSH callbacks and the guest-to-host relay task.
+struct TcpBulkSender {
+    state: Mutex<BulkSendState>,
+    credit_ready: Notify,
+    closed: AtomicBool,
+}
+
+struct TcpRelayCloseGuard(Option<Arc<TcpBulkSender>>);
 
 #[derive(Clone)]
 struct PtyInfo {
@@ -980,6 +999,106 @@ impl SshServer {
 }
 
 //--------------------------------------------------------------------------------------------------
+// Methods: TcpBulkSender
+//--------------------------------------------------------------------------------------------------
+
+impl TcpBulkSender {
+    fn new(state: BulkSendState) -> Self {
+        Self {
+            state: Mutex::new(state),
+            credit_ready: Notify::new(),
+            closed: AtomicBool::new(false),
+        }
+    }
+
+    async fn send(&self, client: &AgentClient, id: u32, data: &[u8]) -> MicrosandboxResult<()> {
+        let mut remaining = data;
+        while !remaining.is_empty() {
+            if self.closed.load(Ordering::Acquire) {
+                return Err(MicrosandboxError::Custom(
+                    "TCP bulk stream is already closed".into(),
+                ));
+            }
+            // Register the waiter before inspecting credit so an update cannot be lost between
+            // the check and the await.
+            let notified = self.credit_ready.notified();
+            let next = {
+                let mut state = self.state.lock().await;
+                let len = remaining
+                    .len()
+                    .min(state.max_record_payload() as usize)
+                    .min(state.available_credit() as usize);
+                if len == 0 {
+                    None
+                } else {
+                    let offset = state.admit(len).map_err(|error| {
+                        MicrosandboxError::Custom(format!("admit TCP bulk record: {error}"))
+                    })?;
+                    Some((offset, len))
+                }
+            };
+
+            let Some((offset, len)) = next else {
+                if self.closed.load(Ordering::Acquire) {
+                    return Err(MicrosandboxError::Custom(
+                        "TCP bulk stream closed while waiting for credit".into(),
+                    ));
+                }
+                notified.await;
+                continue;
+            };
+            client
+                .send_bulk(BulkRecord {
+                    id,
+                    kind: BulkKind::Tcp,
+                    flow: BulkFlow::HostToGuest,
+                    offset,
+                    payload: Bytes::copy_from_slice(&remaining[..len]),
+                })
+                .await?;
+            remaining = &remaining[len..];
+        }
+        Ok(())
+    }
+
+    async fn apply_credit(&self, credit: BulkCredit) -> MicrosandboxResult<()> {
+        if self.closed.load(Ordering::Acquire) {
+            return Err(MicrosandboxError::Custom(
+                "TCP bulk stream is already closed".into(),
+            ));
+        }
+        self.state
+            .lock()
+            .await
+            .apply_credit(credit)
+            .map_err(|error| {
+                MicrosandboxError::Custom(format!("apply TCP bulk credit: {error}"))
+            })?;
+        self.credit_ready.notify_waiters();
+        Ok(())
+    }
+
+    async fn finish(&self, client: &AgentClient, id: u32) -> MicrosandboxResult<()> {
+        if self.closed.load(Ordering::Acquire) {
+            return Err(MicrosandboxError::Custom(
+                "TCP bulk stream is already closed".into(),
+            ));
+        }
+        let finish =
+            self.state.lock().await.finish().map_err(|error| {
+                MicrosandboxError::Custom(format!("finish TCP bulk flow: {error}"))
+            })?;
+        client.send(id, MessageType::BulkFinish, &finish).await?;
+        Ok(())
+    }
+
+    fn close(&self) {
+        self.closed.store(true, Ordering::Release);
+        self.credit_ready.notify_waiters();
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
 // Methods: SshSession
 //--------------------------------------------------------------------------------------------------
 
@@ -1156,8 +1275,11 @@ impl SshSession {
         let req = TcpConnect {
             host: host_to_connect.to_string(),
             port: port_to_connect as u16,
+            bulk: client
+                .supports(MessageType::BulkAccepted)
+                .then(BulkOffer::tcp),
         };
-        let (tcp_id, mut tcp_rx) = client.stream(MessageType::TcpConnect, &req).await?;
+        let (tcp_id, mut tcp_rx) = client.stream_frames(MessageType::TcpConnect, &req).await?;
         let Some(first) = tcp_rx.recv().await else {
             tracing::debug!(
                 host = host_to_connect,
@@ -1167,18 +1289,98 @@ impl SshSession {
             return Ok(false);
         };
 
+        let AgentFrame::Control(first) = first else {
+            tracing::warn!(
+                host = host_to_connect,
+                port = port_to_connect,
+                "ssh direct-tcpip received raw data before connect reply"
+            );
+            return Ok(false);
+        };
         match first.t {
             MessageType::TcpConnected => {
                 let _: TcpConnected = first.payload()?;
+                let (bulk_sender, bulk_receiver) = match req.bulk {
+                    Some(offer) => {
+                        let Some(AgentFrame::Control(accepted_message)) = tcp_rx.recv().await
+                        else {
+                            tracing::warn!(
+                                host = host_to_connect,
+                                port = port_to_connect,
+                                "ssh direct-tcpip stream closed before bulk acceptance"
+                            );
+                            return Ok(false);
+                        };
+                        if accepted_message.t != MessageType::BulkAccepted {
+                            tracing::warn!(
+                                host = host_to_connect,
+                                port = port_to_connect,
+                                message_type = accepted_message.t.as_str(),
+                                "ssh direct-tcpip received unexpected bulk negotiation reply"
+                            );
+                            return Ok(false);
+                        }
+                        let accepted = accepted_message
+                            .payload::<microsandbox_protocol::bulk::BulkAccepted>()?;
+                        let accepted = accepted
+                            .validate_against(
+                                offer,
+                                BulkKind::Tcp,
+                                BULK_FLOW_MASK_HOST_TO_GUEST | BULK_FLOW_MASK_GUEST_TO_HOST,
+                            )
+                            .map_err(|error| {
+                                MicrosandboxError::Custom(format!(
+                                    "invalid TCP bulk acceptance: {error}"
+                                ))
+                            })?;
+                        let sender = BulkSendState::new(
+                            BulkKind::Tcp,
+                            BulkFlow::HostToGuest,
+                            accepted.max_record_payload,
+                            accepted.host_to_guest_credit_limit,
+                        )
+                        .map_err(|error| {
+                            MicrosandboxError::Custom(format!(
+                                "create TCP bulk send state: {error}"
+                            ))
+                        })?;
+                        let receiver = BulkReceiveState::new(
+                            BulkKind::Tcp,
+                            BulkFlow::GuestToHost,
+                            accepted.max_record_payload,
+                            accepted.guest_to_host_credit_limit,
+                            offer.guest_to_host_credit_limit,
+                        )
+                        .map_err(|error| {
+                            MicrosandboxError::Custom(format!(
+                                "create TCP bulk receive state: {error}"
+                            ))
+                        })?;
+                        (Some(Arc::new(TcpBulkSender::new(sender))), Some(receiver))
+                    }
+                    None => (None, None),
+                };
                 let session_handle = session.handle();
+                let relay_client = Arc::clone(&client);
+                let relay_sender = bulk_sender.as_ref().map(Arc::clone);
                 let relay = tokio::spawn(async move {
-                    relay_tcp_to_ssh(channel_id, tcp_rx, session_handle).await;
+                    relay_tcp_to_ssh(
+                        channel_id,
+                        tcp_id,
+                        tcp_rx,
+                        session_handle,
+                        relay_client,
+                        relay_sender,
+                        bulk_receiver,
+                    )
+                    .await;
                 });
                 self.channels.insert(
                     channel_id,
                     ChannelState::Tcp {
                         id: tcp_id,
                         client,
+                        bulk: bulk_sender,
                         relay,
                     },
                 );
@@ -1403,19 +1605,25 @@ impl russh::server::Handler for SshSession {
         _session: &mut Session,
     ) -> Result<(), Self::Error> {
         let tcp = match self.channels.get(&channel) {
-            Some(ChannelState::Tcp { id, client, .. }) => Some((*id, Arc::clone(client))),
+            Some(ChannelState::Tcp {
+                id, client, bulk, ..
+            }) => Some((*id, Arc::clone(client), bulk.as_ref().map(Arc::clone))),
             _ => None,
         };
-        if let Some((id, client)) = tcp {
-            client
-                .send(
-                    id,
-                    MessageType::TcpData,
-                    &TcpData {
-                        data: data.to_vec(),
-                    },
-                )
-                .await?;
+        if let Some((id, client, bulk)) = tcp {
+            if let Some(bulk) = bulk {
+                bulk.send(&client, id, data).await?;
+            } else {
+                client
+                    .send(
+                        id,
+                        MessageType::TcpData,
+                        &TcpData {
+                            data: data.to_vec(),
+                        },
+                    )
+                    .await?;
+            }
             return Ok(());
         }
 
@@ -1434,11 +1642,17 @@ impl russh::server::Handler for SshSession {
         _session: &mut Session,
     ) -> Result<(), Self::Error> {
         let tcp = match self.channels.get(&channel) {
-            Some(ChannelState::Tcp { id, client, .. }) => Some((*id, Arc::clone(client))),
+            Some(ChannelState::Tcp {
+                id, client, bulk, ..
+            }) => Some((*id, Arc::clone(client), bulk.as_ref().map(Arc::clone))),
             _ => None,
         };
-        if let Some((id, client)) = tcp {
-            client.send(id, MessageType::TcpEof, &TcpEof {}).await?;
+        if let Some((id, client, bulk)) = tcp {
+            if let Some(bulk) = bulk {
+                bulk.finish(&client, id).await?;
+            } else {
+                client.send(id, MessageType::TcpEof, &TcpEof {}).await?;
+            }
             return Ok(());
         }
 
@@ -1457,9 +1671,12 @@ impl russh::server::Handler for SshSession {
         _session: &mut Session,
     ) -> Result<(), Self::Error> {
         match self.channels.remove(&channel) {
-            Some(ChannelState::Tcp { id, client, relay }) => {
+            Some(ChannelState::Tcp {
+                id, client, relay, ..
+            }) => {
                 relay.abort();
                 let _ = client.send(id, MessageType::TcpClose, &TcpClose {}).await;
+                client.forget_stream(id).await;
             }
             Some(ChannelState::Exec { control, stdin }) => {
                 if let Some(stdin) = stdin {
@@ -1513,6 +1730,14 @@ impl russh::server::Handler for SshSession {
 //--------------------------------------------------------------------------------------------------
 // Trait Implementations
 //--------------------------------------------------------------------------------------------------
+
+impl Drop for TcpRelayCloseGuard {
+    fn drop(&mut self) {
+        if let Some(sender) = &self.0 {
+            sender.close();
+        }
+    }
+}
 
 impl russh::client::Handler for SshClientHandler {
     type Error = anyhow::Error;
@@ -1947,53 +2172,179 @@ impl AsyncWrite for SshStdioStream {
 
 async fn relay_tcp_to_ssh(
     channel: ChannelId,
-    mut tcp_rx: tokio::sync::mpsc::Receiver<Message>,
+    tcp_id: u32,
+    mut tcp_rx: tokio::sync::mpsc::Receiver<AgentFrame>,
     session: russh::server::Handle,
+    client: Arc<AgentClient>,
+    bulk_sender: Option<Arc<TcpBulkSender>>,
+    mut bulk_receiver: Option<BulkReceiveState>,
 ) {
-    while let Some(msg) = tcp_rx.recv().await {
-        match msg.t {
-            MessageType::TcpData => match msg.payload::<TcpData>() {
-                Ok(data) => {
-                    if session.data(channel, Bytes::from(data.data)).await.is_err() {
+    let _close_guard = TcpRelayCloseGuard(bulk_sender.as_ref().map(Arc::clone));
+    while let Some(frame) = tcp_rx.recv().await {
+        match frame {
+            AgentFrame::Bulk(record) => {
+                let Some(receiver) = bulk_receiver.as_mut() else {
+                    tracing::warn!("ssh direct-tcpip: raw data arrived without bulk negotiation");
+                    let _ = session.close(channel).await;
+                    return;
+                };
+                let end = match receiver.accept_record(&record) {
+                    Ok(end) => end,
+                    Err(error) => {
+                        tracing::warn!("ssh direct-tcpip: invalid raw TCP record: {error}");
+                        let _ = session.close(channel).await;
+                        return;
+                    }
+                };
+                if session.data(channel, record.payload).await.is_err() {
+                    return;
+                }
+                match receiver.consume(end) {
+                    Ok(Some(credit)) => {
+                        if let Err(error) =
+                            client.send(tcp_id, MessageType::BulkCredit, &credit).await
+                        {
+                            tracing::warn!(
+                                "ssh direct-tcpip: failed to replenish TCP bulk credit: {error}"
+                            );
+                            return;
+                        }
+                    }
+                    Ok(None) => {}
+                    Err(error) => {
+                        tracing::warn!(
+                            "ssh direct-tcpip: failed to advance TCP bulk credit: {error}"
+                        );
+                        let _ = session.close(channel).await;
                         return;
                     }
                 }
-                Err(e) => {
-                    tracing::warn!("ssh direct-tcpip: failed to decode tcp data: {e}");
+            }
+            AgentFrame::Control(msg) => match msg.t {
+                MessageType::TcpData => {
+                    if bulk_receiver.is_some() {
+                        tracing::warn!(
+                            "ssh direct-tcpip: CBOR TCP data arrived after bulk acceptance"
+                        );
+                        let _ = session.close(channel).await;
+                        return;
+                    }
+                    match msg.payload::<TcpData>() {
+                        Ok(data) => {
+                            if session.data(channel, Bytes::from(data.data)).await.is_err() {
+                                return;
+                            }
+                        }
+                        Err(e) => {
+                            tracing::warn!("ssh direct-tcpip: failed to decode tcp data: {e}");
+                            let _ = session.close(channel).await;
+                            return;
+                        }
+                    }
+                }
+                MessageType::BulkCredit => {
+                    let Some(sender) = bulk_sender.as_ref() else {
+                        tracing::warn!("ssh direct-tcpip: bulk credit arrived without negotiation");
+                        let _ = session.close(channel).await;
+                        return;
+                    };
+                    match msg.payload::<BulkCredit>() {
+                        Ok(credit) => {
+                            if let Err(error) = sender.apply_credit(credit).await {
+                                tracing::warn!(
+                                    "ssh direct-tcpip: invalid TCP bulk credit: {error}"
+                                );
+                                let _ = session.close(channel).await;
+                                return;
+                            }
+                        }
+                        Err(error) => {
+                            tracing::warn!(
+                                "ssh direct-tcpip: failed to decode TCP bulk credit: {error}"
+                            );
+                            let _ = session.close(channel).await;
+                            return;
+                        }
+                    }
+                }
+                MessageType::BulkFinish => {
+                    let Some(receiver) = bulk_receiver.as_mut() else {
+                        tracing::warn!("ssh direct-tcpip: bulk finish arrived without negotiation");
+                        let _ = session.close(channel).await;
+                        return;
+                    };
+                    match msg.payload::<BulkFinish>() {
+                        Ok(finish) => {
+                            if let Err(error) = receiver.accept_finish(finish) {
+                                tracing::warn!(
+                                    "ssh direct-tcpip: invalid TCP bulk finish: {error}"
+                                );
+                                let _ = session.close(channel).await;
+                                return;
+                            }
+                            let _ = session.eof(channel).await;
+                        }
+                        Err(error) => {
+                            tracing::warn!(
+                                "ssh direct-tcpip: failed to decode TCP bulk finish: {error}"
+                            );
+                            let _ = session.close(channel).await;
+                            return;
+                        }
+                    }
+                }
+                MessageType::BulkCancel => {
+                    match msg.payload::<BulkCancel>() {
+                        Ok(cancel) => tracing::debug!(
+                            reason = ?cancel.reason,
+                            message = cancel.message,
+                            "ssh direct-tcpip: guest cancelled TCP bulk stream"
+                        ),
+                        Err(error) => tracing::warn!(
+                            "ssh direct-tcpip: failed to decode TCP bulk cancellation: {error}"
+                        ),
+                    }
                     let _ = session.close(channel).await;
                     return;
                 }
-            },
-            MessageType::TcpEof => {
-                if let Err(e) = msg.payload::<TcpEof>() {
-                    tracing::warn!("ssh direct-tcpip: failed to decode tcp eof: {e}");
-                }
-                let _ = session.eof(channel).await;
-            }
-            MessageType::TcpClosed => {
-                if let Err(e) = msg.payload::<TcpClosed>() {
-                    tracing::warn!("ssh direct-tcpip: failed to decode tcp closed: {e}");
-                }
-                let _ = session.eof(channel).await;
-                let _ = session.close(channel).await;
-                return;
-            }
-            MessageType::TcpFailed => {
-                match msg.payload::<TcpFailed>() {
-                    Ok(failed) => {
-                        tracing::debug!(
-                            error = failed.error,
-                            "ssh direct-tcpip: guest TCP stream failed"
+                MessageType::TcpEof => {
+                    if bulk_receiver.is_some() {
+                        tracing::warn!(
+                            "ssh direct-tcpip: CBOR TCP EOF arrived after bulk acceptance"
                         );
+                        let _ = session.close(channel).await;
+                        return;
                     }
-                    Err(e) => {
-                        tracing::warn!("ssh direct-tcpip: failed to decode tcp failed: {e}");
+                    if let Err(e) = msg.payload::<TcpEof>() {
+                        tracing::warn!("ssh direct-tcpip: failed to decode tcp eof: {e}");
                     }
+                    let _ = session.eof(channel).await;
                 }
-                let _ = session.close(channel).await;
-                return;
-            }
-            _ => {}
+                MessageType::TcpClosed => {
+                    if let Err(e) = msg.payload::<TcpClosed>() {
+                        tracing::warn!("ssh direct-tcpip: failed to decode tcp closed: {e}");
+                    }
+                    let _ = session.eof(channel).await;
+                    let _ = session.close(channel).await;
+                    return;
+                }
+                MessageType::TcpFailed => {
+                    match msg.payload::<TcpFailed>() {
+                        Ok(failed) => {
+                            tracing::debug!(
+                                error = failed.error,
+                                "ssh direct-tcpip: guest TCP stream failed"
+                            );
+                        }
+                        Err(e) => {
+                            tracing::warn!("ssh direct-tcpip: failed to decode tcp failed: {e}");
+                        }
+                    }
+                    let _ = session.close(channel).await;
+                    return;
+                }
+                _ => {}
+            },
         }
     }
 
@@ -2215,7 +2566,7 @@ fn signal_to_libc(signal: Sig) -> Option<i32> {
 }
 
 async fn sftp_response(client: &AgentClient, op: FsOp) -> MicrosandboxResult<FsResponse> {
-    let req = FsRequest { op };
+    let req = FsRequest { op, bulk: None };
     let resp_msg = client.request(MessageType::FsRequest, &req).await?;
     let resp: FsResponse = resp_msg.payload()?;
     if resp.ok {
@@ -2288,90 +2639,44 @@ async fn sftp_close_handle(
 }
 
 async fn sftp_read_handle(
-    client: &AgentClient,
+    client: &Arc<AgentClient>,
     handle: crate::sandbox::fs::FsHandle,
     offset: u64,
     len: Option<u64>,
 ) -> MicrosandboxResult<Bytes> {
-    let req = FsRequest {
-        op: FsOp::Read {
-            handle,
-            offset,
-            len,
-        },
-    };
-    let (_id, mut rx) = client.stream(MessageType::FsRequest, &req).await?;
-
+    let mut stream = crate::sandbox::fs::agent::read_handle_stream(
+        Arc::clone(client),
+        handle,
+        offset,
+        len,
+        None,
+    )
+    .await?;
     let mut data = Vec::new();
-    while let Some(msg) = rx.recv().await {
-        match msg.t {
-            MessageType::FsData => {
-                let chunk: FsData = msg.payload()?;
-                data.extend_from_slice(&chunk.data);
-            }
-            MessageType::FsResponse => {
-                let resp: FsResponse = msg.payload()?;
-                if resp.ok {
-                    return Ok(Bytes::from(data));
-                }
-                return Err(MicrosandboxError::SandboxFsOps(
-                    resp.error.unwrap_or_else(|| "unknown error".into()),
-                ));
-            }
-            _ => {}
-        }
+    while let Some(chunk) = stream.recv().await? {
+        data.extend_from_slice(&chunk);
     }
-
-    Err(MicrosandboxError::SandboxFsOps(
-        "channel closed before read response".into(),
-    ))
+    Ok(Bytes::from(data))
 }
 
 async fn sftp_write_handle(
-    client: &AgentClient,
+    client: &Arc<AgentClient>,
     handle: crate::sandbox::fs::FsHandle,
     offset: u64,
     data: Vec<u8>,
 ) -> MicrosandboxResult<()> {
-    let req = FsRequest {
-        op: FsOp::Write {
-            handle,
-            offset,
-            len: Some(data.len() as u64),
-        },
-    };
-    let (id, mut rx) = client.stream(MessageType::FsRequest, &req).await?;
-
+    let sink = crate::sandbox::fs::agent::write_handle_stream(
+        Arc::clone(client),
+        handle,
+        offset,
+        Some(data.len() as u64),
+        None,
+    )
+    .await?;
     for chunk in data.chunks(FS_CHUNK_SIZE) {
-        client
-            .send(
-                id,
-                MessageType::FsData,
-                &FsData {
-                    data: chunk.to_vec(),
-                },
-            )
-            .await?;
+        sink.write(chunk).await?;
     }
-    client
-        .send(id, MessageType::FsData, &FsData { data: Vec::new() })
-        .await?;
-
-    while let Some(msg) = rx.recv().await {
-        if msg.t == MessageType::FsResponse {
-            let resp: FsResponse = msg.payload()?;
-            if resp.ok {
-                return Ok(());
-            }
-            return Err(MicrosandboxError::SandboxFsOps(
-                resp.error.unwrap_or_else(|| "unknown error".into()),
-            ));
-        }
-    }
-
-    Err(MicrosandboxError::SandboxFsOps(
-        "channel closed before write response".into(),
-    ))
+    sink.close().await
 }
 
 async fn sftp_stat(


### PR DESCRIPTION
## TL;DR

Move filesystem and TCP payloads out of nested CBOR into generation-8 raw records with bounded credit.

## Description

- Add negotiated raw records for filesystem and direct-TCP payloads.
- Keep requests, errors, credits, cancellation, and terminal results as typed control messages.
- Preserve generation-7 and older CBOR fallback whenever either peer does not support raw bulk.
- Keep generation 7 frozen as the `core.bootstrap` generation and add a separate generation-8 schema.
- Keep the high-level SDK API unchanged.

## Complete-stack performance

This is the last complete-stack Linux benchmark, comparing the original baseline at `05f53e7a` with the pre-restack cumulative stack at `7f3f44ce`. The cumulative benchmark will be rerun after #1360 and #1384 are restacked.

| Workload | Original baseline | Complete stack | Change |
|---|---:|---:|---:|
| FS host to guest, 256 MiB | 153.5 MiB/s | 323.4 MiB/s | +110.6% |
| TCP host to guest, 64 MiB | 198.8 MiB/s | 210.1 MiB/s | +5.7% |
| FS guest to host, 256 MiB | 254.6 MiB/s | 564.9 MiB/s | +121.9% |
| TCP guest to host, 64 MiB | 511.8 MiB/s | 649.7 MiB/s | +26.9% |
| TCP full duplex, 64 MiB each way | 244.4 MiB/s | 381.8 MiB/s | +56.2% |
| Idle ping median | 0.1383 ms | 0.1471 ms | +0.0088 ms |
| Ping under FS load, p95 | 480.3 ms | 1.929 ms | 99.60% lower |

Environment: OVH Advance-4, Linux/KVM, 1-vCPU guest, host CPU 8 affinity, guest tmpfs, public Rust SDK, verified payload hashes, and empty stderr.

## Test Plan

- [x] Preserve the immutable generation-7 schema and add the generated generation-8 schema
- [x] Verify that generation-7 peers do not advertise or receive raw bulk
- [x] Protocol, agentd, agent-client, SDK, and runtime unit tests pass locally
- [ ] Full CI passes on the rebased head
- [ ] Rerun the baseline-versus-complete-stack Linux transport benchmark after the remaining PRs are restacked










<!-- greptile_comment -->

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because no blocking failure remains.

No blocking failure remains.
</details>

<sub>Reviews (10): Last reviewed commit: ["test(agent): assert bootstrap compatibil..."](https://github.com/superradcompany/microsandbox/commit/ee6415341da8ab9881ce0b0da0da062ec08c7b0c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53715745)</sub>

<!-- /greptile_comment -->