### PR TITLE
fix(runtime): fix broken build from bind-mount permission diagnostic

### DIFF
--- a/crates/runtime/lib/vm.rs
+++ b/crates/runtime/lib/vm.rs
@@ -1604,9 +1604,8 @@ fn build_vm(
             // Name the folder on a permission error, usually an OS access restriction.
             if e.kind() == std::io::ErrorKind::PermissionDenied {
                 RuntimeError::Custom(format!(
-                    "mount {tag}: permission denied reading host folder {} ({e}). \
-                     On macOS, grant access in System Settings > Privacy & Security.",
-                    host_path.display()
+                    "mount {tag}: permission denied reading host folder {host_path} ({e}). \
+                     On macOS, grant access in System Settings > Privacy & Security."
                 ))
             } else {
                 RuntimeError::Custom(format!("mount {tag}: {e}"))


### PR DESCRIPTION
## what

pr #1325 (merged to main as 1daaaa5e) broke the build on every platform. it called `.display()` on `host_path`, which is a `String`, not a `Path`:

```
error[E0599]: no method named `display` found for struct `std::string::String` in the current scope
  --> crates/runtime/lib/vm.rs:1609:31
```

this failed the `Check` workflow across all targets (linux, darwin, windows, integration tests).

## fix

`host_path` is already a `String`, so it interpolates directly. dropped the invalid `.display()` call and inlined the value in the format string.

## verification

`cargo check -p microsandbox-runtime` passes locally.

<!-- greptile_comment -->

<sub>Reviews (1): Last reviewed commit: ["fix(runtime): correct permission-error m..."](https://github.com/superradcompany/microsandbox/commit/6b1141b2933db6feba40beeb2c994615e4c9c4cc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53831585)</sub>

<!-- /greptile_comment -->