### PR TITLE
docs: update Windows troubleshooting guide path

### DIFF
--- a/sdk/node-ts/README.md
+++ b/sdk/node-ts/README.md
@@ -26,7 +26,7 @@ For the full API reference and longer guides, use the docs site:
 
 - Node.js 22+
 - Linux with KVM, macOS with Apple Silicon, or Windows with Windows Hypervisor Platform
-- Windows support is currently preview; see the [Windows troubleshooting guide](https://docs.microsandbox.dev/getting-started/windows-troubleshooting) for WHP and runtime setup notes.
+- Windows support is currently preview; see the [Windows troubleshooting guide](https://docs.microsandbox.dev/troubleshooting/windows) for WHP and runtime setup notes.
 
 The package root is ESM-only for normal imports:
 

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -25,7 +25,7 @@ For the full API reference and longer guides, use the docs site:
 
 - Python 3.10+
 - Linux with KVM, macOS with Apple Silicon, or Windows with Windows Hypervisor Platform
-- Windows support is currently preview; see the [Windows troubleshooting guide](https://docs.microsandbox.dev/getting-started/windows-troubleshooting) for WHP and runtime setup notes.
+- Windows support is currently preview; see the [Windows troubleshooting guide](https://docs.microsandbox.dev/troubleshooting/windows) for WHP and runtime setup notes.
 
 ## Supported Platforms
 

--- a/sdk/rust/README.md
+++ b/sdk/rust/README.md
@@ -26,7 +26,7 @@ For full API documentation, use the docs site and generated Rust docs:
 
 - Rust toolchain with Rust 2024 edition support
 - Linux with KVM, macOS with Apple Silicon, or Windows with Windows Hypervisor Platform
-- Windows support is currently preview; see the [Windows troubleshooting guide](https://docs.microsandbox.dev/getting-started/windows-troubleshooting) for WHP and runtime setup notes.
+- Windows support is currently preview; see the [Windows troubleshooting guide](https://docs.microsandbox.dev/troubleshooting/windows) for WHP and runtime setup notes.
 
 ## Installation
 


### PR DESCRIPTION
The Windows troubleshooting guide moved from `/getting-started/windows-troubleshooting` to `/troubleshooting/windows` on the docs site (verified via sitemap, 200). Updated across 3 SDK READMEs (node-ts, python, rust).

<!-- greptile_comment -->

<sub>Reviews (1): Last reviewed commit: ["docs: update Windows troubleshooting gui..."](https://github.com/superradcompany/microsandbox/commit/3bec4a00863de0c8495af4631cb6302b3c1df7db) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53719990)</sub>

<!-- /greptile_comment -->