### PR TITLE
fix(runtime): move guest bootstrap off kernel command line

### DIFF
--- a/crates/agentd/bin/main.rs
+++ b/crates/agentd/bin/main.rs
@@ -6,7 +6,7 @@
 use std::process;
 
 #[cfg(target_os = "linux")]
-use microsandbox_agentd::{AgentdConfig, AgentdError, BootParams, agent, clock, handoff, init};
+use microsandbox_agentd::{AgentdError, BootParams, agent, clock, handoff, init};
 
 //--------------------------------------------------------------------------------------------------
 // Functions: main
@@ -23,23 +23,34 @@ fn main() {
     // Capture CLOCK_BOOTTIME immediately — this represents kernel boot duration.
     let boot_time_ns = clock::boottime_ns();
 
-    // Read all MSB_* environment variables once at startup. `BootParams`
-    // carries the one-shot init data; `AgentdConfig` carries the runtime
-    // config that outlives init.
-    let mut boot = match BootParams::from_env() {
-        Ok(b) => b,
+    // Mount only what console discovery needs, then receive the typed
+    // bootstrap frame that the host queued before entering the VM.
+    if let Err(e) = init::prepare_bootstrap_console() {
+        eprintln!("agentd: early init failed: {e}");
+        process::exit(1);
+    }
+    let port = match agent::open_serial_port() {
+        Ok(port) => port,
         Err(e) => {
-            eprintln!("agentd: config parse failed: {e}");
+            eprintln!("agentd: console open failed: {e}");
             process::exit(1);
         }
     };
-    let config = match AgentdConfig::from_env() {
-        Ok(c) => c,
+    let (bootstrap, mut boot_console) = match agent::receive_bootstrap(&port) {
+        Ok(result) => result,
         Err(e) => {
-            eprintln!("agentd: config parse failed: {e}");
+            eprintln!("agentd: bootstrap receive failed: {e}");
             process::exit(1);
         }
     };
+    let (mut boot, config) = match BootParams::from_bootstrap(bootstrap) {
+        Ok(result) => result,
+        Err(e) => {
+            eprintln!("agentd: bootstrap validation failed: {e}");
+            process::exit(1);
+        }
+    };
+    config.install_default_env();
 
     // Extract handoff spec (if any) before `init::init` consumes
     // `BootParams` by value. The handoff itself fires after init so
@@ -47,13 +58,9 @@ fn main() {
     let handoff_spec = boot.take_handoff_init();
 
     // Phase 1: Synchronous init (mount filesystems, prepare runtime directories).
-    let mut port_file = None;
     let init_start = clock::boottime_ns();
     if let Err(e) = init::init(boot, || {
-        let port = agent::open_serial_port()?;
-        agent::report_init_context(&port, config.user())?;
-        port_file = Some(port);
-        Ok(())
+        agent::report_init_context(&port, &mut boot_console, config.user())
     }) {
         eprintln!("agentd: init failed: {e}");
         process::exit(1);
@@ -76,14 +83,7 @@ fn main() {
         .expect("agentd: failed to build tokio runtime");
 
     rt.block_on(async {
-        match agent::run(
-            boot_time_ns,
-            init_time_ns,
-            &config,
-            port_file.expect("serial port opened during init"),
-        )
-        .await
-        {
+        match agent::run(boot_time_ns, init_time_ns, &config, port, boot_console).await {
             Ok(()) => {}
             Err(AgentdError::Shutdown) => {}
             Err(e) => {

--- a/crates/agentd/lib/agent.rs
+++ b/crates/agentd/lib/agent.rs
@@ -14,6 +14,7 @@ use tokio::sync::{mpsc, watch};
 use tokio::time::{self, Duration};
 
 use microsandbox_protocol::HANDOFF_POWEROFF_TIMEOUT;
+use microsandbox_protocol::bootstrap::GuestBootstrap;
 use microsandbox_protocol::codec::{self, MAX_FRAME_SIZE};
 use microsandbox_protocol::core::{
     ClockSync, CoreError, CoreErrorKind, InitAck, InitResolved, Ping, Pong, Ready,
@@ -28,7 +29,7 @@ use microsandbox_protocol::heartbeat::{ActivityCounters, Heartbeat};
 use microsandbox_protocol::message::{Message, MessageType};
 use microsandbox_protocol::tcp::{TcpClose, TcpConnect, TcpData, TcpEof, TcpFailed};
 
-use crate::config::AgentdConfig;
+use crate::config::{AgentdConfig, scripts_path};
 use crate::error::{AgentdError, AgentdResult};
 use crate::fs::{FsReadSession, FsState, FsStreamSession, FsWriteSession};
 use crate::process::ProcessManager;
@@ -74,6 +75,15 @@ struct AgentState {
 struct ActivityTracker {
     activity_seq: u64,
     counters: ActivityCounters,
+}
+
+/// Buffered console input retained across the bootstrap and init handshakes.
+///
+/// A single device read may contain multiple frames, so boot phases must share
+/// this buffer instead of dropping bytes after decoding their expected frame.
+#[derive(Default)]
+pub struct BootConsoleState {
+    input: Vec<u8>,
 }
 
 #[derive(Clone)]
@@ -141,6 +151,7 @@ pub async fn run(
     init_time_ns: u64,
     config: &AgentdConfig,
     port_file: File,
+    boot_console: BootConsoleState,
 ) -> AgentdResult<()> {
     let process_manager = ProcessManager::get()?;
     let mut process_manager_failure = process_manager.subscribe_failure()?;
@@ -155,7 +166,7 @@ pub async fn run(
 
     // Buffer for serial reads.
     let mut read_buf = vec![0u8; SERIAL_READ_BUF_SIZE];
-    let mut serial_in_buf = Vec::new();
+    let mut serial_in_buf = boot_console.input;
     let mut serial_out_buf = Vec::new();
 
     let mut state = AgentState::default();
@@ -381,8 +392,48 @@ pub fn open_serial_port() -> AgentdResult<File> {
     Ok(OpenOptions::new().read(true).write(true).open(&port_path)?)
 }
 
+/// Receive and validate the first host-to-guest bootstrap frame.
+pub fn receive_bootstrap(port_file: &File) -> AgentdResult<(GuestBootstrap, BootConsoleState)> {
+    let fd = port_file.as_raw_fd();
+    set_nonblocking(fd)?;
+    let deadline = init_ack_deadline();
+    let mut state = BootConsoleState::default();
+    let msg = read_boot_message(fd, &mut state, deadline, "guest bootstrap")?;
+    let bootstrap = decode_bootstrap_message(msg)?;
+    Ok((bootstrap, state))
+}
+
+fn decode_bootstrap_message(msg: Message) -> AgentdResult<GuestBootstrap> {
+    if msg.id != 0 || msg.flags != 0 {
+        return Err(AgentdError::Config(format!(
+            "guest bootstrap requires id=0 and flags=0, got id={} flags={}",
+            msg.id, msg.flags
+        )));
+    }
+    if msg.t != MessageType::Bootstrap {
+        return Err(AgentdError::Config(format!(
+            "expected core.bootstrap as first console frame, got {}",
+            msg.t.as_str()
+        )));
+    }
+    let min_version = MessageType::Bootstrap.min_protocol_version();
+    if msg.v < min_version {
+        return Err(AgentdError::Config(format!(
+            "guest bootstrap requires protocol generation {min_version} or newer, got {}",
+            msg.v
+        )));
+    }
+
+    msg.payload::<GuestBootstrap>()
+        .map_err(|e| AgentdError::Config(format!("decode guest bootstrap payload: {e}")))
+}
+
 /// Reports init-time guest context to the host and waits for an acknowledgement.
-pub fn report_init_context(port_file: &File, default_user: Option<&str>) -> AgentdResult<()> {
+pub fn report_init_context(
+    port_file: &File,
+    boot_console: &mut BootConsoleState,
+    default_user: Option<&str>,
+) -> AgentdResult<()> {
     let (uid, gid) = resolve_default_user(default_user)?;
     let deadline = init_ack_deadline();
     let fd = port_file.as_raw_fd();
@@ -401,7 +452,7 @@ pub fn report_init_context(port_file: &File, default_user: Option<&str>) -> Agen
     codec::encode_to_buf(&msg, &mut out)
         .map_err(|e| AgentdError::ExecSession(format!("encode init context frame: {e}")))?;
     write_all_to_fd(fd, &out, deadline)?;
-    wait_for_init_ack(fd, deadline)
+    wait_for_init_ack(fd, boot_console, deadline)
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -449,6 +500,9 @@ async fn handle_message(
             let Some(mut req) = decode_payload_or_core_error::<ExecRequest>(&msg, out_buf)? else {
                 return Ok(());
             };
+            if req.cwd.is_none() {
+                req.cwd = config.default_cwd().map(str::to_string);
+            }
             prepend_scripts_to_path(&mut req);
             match ExecSession::spawn(
                 msg.id,
@@ -698,9 +752,6 @@ async fn handle_message(
 ///
 /// If the request already has a PATH entry, prepends to it. Otherwise
 /// inherits from agentd's environment and prepends.
-/// Default PATH for the guest when no PATH is inherited.
-const DEFAULT_GUEST_PATH: &str = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin";
-
 /// Returns whether a host message should refresh the sandbox idle timer.
 ///
 /// Maintenance traffic such as clock synchronization and reachability checks
@@ -1025,17 +1076,14 @@ fn errno_name(code: i32) -> Option<String> {
 }
 
 fn prepend_scripts_to_path(req: &mut microsandbox_protocol::exec::ExecRequest) {
-    let scripts = microsandbox_protocol::SCRIPTS_PATH;
-
     // Check if the request already specifies PATH.
     if let Some(entry) = req.env.iter_mut().find(|e| e.starts_with("PATH=")) {
         let existing = &entry["PATH=".len()..];
-        *entry = format!("PATH={scripts}:{existing}");
+        *entry = format!("PATH={}", scripts_path(Some(existing)));
     } else {
-        // Inherit from agentd's process environment, falling back to a
-        // sensible default since PID 1 in a minimal guest may not have PATH.
-        let inherited = env::var("PATH").unwrap_or_else(|_| DEFAULT_GUEST_PATH.to_string());
-        req.env.push(format!("PATH={scripts}:{inherited}"));
+        let inherited = env::var("PATH").ok();
+        req.env
+            .push(format!("PATH={}", scripts_path(inherited.as_deref())));
     }
 }
 
@@ -1060,55 +1108,68 @@ fn init_ack_timeout() -> AgentdError {
     AgentdError::ExecSession("timed out waiting for init ack".into())
 }
 
-fn wait_for_init_ack(fd: i32, deadline: Instant) -> AgentdResult<()> {
-    let mut serial_in_buf = Vec::new();
+fn wait_for_init_ack(
+    fd: i32,
+    boot_console: &mut BootConsoleState,
+    deadline: Instant,
+) -> AgentdResult<()> {
+    let msg = read_boot_message(fd, boot_console, deadline, "init ack")?;
+    if msg.t == MessageType::InitAck {
+        let _: InitAck = msg
+            .payload()
+            .map_err(|e| AgentdError::ExecSession(format!("decode init ack payload: {e}")))?;
+        return Ok(());
+    }
+
+    Err(AgentdError::ExecSession(format!(
+        "expected core.init.ack, got {}",
+        msg.t.as_str()
+    )))
+}
+
+fn read_boot_message(
+    fd: i32,
+    state: &mut BootConsoleState,
+    deadline: Instant,
+    context: &str,
+) -> AgentdResult<Message> {
     let mut read_buf = [0u8; 4096];
-
     loop {
-        if let Some(msg) = codec::try_decode_from_buf(&mut serial_in_buf)
-            .map_err(|e| AgentdError::ExecSession(format!("decode init ack: {e}")))?
+        if let Some(msg) = codec::try_decode_from_buf(&mut state.input)
+            .map_err(|e| AgentdError::ExecSession(format!("decode {context}: {e}")))?
         {
-            if msg.t == MessageType::InitAck {
-                let _: InitAck = msg.payload().map_err(|e| {
-                    AgentdError::ExecSession(format!("decode init ack payload: {e}"))
-                })?;
-                return Ok(());
-            }
-
+            return Ok(msg);
+        }
+        if state.input.len() > MAX_INPUT_BUF_SIZE {
             return Err(AgentdError::ExecSession(format!(
-                "expected core.init.ack, got {}",
-                msg.t.as_str()
+                "serial input buffer exceeded maximum size while waiting for {context}"
             )));
         }
-
-        if serial_in_buf.len() > MAX_INPUT_BUF_SIZE {
-            return Err(AgentdError::ExecSession(
-                "serial input buffer exceeded maximum size while waiting for init ack".into(),
-            ));
-        }
-
         if !poll_fd_until(fd, libc::POLLIN, deadline)? {
-            return Err(init_ack_timeout());
+            return Err(if context == "init ack" {
+                init_ack_timeout()
+            } else {
+                AgentdError::ExecSession(format!("timed out waiting for {context}"))
+            });
         }
-
         let n = match read_from_fd(fd, &mut read_buf) {
             Ok(n) => n,
-            Err(e)
+            Err(error)
                 if matches!(
-                    e.kind(),
+                    error.kind(),
                     std::io::ErrorKind::Interrupted | std::io::ErrorKind::WouldBlock
                 ) =>
             {
                 continue;
             }
-            Err(e) => return Err(e.into()),
+            Err(error) => return Err(error.into()),
         };
         if n == 0 {
-            return Err(AgentdError::ExecSession(
-                "serial port closed while waiting for init ack".into(),
-            ));
+            return Err(AgentdError::ExecSession(format!(
+                "serial port closed while waiting for {context}"
+            )));
         }
-        serial_in_buf.extend_from_slice(&read_buf[..n]);
+        state.input.extend_from_slice(&read_buf[..n]);
     }
 }
 
@@ -1238,6 +1299,87 @@ fn request_guest_poweroff() -> AgentdResult<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use microsandbox_protocol::message::PROTOCOL_VERSION;
+
+    #[test]
+    fn coalesced_bootstrap_and_init_ack_retain_the_second_frame() {
+        let bootstrap = GuestBootstrap::default();
+        let bootstrap_message =
+            Message::with_payload(MessageType::Bootstrap, 0, &bootstrap).unwrap();
+        let ack_message = Message::with_payload(MessageType::InitAck, 0, &InitAck {}).unwrap();
+        let mut state = BootConsoleState::default();
+        codec::encode_to_buf(&bootstrap_message, &mut state.input).unwrap();
+        codec::encode_to_buf(&ack_message, &mut state.input).unwrap();
+
+        let decoded = read_boot_message(
+            -1,
+            &mut state,
+            Instant::now() + std::time::Duration::from_secs(1),
+            "guest bootstrap",
+        )
+        .unwrap();
+        assert_eq!(decode_bootstrap_message(decoded).unwrap(), bootstrap);
+        assert!(
+            !state.input.is_empty(),
+            "init ack frame should remain buffered"
+        );
+
+        wait_for_init_ack(
+            -1,
+            &mut state,
+            Instant::now() + std::time::Duration::from_secs(1),
+        )
+        .unwrap();
+        assert!(state.input.is_empty());
+    }
+
+    #[test]
+    fn bootstrap_rejects_non_control_correlation_fields() {
+        let mut message =
+            Message::with_payload(MessageType::Bootstrap, 1, &GuestBootstrap::default()).unwrap();
+        message.flags = 1;
+
+        let error = decode_bootstrap_message(message).unwrap_err();
+        assert!(error.to_string().contains("requires id=0 and flags=0"));
+    }
+
+    #[test]
+    fn bootstrap_rejects_wrong_first_message_type() {
+        let message = Message::with_payload(MessageType::Ping, 0, &Ping {}).unwrap();
+
+        let error = decode_bootstrap_message(message).unwrap_err();
+        assert!(error.to_string().contains("expected core.bootstrap"));
+    }
+
+    #[test]
+    fn bootstrap_rejects_older_protocol_generation() {
+        let mut message =
+            Message::with_payload(MessageType::Bootstrap, 0, &GuestBootstrap::default()).unwrap();
+        message.v = PROTOCOL_VERSION - 1;
+
+        let error = decode_bootstrap_message(message).unwrap_err();
+        assert!(error.to_string().contains("or newer"));
+    }
+
+    #[test]
+    fn bootstrap_accepts_newer_additive_protocol_generation() {
+        let mut message =
+            Message::with_payload(MessageType::Bootstrap, 0, &GuestBootstrap::default()).unwrap();
+        message.v = PROTOCOL_VERSION + 1;
+
+        assert_eq!(
+            decode_bootstrap_message(message).unwrap(),
+            GuestBootstrap::default()
+        );
+    }
+
+    #[test]
+    fn bootstrap_rejects_malformed_payload() {
+        let message = Message::new(MessageType::Bootstrap, 0, vec![0xff]);
+
+        let error = decode_bootstrap_message(message).unwrap_err();
+        assert!(error.to_string().contains("decode guest bootstrap payload"));
+    }
 
     #[test]
     fn record_encoded_guest_messages_counts_only_appended_frames() {

--- a/crates/agentd/lib/config.rs
+++ b/crates/agentd/lib/config.rs
@@ -1,15 +1,14 @@
-//! Agentd configuration, read once from environment variables at startup.
+//! Agentd configuration, received once over the guest console at startup.
 //!
 //! Split into two structs with different lifetimes:
 //!
-//! - [`BootParams`] — one-shot MSB_* env vars consumed by [`init::init`] and
+//! - [`BootParams`] - one-shot bootstrap values consumed by [`init::init`] and
 //!   dropped once init completes.
 //! - [`AgentdConfig`] — runtime config that outlives init (currently just
 //!   the default guest user), passed by reference to the agent loop.
 //!
-//! Each struct owns its own [`from_env`](BootParams::from_env) constructor
-//! so reading is centralised and validation failures abort boot with a
-//! single clean error before any side effects begin.
+//! The typed bootstrap is validated before full guest initialization. Legacy
+//! environment parsers remain local to this module for compatibility tests.
 //!
 //! [`init::init`]: crate::init::init
 
@@ -23,7 +22,12 @@ use microsandbox_protocol::{
     ENV_BLOCK_ROOT, ENV_DIR_MOUNTS, ENV_DISK_MOUNTS, ENV_FILE_MOUNTS, ENV_HANDOFF_INIT,
     ENV_HANDOFF_INIT_ARGS, ENV_HANDOFF_INIT_CWD, ENV_HANDOFF_INIT_ENV, ENV_HOST_ALIAS,
     ENV_HOSTNAME, ENV_NET, ENV_NET_IPV4, ENV_NET_IPV6, ENV_RLIMITS, ENV_SECURITY_PROFILE,
-    ENV_TMPFS, ENV_USER, HANDOFF_INIT_AUTO, exec::ExecRlimit,
+    ENV_TMPFS, ENV_USER, HANDOFF_INIT_AUTO,
+    bootstrap::{
+        BootstrapBlockRoot, BootstrapBlockRootUpper, BootstrapEnvVar, BootstrapHandoffInit,
+        BootstrapSecurityProfile, GuestBootstrap,
+    },
+    exec::ExecRlimit,
 };
 use serde::de::DeserializeOwned;
 
@@ -34,7 +38,7 @@ use crate::rlimit;
 // Types
 //--------------------------------------------------------------------------------------------------
 
-/// One-shot MSB_* env vars consumed by [`init::init`] and dropped afterward.
+/// One-shot bootstrap values consumed by [`init::init`] and dropped afterward.
 ///
 /// Moved by value into init; owning the data (rather than borrowing) makes
 /// the "consumed once" lifetime explicit in the signature and prevents
@@ -43,48 +47,46 @@ use crate::rlimit;
 /// [`init::init`]: crate::init::init
 #[derive(Debug)]
 pub struct BootParams {
-    /// Parsed `MSB_BLOCK_ROOT` — block device for rootfs switch.
+    /// Block device configuration for a rootfs switch.
     pub(crate) block_root: Option<BlockRootSpec>,
 
-    /// Parsed `MSB_DIR_MOUNTS` — virtiofs directory mount specs (empty when unset).
+    /// Virtiofs directory mount specs (empty when unset).
     pub(crate) dir_mounts: Vec<DirMountSpec>,
 
-    /// Parsed `MSB_FILE_MOUNTS` — virtiofs file mount specs (empty when unset).
+    /// Virtiofs file mount specs (empty when unset).
     pub(crate) file_mounts: Vec<FileMountSpec>,
 
-    /// Parsed `MSB_DISK_MOUNTS` — disk-image mount specs (empty when unset).
+    /// Disk-image mount specs (empty when unset).
     pub(crate) disk_mounts: Vec<DiskMountSpec>,
 
-    /// Parsed `MSB_TMPFS` — tmpfs mount specs (empty when unset).
+    /// Tmpfs mount specs (empty when unset).
     pub(crate) tmpfs: Vec<TmpfsSpec>,
 
-    /// Parsed `MSB_SECURITY_PROFILE` — in-guest security profile.
+    /// In-guest security profile.
     pub(crate) security_profile: SecurityProfile,
 
-    /// `MSB_HOSTNAME` — guest hostname.
+    /// Guest hostname.
     pub(crate) hostname: Option<String>,
 
-    /// `MSB_HOST_ALIAS` — DNS name (e.g. `host.microsandbox.internal`)
-    /// the guest uses to reach the sandbox host. Written into
-    /// `/etc/hosts` pointing at the gateway IPs.
+    /// DNS name (for example `host.microsandbox.internal`) the guest uses to
+    /// reach the sandbox host. Written into `/etc/hosts` at the gateway IPs.
     pub(crate) host_alias: Option<String>,
 
-    /// Parsed `MSB_NET` — network interface config.
+    /// Network interface configuration.
     pub(crate) net: Option<NetSpec>,
 
-    /// Parsed `MSB_NET_IPV4` — IPv4 config.
+    /// IPv4 configuration.
     pub(crate) net_ipv4: Option<NetIpv4Spec>,
 
-    /// Parsed `MSB_NET_IPV6` — IPv6 config.
+    /// IPv6 configuration.
     pub(crate) net_ipv6: Option<NetIpv6Spec>,
 
-    /// Parsed `MSB_RLIMITS` — sandbox-wide resource limits applied to PID 1
-    /// so every guest process inherits the raised baseline (empty when unset).
+    /// Sandbox-wide resource limits applied to PID 1 so every guest process
+    /// inherits the raised baseline (empty when unset).
     pub(crate) rlimits: Vec<ExecRlimit>,
 
-    /// Parsed `MSB_HANDOFF_INIT[_ARGS|_ENV]` — guest init binary to which
-    /// agentd hands off PID 1 after `init::init()`. `None` means agentd
-    /// remains PID 1 (the default).
+    /// Guest init binary to which agentd hands off PID 1 after `init::init()`.
+    /// `None` means agentd remains PID 1 (the default).
     pub(crate) handoff_init: Option<HandoffInit>,
 }
 
@@ -117,13 +119,17 @@ pub struct HandoffInit {
 /// and security profile for exec sessions.
 #[derive(Debug)]
 pub struct AgentdConfig {
-    /// `MSB_USER` — default guest user for exec sessions.
-    ///
-    /// Captured at startup; changes to `MSB_USER` afterward are not observed.
+    /// Default guest user for exec sessions, captured at startup.
     pub(crate) user: Option<String>,
 
     /// In-guest security profile for exec sessions.
     pub(crate) security_profile: SecurityProfile,
+
+    /// Default working directory for requests that omit one.
+    pub(crate) default_cwd: Option<String>,
+
+    /// Baseline image/user environment plus host-generated placeholders.
+    pub(crate) default_env: Vec<BootstrapEnvVar>,
 }
 
 /// In-guest security profile.
@@ -279,6 +285,157 @@ pub(crate) struct NetConfig<'a> {
 //--------------------------------------------------------------------------------------------------
 
 impl BootParams {
+    /// Validate and convert the typed console bootstrap into agentd's init and
+    /// long-lived runtime configuration.
+    pub fn from_bootstrap(bootstrap: GuestBootstrap) -> AgentdResult<(Self, AgentdConfig)> {
+        validate_guest_bootstrap(&bootstrap)?;
+
+        let GuestBootstrap {
+            block_root,
+            dir_mounts,
+            file_mounts,
+            disk_mounts,
+            tmpfs_mounts,
+            hostname,
+            host_alias,
+            network,
+            rlimits,
+            user,
+            default_cwd,
+            default_env,
+            security_profile,
+            handoff_init,
+        } = bootstrap;
+
+        let security_profile = match security_profile {
+            BootstrapSecurityProfile::Default => SecurityProfile::Default,
+            BootstrapSecurityProfile::Restricted => SecurityProfile::Restricted,
+        };
+        let block_root = block_root.map(|root| match root {
+            BootstrapBlockRoot::DiskImage { device, fstype } => {
+                BlockRootSpec::DiskImage { device, fstype }
+            }
+            BootstrapBlockRoot::OciErofs { lower, upper } => BlockRootSpec::OciErofs {
+                lower,
+                upper: match upper {
+                    BootstrapBlockRootUpper::Device { device, fstype } => {
+                        BlockRootUpper::Device { device, fstype }
+                    }
+                    BootstrapBlockRootUpper::Tmpfs { size_mib } => {
+                        BlockRootUpper::Tmpfs { size_mib }
+                    }
+                },
+            },
+        });
+        let dir_mounts = dir_mounts
+            .into_iter()
+            .map(|mount| {
+                let flags = mount.flags;
+                DirMountSpec {
+                    tag: mount.tag,
+                    guest_path: mount.guest_path,
+                    readonly: flags.readonly,
+                    noexec: flags.noexec,
+                    nosuid: flags.nosuid,
+                    nodev: flags.nodev,
+                }
+            })
+            .collect();
+        let file_mounts = file_mounts
+            .into_iter()
+            .map(|mount| {
+                let flags = mount.flags;
+                FileMountSpec {
+                    tag: mount.tag,
+                    filename: mount.filename,
+                    guest_path: mount.guest_path,
+                    readonly: flags.readonly,
+                    noexec: flags.noexec,
+                    nosuid: flags.nosuid,
+                    nodev: flags.nodev,
+                }
+            })
+            .collect();
+        let disk_mounts = disk_mounts
+            .into_iter()
+            .map(|mount| {
+                let flags = mount.flags;
+                DiskMountSpec {
+                    id: mount.id,
+                    guest_path: mount.guest_path,
+                    fstype: mount.fstype,
+                    readonly: flags.readonly,
+                    noexec: flags.noexec,
+                    nosuid: flags.nosuid,
+                    nodev: flags.nodev,
+                }
+            })
+            .collect();
+        let tmpfs = tmpfs_mounts
+            .into_iter()
+            .map(|mount| {
+                let flags = mount.flags;
+                TmpfsSpec {
+                    path: mount.path,
+                    size_mib: mount.size_mib,
+                    mode: mount.mode,
+                    noexec: flags.noexec,
+                    nosuid: flags.nosuid,
+                    nodev: flags.nodev,
+                    readonly: flags.readonly,
+                }
+            })
+            .collect();
+        let (net, net_ipv4, net_ipv6) = match network {
+            Some(network) => {
+                let net = NetSpec {
+                    iface: network.interface,
+                    mac: network.mac,
+                    mtu: network.mtu,
+                };
+                let ipv4 = network.ipv4.map(|ipv4| NetIpv4Spec {
+                    address: ipv4.address,
+                    prefix_len: ipv4.prefix_len,
+                    gateway: ipv4.gateway,
+                    dns: ipv4.dns,
+                });
+                let ipv6 = network.ipv6.map(|ipv6| NetIpv6Spec {
+                    address: ipv6.address,
+                    prefix_len: ipv6.prefix_len,
+                    gateway: ipv6.gateway,
+                    dns: ipv6.dns,
+                });
+                (Some(net), ipv4, ipv6)
+            }
+            None => (None, None, None),
+        };
+        let handoff_init = handoff_init.map(convert_bootstrap_handoff).transpose()?;
+
+        Ok((
+            Self {
+                block_root,
+                dir_mounts,
+                file_mounts,
+                disk_mounts,
+                tmpfs,
+                security_profile,
+                hostname,
+                host_alias,
+                net,
+                net_ipv4,
+                net_ipv6,
+                rlimits,
+                handoff_init,
+            },
+            AgentdConfig {
+                user,
+                security_profile,
+                default_cwd,
+                default_env,
+            },
+        ))
+    }
+
     /// Reads and parses the boot-time `MSB_*` environment variables.
     ///
     /// Empty or whitespace-only values are treated as absent (`None`).
@@ -349,6 +506,33 @@ impl AgentdConfig {
         self.user.as_deref()
     }
 
+    /// Return the sandbox working directory used when an exec request omits one.
+    pub fn default_cwd(&self) -> Option<&str> {
+        self.default_cwd.as_deref()
+    }
+
+    /// Install the baseline workload environment before any guest child is created.
+    pub fn install_default_env(&self) {
+        for variable in &self.default_env {
+            // SAFETY: agentd is still single-threaded during bootstrap, and
+            // `validate_guest_bootstrap` rejected NUL bytes in both fields.
+            unsafe { env::set_var(&variable.key, &variable.value) };
+        }
+
+        // The former libkrun environment transport always installed this
+        // prefix for both agent execs and PID 1 handoff. Preserve that
+        // inheritance without relying on agentd's ambient boot environment.
+        let configured_path = self
+            .default_env
+            .iter()
+            .rev()
+            .find(|variable| variable.key == "PATH")
+            .map(|variable| variable.value.as_str());
+        // SAFETY: `scripts_path` constructs a NUL-free key and value while
+        // agentd is still single-threaded during bootstrap.
+        unsafe { env::set_var("PATH", scripts_path(configured_path)) };
+    }
+
     /// Reads the runtime-config `MSB_*` environment variables.
     ///
     /// Empty or whitespace-only values are treated as absent (`None`).
@@ -359,7 +543,28 @@ impl AgentdConfig {
                 .map(|v| parse_security_profile(&v))
                 .transpose()?
                 .unwrap_or_default(),
+            default_cwd: None,
+            default_env: Vec::new(),
         })
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Functions: Runtime Environment
+//--------------------------------------------------------------------------------------------------
+
+/// Return a guest PATH with the runtime scripts directory present exactly once.
+pub(crate) fn scripts_path(existing: Option<&str>) -> String {
+    const DEFAULT_GUEST_PATH: &str = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin";
+
+    let existing = existing.unwrap_or(DEFAULT_GUEST_PATH);
+    if existing
+        .split(':')
+        .any(|segment| segment == microsandbox_protocol::SCRIPTS_PATH)
+    {
+        existing.to_string()
+    } else {
+        format!("{}:{existing}", microsandbox_protocol::SCRIPTS_PATH)
     }
 }
 
@@ -1102,6 +1307,194 @@ fn parse_handoff_env_pair(key: String, value: String) -> AgentdResult<(OsString,
 // Helper Functions
 //--------------------------------------------------------------------------------------------------
 
+fn validate_guest_bootstrap(bootstrap: &GuestBootstrap) -> AgentdResult<()> {
+    if let Some(root) = &bootstrap.block_root {
+        match root {
+            BootstrapBlockRoot::DiskImage { device, fstype } => {
+                validate_absolute_guest_path("bootstrap block-root device", device)?;
+                if let Some(fstype) = fstype {
+                    validate_nonempty_bootstrap_string("bootstrap block-root fstype", fstype)?;
+                }
+            }
+            BootstrapBlockRoot::OciErofs { lower, upper } => {
+                validate_absolute_guest_path("bootstrap EROFS lower device", lower)?;
+                match upper {
+                    BootstrapBlockRootUpper::Device { device, fstype } => {
+                        validate_absolute_guest_path("bootstrap upper device", device)?;
+                        validate_nonempty_bootstrap_string("bootstrap upper fstype", fstype)?;
+                    }
+                    BootstrapBlockRootUpper::Tmpfs { .. } => {}
+                }
+            }
+        }
+    }
+
+    for mount in &bootstrap.dir_mounts {
+        validate_nonempty_bootstrap_string("bootstrap directory mount tag", &mount.tag)?;
+        validate_absolute_guest_path("bootstrap directory mount path", &mount.guest_path)?;
+    }
+    for mount in &bootstrap.file_mounts {
+        validate_nonempty_bootstrap_string("bootstrap file mount tag", &mount.tag)?;
+        validate_nonempty_bootstrap_string("bootstrap file mount filename", &mount.filename)?;
+        validate_absolute_guest_path("bootstrap file mount path", &mount.guest_path)?;
+    }
+    for mount in &bootstrap.disk_mounts {
+        validate_nonempty_bootstrap_string("bootstrap disk mount id", &mount.id)?;
+        validate_absolute_guest_path("bootstrap disk mount path", &mount.guest_path)?;
+        if let Some(fstype) = &mount.fstype {
+            validate_nonempty_bootstrap_string("bootstrap disk mount fstype", fstype)?;
+        }
+    }
+    for mount in &bootstrap.tmpfs_mounts {
+        validate_absolute_guest_path("bootstrap tmpfs path", &mount.path)?;
+    }
+
+    if let Some(hostname) = &bootstrap.hostname {
+        validate_nonempty_bootstrap_string("bootstrap hostname", hostname)?;
+    }
+    if let Some(host_alias) = &bootstrap.host_alias {
+        validate_nonempty_bootstrap_string("bootstrap host alias", host_alias)?;
+    }
+    if let Some(network) = &bootstrap.network {
+        validate_nonempty_bootstrap_string("bootstrap network interface", &network.interface)?;
+        if let Some(ipv4) = network.ipv4
+            && ipv4.prefix_len > 32
+        {
+            return Err(AgentdError::Config(format!(
+                "bootstrap IPv4 prefix length out of range: {}",
+                ipv4.prefix_len
+            )));
+        }
+        if let Some(ipv6) = network.ipv6
+            && ipv6.prefix_len > 128
+        {
+            return Err(AgentdError::Config(format!(
+                "bootstrap IPv6 prefix length out of range: {}",
+                ipv6.prefix_len
+            )));
+        }
+    }
+
+    let mut seen_rlimits = Vec::new();
+    for rlimit in &bootstrap.rlimits {
+        if rlimit::parse_rlimit_resource(&rlimit.resource).is_none() {
+            return Err(AgentdError::Config(format!(
+                "bootstrap rlimits contains unknown resource: {}",
+                rlimit.resource
+            )));
+        }
+        if rlimit.soft > rlimit.hard {
+            return Err(AgentdError::Config(format!(
+                "bootstrap rlimit {} has soft limit above hard limit",
+                rlimit.resource
+            )));
+        }
+        if seen_rlimits.iter().any(|name| name == &rlimit.resource) {
+            return Err(AgentdError::Config(format!(
+                "bootstrap rlimits contains duplicate resource: {}",
+                rlimit.resource
+            )));
+        }
+        seen_rlimits.push(rlimit.resource.clone());
+    }
+
+    if let Some(user) = &bootstrap.user {
+        validate_nonempty_bootstrap_string("bootstrap user", user)?;
+    }
+    if let Some(cwd) = &bootstrap.default_cwd {
+        validate_nonempty_bootstrap_string("bootstrap default cwd", cwd)?;
+    }
+    for variable in &bootstrap.default_env {
+        validate_bootstrap_env("bootstrap default env", variable)?;
+    }
+    if let Some(handoff) = &bootstrap.handoff_init {
+        validate_bootstrap_handoff(handoff)?;
+    }
+
+    Ok(())
+}
+
+fn validate_bootstrap_handoff(handoff: &BootstrapHandoffInit) -> AgentdResult<()> {
+    if handoff.cmd.contains('\0') {
+        return Err(AgentdError::Config(
+            "bootstrap handoff command must not contain NUL".into(),
+        ));
+    }
+    if handoff.cmd != HANDOFF_INIT_AUTO && !handoff.cmd.starts_with('/') {
+        return Err(AgentdError::Config(format!(
+            "bootstrap handoff command must be absolute or `auto`: {}",
+            handoff.cmd
+        )));
+    }
+    for (index, arg) in handoff.args.iter().enumerate() {
+        if arg.contains('\0') {
+            return Err(AgentdError::Config(format!(
+                "bootstrap handoff argument #{index} must not contain NUL"
+            )));
+        }
+    }
+    if let Some(cwd) = &handoff.cwd {
+        validate_absolute_guest_path("bootstrap handoff cwd", cwd)?;
+    }
+    for variable in &handoff.env {
+        validate_bootstrap_env("bootstrap handoff env", variable)?;
+    }
+    Ok(())
+}
+
+fn validate_bootstrap_env(label: &str, variable: &BootstrapEnvVar) -> AgentdResult<()> {
+    if variable.key.is_empty() {
+        return Err(AgentdError::Config(format!(
+            "{label} contains an empty key"
+        )));
+    }
+    if variable.key.contains('=') || variable.key.contains('\0') {
+        return Err(AgentdError::Config(format!(
+            "{label} key {:?} must not contain '=' or NUL",
+            variable.key
+        )));
+    }
+    if variable.value.contains('\0') {
+        return Err(AgentdError::Config(format!(
+            "{label} value for {:?} must not contain NUL",
+            variable.key
+        )));
+    }
+    Ok(())
+}
+
+fn validate_absolute_guest_path(label: &str, value: &str) -> AgentdResult<()> {
+    validate_nonempty_bootstrap_string(label, value)?;
+    if !value.starts_with('/') {
+        return Err(AgentdError::Config(format!(
+            "{label} must be an absolute Linux path: {value}"
+        )));
+    }
+    Ok(())
+}
+
+fn validate_nonempty_bootstrap_string(label: &str, value: &str) -> AgentdResult<()> {
+    if value.is_empty() || value.contains('\0') {
+        return Err(AgentdError::Config(format!(
+            "{label} must be non-empty and must not contain NUL"
+        )));
+    }
+    Ok(())
+}
+
+fn convert_bootstrap_handoff(handoff: BootstrapHandoffInit) -> AgentdResult<HandoffInit> {
+    Ok(HandoffInit {
+        cmd: PathBuf::from(handoff.cmd),
+        argv: handoff.args.into_iter().map(OsString::from).collect(),
+        cwd: handoff.cwd.map(PathBuf::from),
+        env: handoff
+            .env
+            .into_iter()
+            .map(|variable| (OsString::from(variable.key), OsString::from(variable.value)))
+            .collect(),
+    })
+}
+
 /// Reads a single environment variable, returning `None` for missing or empty values.
 fn read_env(key: &str) -> Option<String> {
     env::var(key)
@@ -1125,6 +1518,130 @@ fn read_env_raw(key: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ---------------------------------------------------------------------------------------------
+    // Typed Bootstrap
+    // ---------------------------------------------------------------------------------------------
+
+    #[test]
+    fn test_scripts_path_uses_stable_default_and_avoids_duplicates() {
+        assert_eq!(
+            scripts_path(None),
+            "/.msb/scripts:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+        );
+        assert_eq!(
+            scripts_path(Some("/custom/bin:/bin")),
+            "/.msb/scripts:/custom/bin:/bin"
+        );
+        assert_eq!(
+            scripts_path(Some("/bin:/.msb/scripts:/usr/bin")),
+            "/bin:/.msb/scripts:/usr/bin"
+        );
+    }
+
+    #[test]
+    fn test_bootstrap_preserves_structured_environment_and_handoff_values() {
+        let bootstrap = GuestBootstrap {
+            hostname: Some("quoted-host".to_string()),
+            network: Some(microsandbox_protocol::bootstrap::BootstrapNetwork {
+                interface: "eth0".to_string(),
+                mac: [0x02, 0x5a, 0x7b, 0x13, 0x01, 0x02],
+                mtu: 1500,
+                ipv4: None,
+                ipv6: None,
+            }),
+            rlimits: vec![ExecRlimit {
+                resource: "nofile".to_string(),
+                soft: 4096,
+                hard: 65_535,
+            }],
+            user: Some("1000:1000".to_string()),
+            default_cwd: Some("/workspace".to_string()),
+            default_env: vec![BootstrapEnvVar {
+                key: "APP_CONFIG".to_string(),
+                value: "{\"message\":\"hello\",\"unicode\":\"lambda λ\"}\nnext\tline=a=b"
+                    .to_string(),
+            }],
+            security_profile: BootstrapSecurityProfile::Restricted,
+            handoff_init: Some(BootstrapHandoffInit {
+                cmd: "/sbin/init".to_string(),
+                args: vec!["--label=\"hello world\"".to_string()],
+                cwd: Some("/workspace".to_string()),
+                env: vec![BootstrapEnvVar {
+                    key: "INIT_CONFIG".to_string(),
+                    value: "{\"enabled\":true}".to_string(),
+                }],
+            }),
+            ..GuestBootstrap::default()
+        };
+
+        let (boot, config) = BootParams::from_bootstrap(bootstrap).unwrap();
+
+        assert_eq!(boot.hostname.as_deref(), Some("quoted-host"));
+        assert_eq!(boot.rlimits[0].hard, 65_535);
+        assert!(matches!(boot.security_profile, SecurityProfile::Restricted));
+        assert_eq!(config.user.as_deref(), Some("1000:1000"));
+        assert_eq!(config.default_cwd.as_deref(), Some("/workspace"));
+        assert_eq!(
+            config.default_env[0].value,
+            "{\"message\":\"hello\",\"unicode\":\"lambda λ\"}\nnext\tline=a=b"
+        );
+
+        let handoff = boot.handoff_init.expect("handoff bootstrap");
+        assert_eq!(
+            handoff.argv,
+            vec![OsString::from("--label=\"hello world\"")]
+        );
+        assert_eq!(
+            handoff.env,
+            vec![(
+                OsString::from("INIT_CONFIG"),
+                OsString::from("{\"enabled\":true}")
+            )]
+        );
+    }
+
+    #[test]
+    fn test_bootstrap_accepts_relative_default_cwd() {
+        let bootstrap = GuestBootstrap {
+            default_cwd: Some("workspace".to_string()),
+            ..GuestBootstrap::default()
+        };
+
+        let (_, config) = BootParams::from_bootstrap(bootstrap).unwrap();
+
+        assert_eq!(config.default_cwd.as_deref(), Some("workspace"));
+    }
+
+    #[test]
+    fn test_bootstrap_rejects_duplicate_rlimits() {
+        let rlimit = ExecRlimit {
+            resource: "nofile".to_string(),
+            soft: 1024,
+            hard: 1024,
+        };
+        let bootstrap = GuestBootstrap {
+            rlimits: vec![rlimit.clone(), rlimit],
+            ..GuestBootstrap::default()
+        };
+
+        let error = BootParams::from_bootstrap(bootstrap).unwrap_err();
+        assert!(error.to_string().contains("duplicate resource"));
+    }
+
+    #[test]
+    fn test_bootstrap_rejects_invalid_environment_key() {
+        let bootstrap = GuestBootstrap {
+            default_env: vec![BootstrapEnvVar {
+                key: "BAD=KEY".to_string(),
+                value: "value".to_string(),
+            }],
+            ..GuestBootstrap::default()
+        };
+
+        let error = BootParams::from_bootstrap(bootstrap).unwrap_err();
+        assert!(error.to_string().contains("must not contain '=' or NUL"));
+    }
 
     // ── Block Root ────────────────────────────────────────────────────
 

--- a/crates/agentd/lib/handoff.rs
+++ b/crates/agentd/lib/handoff.rs
@@ -9,9 +9,9 @@
 //! - **Child** continues as a normal grandchild process and runs the
 //!   agent loop, serving host requests over virtio-serial.
 //!
-//! The handoff happens before any tokio runtime is built and before
-//! virtio-serial is opened, keeping the fork single-threaded and
-//! free of duplicated runtime state.
+//! The handoff happens before any tokio runtime is built. The already-open
+//! virtio-console descriptor is close-on-exec, so the new PID 1 does not
+//! inherit it while the agent child keeps serving the host connection.
 //!
 //! [`init::init`]: crate::init::init
 //!
@@ -77,10 +77,9 @@ pub fn do_handoff(spec: HandoffInit) -> AgentdResult<()> {
     let envp = build_envp(&spec.env);
     let cmd_c = path_to_cstring(&cmd)?;
 
-    // SAFETY: `fork()` in a single-threaded process with no opened
-    // serial fds and no async runtime. The agent loop has not started
-    // yet; tls/init writes are complete; only stdin/stdout/stderr are
-    // inherited from the kernel.
+    // SAFETY: `fork()` runs while agentd is still single-threaded and before
+    // any async runtime exists. The console fd is close-on-exec in the parent
+    // and intentionally retained by the child for the agent loop.
     match unsafe { fork() }? {
         ForkResult::Parent { .. } => {
             // We are now the new PID 1's pre-image. Restore default
@@ -231,18 +230,6 @@ fn build_envp(extras: &[(OsString, OsString)]) -> Vec<CString> {
     use std::collections::HashMap;
 
     let mut env: HashMap<OsString, OsString> = std::env::vars_os().collect();
-
-    // Strip our own boot params from the inherited env so the new
-    // init doesn't see stale MSB_* values that referred to agentd's
-    // boot, not its own runtime.
-    for var in [
-        microsandbox_protocol::ENV_HANDOFF_INIT,
-        microsandbox_protocol::ENV_HANDOFF_INIT_ARGS,
-        microsandbox_protocol::ENV_HANDOFF_INIT_CWD,
-        microsandbox_protocol::ENV_HANDOFF_INIT_ENV,
-    ] {
-        env.remove(&OsString::from(var));
-    }
 
     for (k, v) in extras {
         env.insert(k.clone(), v.clone());

--- a/crates/agentd/lib/init.rs
+++ b/crates/agentd/lib/init.rs
@@ -8,6 +8,14 @@ use crate::{network, rlimit, tls};
 // Functions
 //--------------------------------------------------------------------------------------------------
 
+/// Mount only the filesystems needed to discover and open the agent console.
+///
+/// The console descriptor remains valid when a block-backed root later pivots
+/// and remounts the essential filesystems inside the final guest root.
+pub fn prepare_bootstrap_console() -> AgentdResult<()> {
+    linux::mount_bootstrap_filesystems()
+}
+
 /// Performs synchronous PID 1 initialization.
 ///
 /// Applies sandbox-wide resource limits first so every later guest process
@@ -151,17 +159,16 @@ mod linux {
         }
     }
 
+    /// Mount the minimum filesystems needed for virtio-console discovery.
+    pub fn mount_bootstrap_filesystems() -> AgentdResult<()> {
+        mount_dev()?;
+        mount_sys()?;
+        Ok(())
+    }
+
     /// Mounts essential Linux filesystems.
     pub fn mount_filesystems() -> AgentdResult<()> {
-        // /dev — devtmpfs
-        mkdir_ignore_exists("/dev")?;
-        mount_ignore_busy(
-            Some("devtmpfs"),
-            "/dev",
-            Some("devtmpfs"),
-            MsFlags::MS_RELATIME,
-            None::<&str>,
-        )?;
+        mount_dev()?;
 
         // /proc — proc
         let nodev_noexec_nosuid =
@@ -176,15 +183,7 @@ mod linux {
             None::<&str>,
         )?;
 
-        // /sys — sysfs
-        mkdir_ignore_exists("/sys")?;
-        mount_ignore_busy(
-            Some("sysfs"),
-            "/sys",
-            Some("sysfs"),
-            nodev_noexec_nosuid,
-            None::<&str>,
-        )?;
+        mount_sys()?;
 
         // /sys/fs/cgroup — cgroup2
         mkdir_ignore_exists("/sys/fs/cgroup")?;
@@ -225,6 +224,24 @@ mod linux {
         }
 
         Ok(())
+    }
+
+    fn mount_dev() -> AgentdResult<()> {
+        mkdir_ignore_exists("/dev")?;
+        mount_ignore_busy(
+            Some("devtmpfs"),
+            "/dev",
+            Some("devtmpfs"),
+            MsFlags::MS_RELATIME,
+            None::<&str>,
+        )
+    }
+
+    fn mount_sys() -> AgentdResult<()> {
+        let flags =
+            MsFlags::MS_NODEV | MsFlags::MS_NOEXEC | MsFlags::MS_NOSUID | MsFlags::MS_RELATIME;
+        mkdir_ignore_exists("/sys")?;
+        mount_ignore_busy(Some("sysfs"), "/sys", Some("sysfs"), flags, None::<&str>)
     }
 
     /// Mounts the virtiofs runtime filesystem at the canonical mount point.

--- a/crates/agentd/lib/rlimit.rs
+++ b/crates/agentd/lib/rlimit.rs
@@ -39,7 +39,7 @@ pub(crate) fn to_libc(rlimits: &[ExecRlimit]) -> Vec<(libc::c_int, libc::rlimit)
 /// started through the per-exec API.
 ///
 /// Callers must have validated resource names upfront (e.g. via
-/// [`BootParams::from_env`](crate::config::BootParams::from_env)); unknown
+/// [`BootParams::from_bootstrap`](crate::config::BootParams::from_bootstrap)); unknown
 /// names here produce an [`AgentdError::Init`] rather than silently skipping.
 pub(crate) fn apply_baseline(rlimits: &[ExecRlimit]) -> AgentdResult<()> {
     for rlimit in rlimits {

--- a/crates/cli/lib/sandbox_cmd.rs
+++ b/crates/cli/lib/sandbox_cmd.rs
@@ -247,8 +247,7 @@ pub fn run(args: SandboxArgs) -> ! {
         #[cfg(unix)]
         backends: vec![],
         init_path: launch.init_path,
-        env: launch.env,
-        workdir: launch.workdir,
+        bootstrap: launch.bootstrap,
         exec_path: launch.exec_path,
         exec_args: launch.exec_args,
         #[cfg(feature = "net")]
@@ -438,12 +437,12 @@ fn validate_open_fd(fd: i32, expected_fd: i32, arg_name: &str) -> Result<(), Str
 
 /// Parse `--disk id:host_path:format[:ro]` entries into typed specs.
 ///
-/// `guest` and `fstype` are not in this arg — they travel in the
-/// `MSB_DISK_MOUNTS` env var and are consumed by agentd, so the runtime
-/// only needs what `DiskBuilder` will set.
+/// `guest` and `fstype` are not in this arg. They travel in the typed guest
+/// bootstrap consumed by agentd, so the runtime only needs what `DiskBuilder`
+/// will set.
 ///
-/// Malformed entries are hard errors so the host-side `MSB_DISK_MOUNTS`
-/// handoff cannot mention a disk that the runtime silently failed to attach.
+/// Malformed entries are hard errors so bootstrap cannot mention a disk that
+/// the runtime silently failed to attach.
 fn parse_disk_args(entries: &[String]) -> Result<Vec<DiskMountSpec>, String> {
     entries
         .iter()
@@ -666,11 +665,18 @@ mod tests {
 
     #[test]
     fn test_load_launch_config_from_file() {
+        use microsandbox_protocol::bootstrap::{BootstrapEnvVar, GuestBootstrap};
         use std::io::Write;
 
         let launch = LaunchConfig {
             db_path: PathBuf::from("/tmp/x.db"),
-            env: vec!["TOKEN=secret".to_string()],
+            bootstrap: GuestBootstrap {
+                default_env: vec![BootstrapEnvVar {
+                    key: "TOKEN".to_string(),
+                    value: "secret".to_string(),
+                }],
+                ..GuestBootstrap::default()
+            },
             block_writeback_limit_bytes: Some(512 * 1024 * 1024),
             block_writeback_pool_bytes: Some(4 * 1024 * 1024 * 1024),
             writeback_lease_dir: PathBuf::from("/tmp/writeback-leases"),
@@ -684,7 +690,13 @@ mod tests {
         let loaded = load_launch_config(&args).unwrap();
 
         assert_eq!(loaded.db_path, PathBuf::from("/tmp/x.db"));
-        assert_eq!(loaded.env, vec!["TOKEN=secret".to_string()]);
+        assert_eq!(
+            loaded.bootstrap.default_env,
+            vec![BootstrapEnvVar {
+                key: "TOKEN".to_string(),
+                value: "secret".to_string(),
+            }]
+        );
         assert_eq!(loaded.block_writeback_limit_bytes, Some(512 * 1024 * 1024));
         assert_eq!(
             loaded.block_writeback_pool_bytes,
@@ -736,7 +748,10 @@ mod tests {
         use std::os::fd::IntoRawFd;
 
         let launch = LaunchConfig {
-            workdir: Some(PathBuf::from("/srv")),
+            bootstrap: microsandbox_protocol::bootstrap::GuestBootstrap {
+                default_cwd: Some("/srv".to_string()),
+                ..Default::default()
+            },
             ..Default::default()
         };
         let mut file = tempfile::tempfile().unwrap();
@@ -748,7 +763,7 @@ mod tests {
         let args = args_with(Some(fd), None);
         let loaded = load_launch_config(&args).unwrap();
 
-        assert_eq!(loaded.workdir, Some(PathBuf::from("/srv")));
+        assert_eq!(loaded.bootstrap.default_cwd.as_deref(), Some("/srv"));
     }
 
     #[test]

--- a/crates/network/lib/network.rs
+++ b/crates/network/lib/network.rs
@@ -10,6 +10,9 @@ use std::sync::Arc;
 use std::thread::JoinHandle;
 
 use ipnetwork::{Ipv4Network, Ipv6Network};
+use microsandbox_protocol::bootstrap::{
+    BootstrapEnvVar, BootstrapIpv4, BootstrapIpv6, BootstrapNetwork,
+};
 use microsandbox_protocol::{ENV_HOST_ALIAS, ENV_NET, ENV_NET_IPV4, ENV_NET_IPV6};
 use microsandbox_types::{
     DeploymentProfile, NetworkRateLimitDirection, RateLimitConfigError, RateLimiterConfig,
@@ -50,7 +53,7 @@ const MULTI_TENANT_MAX_CONNECTIONS: usize = 256;
 ///
 /// Owns the smoltcp poll thread and provides:
 /// - [`take_backend()`](Self::take_backend) — the `NetBackend` for `VmBuilder::net()`
-/// - [`guest_env_vars()`](Self::guest_env_vars) — `MSB_NET*` env vars for the guest
+/// - [`guest_bootstrap_network()`](Self::guest_bootstrap_network) — typed guest network setup
 /// - [`ca_cert_pem()`](Self::ca_cert_pem) — CA certificate for TLS interception
 pub struct SmoltcpNetwork {
     config: NetworkConfig,
@@ -406,6 +409,54 @@ impl SmoltcpNetwork {
         }
 
         vars
+    }
+
+    /// Build the typed network payload consumed by agentd during bootstrap.
+    pub fn guest_bootstrap_network(&self) -> BootstrapNetwork {
+        BootstrapNetwork {
+            interface: "eth0".to_string(),
+            mac: self.guest_mac,
+            mtu: self.mtu,
+            ipv4: self
+                .guest_ipv4
+                .zip(self.gateway_ipv4)
+                .map(|(address, gateway)| BootstrapIpv4 {
+                    address,
+                    prefix_len: 30,
+                    gateway,
+                    dns: Some(gateway),
+                }),
+            ipv6: self
+                .guest_ipv6
+                .zip(self.gateway_ipv6)
+                .map(|(address, gateway)| BootstrapIpv6 {
+                    address,
+                    prefix_len: 64,
+                    gateway,
+                    dns: Some(gateway),
+                }),
+        }
+    }
+
+    /// Return the stable hostname used by guests to address the host gateway.
+    pub fn guest_host_alias(&self) -> &'static str {
+        crate::HOST_ALIAS
+    }
+
+    /// Return guest-visible secret placeholders for the baseline environment.
+    ///
+    /// Real secret values stay in the host-side network handler and never
+    /// enter this payload.
+    pub fn guest_secret_env(&self) -> Vec<BootstrapEnvVar> {
+        self.config
+            .secrets
+            .secrets
+            .iter()
+            .map(|secret| BootstrapEnvVar {
+                key: secret.env_var.clone(),
+                value: secret.placeholder.clone(),
+            })
+            .collect()
     }
 
     /// CA certificate PEM bytes if TLS interception is enabled.
@@ -833,6 +884,31 @@ mod tests {
         assert_eq!(vars.len(), 2);
         assert_eq!(vars[0].0, ENV_NET);
         assert_eq!(vars[1].0, ENV_HOST_ALIAS);
+    }
+
+    #[test]
+    fn guest_bootstrap_network_preserves_active_address_families() {
+        let net = SmoltcpNetwork::new_with_routes(NetworkConfig::default(), 7, true, true).unwrap();
+
+        let bootstrap = net.guest_bootstrap_network();
+
+        assert_eq!(bootstrap.interface, "eth0");
+        assert_eq!(bootstrap.mac, net.guest_mac());
+        assert_eq!(bootstrap.mtu, 1500);
+        assert_eq!(bootstrap.ipv4.unwrap().prefix_len, 30);
+        assert_eq!(bootstrap.ipv6.unwrap().prefix_len, 64);
+        assert_eq!(net.guest_host_alias(), crate::HOST_ALIAS);
+    }
+
+    #[test]
+    fn guest_bootstrap_network_allows_no_active_address_family() {
+        let net =
+            SmoltcpNetwork::new_with_routes(NetworkConfig::default(), 0, false, false).unwrap();
+
+        let bootstrap = net.guest_bootstrap_network();
+
+        assert!(bootstrap.ipv4.is_none());
+        assert!(bootstrap.ipv6.is_none());
     }
 
     #[test]

--- a/crates/protocol/VERSIONING.md
+++ b/crates/protocol/VERSIONING.md
@@ -63,6 +63,12 @@ numbers but aren't:
 
 One number, agreed once. Hold onto that.
 
+## The boot-time bootstrap exception
+
+`core.bootstrap` is a one-shot startup frame sent before the normal `core.ready` handshake. It configures a VM that is being launched with the `agentd` binary bundled by the same microsandbox build, so it is not part of reconnecting a newer SDK or CLI to an already-running older sandbox. The guest requires at least the generation that introduced the message and accepts newer generations because bootstrap fields follow the same optional-field rule as the rest of the protocol.
+
+After startup, the ordinary handshake and lower-generation negotiation described in this document apply unchanged. A stopped sandbox started after an upgrade receives the newly bundled agent and bootstrap together; an already-running sandbox never receives this frame.
+
 ## How the protocol changes without breaking older runtimes
 
 There are three kinds of change, from easiest to hardest. Almost everything we ever do is the

--- a/crates/protocol/lib/bootstrap.rs
+++ b/crates/protocol/lib/bootstrap.rs
@@ -1,0 +1,417 @@
+//! Typed host-to-guest configuration delivered before agent initialization.
+
+use std::net::{Ipv4Addr, Ipv6Addr};
+
+use serde::{Deserialize, Serialize};
+
+use crate::exec::ExecRlimit;
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// Complete one-shot configuration consumed by agentd during guest boot.
+///
+/// The runtime preloads this payload into the agent console before the VM
+/// starts. The surrounding protocol envelope supplies the schema generation.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GuestBootstrap {
+    /// Block-backed root filesystem assembly, when required.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub block_root: Option<BootstrapBlockRoot>,
+
+    /// Virtiofs directory mounts installed inside the guest.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub dir_mounts: Vec<BootstrapDirMount>,
+
+    /// Virtiofs file mounts installed inside the guest.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub file_mounts: Vec<BootstrapFileMount>,
+
+    /// Additional block-device mounts installed inside the guest.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub disk_mounts: Vec<BootstrapDiskMount>,
+
+    /// Tmpfs mounts installed inside the guest.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub tmpfs_mounts: Vec<BootstrapTmpfsMount>,
+
+    /// Guest hostname.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub hostname: Option<String>,
+
+    /// Host alias written into the guest's hosts file.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub host_alias: Option<String>,
+
+    /// Guest network interface and address configuration.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub network: Option<BootstrapNetwork>,
+
+    /// Sandbox-wide resource limits inherited by guest workloads.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub rlimits: Vec<ExecRlimit>,
+
+    /// Default guest user for command execution.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub user: Option<String>,
+
+    /// Default working directory for requests that omit one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub default_cwd: Option<String>,
+
+    /// Environment inherited by requests that do not override a key.
+    ///
+    /// Secret entries contain guest-visible placeholders, never host secret
+    /// values. Explicit exec and handoff environment entries take precedence.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub default_env: Vec<BootstrapEnvVar>,
+
+    /// In-guest security policy.
+    #[serde(default)]
+    pub security_profile: BootstrapSecurityProfile,
+
+    /// Optional PID 1 handoff after agentd finishes guest initialization.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub handoff_init: Option<BootstrapHandoffInit>,
+}
+
+/// Block-backed root filesystem configuration.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "kebab-case")]
+pub enum BootstrapBlockRoot {
+    /// A single filesystem image mounted as the guest root.
+    DiskImage {
+        /// Guest block-device path.
+        device: String,
+
+        /// Filesystem type, or `None` to probe inside the guest.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        fstype: Option<String>,
+    },
+
+    /// An EROFS lower filesystem combined with a writable overlay upper.
+    OciErofs {
+        /// Read-only EROFS block-device path.
+        lower: String,
+
+        /// Writable overlay backing.
+        upper: BootstrapBlockRootUpper,
+    },
+}
+
+/// Writable backing for an OCI EROFS root.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "kebab-case")]
+pub enum BootstrapBlockRootUpper {
+    /// Writable filesystem supplied by a guest block device.
+    Device {
+        /// Guest block-device path.
+        device: String,
+
+        /// Filesystem type on the device.
+        fstype: String,
+    },
+
+    /// RAM-backed writable upper.
+    Tmpfs {
+        /// Optional maximum size in MiB.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        size_mib: Option<u32>,
+    },
+}
+
+/// Common guest mount flags.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BootstrapMountFlags {
+    /// Mount read-only.
+    #[serde(default)]
+    pub readonly: bool,
+
+    /// Disallow execution from the mount.
+    #[serde(default)]
+    pub noexec: bool,
+
+    /// Ignore set-user-ID and set-group-ID bits.
+    #[serde(default)]
+    pub nosuid: bool,
+
+    /// Disallow device nodes.
+    #[serde(default)]
+    pub nodev: bool,
+}
+
+/// Guest-side virtiofs directory mount.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BootstrapDirMount {
+    /// Virtiofs device tag.
+    pub tag: String,
+
+    /// Absolute guest mount path.
+    pub guest_path: String,
+
+    /// Guest mount flags.
+    #[serde(default)]
+    pub flags: BootstrapMountFlags,
+}
+
+/// Guest-side virtiofs file mount.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BootstrapFileMount {
+    /// Virtiofs device tag.
+    pub tag: String,
+
+    /// Filename inside the staged virtiofs directory.
+    pub filename: String,
+
+    /// Absolute guest file path.
+    pub guest_path: String,
+
+    /// Guest mount flags.
+    #[serde(default)]
+    pub flags: BootstrapMountFlags,
+}
+
+/// Guest-side block-device mount.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BootstrapDiskMount {
+    /// Virtio block-device identifier.
+    pub id: String,
+
+    /// Absolute guest mount path.
+    pub guest_path: String,
+
+    /// Filesystem type, or `None` to probe inside the guest.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fstype: Option<String>,
+
+    /// Guest mount flags.
+    #[serde(default)]
+    pub flags: BootstrapMountFlags,
+}
+
+/// Guest-side tmpfs mount.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BootstrapTmpfsMount {
+    /// Absolute guest mount path.
+    pub path: String,
+
+    /// Optional maximum size in MiB.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub size_mib: Option<u32>,
+
+    /// Optional Unix mode applied to the tmpfs root.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mode: Option<u32>,
+
+    /// Guest mount flags.
+    #[serde(default)]
+    pub flags: BootstrapMountFlags,
+}
+
+/// Guest network interface and address configuration.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BootstrapNetwork {
+    /// Guest interface name.
+    pub interface: String,
+
+    /// Guest interface MAC address.
+    pub mac: [u8; 6],
+
+    /// Guest interface MTU.
+    pub mtu: u16,
+
+    /// IPv4 address configuration when IPv4 is active.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ipv4: Option<BootstrapIpv4>,
+
+    /// IPv6 address configuration when IPv6 is active.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ipv6: Option<BootstrapIpv6>,
+}
+
+/// Guest IPv4 address configuration.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BootstrapIpv4 {
+    /// Guest IPv4 address.
+    pub address: Ipv4Addr,
+
+    /// CIDR prefix length.
+    pub prefix_len: u8,
+
+    /// Default gateway.
+    pub gateway: Ipv4Addr,
+
+    /// DNS resolver address.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dns: Option<Ipv4Addr>,
+}
+
+/// Guest IPv6 address configuration.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BootstrapIpv6 {
+    /// Guest IPv6 address.
+    pub address: Ipv6Addr,
+
+    /// CIDR prefix length.
+    pub prefix_len: u8,
+
+    /// Default gateway.
+    pub gateway: Ipv6Addr,
+
+    /// DNS resolver address.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dns: Option<Ipv6Addr>,
+}
+
+/// A baseline guest environment entry.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BootstrapEnvVar {
+    /// Environment variable name.
+    pub key: String,
+
+    /// Environment variable value.
+    pub value: String,
+}
+
+/// In-guest security profile selected for a sandbox.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BootstrapSecurityProfile {
+    /// Preserve normal guest-root behavior.
+    #[default]
+    Default,
+
+    /// Restrict mount and process privileges inside the guest.
+    Restricted,
+}
+
+/// Optional PID 1 handoff after agentd completes initialization.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BootstrapHandoffInit {
+    /// Absolute init path inside the guest, or the `auto` sentinel.
+    pub cmd: String,
+
+    /// Arguments following `argv[0]`.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub args: Vec<String>,
+
+    /// Working directory entered before the handoff.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cwd: Option<String>,
+
+    /// Environment merged over the inherited runtime environment.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub env: Vec<BootstrapEnvVar>,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests
+//--------------------------------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        codec,
+        message::{Message, MessageType, PROTOCOL_VERSION},
+    };
+
+    #[test]
+    fn guest_bootstrap_round_trips_transport_sensitive_values() {
+        let bootstrap = GuestBootstrap {
+            block_root: Some(BootstrapBlockRoot::OciErofs {
+                lower: "/dev/vda".to_string(),
+                upper: BootstrapBlockRootUpper::Tmpfs {
+                    size_mib: Some(512),
+                },
+            }),
+            dir_mounts: vec![BootstrapDirMount {
+                tag: "workspace".to_string(),
+                guest_path: "/workspace:with separators".to_string(),
+                flags: BootstrapMountFlags {
+                    noexec: true,
+                    ..BootstrapMountFlags::default()
+                },
+            }],
+            file_mounts: vec![BootstrapFileMount {
+                tag: "config".to_string(),
+                filename: "app.json".to_string(),
+                guest_path: "/etc/app.json".to_string(),
+                flags: BootstrapMountFlags {
+                    readonly: true,
+                    ..BootstrapMountFlags::default()
+                },
+            }],
+            disk_mounts: vec![BootstrapDiskMount {
+                id: "data".to_string(),
+                guest_path: "/data".to_string(),
+                fstype: Some("ext4".to_string()),
+                flags: BootstrapMountFlags::default(),
+            }],
+            tmpfs_mounts: vec![BootstrapTmpfsMount {
+                path: "/tmp".to_string(),
+                size_mib: Some(64),
+                mode: Some(0o1777),
+                flags: BootstrapMountFlags::default(),
+            }],
+            hostname: Some("quoted-env-test".to_string()),
+            host_alias: Some("host.microsandbox.internal".to_string()),
+            network: Some(BootstrapNetwork {
+                interface: "eth0".to_string(),
+                mac: [0x02, 0x00, 0x00, 0x00, 0x00, 0x02],
+                mtu: 1500,
+                ipv4: Some(BootstrapIpv4 {
+                    address: "172.16.0.2".parse().unwrap(),
+                    prefix_len: 30,
+                    gateway: "172.16.0.1".parse().unwrap(),
+                    dns: Some("172.16.0.1".parse().unwrap()),
+                }),
+                ipv6: Some(BootstrapIpv6 {
+                    address: "fd42:6d73:62::2".parse().unwrap(),
+                    prefix_len: 64,
+                    gateway: "fd42:6d73:62::1".parse().unwrap(),
+                    dns: Some("fd42:6d73:62::1".parse().unwrap()),
+                }),
+            }),
+            rlimits: vec![ExecRlimit {
+                resource: "nofile".to_string(),
+                soft: 1024,
+                hard: 4096,
+            }],
+            user: Some("1000:1000".to_string()),
+            default_cwd: Some("/workspace with spaces".to_string()),
+            default_env: vec![
+                BootstrapEnvVar {
+                    key: "APP_CONFIG".to_string(),
+                    value: "{\"message\":\"hello\"}".to_string(),
+                },
+                BootstrapEnvVar {
+                    key: "UNICODE".to_string(),
+                    value: "snowman: \u{2603}\nnext\tcolumn".to_string(),
+                },
+                BootstrapEnvVar {
+                    key: "EMPTY".to_string(),
+                    value: String::new(),
+                },
+            ],
+            security_profile: BootstrapSecurityProfile::Restricted,
+            handoff_init: Some(BootstrapHandoffInit {
+                cmd: "/sbin/init".to_string(),
+                args: vec!["--unit=multi user.target".to_string()],
+                cwd: Some("/workspace with spaces".to_string()),
+                env: vec![BootstrapEnvVar {
+                    key: "HANDOFF_JSON".to_string(),
+                    value: "{\"enabled\":true}".to_string(),
+                }],
+            }),
+        };
+
+        let message = Message::with_payload(MessageType::Bootstrap, 0, &bootstrap).unwrap();
+        assert_eq!(message.v, PROTOCOL_VERSION);
+        let mut frame = Vec::new();
+        codec::encode_to_buf(&message, &mut frame).unwrap();
+        let decoded = codec::decode_message_frame(&frame).unwrap();
+        assert_eq!(decoded.payload::<GuestBootstrap>().unwrap(), bootstrap);
+    }
+}

--- a/crates/protocol/lib/lib.rs
+++ b/crates/protocol/lib/lib.rs
@@ -298,11 +298,9 @@ pub const ENV_HOSTNAME: &str = "MSB_HOSTNAME";
 /// Environment variable carrying the DNS name the guest uses to reach
 /// the sandbox host (Docker's `host.docker.internal` equivalent).
 ///
-/// The host-side network stack emits this value via its
-/// `guest_env_vars()` method; agentd reads it into
-/// [`crate::exec`]-adjacent boot params and writes the mapping into
-/// `/etc/hosts`. The value the network stack emits is a fixed
-/// protocol constant — today always `host.microsandbox.internal`.
+/// Legacy environment spelling for the host alias now carried in the typed
+/// guest bootstrap. Agentd writes the mapping into `/etc/hosts`. The value the
+/// network stack emits is fixed at `host.microsandbox.internal`.
 pub const ENV_HOST_ALIAS: &str = "MSB_HOST_ALIAS";
 
 /// Environment variable carrying sandbox-wide resource limits.
@@ -433,6 +431,7 @@ pub const GUEST_TLS_HOST_CAS_PATH: &str = "/.msb/tls/host-cas.pem";
 // Exports
 //--------------------------------------------------------------------------------------------------
 
+pub mod bootstrap;
 pub mod codec;
 pub mod core;
 pub mod exec;

--- a/crates/protocol/lib/message.rs
+++ b/crates/protocol/lib/message.rs
@@ -9,7 +9,7 @@ use crate::error::ProtocolResult;
 //--------------------------------------------------------------------------------------------------
 
 /// Current protocol version.
-pub const PROTOCOL_VERSION: u8 = 6;
+pub const PROTOCOL_VERSION: u8 = 7;
 
 /// Frame flag: this is the last message for the given correlation ID.
 ///
@@ -222,6 +222,10 @@ pub enum MessageType {
     /// Guest reports that a TCP session failed. Terminal.
     #[strum(serialize = "core.tcp.failed")]
     TcpFailed,
+
+    /// Host supplies one-shot guest bootstrap configuration.
+    #[strum(serialize = "core.bootstrap")]
+    Bootstrap,
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -324,6 +328,7 @@ impl MessageType {
             Self::FsRequest | Self::FsResponse | Self::FsData => 2,
             Self::CoreError => 5,
             Self::Ping | Self::Pong | Self::Touch | Self::Touched => 6,
+            Self::Bootstrap => 7,
             Self::TcpConnect
             | Self::TcpConnected
             | Self::TcpData
@@ -396,6 +401,7 @@ mod tests {
     #[test]
     fn test_message_type_roundtrip() {
         let types = [
+            (MessageType::Bootstrap, "core.bootstrap"),
             (MessageType::Ready, "core.ready"),
             (MessageType::InitResolved, "core.init.resolved"),
             (MessageType::InitAck, "core.init.ack"),
@@ -441,6 +447,7 @@ mod tests {
     #[test]
     fn test_message_type_serde_roundtrip() {
         let types = [
+            MessageType::Bootstrap,
             MessageType::Ready,
             MessageType::InitResolved,
             MessageType::InitAck,
@@ -515,6 +522,7 @@ mod tests {
         assert_eq!(MessageType::FsRequest.flags(), FLAG_SESSION_START);
         assert_eq!(MessageType::TcpConnect.flags(), FLAG_SESSION_START);
         assert_eq!(MessageType::Ready.flags(), 0);
+        assert_eq!(MessageType::Bootstrap.flags(), 0);
         assert_eq!(MessageType::InitResolved.flags(), 0);
         assert_eq!(MessageType::InitAck.flags(), 0);
         assert_eq!(MessageType::Shutdown.flags(), FLAG_SHUTDOWN);
@@ -583,6 +591,9 @@ mod tests {
         assert!(!MessageType::Ping.is_available_at(5));
         assert!(MessageType::Ping.is_available_at(6));
         assert!(MessageType::Ping.is_available_at(PROTOCOL_VERSION));
+        // Bootstrap is internal to generation-7 host/agent boot.
+        assert!(!MessageType::Bootstrap.is_available_at(6));
+        assert!(MessageType::Bootstrap.is_available_at(PROTOCOL_VERSION));
     }
 
     #[test]
@@ -629,6 +640,8 @@ mod tests {
         ] {
             assert_eq!(mt.min_protocol_version(), 6, "{mt:?} should require gen 6");
         }
+
+        assert_eq!(MessageType::Bootstrap.min_protocol_version(), 7);
 
         // Every current type must be sendable to a current peer.
         assert!(MessageType::FsRequest.min_protocol_version() <= PROTOCOL_VERSION);

--- a/crates/protocol/schema/gen-7.json
+++ b/crates/protocol/schema/gen-7.json
@@ -1,0 +1,140 @@
+{
+  "frame": {
+    "flag_session_start": 2,
+    "flag_shutdown": 4,
+    "flag_terminal": 1,
+    "header_size": 5,
+    "max_frame_size": 4194304
+  },
+  "message_types": [
+    {
+      "introduced_in": 1,
+      "wire": "core.ready"
+    },
+    {
+      "introduced_in": 1,
+      "wire": "core.init.resolved"
+    },
+    {
+      "introduced_in": 1,
+      "wire": "core.init.ack"
+    },
+    {
+      "introduced_in": 1,
+      "wire": "core.shutdown"
+    },
+    {
+      "introduced_in": 1,
+      "wire": "core.relay.client.disconnected"
+    },
+    {
+      "introduced_in": 1,
+      "wire": "core.clock.sync"
+    },
+    {
+      "introduced_in": 6,
+      "wire": "core.ping"
+    },
+    {
+      "introduced_in": 6,
+      "wire": "core.pong"
+    },
+    {
+      "introduced_in": 6,
+      "wire": "core.touch"
+    },
+    {
+      "introduced_in": 6,
+      "wire": "core.touched"
+    },
+    {
+      "introduced_in": 5,
+      "wire": "core.error"
+    },
+    {
+      "introduced_in": 1,
+      "wire": "core.exec.request"
+    },
+    {
+      "introduced_in": 1,
+      "wire": "core.exec.started"
+    },
+    {
+      "introduced_in": 1,
+      "wire": "core.exec.stdin"
+    },
+    {
+      "introduced_in": 1,
+      "wire": "core.exec.stdin.error"
+    },
+    {
+      "introduced_in": 1,
+      "wire": "core.exec.stdout"
+    },
+    {
+      "introduced_in": 1,
+      "wire": "core.exec.stderr"
+    },
+    {
+      "introduced_in": 1,
+      "wire": "core.exec.exited"
+    },
+    {
+      "introduced_in": 1,
+      "wire": "core.exec.failed"
+    },
+    {
+      "introduced_in": 1,
+      "wire": "core.exec.resize"
+    },
+    {
+      "introduced_in": 1,
+      "wire": "core.exec.signal"
+    },
+    {
+      "introduced_in": 2,
+      "wire": "core.fs.request"
+    },
+    {
+      "introduced_in": 2,
+      "wire": "core.fs.response"
+    },
+    {
+      "introduced_in": 2,
+      "wire": "core.fs.data"
+    },
+    {
+      "introduced_in": 4,
+      "wire": "core.tcp.connect"
+    },
+    {
+      "introduced_in": 4,
+      "wire": "core.tcp.connected"
+    },
+    {
+      "introduced_in": 4,
+      "wire": "core.tcp.data"
+    },
+    {
+      "introduced_in": 4,
+      "wire": "core.tcp.eof"
+    },
+    {
+      "introduced_in": 4,
+      "wire": "core.tcp.close"
+    },
+    {
+      "introduced_in": 4,
+      "wire": "core.tcp.closed"
+    },
+    {
+      "introduced_in": 4,
+      "wire": "core.tcp.failed"
+    },
+    {
+      "introduced_in": 7,
+      "wire": "core.bootstrap"
+    }
+  ],
+  "protocol_version": 7
+}

--- a/crates/runtime/lib/launch.rs
+++ b/crates/runtime/lib/launch.rs
@@ -10,6 +10,7 @@
 
 use std::path::PathBuf;
 
+use microsandbox_protocol::bootstrap::GuestBootstrap;
 use microsandbox_types::{CpuPlacement, DeploymentProfile, PlacementProfile, VsockRouteSpec};
 use serde::{Deserialize, Serialize};
 
@@ -102,11 +103,8 @@ pub struct LaunchConfig {
     /// Path to the init binary in the guest.
     pub init_path: Option<PathBuf>,
 
-    /// Environment variables as `KEY=VALUE` (guest env plus `MSB_*` specs).
-    pub env: Vec<String>,
-
-    /// Working directory inside the guest.
-    pub workdir: Option<PathBuf>,
+    /// Typed one-shot configuration delivered to agentd over its console.
+    pub bootstrap: GuestBootstrap,
 
     /// Path to the executable to run in the guest.
     pub exec_path: Option<PathBuf>,

--- a/crates/runtime/lib/vm.rs
+++ b/crates/runtime/lib/vm.rs
@@ -24,6 +24,7 @@ use microsandbox_filesystem::{
 };
 use microsandbox_metrics::{ActivateSlot, MetricsRegistry, ReleaseMode};
 use microsandbox_protocol::{
+    bootstrap::{BootstrapBlockRoot, GuestBootstrap},
     codec,
     message::{Message, MessageType},
 };
@@ -227,7 +228,7 @@ enum ParentWatchdogSignal {
 /// `backing`); a user-supplied disk-image root disk carries its own path
 /// and format. A tmpfs root disk attaches no upper device at all — the
 /// caller leaves both `rootfs_upper` and `rootfs_upper_spec` unset and
-/// signals tmpfs through `MSB_BLOCK_ROOT`. The shape stays
+/// selects tmpfs in the typed guest bootstrap. The shape stays
 /// forward-compatible with qcow2 backing chains: when chains land,
 /// `backing` lists ancestor files that the runtime attaches read-only
 /// ahead of the head file.
@@ -247,7 +248,7 @@ pub struct UpperSpec {
 /// Specification for a disk-image volume mount attached to the guest.
 ///
 /// Each entry becomes one extra virtio-blk device. Agentd consumes the
-/// companion `MSB_DISK_MOUNTS` env var to know which device to mount where.
+/// companion typed bootstrap entry to know which device to mount where.
 #[derive(Debug, Clone)]
 pub struct DiskMountSpec {
     /// Stable block id. Surfaced in the guest as the virtio-blk `serial`
@@ -258,7 +259,7 @@ pub struct DiskMountSpec {
     pub host: PathBuf,
 
     /// Guest mount path. Not needed by the VMM, but carried here for
-    /// logging/validation; agentd reads the canonical value from the env.
+    /// logging/validation; agentd reads the canonical value from bootstrap.
     pub guest: String,
 
     /// Disk image format.
@@ -357,11 +358,8 @@ pub struct VmConfig {
     /// Path to the init binary in the guest.
     pub init_path: Option<PathBuf>,
 
-    /// Environment variables as `KEY=VALUE` pairs.
-    pub env: Vec<String>,
-
-    /// Working directory inside the guest.
-    pub workdir: Option<PathBuf>,
+    /// Typed one-shot configuration delivered to agentd over its console.
+    pub bootstrap: GuestBootstrap,
 
     /// Path to the executable to run in the guest.
     pub exec_path: Option<PathBuf>,
@@ -425,6 +423,7 @@ type VmBuildOutput = (
     Option<NetworkTerminationHandle>,
     Option<NetworkMetricsHandle>,
     Option<NetworkSecretsHandle>,
+    Vec<u8>,
     BindIdentityMapRegistration,
 );
 
@@ -475,8 +474,7 @@ impl std::fmt::Debug for VmConfig {
         debug.field("backends", &format!("[{} backend(s)]", self.backends.len()));
         debug
             .field("init_path", &self.init_path)
-            .field("env", &self.env)
-            .field("workdir", &self.workdir)
+            .field("bootstrap", &self.bootstrap)
             .field("exec_path", &self.exec_path)
             .field("exec_args", &self.exec_args)
             .finish()
@@ -875,6 +873,7 @@ fn run(config: Config) -> RuntimeResult<std::convert::Infallible> {
         _network_termination_handle,
         network_metrics_handle,
         _network_secrets_handle,
+        bootstrap_frame,
         bind_identity_map,
     ) = match build_result {
         Ok(vm) => vm,
@@ -901,6 +900,12 @@ fn run(config: Config) -> RuntimeResult<std::convert::Infallible> {
             return Err(e);
         }
     };
+
+    // This must be the first host-to-guest frame. It is queued before the
+    // watchdog and relay tasks can produce shutdown or init-ack messages, and
+    // remains buffered until agentd opens the console during early boot.
+    relay::push_guest_frame_blocking(&shared, bootstrap_frame)?;
+
     #[cfg(unix)]
     {
         relay =
@@ -1399,8 +1404,8 @@ fn build_vm(
     host_placement: HostPlacement<'_>,
     writeback_limit: Option<&msb_krun::WritebackLimit>,
 ) -> RuntimeResult<VmBuildOutput> {
-    let mut exec_env = config.vm.env.clone();
     let vm = &config.vm;
+    let mut bootstrap = vm.bootstrap.clone();
     let balloon_stats_interval = config
         .metrics_sample_interval_ms
         .map(|interval_ms| Duration::from_millis(interval_ms.get()));
@@ -1518,8 +1523,6 @@ fn build_vm(
                 apply_block_writeback_limit(d, format, false, writeback_limit.as_ref())
             });
         }
-
-        // MSB_BLOCK_ROOT env var is set by the caller (spawn_sandbox).
     } else if let Some(ref disk_path) = vm.rootfs_disk {
         #[cfg(unix)]
         {
@@ -1551,7 +1554,12 @@ fn build_vm(
             let d = d.path(&disk_path).format(format).read_only(readonly);
             apply_block_writeback_limit(d, format, readonly, writeback_limit.as_ref())
         });
-        append_block_root_env(&mut exec_env);
+        if bootstrap.block_root.is_none() {
+            bootstrap.block_root = Some(BootstrapBlockRoot::DiskImage {
+                device: "/dev/vda".to_string(),
+                fstype: None,
+            });
+        }
     }
 
     // Runtime directory mount — agentd mounts this at /.msb for scripts
@@ -1788,9 +1796,9 @@ fn build_vm(
             }
         }
 
-        for (key, value) in network.guest_env_vars() {
-            exec_env.push(format!("{key}={value}"));
-        }
+        bootstrap.network = Some(network.guest_bootstrap_network());
+        bootstrap.host_alias = Some(network.guest_host_alias().to_string());
+        bootstrap.default_env.extend(network.guest_secret_env());
 
         builder = builder.net(move |mut n| {
             n = n.mac(guest_mac);
@@ -1804,22 +1812,14 @@ fn build_vm(
         });
     }
 
-    // Execution configuration.
-    prepend_scripts_path(&mut exec_env);
+    // The kernel command line only selects agentd. Workload environment and
+    // cwd now travel through the typed bootstrap and exec protocols.
     builder = builder.exec(|mut e| {
         if let Some(ref path) = vm.exec_path {
             e = e.path(path);
         }
         if !vm.exec_args.is_empty() {
             e = e.args(&vm.exec_args);
-        }
-        for env_str in &exec_env {
-            if let Some((key, value)) = env_str.split_once('=') {
-                e = e.env(key, value);
-            }
-        }
-        if let Some(ref workdir) = vm.workdir {
-            e = e.workdir(workdir);
         }
         e
     });
@@ -1857,13 +1857,25 @@ fn build_vm(
         .build()
         .map_err(|e| RuntimeError::Custom(format!("build VM: {e}")))?;
 
+    let bootstrap_frame = encode_bootstrap_frame(&bootstrap)?;
+
     Ok((
         vm,
         network_termination_handle,
         network_metrics_handle,
         network_secrets_handle,
+        bootstrap_frame,
         bind_identity_map,
     ))
+}
+
+fn encode_bootstrap_frame(bootstrap: &GuestBootstrap) -> RuntimeResult<Vec<u8>> {
+    let message = Message::with_payload(MessageType::Bootstrap, 0, bootstrap)
+        .map_err(|e| RuntimeError::Custom(format!("encode guest bootstrap: {e}")))?;
+    let mut frame = Vec::new();
+    codec::encode_to_buf(&message, &mut frame)
+        .map_err(|e| RuntimeError::Custom(format!("encode guest bootstrap frame: {e}")))?;
+    Ok(frame)
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -2606,7 +2618,10 @@ pub fn validate_disk_format(format: Option<&str>) -> msb_krun::Result<msb_krun::
     }
 }
 
-/// Append the default block root env var if not already set.
+/// Append the legacy default block-root environment value if not already set.
+///
+/// Retained for downstream source compatibility. VM launch now carries this
+/// value in [`GuestBootstrap`] and does not call this helper.
 pub fn append_block_root_env(env: &mut Vec<String>) {
     let prefix = format!("{}=", microsandbox_protocol::ENV_BLOCK_ROOT);
     if env.iter().any(|entry| entry.starts_with(&prefix)) {
@@ -2615,7 +2630,10 @@ pub fn append_block_root_env(env: &mut Vec<String>) {
     env.push(format!("{prefix}/dev/vda"));
 }
 
-/// Prepend `/.msb/scripts` to PATH for the initial guest command.
+/// Prepend `/.msb/scripts` to a legacy initial-command environment.
+///
+/// Retained for downstream source compatibility. Agentd now prepares PATH for
+/// each exec request after receiving the typed bootstrap.
 pub fn prepend_scripts_path(env: &mut Vec<String>) {
     let scripts = microsandbox_protocol::SCRIPTS_PATH;
     let prefix = "PATH=";
@@ -2652,14 +2670,14 @@ mod tests {
     };
     use super::{
         ConsoleSharedState, HostPermissions, StatVirtualization, append_block_root_env,
-        bind_rootfs_backend, guest_shutdown_flush_timeout,
+        bind_rootfs_backend, encode_bootstrap_frame, guest_shutdown_flush_timeout,
         guest_shutdown_flush_timeout_with_override, parse_mount_spec, prepend_scripts_path,
         request_guest_shutdown, request_guest_shutdown_with_timeout, thp_kernel_cmdline,
         validate_disk_format,
     };
 
     use microsandbox_filesystem::{Context, DynFileSystem, FsOptions};
-    use microsandbox_protocol::{codec, message::MessageType};
+    use microsandbox_protocol::{bootstrap::GuestBootstrap, codec, message::MessageType};
     #[cfg(unix)]
     use std::io::Write;
     #[cfg(unix)]
@@ -2948,6 +2966,27 @@ mod tests {
         let msg = codec::try_decode_from_buf(&mut frame).unwrap().unwrap();
         assert_eq!(msg.t, MessageType::Shutdown);
         assert_eq!(msg.id, 0);
+    }
+
+    #[test]
+    fn test_bootstrap_frame_is_a_generation_seven_control_message() {
+        let bootstrap = GuestBootstrap {
+            default_env: vec![microsandbox_protocol::bootstrap::BootstrapEnvVar {
+                key: "APP_CONFIG".to_string(),
+                value: "{\"message\":\"hello\"}".to_string(),
+            }],
+            ..GuestBootstrap::default()
+        };
+
+        let mut frame = encode_bootstrap_frame(&bootstrap).unwrap();
+        let message = codec::try_decode_from_buf(&mut frame).unwrap().unwrap();
+
+        assert_eq!(message.t, MessageType::Bootstrap);
+        assert_eq!(message.id, 0);
+        assert_eq!(message.flags, 0);
+        assert_eq!(message.v, microsandbox_protocol::message::PROTOCOL_VERSION);
+        assert_eq!(message.payload::<GuestBootstrap>().unwrap(), bootstrap);
+        assert!(frame.is_empty());
     }
 
     #[test]

--- a/sdk/rust/lib/runtime/spawn.rs
+++ b/sdk/rust/lib/runtime/spawn.rs
@@ -28,12 +28,11 @@ use std::{
     process::Stdio,
 };
 
-use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
 #[cfg(windows)]
 use rand::Rng;
 use rand::RngExt;
 use sea_orm::{ColumnTrait, EntityTrait, QueryFilter, Set};
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use sha2::{Digest as Sha2Digest, Sha256};
 use tempfile::TempDir;
 #[cfg(windows)]
@@ -60,9 +59,12 @@ use windows_sys::Win32::System::Threading::{
 use microsandbox_image::{Digest, GlobalCache};
 use microsandbox_metrics::{MetricsRegistry, ReserveSlot, SlotReservation};
 use microsandbox_protocol::{
-    ENV_BLOCK_ROOT, ENV_DIR_MOUNTS, ENV_DISK_MOUNTS, ENV_FILE_MOUNTS, ENV_HANDOFF_INIT,
-    ENV_HANDOFF_INIT_ARGS, ENV_HANDOFF_INIT_CWD, ENV_HANDOFF_INIT_ENV, ENV_HOSTNAME,
-    ENV_SECURITY_PROFILE, ENV_TMPFS, ENV_USER,
+    bootstrap::{
+        BootstrapBlockRoot, BootstrapBlockRootUpper, BootstrapDirMount, BootstrapDiskMount,
+        BootstrapEnvVar, BootstrapFileMount, BootstrapHandoffInit, BootstrapMountFlags,
+        BootstrapSecurityProfile, BootstrapTmpfsMount, GuestBootstrap,
+    },
+    exec::ExecRlimit,
 };
 use microsandbox_runtime::launch::{LaunchConfig, Lifecycle};
 use microsandbox_runtime::vm::{MetricsSlotHandoff, StartupCommand};
@@ -81,7 +83,7 @@ use crate::{
     db::entity::volume as volume_entity,
     runtime::handle::MetricsReservationCleanup,
     sandbox::{
-        DiskImageFormat, HostPermissions, MountOptions, NamedVolumeMode, Rlimit, RootfsSource,
+        DiskImageFormat, HostPermissions, MountOptions, NamedVolumeMode, RootfsSource,
         SandboxConfig, StatVirtualization, VolumeMount, validate_named_disk_mount_options,
     },
     volume::{
@@ -2174,13 +2176,6 @@ async fn stage_file_mounts(
             ))
         })?;
 
-        // The MSB_FILE_MOUNTS protocol uses `:` and `;` as delimiters.
-        if filename.contains(':') || filename.contains(';') {
-            return Err(crate::MicrosandboxError::InvalidConfig(format!(
-                "file mount filename must not contain ':' or ';': {filename}"
-            )));
-        }
-
         let target = file_mount_dir.join(filename);
 
         // Hard-link preserves the same inode — writes in the guest propagate
@@ -2271,18 +2266,6 @@ fn push_dir_mount_arg(
     mounts.push(arg);
 }
 
-/// Append a `tag:guest_path[:ro]` entry to the `MSB_DIR_MOUNTS` env var value.
-fn push_dir_mounts_spec(dir_mounts_val: &mut String, guest: &str, options: MountOptions) {
-    if !dir_mounts_val.is_empty() {
-        dir_mounts_val.push(';');
-    }
-    let tag = guest_mount_tag(guest);
-    dir_mounts_val.push_str(&tag);
-    dir_mounts_val.push(':');
-    dir_mounts_val.push_str(guest);
-    append_option_block(dir_mounts_val, mount_option_tokens(options));
-}
-
 /// Collect a `fm_tag:file_mount_dir[:ro]` mount entry.
 fn push_file_mount_arg(
     mounts: &mut Vec<String>,
@@ -2316,46 +2299,6 @@ fn push_disk_mount_arg(
     disks.push(arg);
 }
 
-/// Append a `id:guest_path[:opts]` entry to the `MSB_DISK_MOUNTS` env var value.
-fn push_disk_mounts_spec(
-    disk_mounts_val: &mut String,
-    id: &str,
-    guest: &str,
-    fstype: Option<&str>,
-    options: MountOptions,
-) {
-    if !disk_mounts_val.is_empty() {
-        disk_mounts_val.push(';');
-    }
-    disk_mounts_val.push_str(id);
-    disk_mounts_val.push(':');
-    disk_mounts_val.push_str(guest);
-    let mut opts = mount_option_tokens(options);
-    if let Some(fs) = fstype {
-        opts.push(format!("fstype={fs}"));
-    }
-    append_option_block(disk_mounts_val, opts);
-}
-
-/// Append a `tag:filename:guest_path[:ro]` entry to the `MSB_FILE_MOUNTS` env var value.
-fn push_file_mounts_spec(
-    file_mounts_val: &mut String,
-    tag: &str,
-    filename: &str,
-    guest: &str,
-    options: MountOptions,
-) {
-    if !file_mounts_val.is_empty() {
-        file_mounts_val.push(';');
-    }
-    file_mounts_val.push_str(tag);
-    file_mounts_val.push(':');
-    file_mounts_val.push_str(filename);
-    file_mounts_val.push(':');
-    file_mounts_val.push_str(guest);
-    append_option_block(file_mounts_val, mount_option_tokens(options));
-}
-
 fn mount_option_tokens(options: MountOptions) -> Vec<String> {
     let mut tokens = Vec::new();
     if options.readonly {
@@ -2371,6 +2314,15 @@ fn mount_option_tokens(options: MountOptions) -> Vec<String> {
         tokens.push("nodev".to_string());
     }
     tokens
+}
+
+fn bootstrap_mount_flags(options: MountOptions) -> BootstrapMountFlags {
+    BootstrapMountFlags {
+        readonly: options.readonly,
+        noexec: options.noexec,
+        nosuid: options.nosuid,
+        nodev: options.nodev,
+    }
 }
 
 fn append_policy_options(
@@ -2401,33 +2353,6 @@ fn append_option_block(spec: &mut String, opts: Vec<String>) {
     }
     spec.push(':');
     spec.push_str(&opts.join(","));
-}
-
-/// Encodes sandbox-wide rlimits for the guest init environment.
-fn encode_rlimits(rlimits: &[Rlimit]) -> String {
-    use std::fmt::Write;
-
-    let mut out = String::with_capacity(rlimits.len() * 32);
-    for (i, rlimit) in rlimits.iter().enumerate() {
-        if i > 0 {
-            out.push(';');
-        }
-        write!(
-            out,
-            "{}={}:{}",
-            rlimit.resource.as_str(),
-            rlimit.soft,
-            rlimit.hard
-        )
-        .expect("writing to String cannot fail");
-    }
-    out
-}
-
-/// Encodes a handoff-init argv/env payload into printable env-var text.
-fn encode_handoff_json<T: Serialize>(value: &T) -> String {
-    let json = serde_json::to_vec(value).expect("handoff init payload is JSON-serializable");
-    URL_SAFE_NO_PAD.encode(json)
 }
 
 /// Derive a stable, collision-resistant identifier from a guest mount path.
@@ -2559,7 +2484,52 @@ fn sandbox_cli_args(
         vsock: config.spec.vsock.routes.clone(),
         #[cfg(feature = "net")]
         deployment_profile: config.spec.deployment_profile,
-        workdir: config.spec.runtime.workdir.as_ref().map(PathBuf::from),
+        bootstrap: GuestBootstrap {
+            hostname: Some(
+                config.spec.runtime.hostname.clone().unwrap_or_else(|| {
+                    crate::sandbox::hostname_from_sandbox_name(&config.spec.name)
+                }),
+            ),
+            rlimits: config
+                .spec
+                .rlimits
+                .iter()
+                .map(|rlimit| ExecRlimit {
+                    resource: rlimit.resource.as_str().to_string(),
+                    soft: rlimit.soft,
+                    hard: rlimit.hard,
+                })
+                .collect(),
+            user: config.spec.runtime.user.clone(),
+            default_cwd: config.spec.runtime.workdir.clone(),
+            default_env: config
+                .spec
+                .env
+                .iter()
+                .map(|var| BootstrapEnvVar {
+                    key: var.key.clone(),
+                    value: var.value.clone(),
+                })
+                .collect(),
+            security_profile: match config.spec.security_profile {
+                crate::sandbox::SecurityProfile::Default => BootstrapSecurityProfile::Default,
+                crate::sandbox::SecurityProfile::Restricted => BootstrapSecurityProfile::Restricted,
+            },
+            handoff_init: config.spec.init.as_ref().map(|init| BootstrapHandoffInit {
+                cmd: init.cmd.clone(),
+                args: init.args.clone(),
+                cwd: config.spec.runtime.workdir.clone(),
+                env: init
+                    .env
+                    .iter()
+                    .map(|(key, value)| BootstrapEnvVar {
+                        key: key.clone(),
+                        value: value.clone(),
+                    })
+                    .collect(),
+            }),
+            ..GuestBootstrap::default()
+        },
         ..Default::default()
     };
 
@@ -2589,11 +2559,10 @@ fn sandbox_cli_args(
                 launch.rootfs.disk =
                     Some(sandbox_dir.join(crate::sandbox::flat_rootfs::FLAT_ROOTFS_FILENAME));
                 launch.rootfs.disk_format = Some("raw".to_string());
-                launch.env.push(format!(
-                    "{}=kind=disk-image,device=/dev/vda,fstype={}",
-                    ENV_BLOCK_ROOT,
-                    fstype.as_deref().unwrap_or("ext4")
-                ));
+                launch.bootstrap.block_root = Some(BootstrapBlockRoot::DiskImage {
+                    device: "/dev/vda".to_string(),
+                    fstype: Some(fstype.as_deref().unwrap_or("ext4").to_string()),
+                });
             // Derive VMDK + upper paths from the stored manifest digest.
             } else if let Some(ref digest_str) = config.manifest_digest {
                 let cache_dir = local.cache_dir();
@@ -2613,13 +2582,19 @@ fn sandbox_cli_args(
                     None | Some(RootDisk::Managed { .. }) => {
                         let sandbox_dir = local.sandboxes_dir().join(&config.spec.name);
                         launch.rootfs.upper = Some(sandbox_dir.join("upper.ext4"));
-                        "kind=oci-erofs,lower=/dev/vda,upper=/dev/vdb,upper_fstype=ext4".to_string()
+                        BootstrapBlockRoot::OciErofs {
+                            lower: "/dev/vda".to_string(),
+                            upper: BootstrapBlockRootUpper::Device {
+                                device: "/dev/vdb".to_string(),
+                                fstype: "ext4".to_string(),
+                            },
+                        }
                     }
-                    Some(RootDisk::Tmpfs { size_mib }) => match size_mib {
-                        Some(mib) => format!(
-                            "kind=oci-erofs,lower=/dev/vda,upper=tmpfs,upper_size_mib={mib}"
-                        ),
-                        None => "kind=oci-erofs,lower=/dev/vda,upper=tmpfs".to_string(),
+                    Some(RootDisk::Tmpfs { size_mib }) => BootstrapBlockRoot::OciErofs {
+                        lower: "/dev/vda".to_string(),
+                        upper: BootstrapBlockRootUpper::Tmpfs {
+                            size_mib: *size_mib,
+                        },
                     },
                     Some(RootDisk::DiskImage {
                         path,
@@ -2628,16 +2603,19 @@ fn sandbox_cli_args(
                     }) => {
                         launch.rootfs.upper = Some(path.clone());
                         launch.rootfs.upper_format = Some(format.as_str().to_string());
-                        format!(
-                            "kind=oci-erofs,lower=/dev/vda,upper=/dev/vdb,upper_fstype={}",
-                            fstype.as_deref().unwrap_or("ext4")
-                        )
+                        BootstrapBlockRoot::OciErofs {
+                            lower: "/dev/vda".to_string(),
+                            upper: BootstrapBlockRootUpper::Device {
+                                device: "/dev/vdb".to_string(),
+                                fstype: fstype.as_deref().unwrap_or("ext4").to_string(),
+                            },
+                        }
                     }
                     Some(RootDisk::Flat { .. }) => {
                         unreachable!("flat root disks are handled before layered root assembly")
                     }
                 };
-                launch.env.push(format!("{}={block_root}", ENV_BLOCK_ROOT));
+                launch.bootstrap.block_root = Some(block_root);
             }
         }
         RootfsSource::DiskImage {
@@ -2648,24 +2626,15 @@ fn sandbox_cli_args(
             launch.rootfs.disk = Some(path.clone());
             launch.rootfs.disk_format = Some(format.as_str().to_string());
 
-            // Build MSB_BLOCK_ROOT env var value.
-            let mut block_root_val = String::from("kind=disk-image,device=/dev/vda");
-            if let Some(ft) = fstype {
-                block_root_val.push_str(&format!(",fstype={ft}"));
-            }
-            launch
-                .env
-                .push(format!("{}={block_root_val}", ENV_BLOCK_ROOT));
+            launch.bootstrap.block_root = Some(BootstrapBlockRoot::DiskImage {
+                device: "/dev/vda".to_string(),
+                fstype: fstype.clone(),
+            });
         }
     }
 
-    // Process mounts: emit --mount args for virtiofs mounts, --disk args
-    // for disk-image mounts, and collect guest-side mount specs as env
-    // vars for agentd.
-    let mut tmpfs_val = String::new();
-    let mut dir_mounts_val = String::new();
-    let mut file_mounts_val = String::new();
-    let mut disk_mounts_val = String::new();
+    // Process mounts: emit host-side device args and collect the matching
+    // typed guest-side mount instructions for agentd.
     for mount in &config.spec.mounts {
         match mount {
             VolumeMount::Bind {
@@ -2686,7 +2655,12 @@ fn sandbox_cli_args(
                         *stat_virtualization,
                         *host_permissions,
                     );
-                    push_file_mounts_spec(&mut file_mounts_val, tag, filename, guest, *options);
+                    launch.bootstrap.file_mounts.push(BootstrapFileMount {
+                        tag: tag.clone(),
+                        filename: filename.clone(),
+                        guest_path: guest.clone(),
+                        flags: bootstrap_mount_flags(*options),
+                    });
                 } else {
                     // A directory bind mount gets a protective guest-write
                     // quota: the caller's override, or the default.
@@ -2701,7 +2675,11 @@ fn sandbox_cli_args(
                         *follow_root_symlinks,
                         Some(quota),
                     );
-                    push_dir_mounts_spec(&mut dir_mounts_val, guest, *options);
+                    launch.bootstrap.dir_mounts.push(BootstrapDirMount {
+                        tag: guest_mount_tag(guest),
+                        guest_path: guest.clone(),
+                        flags: bootstrap_mount_flags(*options),
+                    });
                 }
             }
             VolumeMount::Named {
@@ -2735,13 +2713,12 @@ fn sandbox_cli_args(
                             format,
                             *options,
                         );
-                        push_disk_mounts_spec(
-                            &mut disk_mounts_val,
-                            &id,
-                            guest,
-                            fstype.as_deref(),
-                            *options,
-                        );
+                        launch.bootstrap.disk_mounts.push(BootstrapDiskMount {
+                            id,
+                            guest_path: guest.clone(),
+                            fstype: fstype.clone(),
+                            flags: bootstrap_mount_flags(*options),
+                        });
                     }
                     ResolvedNamedVolume {
                         path, quota_mib, ..
@@ -2756,7 +2733,11 @@ fn sandbox_cli_args(
                             *follow_root_symlinks,
                             *quota_mib,
                         );
-                        push_dir_mounts_spec(&mut dir_mounts_val, guest, *options);
+                        launch.bootstrap.dir_mounts.push(BootstrapDirMount {
+                            tag: guest_mount_tag(guest),
+                            guest_path: guest.clone(),
+                            flags: bootstrap_mount_flags(*options),
+                        });
                     }
                 }
             }
@@ -2765,16 +2746,12 @@ fn sandbox_cli_args(
                 size_mib,
                 options,
             } => {
-                if !tmpfs_val.is_empty() {
-                    tmpfs_val.push(';');
-                }
-                tmpfs_val.push_str(guest);
-                let mut opts = Vec::new();
-                if let Some(s) = size_mib {
-                    opts.push(format!("size={s}"));
-                }
-                opts.extend(mount_option_tokens(*options));
-                append_option_block(&mut tmpfs_val, opts);
+                launch.bootstrap.tmpfs_mounts.push(BootstrapTmpfsMount {
+                    path: guest.clone(),
+                    size_mib: *size_mib,
+                    mode: None,
+                    flags: bootstrap_mount_flags(*options),
+                });
             }
             VolumeMount::DiskImage {
                 host,
@@ -2785,42 +2762,14 @@ fn sandbox_cli_args(
             } => {
                 let id = guest_mount_tag(guest);
                 push_disk_mount_arg(&mut launch.disks, &id, &host.display(), format, *options);
-                push_disk_mounts_spec(
-                    &mut disk_mounts_val,
-                    &id,
-                    guest,
-                    fstype.as_deref(),
-                    *options,
-                );
+                launch.bootstrap.disk_mounts.push(BootstrapDiskMount {
+                    id,
+                    guest_path: guest.clone(),
+                    fstype: fstype.clone(),
+                    flags: bootstrap_mount_flags(*options),
+                });
             }
         }
-    }
-
-    if !tmpfs_val.is_empty() {
-        launch.env.push(format!("{}={tmpfs_val}", ENV_TMPFS));
-    }
-    if !dir_mounts_val.is_empty() {
-        launch
-            .env
-            .push(format!("{}={dir_mounts_val}", ENV_DIR_MOUNTS));
-    }
-    if !file_mounts_val.is_empty() {
-        launch
-            .env
-            .push(format!("{}={file_mounts_val}", ENV_FILE_MOUNTS));
-    }
-    if !disk_mounts_val.is_empty() {
-        launch
-            .env
-            .push(format!("{}={disk_mounts_val}", ENV_DISK_MOUNTS));
-    }
-
-    if !config.spec.rlimits.is_empty() {
-        launch.env.push(format!(
-            "{}={}",
-            microsandbox_protocol::ENV_RLIMITS,
-            encode_rlimits(&config.spec.rlimits)
-        ));
     }
 
     // Network configuration travels as a typed value inside the JSON payload.
@@ -2832,57 +2781,6 @@ fn sandbox_cli_args(
                 .expect("sandbox network spec should decode to local network config"),
         );
         launch.sandbox_slot = sandbox_id as u64;
-    }
-
-    for var in &config.spec.env {
-        launch.env.push(format!("{}={}", var.key, var.value));
-    }
-
-    if let Some(ref user) = config.spec.runtime.user {
-        launch.env.push(format!("{}={user}", ENV_USER));
-    }
-
-    launch.env.push(format!(
-        "{}={}",
-        ENV_SECURITY_PROFILE,
-        match config.spec.security_profile {
-            crate::sandbox::SecurityProfile::Default => "default",
-            crate::sandbox::SecurityProfile::Restricted => "restricted",
-        }
-    ));
-
-    // Hostname: explicit value or fall back to a sandbox-name-derived form
-    // that fits within the Linux UTS limit.
-    {
-        let hostname = match config.spec.runtime.hostname.as_deref() {
-            Some(h) => h.to_string(),
-            None => crate::sandbox::hostname_from_sandbox_name(&config.spec.name),
-        };
-        launch.env.push(format!("{}={hostname}", ENV_HOSTNAME));
-    }
-
-    // Handoff-init: PID 1 hand-off to a user-supplied init binary.
-    // The builder's `validate()` rejects cmd paths containing NUL or `\`,
-    // args/env containing NUL, and env keys containing `=`, so the JSON
-    // payloads below can't produce a corrupted execve wire format.
-    if let Some(ref init) = config.spec.init {
-        launch.env.push(format!("{ENV_HANDOFF_INIT}={}", init.cmd));
-
-        if !init.args.is_empty() {
-            let argv_val = encode_handoff_json(&init.args);
-            launch
-                .env
-                .push(format!("{ENV_HANDOFF_INIT_ARGS}={argv_val}"));
-        }
-
-        if let Some(ref workdir) = config.spec.runtime.workdir {
-            launch.env.push(format!("{ENV_HANDOFF_INIT_CWD}={workdir}"));
-        }
-
-        if !init.env.is_empty() {
-            let env_val = encode_handoff_json(&init.env);
-            launch.env.push(format!("{ENV_HANDOFF_INIT_ENV}={env_val}"));
-        }
     }
 
     (visible, launch)
@@ -2945,10 +2843,12 @@ mod tests {
     use std::num::NonZero;
     use std::path::{Path, PathBuf};
 
-    use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
+    use microsandbox_protocol::{
+        bootstrap::{BootstrapBlockRoot, BootstrapEnvVar, BootstrapMountFlags},
+        exec::ExecRlimit,
+    };
     use microsandbox_types::HandoffInit;
     use sea_orm::{ActiveModelTrait, ColumnTrait, EntityTrait, QueryFilter, Set};
-    use serde::de::DeserializeOwned;
     use tempfile::tempdir;
 
     use microsandbox_runtime::launch::LaunchConfig;
@@ -2964,9 +2864,8 @@ mod tests {
         backend::LocalBackend,
         config::{BlockWritebackConfig, RuntimeConfig},
         sandbox::{
-            DiskImageFormat, HostPermissions, MountOptions, OciRootfsSource, Rlimit,
-            RlimitResource, RootfsSource, SandboxBuilder, SandboxConfig, StatVirtualization,
-            VolumeMount,
+            DiskImageFormat, HostPermissions, MountOptions, OciRootfsSource, RlimitResource,
+            RootfsSource, SandboxBuilder, SandboxConfig, StatVirtualization, VolumeMount,
         },
         volume::VolumeKind,
     };
@@ -3036,6 +2935,29 @@ mod tests {
     /// touches.
     fn test_local_backend() -> LocalBackend {
         LocalBackend::lazy()
+    }
+
+    /// Return the typed launch payload generated for a sandbox configuration.
+    fn render_launch(config: &SandboxConfig) -> LaunchConfig {
+        let local = test_local_backend();
+        let (_, launch) = sandbox_cli_args(
+            &local,
+            config,
+            42,
+            Path::new("/tmp/msb.db"),
+            30,
+            Path::new("/tmp/logs"),
+            Path::new("/tmp/runtime"),
+            Path::new("/tmp/agent.sock"),
+            Path::new("/tmp/libkrunfw.dylib"),
+            &HashMap::new(),
+            &HashMap::new(),
+            None,
+            None,
+            None,
+            None,
+        );
+        launch
     }
 
     /// Re-expand a [`LaunchConfig`] into the historical `--flag value` token
@@ -3119,8 +3041,121 @@ mod tests {
         for d in &launch.disks {
             pair(&mut out, "--disk", d.clone());
         }
-        for e in &launch.env {
-            pair(&mut out, "--env", e.clone());
+
+        // Project typed bootstrap mount data into the former environment
+        // spelling so long-standing rendering tests can keep checking the
+        // exact mount semantics. This is a test-only view, not launch argv.
+        fn mount_flags(flags: BootstrapMountFlags) -> Vec<&'static str> {
+            let mut values = Vec::new();
+            if flags.readonly {
+                values.push("ro");
+            }
+            if flags.noexec {
+                values.push("noexec");
+            }
+            if flags.nosuid {
+                values.push("nosuid");
+            }
+            if flags.nodev {
+                values.push("nodev");
+            }
+            values
+        }
+        fn with_options(mut base: String, options: Vec<String>) -> String {
+            if !options.is_empty() {
+                base.push(':');
+                base.push_str(&options.join(","));
+            }
+            base
+        }
+
+        if let Some(BootstrapBlockRoot::DiskImage { device, fstype }) = &launch.bootstrap.block_root
+        {
+            let mut value = format!("kind=disk-image,device={device}");
+            if let Some(fstype) = fstype {
+                value.push_str(&format!(",fstype={fstype}"));
+            }
+            pair(&mut out, "--env", format!("MSB_BLOCK_ROOT={value}"));
+        }
+        if !launch.bootstrap.dir_mounts.is_empty() {
+            let value = launch
+                .bootstrap
+                .dir_mounts
+                .iter()
+                .map(|mount| {
+                    with_options(
+                        format!("{}:{}", mount.tag, mount.guest_path),
+                        mount_flags(mount.flags)
+                            .into_iter()
+                            .map(str::to_string)
+                            .collect(),
+                    )
+                })
+                .collect::<Vec<_>>()
+                .join(";");
+            pair(&mut out, "--env", format!("MSB_DIR_MOUNTS={value}"));
+        }
+        if !launch.bootstrap.file_mounts.is_empty() {
+            let value = launch
+                .bootstrap
+                .file_mounts
+                .iter()
+                .map(|mount| {
+                    with_options(
+                        format!("{}:{}:{}", mount.tag, mount.filename, mount.guest_path),
+                        mount_flags(mount.flags)
+                            .into_iter()
+                            .map(str::to_string)
+                            .collect(),
+                    )
+                })
+                .collect::<Vec<_>>()
+                .join(";");
+            pair(&mut out, "--env", format!("MSB_FILE_MOUNTS={value}"));
+        }
+        if !launch.bootstrap.disk_mounts.is_empty() {
+            let value = launch
+                .bootstrap
+                .disk_mounts
+                .iter()
+                .map(|mount| {
+                    let mut options = Vec::new();
+                    if let Some(fstype) = &mount.fstype {
+                        options.push(format!("fstype={fstype}"));
+                    }
+                    options.extend(mount_flags(mount.flags).into_iter().map(str::to_string));
+                    with_options(format!("{}:{}", mount.id, mount.guest_path), options)
+                })
+                .collect::<Vec<_>>()
+                .join(";");
+            pair(&mut out, "--env", format!("MSB_DISK_MOUNTS={value}"));
+        }
+        if !launch.bootstrap.tmpfs_mounts.is_empty() {
+            let value = launch
+                .bootstrap
+                .tmpfs_mounts
+                .iter()
+                .map(|mount| {
+                    let mut options = Vec::new();
+                    if let Some(size_mib) = mount.size_mib {
+                        options.push(format!("size={size_mib}"));
+                    }
+                    if let Some(mode) = mount.mode {
+                        options.push(format!("mode={mode:o}"));
+                    }
+                    options.extend(mount_flags(mount.flags).into_iter().map(str::to_string));
+                    with_options(mount.path.clone(), options)
+                })
+                .collect::<Vec<_>>()
+                .join(";");
+            pair(&mut out, "--env", format!("MSB_TMPFS={value}"));
+        }
+        for variable in &launch.bootstrap.default_env {
+            pair(
+                &mut out,
+                "--env",
+                format!("{}={}", variable.key, variable.value),
+            );
         }
         #[cfg(feature = "net")]
         if let Some(net) = &launch.network {
@@ -3131,8 +3166,8 @@ mod tests {
             );
             pair(&mut out, "--sandbox-slot", launch.sandbox_slot.to_string());
         }
-        if let Some(w) = &launch.workdir {
-            pair(&mut out, "--workdir", path(w));
+        if let Some(cwd) = &launch.bootstrap.default_cwd {
+            pair(&mut out, "--workdir", cwd.clone());
         }
         out
     }
@@ -3258,11 +3293,6 @@ mod tests {
             .into_iter()
             .map(|arg| arg.to_string_lossy().into_owned())
             .collect()
-    }
-
-    fn decode_handoff_json<T: DeserializeOwned>(value: &str) -> T {
-        let json = URL_SAFE_NO_PAD.decode(value).expect("base64url payload");
-        serde_json::from_slice(&json).expect("handoff JSON payload")
     }
 
     fn render_args_with_file_mounts(
@@ -3472,28 +3502,20 @@ mod tests {
         });
         config.clear_launch_intent();
 
-        let rendered = render_args(&config);
+        let launch = render_launch(&config);
+        let handoff = launch.bootstrap.handoff_init.expect("handoff bootstrap");
 
+        assert_eq!(handoff.cmd, "/init");
         assert_eq!(
-            find_env(&rendered, "MSB_HANDOFF_INIT").as_deref(),
-            Some("/init")
-        );
-        let argv = find_env(&rendered, "MSB_HANDOFF_INIT_ARGS").expect("argv env present");
-        let decoded: Vec<String> = decode_handoff_json(&argv);
-        assert_eq!(
-            decoded,
+            handoff.args,
             vec![
                 "/opt/hermes/docker/main-wrapper.sh".to_string(),
                 "gateway".to_string(),
                 "run".to_string(),
             ]
         );
-        assert_eq!(
-            find_env(&rendered, "MSB_HANDOFF_INIT_CWD").as_deref(),
-            Some("/opt/hermes")
-        );
-        assert!(!rendered.iter().any(|arg| arg.starts_with("--startup-cmd")));
-        assert!(!rendered.iter().any(|arg| arg.starts_with("--startup-arg")));
+        assert_eq!(handoff.cwd.as_deref(), Some("/opt/hermes"));
+        assert!(launch.startup.is_none());
     }
 
     #[tokio::test]
@@ -3588,7 +3610,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_sandbox_cli_args_include_rlimits_env() {
+    async fn test_sandbox_bootstrap_includes_rlimits() {
         let config = SandboxBuilder::new("test")
             .image("/tmp/rootfs")
             .rlimit(RlimitResource::Nofile, 65_535)
@@ -3596,12 +3618,16 @@ mod tests {
             .await
             .unwrap();
 
-        let rendered = render_args(&config);
+        let launch = render_launch(&config);
 
-        assert!(rendered.windows(2).any(|pair| {
-            pair[0] == "--env"
-                && pair[1] == format!("{}=nofile=65535:65535", microsandbox_protocol::ENV_RLIMITS)
-        }));
+        assert_eq!(
+            launch.bootstrap.rlimits,
+            vec![ExecRlimit {
+                resource: "nofile".to_string(),
+                soft: 65_535,
+                hard: 65_535,
+            }]
+        );
     }
 
     #[tokio::test]
@@ -3637,35 +3663,52 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_encode_rlimits_round_trips_through_protocol_parser() {
-        use microsandbox_protocol::exec::ExecRlimit;
+    async fn test_bootstrap_preserves_quoted_environment_without_visible_argv_exposure() {
+        let value = "{\"message\":\"hello\",\"unicode\":\"lambda λ\"}\nnext\tline=a=b";
+        let config = SandboxBuilder::new("test")
+            .image("/tmp/rootfs")
+            .env("APP_CONFIG", value)
+            .build()
+            .await
+            .unwrap();
 
-        let rlimits = vec![
-            Rlimit {
-                resource: RlimitResource::Nofile,
-                soft: 4096,
-                hard: 65_535,
-            },
-            Rlimit {
-                resource: RlimitResource::Nproc,
-                soft: 1024,
-                hard: 1024,
-            },
-        ];
+        let launch = render_launch(&config);
+        let visible = render_visible_args(&config);
 
-        let encoded = super::encode_rlimits(&rlimits);
-        let parsed: Vec<ExecRlimit> = encoded
-            .split(';')
-            .map(|entry| entry.parse::<ExecRlimit>().unwrap())
-            .collect();
+        assert_eq!(
+            launch.bootstrap.default_env,
+            vec![BootstrapEnvVar {
+                key: "APP_CONFIG".to_string(),
+                value: value.to_string(),
+            }]
+        );
+        assert!(
+            visible
+                .iter()
+                .all(|arg| !arg.contains("APP_CONFIG") && !arg.contains(value)),
+            "guest environment leaked into visible argv: {visible:?}"
+        );
+    }
 
-        assert_eq!(parsed.len(), 2);
-        assert_eq!(parsed[0].resource, "nofile");
-        assert_eq!(parsed[0].soft, 4096);
-        assert_eq!(parsed[0].hard, 65_535);
-        assert_eq!(parsed[1].resource, "nproc");
-        assert_eq!(parsed[1].soft, 1024);
-        assert_eq!(parsed[1].hard, 1024);
+    #[tokio::test]
+    async fn test_sandbox_bootstrap_preserves_multiple_rlimits() {
+        let config = SandboxBuilder::new("test")
+            .image("/tmp/rootfs")
+            .rlimit_range(RlimitResource::Nofile, 4096, 65_535)
+            .rlimit(RlimitResource::Nproc, 1024)
+            .build()
+            .await
+            .unwrap();
+
+        let launch = render_launch(&config);
+
+        assert_eq!(launch.bootstrap.rlimits.len(), 2);
+        assert_eq!(launch.bootstrap.rlimits[0].resource, "nofile");
+        assert_eq!(launch.bootstrap.rlimits[0].soft, 4096);
+        assert_eq!(launch.bootstrap.rlimits[0].hard, 65_535);
+        assert_eq!(launch.bootstrap.rlimits[1].resource, "nproc");
+        assert_eq!(launch.bootstrap.rlimits[1].soft, 1024);
+        assert_eq!(launch.bootstrap.rlimits[1].hard, 1024);
     }
 
     #[tokio::test]
@@ -4665,23 +4708,11 @@ mod tests {
     }
 
     //----------------------------------------------------------------------------------------------
-    // Tests: Handoff init env-var construction
+    // Tests: Handoff init bootstrap construction
     //----------------------------------------------------------------------------------------------
 
-    /// Helper to grep the rendered args for an `--env KEY=...` entry.
-    fn find_env(args: &[String], key: &str) -> Option<String> {
-        let prefix = format!("{key}=");
-        args.windows(2).find_map(|pair| {
-            if pair[0] == "--env" && pair[1].starts_with(&prefix) {
-                Some(pair[1][prefix.len()..].to_string())
-            } else {
-                None
-            }
-        })
-    }
-
     #[tokio::test]
-    async fn test_handoff_init_emits_only_cmd_when_args_and_env_empty() {
+    async fn test_handoff_init_bootstrap_contains_only_cmd_when_args_and_env_empty() {
         let config = SandboxBuilder::new("test")
             .image("/tmp/rootfs")
             .init("/lib/systemd/systemd")
@@ -4689,19 +4720,17 @@ mod tests {
             .await
             .unwrap();
 
-        let args = render_args(&config);
+        let launch = render_launch(&config);
+        let handoff = launch.bootstrap.handoff_init.expect("handoff bootstrap");
 
-        assert_eq!(
-            find_env(&args, "MSB_HANDOFF_INIT").as_deref(),
-            Some("/lib/systemd/systemd")
-        );
-        assert!(find_env(&args, "MSB_HANDOFF_INIT_ARGS").is_none());
-        assert!(find_env(&args, "MSB_HANDOFF_INIT_CWD").is_none());
-        assert!(find_env(&args, "MSB_HANDOFF_INIT_ENV").is_none());
+        assert_eq!(handoff.cmd, "/lib/systemd/systemd");
+        assert!(handoff.args.is_empty());
+        assert!(handoff.cwd.is_none());
+        assert!(handoff.env.is_empty());
     }
 
     #[tokio::test]
-    async fn test_handoff_init_emits_cwd_when_workdir_set() {
+    async fn test_handoff_init_bootstrap_contains_cwd_when_workdir_set() {
         let config = SandboxBuilder::new("test")
             .image("/tmp/rootfs")
             .init("/init")
@@ -4710,16 +4739,14 @@ mod tests {
             .await
             .unwrap();
 
-        let args = render_args(&config);
+        let launch = render_launch(&config);
+        let handoff = launch.bootstrap.handoff_init.expect("handoff bootstrap");
 
-        assert_eq!(
-            find_env(&args, "MSB_HANDOFF_INIT_CWD").as_deref(),
-            Some("/opt/hermes")
-        );
+        assert_eq!(handoff.cwd.as_deref(), Some("/opt/hermes"));
     }
 
     #[tokio::test]
-    async fn test_handoff_init_encodes_argv_as_base64url_json() {
+    async fn test_handoff_init_bootstrap_preserves_argv() {
         let config = SandboxBuilder::new("test")
             .image("/tmp/rootfs")
             .init_with("/lib/systemd/systemd", |i| {
@@ -4733,12 +4760,11 @@ mod tests {
             .await
             .unwrap();
 
-        let args = render_args(&config);
-        let argv = find_env(&args, "MSB_HANDOFF_INIT_ARGS").expect("argv env present");
-        let decoded: Vec<String> = decode_handoff_json(&argv);
+        let launch = render_launch(&config);
+        let handoff = launch.bootstrap.handoff_init.expect("handoff bootstrap");
 
         assert_eq!(
-            decoded,
+            handoff.args,
             vec![
                 "--unit=multi-user.target",
                 "--log-level=warning",
@@ -4748,7 +4774,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_handoff_init_encodes_env_pairs_as_base64url_json() {
+    async fn test_handoff_init_bootstrap_preserves_environment() {
         let config = SandboxBuilder::new("test")
             .image("/tmp/rootfs")
             .init_with("/sbin/init", |i| {
@@ -4760,16 +4786,24 @@ mod tests {
             .await
             .unwrap();
 
-        let args = render_args(&config);
-        let env_val = find_env(&args, "MSB_HANDOFF_INIT_ENV").expect("env present");
-        let decoded: Vec<(String, String)> = decode_handoff_json(&env_val);
+        let launch = render_launch(&config);
+        let handoff = launch.bootstrap.handoff_init.expect("handoff bootstrap");
 
         assert_eq!(
-            decoded,
+            handoff.env,
             vec![
-                ("container".to_string(), "microsandbox".to_string()),
-                ("LANG".to_string(), "C.UTF-8".to_string()),
-                ("TOKEN".to_string(), "a=b;c\x1fd".to_string())
+                BootstrapEnvVar {
+                    key: "container".to_string(),
+                    value: "microsandbox".to_string(),
+                },
+                BootstrapEnvVar {
+                    key: "LANG".to_string(),
+                    value: "C.UTF-8".to_string(),
+                },
+                BootstrapEnvVar {
+                    key: "TOKEN".to_string(),
+                    value: "a=b;c\x1fd".to_string(),
+                },
             ]
         );
     }
@@ -4782,11 +4816,9 @@ mod tests {
             .await
             .unwrap();
 
-        let args = render_args(&config);
+        let launch = render_launch(&config);
 
-        assert!(find_env(&args, "MSB_HANDOFF_INIT").is_none());
-        assert!(find_env(&args, "MSB_HANDOFF_INIT_ARGS").is_none());
-        assert!(find_env(&args, "MSB_HANDOFF_INIT_ENV").is_none());
+        assert!(launch.bootstrap.handoff_init.is_none());
     }
 
     #[tokio::test]
@@ -4797,11 +4829,10 @@ mod tests {
             .build()
             .await
             .unwrap();
-        let args = render_args(&config);
-        let argv = find_env(&args, "MSB_HANDOFF_INIT_ARGS").expect("argv env present");
-        let decoded: Vec<String> = decode_handoff_json(&argv);
+        let launch = render_launch(&config);
+        let handoff = launch.bootstrap.handoff_init.expect("handoff bootstrap");
 
-        assert_eq!(decoded, vec!["foo\x1fbar"]);
+        assert_eq!(handoff.args, vec!["foo\x1fbar"]);
     }
 
     #[tokio::test]

--- a/sdk/rust/lib/sandbox/init.rs
+++ b/sdk/rust/lib/sandbox/init.rs
@@ -93,9 +93,8 @@ impl InitOptionsBuilder {
 // Functions: Validation
 //--------------------------------------------------------------------------------------------------
 
-/// Validate a populated [`HandoffInit`] before it's persisted into
-/// [`super::SandboxConfig`] or serialised onto MSB_HANDOFF_INIT* env
-/// vars.
+/// Validate a populated [`HandoffInit`] before it is persisted into
+/// [`super::SandboxConfig`] or serialized into the typed guest bootstrap.
 ///
 /// Constraints (each violation produces an `InvalidConfig` error):
 /// - `cmd` must be either an absolute path or the literal sentinel

--- a/sdk/rust/tests/create_from_spec.rs
+++ b/sdk/rust/tests/create_from_spec.rs
@@ -10,6 +10,7 @@ use microsandbox::{Sandbox, sandbox::SandboxBuilder};
 use test_utils::msb_test;
 
 const IMAGE: &str = "mirror.gcr.io/library/alpine";
+const FROM_SPEC_VALUE: &str = "{\"message\":\"hello\",\"nested\":{\"quote\":\"a=b\"}}";
 
 async fn cleanup(name: &str) {
     if let Ok(h) = Sandbox::get(name).await {
@@ -32,15 +33,14 @@ async fn assert_shell_ok(sandbox: &Sandbox, command: &str, expected: &str) {
 /// A full `SandboxSpec` — image, resources, a guest hostname, and an env var.
 /// Everything else falls back to the spec defaults.
 fn spec_json(name: &str) -> String {
-    format!(
-        r#"{{
-            "name": "{name}",
-            "image": {{ "Oci": {{ "reference": "{IMAGE}" }} }},
-            "resources": {{ "cpus": 1, "memory_mib": 256 }},
-            "runtime": {{ "hostname": "spec-host" }},
-            "env": [{{ "key": "FROM_SPEC", "value": "applied" }}]
-        }}"#
-    )
+    serde_json::json!({
+        "name": name,
+        "image": { "Oci": { "reference": IMAGE } },
+        "resources": { "cpus": 1, "memory_mib": 256 },
+        "runtime": { "hostname": "spec-host" },
+        "env": [{ "key": "FROM_SPEC", "value": FROM_SPEC_VALUE }]
+    })
+    .to_string()
 }
 
 /// A full spec JSON boots and its fields take effect in the guest — the whole
@@ -57,8 +57,16 @@ async fn from_spec_json_boots_and_applies_spec_fields() {
         .await
         .expect("create from spec");
 
-    assert_shell_ok(&sandbox, r#"printf %s "$FROM_SPEC""#, "applied").await;
+    assert_shell_ok(&sandbox, r#"printf %s "$FROM_SPEC""#, FROM_SPEC_VALUE).await;
     assert_shell_ok(&sandbox, "hostname", "spec-host").await;
+    let cmdline = sandbox
+        .shell("cat /proc/cmdline")
+        .await
+        .expect("read kernel command line")
+        .stdout()
+        .unwrap_or_default();
+    assert!(!cmdline.contains("FROM_SPEC"));
+    assert!(!cmdline.contains(FROM_SPEC_VALUE));
 
     let _ = sandbox.stop().await;
     cleanup(name).await;
@@ -80,7 +88,7 @@ async fn from_spec_json_options_override_spec() {
         .expect("create from spec with override");
 
     assert_shell_ok(&sandbox, "hostname", "override-host").await;
-    assert_shell_ok(&sandbox, r#"printf %s "$FROM_SPEC""#, "applied").await;
+    assert_shell_ok(&sandbox, r#"printf %s "$FROM_SPEC""#, FROM_SPEC_VALUE).await;
 
     let _ = sandbox.stop().await;
     cleanup(name).await;


### PR DESCRIPTION
## TL;DR
Move guest boot configuration and workload environment values from the kernel command line to a typed, versioned console bootstrap. JSON environment values containing double quotes now survive CLI and SDK launches without appearing in `/proc/cmdline`.

Closes #1364

## Description
- add the generation 7 `core.bootstrap` message with typed root, mount, network, environment, security, and handoff data
- queue bootstrap before VM entry and consume it through agentd's already-open console before full guest initialization
- preserve init acknowledgement ordering, relative cwd behavior, scripts `PATH`, secret-placeholder precedence, and PID 1 handoff behavior
- keep normal live-sandbox protocol negotiation unchanged and document the bundled host-agent boot boundary
- cover transport-sensitive JSON, Unicode, control characters, IPv4/IPv6, coalesced frames, and kernel command-line leakage

## Test Plan
- [x] `cargo fmt --all -- --check` and `git diff --check` pass
- [x] `cargo test -p microsandbox-protocol --test schema_snapshot` passes
- [x] `cargo test -p microsandbox-protocol -p microsandbox-network -p microsandbox-runtime -p microsandbox --lib` passes
- [x] Linux musl `cargo test -p microsandbox-agentd --lib` and `cargo clippy -p microsandbox-agentd --all-targets -- -D warnings` pass
- [x] a signed local CLI preserves quoted Unicode JSON and keeps it out of guest `/proc/cmdline`
- [x] `cargo test -p microsandbox --test create_from_spec from_spec_json_boots_and_applies_spec_fields -- --ignored --exact --nocapture` passes against the signed CLI

<!-- greptile_comment -->

<sub>Reviews (2): Last reviewed commit: ["fix(runtime): move guest bootstrap off k..."](https://github.com/superradcompany/microsandbox/commit/7a182fa880a22b938281036f5b45692a4b3e2d5b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53957329)</sub>

**Context used:**

- Context used - AGENTS.md ([source](https://github.com/superradcompany/microsandbox/blob/main/AGENTS.md))

<!-- /greptile_comment -->