### PR TITLE
feat(cli): add plural resource list aliases

### DIFF
--- a/crates/cli/bin/main.rs
+++ b/crates/cli/bin/main.rs
@@ -164,6 +164,18 @@ enum Commands {
     #[command(hide = true)]
     Images(image::ImageListArgs),
 
+    /// List named volumes (alias for `volume ls`).
+    #[command(alias = "vols", hide = true)]
+    Volumes(volume::VolumeListArgs),
+
+    /// List disk snapshots (alias for `snapshot ls`).
+    #[command(alias = "snaps", hide = true)]
+    Snapshots(snapshot::SnapshotListArgs),
+
+    /// List configured registries (alias for `registry ls`).
+    #[command(alias = "regs", hide = true)]
+    Registries(registry::RegistryListArgs),
+
     /// Remove a cached image (alias for `image rm`).
     #[command(hide = true)]
     Rmi(image::ImageRemoveArgs),
@@ -676,6 +688,24 @@ fn run_async_command_anyhow(
             #[cfg(feature = "ssh")]
             Commands::Ssh(args) => microsandbox_cli::commands::ssh::run(args).await,
             Commands::Images(args) => image::run_list(args).await,
+            Commands::Volumes(args) => {
+                volume::run(volume::VolumeArgs {
+                    command: volume::VolumeCommands::List(args),
+                })
+                .await
+            }
+            Commands::Snapshots(args) => {
+                snapshot::run(snapshot::SnapshotArgs {
+                    command: snapshot::SnapshotCommands::List(args),
+                })
+                .await
+            }
+            Commands::Registries(args) => {
+                registry::run(registry::RegistryArgs {
+                    command: registry::RegistryCommands::List(args),
+                })
+                .await
+            }
             Commands::Rmi(args) => image::run_remove(args).await,
             Commands::Inspect(args) => inspect::run(args).await,
             Commands::Volume(args) => volume::run(args).await,
@@ -778,6 +808,27 @@ mod command_tests {
         assert!(shows_backend_notice(&exec.command));
         assert!(!shows_backend_notice(&context.command));
         assert!(matches!(context_alias.command, Commands::Context(_)));
+    }
+
+    #[test]
+    fn plural_resource_commands_route_to_list_actions() {
+        let cli = Cli::try_parse_from(["msb", "images"]).unwrap();
+        assert!(matches!(cli.command, Commands::Images(_)));
+
+        for command in ["volumes", "vols"] {
+            let cli = Cli::try_parse_from(["msb", command]).unwrap();
+            assert!(matches!(cli.command, Commands::Volumes(_)));
+        }
+
+        for command in ["snapshots", "snaps"] {
+            let cli = Cli::try_parse_from(["msb", command]).unwrap();
+            assert!(matches!(cli.command, Commands::Snapshots(_)));
+        }
+
+        for command in ["registries", "regs"] {
+            let cli = Cli::try_parse_from(["msb", command]).unwrap();
+            assert!(matches!(cli.command, Commands::Registries(_)));
+        }
     }
 
     #[cfg(feature = "ssh")]

--- a/docs/cli/image-commands.mdx
+++ b/docs/cli/image-commands.mdx
@@ -149,7 +149,7 @@ Manage registry authentication.
 msb registry login ghcr.io --username octocat
 printf '%s\n' "$GHCR_TOKEN" | msb registry login ghcr.io --username octocat --password-stdin
 msb registry logout ghcr.io
-msb registry ls
+msb registries                 # Also: msb regs, msb registry ls
 ```
 
 | Subcommand | Description |

--- a/docs/cli/overview.mdx
+++ b/docs/cli/overview.mdx
@@ -78,7 +78,7 @@ msb rmi python        # Remove a cached image
 
 # Volumes
 msb volume create data --size 10G
-msb volume ls
+msb volumes              # Also: msb vols
 msb volume rm data
 
 # Install as a system command

--- a/docs/cli/volume-commands.mdx
+++ b/docs/cli/volume-commands.mdx
@@ -24,13 +24,15 @@ msb volume create docker-data --kind disk --size 10G
 | `--size` | Disk capacity for `--kind disk` (e.g. `100M`, `1G`, `10G`) |
 | `-q`, `--quiet` | Suppress output (only print the volume name) |
 
-## msb volume ls
+## msb volumes
 
 ```bash
-msb volume ls
-msb volume ls --format json
-msb volume ls -q               # Names only
+msb volumes
+msb volumes --format json
+msb volumes -q               # Names only
 ```
+
+Expanded form: `msb volume ls`. The shorter plural alias `msb vols` is also available.
 
 | Flag | Description |
 |------|-------------|

--- a/docs/sandboxes/snapshots.mdx
+++ b/docs/sandboxes/snapshots.mdx
@@ -200,7 +200,7 @@ _, err = m.Snapshot.Reindex(ctx, "/data/snapshots")
 ```
 
 ```bash CLI
-msb snapshot ls
+msb snapshots                  # Also: msb snaps, msb snapshot ls
 msb snapshot inspect after-pip-install
 msb snapshot rm after-pip-install
 


### PR DESCRIPTION
## TL;DR
Add consistent top-level plural shortcuts for listing volumes, snapshots, and configured registries.

## Description
- Route `volumes` and `vols` to `volume list`.
- Route `snapshots` and `snaps` to `snapshot list`.
- Route `registries` and `regs` to `registry list`.
- Keep the shortcuts hidden from top-level help, matching the existing `images` behavior.
- Document the new spellings and cover all plural resource commands with parser tests.
- Use the shortcuts like this:

```bash
msb volumes
msb vols --format json
msb snapshots
msb snaps -q
msb registries
msb regs
```

## Test Plan
- [x] `cargo fmt --all -- --check` exits 0
- [x] `cargo test -p microsandbox-cli --bin msb command_tests` passes
- [x] `git diff --check` exits 0

<!-- greptile_comment -->

<sub>Reviews (1): Last reviewed commit: ["feat(cli): add plural resource list alia..."](https://github.com/superradcompany/microsandbox/commit/e26bb2b2114dc3096be884d7aed93816b15d1b7f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53882914)</sub>

<!-- /greptile_comment -->