### PR TITLE
fix(network): fall back between host loopback families

### DIFF
--- a/crates/network/lib/proxy.rs
+++ b/crates/network/lib/proxy.rs
@@ -200,8 +200,6 @@ async fn tcp_proxy_task(
     tls_state: Option<Arc<TlsState>>,
     proxy_connect: Arc<ProxyConnectState>,
 ) -> io::Result<()> {
-    let connect_dst = connect_target.primary();
-
     // Pre-connect peek is only for domain policy: the hostname has to be known
     // before we dial upstream so a Deny never opens a connection. Secrets do
     // *not* gate the connect, so they no longer force a peek here — that work is
@@ -273,6 +271,7 @@ async fn tcp_proxy_task(
     // seen the server's banner; with the socket already open we can relay that
     // banner while we wait, instead of burning the peek budget pre-connect.
     let stream = connect_target.connect(&proxy_connect, &shared).await?;
+    let connect_dst = stream.peer_addr().unwrap_or(connect_target.primary());
     let (mut server_rx, mut server_tx) = stream.into_split();
 
     // Finish classifying the first flight (TLS vs plain HTTP) and, for

--- a/crates/network/lib/proxy.rs
+++ b/crates/network/lib/proxy.rs
@@ -5,6 +5,8 @@
 //! channel pair (connected to the smoltcp socket in the poll loop) and the
 //! real server.
 
+pub(crate) mod upstream;
+
 use std::borrow::Cow;
 use std::io;
 use std::net::{IpAddr, SocketAddr};
@@ -16,6 +18,7 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpStream;
 use tokio::sync::mpsc;
 
+use self::upstream::UpstreamTcpTarget;
 use crate::conn::ProxyConnectState;
 use crate::policy::{EgressEvaluation, HostnameSource, NetworkPolicy, Protocol};
 use crate::secrets::config::{SecretsConfig, SecretsConfigExt, ViolationAction};
@@ -115,31 +118,10 @@ impl ConnectTarget {
 // Functions
 //--------------------------------------------------------------------------------------------------
 
-/// Dial `dst` and update proxy state; wakes the poll thread on failure.
-pub(crate) async fn connect_upstream(
-    dst: SocketAddr,
-    proxy_connect: &ProxyConnectState,
-    shared: &SharedState,
-) -> io::Result<TcpStream> {
-    match TcpStream::connect(dst).await {
-        Ok(s) => {
-            proxy_connect.mark_connected();
-            Ok(s)
-        }
-        Err(e) => {
-            proxy_connect.mark_upstream_connect_failed();
-            shared.proxy_wake.wake();
-            Err(e)
-        }
-    }
-}
-
 /// Spawn a TCP proxy task for a newly established connection.
 ///
-/// `guest_dst` is what the guest dialed — the address policy rules
-/// match against. `connect_dst` is the host-side address tokio actually
-/// dials; for host-alias connections it's loopback (gateway rewritten).
-/// For everything else the two are identical.
+/// `guest_dst` is what the guest dialed — the address policy rules match
+/// against. `connect_dst` is the host-side address tokio actually dials.
 ///
 /// `proxy_connect` is updated before the task exits so the connection
 /// tracker can decide between FIN (clean close) and RST (upstream
@@ -157,10 +139,38 @@ pub fn spawn_tcp_proxy(
     tls_state: Option<Arc<TlsState>>,
     proxy_connect: Arc<ProxyConnectState>,
 ) {
+    spawn_tcp_proxy_with_target(
+        handle,
+        guest_dst,
+        UpstreamTcpTarget::direct(connect_dst),
+        from_smoltcp,
+        to_smoltcp,
+        shared,
+        network_policy,
+        secrets,
+        tls_state,
+        proxy_connect,
+    );
+}
+
+/// Spawn a TCP proxy with an optional alternate host-loopback destination.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn spawn_tcp_proxy_with_target(
+    handle: &tokio::runtime::Handle,
+    guest_dst: SocketAddr,
+    connect_target: UpstreamTcpTarget,
+    from_smoltcp: mpsc::Receiver<Bytes>,
+    to_smoltcp: mpsc::Sender<Bytes>,
+    shared: Arc<SharedState>,
+    network_policy: Arc<NetworkPolicy>,
+    secrets: Arc<SecretsConfig>,
+    tls_state: Option<Arc<TlsState>>,
+    proxy_connect: Arc<ProxyConnectState>,
+) {
     handle.spawn(async move {
         if let Err(e) = tcp_proxy_task(
             guest_dst,
-            connect_dst,
+            connect_target,
             from_smoltcp,
             to_smoltcp,
             shared,
@@ -171,7 +181,7 @@ pub fn spawn_tcp_proxy(
         )
         .await
         {
-            tracing::debug!(dst = %connect_dst, error = %e, "TCP proxy task ended");
+            tracing::debug!(dst = %connect_target.primary(), error = %e, "TCP proxy task ended");
         }
     });
 }
@@ -181,7 +191,7 @@ pub fn spawn_tcp_proxy(
 #[allow(clippy::too_many_arguments)]
 async fn tcp_proxy_task(
     guest_dst: SocketAddr,
-    connect_dst: SocketAddr,
+    connect_target: UpstreamTcpTarget,
     mut from_smoltcp: mpsc::Receiver<Bytes>,
     to_smoltcp: mpsc::Sender<Bytes>,
     shared: Arc<SharedState>,
@@ -190,6 +200,8 @@ async fn tcp_proxy_task(
     tls_state: Option<Arc<TlsState>>,
     proxy_connect: Arc<ProxyConnectState>,
 ) -> io::Result<()> {
+    let connect_dst = connect_target.primary();
+
     // Pre-connect peek is only for domain policy: the hostname has to be known
     // before we dial upstream so a Deny never opens a connection. Secrets do
     // *not* gate the connect, so they no longer force a peek here — that work is
@@ -242,7 +254,7 @@ async fn tcp_proxy_task(
         if could_be_connect_request(&initial_buf) {
             return handle_connect_tunnel(
                 guest_dst,
-                connect_dst,
+                connect_target,
                 initial_buf,
                 from_smoltcp,
                 to_smoltcp,
@@ -260,7 +272,7 @@ async fn tcp_proxy_task(
     // server-first protocol (SSH, SMTP, a database) sends nothing until it has
     // seen the server's banner; with the socket already open we can relay that
     // banner while we wait, instead of burning the peek budget pre-connect.
-    let stream = connect_upstream(connect_dst, &proxy_connect, &shared).await?;
+    let stream = connect_target.connect(&proxy_connect, &shared).await?;
     let (mut server_rx, mut server_tx) = stream.into_split();
 
     // Finish classifying the first flight (TLS vs plain HTTP) and, for
@@ -297,7 +309,7 @@ async fn tcp_proxy_task(
             .map_err(|_| io::Error::other("failed to reunite proxy stream halves"))?;
         return handle_connect_tunnel(
             guest_dst,
-            connect_dst,
+            connect_target,
             initial_buf,
             from_smoltcp,
             to_smoltcp,
@@ -374,7 +386,7 @@ async fn tcp_proxy_task(
                                 .map_err(|_| io::Error::other("failed to reunite proxy stream halves"))?;
                             return handle_connect_tunnel(
                                 guest_dst,
-                                connect_dst,
+                                connect_target,
                                 bytes.to_vec(),
                                 from_smoltcp,
                                 to_smoltcp,
@@ -457,12 +469,12 @@ async fn tcp_proxy_task(
 /// Forward an HTTP CONNECT tunnel: dial the proxy, splice the handshake,
 /// then hand the established stream to `tls_proxy_task` for TLS MITM.
 ///
-/// `guest_dst` is what the guest dialed; `proxy_dst` is the rewritten
-/// loopback address the gateway actually connects to.
+/// `guest_dst` is what the guest dialed; `proxy_target` contains the rewritten
+/// loopback address the gateway actually connects to and its optional fallback.
 #[allow(clippy::too_many_arguments)]
 async fn handle_connect_tunnel(
     guest_dst: SocketAddr,
-    proxy_dst: SocketAddr,
+    proxy_target: UpstreamTcpTarget,
     initial_buf: Vec<u8>,
     mut from_smoltcp: mpsc::Receiver<Bytes>,
     to_smoltcp: mpsc::Sender<Bytes>,
@@ -472,6 +484,7 @@ async fn handle_connect_tunnel(
     proxy_connect: Arc<ProxyConnectState>,
     preconnected_proxy: Option<TcpStream>,
 ) -> io::Result<()> {
+    let proxy_dst = proxy_target.primary();
     let connect_req =
         parse_connect_request(buffer_connect_request(initial_buf, &mut from_smoltcp).await?)?;
 
@@ -492,14 +505,7 @@ async fn handle_connect_tunnel(
     // Dial the proxy and forward the CONNECT request so it opens the tunnel.
     let mut proxy_stream = match preconnected_proxy {
         Some(stream) => stream,
-        None => match TcpStream::connect(proxy_dst).await {
-            Ok(s) => s,
-            Err(e) => {
-                proxy_connect.mark_upstream_connect_failed();
-                shared.proxy_wake.wake();
-                return Err(e);
-            }
-        },
+        None => proxy_target.connect(&proxy_connect, &shared).await?,
     };
 
     if !connect_req.target.is_intercepted(&tls_state) {
@@ -570,7 +576,7 @@ async fn handle_connect_tunnel(
     tls_proxy_task(
         TlsProxyContext {
             guest_dst: tls_guest_dst,
-            connect_dst: proxy_dst,
+            connect_target: proxy_target,
             shared,
             tls_state,
             network_policy,
@@ -1656,7 +1662,7 @@ mod tests {
 
         tcp_proxy_task(
             server_addr,
-            server_addr,
+            UpstreamTcpTarget::direct(server_addr),
             from_rx,
             to_tx,
             Arc::new(shared),
@@ -1696,7 +1702,7 @@ mod tests {
 
         tcp_proxy_task(
             addr,
-            addr,
+            UpstreamTcpTarget::direct(addr),
             from_rx,
             to_tx,
             Arc::new(SharedState::new(4)),
@@ -1766,7 +1772,7 @@ mod tests {
 
         tcp_proxy_task(
             addr,
-            addr,
+            UpstreamTcpTarget::direct(addr),
             from_rx,
             to_tx,
             Arc::new(shared),
@@ -1866,7 +1872,7 @@ mod tests {
 
         tcp_proxy_task(
             addr,
-            addr,
+            UpstreamTcpTarget::direct(addr),
             from_rx,
             to_tx,
             Arc::new(SharedState::new(4)),

--- a/crates/network/lib/proxy/upstream.rs
+++ b/crates/network/lib/proxy/upstream.rs
@@ -1,0 +1,143 @@
+//! Host-side TCP destination selection and connection state reporting.
+
+use std::io;
+use std::net::SocketAddr;
+
+use tokio::net::TcpStream;
+
+use crate::conn::ProxyConnectState;
+use crate::shared::SharedState;
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// Ordered host-side TCP destinations for one guest connection.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct UpstreamTcpTarget {
+    primary: SocketAddr,
+    fallback: Option<SocketAddr>,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Methods
+//--------------------------------------------------------------------------------------------------
+
+impl UpstreamTcpTarget {
+    /// Create a target with no address-family fallback.
+    pub(crate) fn direct(primary: SocketAddr) -> Self {
+        Self {
+            primary,
+            fallback: None,
+        }
+    }
+
+    /// Create a target with an alternate address-family destination.
+    pub(crate) fn with_fallback(primary: SocketAddr, fallback: SocketAddr) -> Self {
+        Self {
+            primary,
+            fallback: Some(fallback),
+        }
+    }
+
+    /// Return the first host-side address to dial.
+    pub(crate) fn primary(self) -> SocketAddr {
+        self.primary
+    }
+
+    /// Connect and publish the final outcome to the guest proxy state.
+    pub(crate) async fn connect(
+        self,
+        proxy_connect: &ProxyConnectState,
+        shared: &SharedState,
+    ) -> io::Result<TcpStream> {
+        let stream = match self.dial().await {
+            Ok(stream) => stream,
+            Err(error) => {
+                proxy_connect.mark_upstream_connect_failed();
+                shared.proxy_wake.wake();
+
+                return Err(error);
+            }
+        };
+
+        proxy_connect.mark_connected();
+
+        Ok(stream)
+    }
+
+    async fn dial(self) -> io::Result<TcpStream> {
+        let primary_error = match TcpStream::connect(self.primary).await {
+            Ok(stream) => return Ok(stream),
+            Err(error) => error,
+        };
+
+        let Some(fallback) = self.fallback.filter(|_| fallback_eligible(&primary_error)) else {
+            return Err(primary_error);
+        };
+
+        tracing::debug!(
+            primary = %self.primary,
+            fallback = %fallback,
+            error = %primary_error,
+            "primary host loopback connection failed; trying alternate address family"
+        );
+
+        TcpStream::connect(fallback)
+            .await
+            .map_err(|fallback_error| {
+                let primary = self.primary;
+                let message = format!(
+                    "failed to connect to host loopback {primary} ({primary_error}); alternate \
+                     {fallback} also failed ({fallback_error})"
+                );
+
+                io::Error::new(fallback_error.kind(), message)
+            })
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+fn fallback_eligible(error: &io::Error) -> bool {
+    matches!(
+        error.kind(),
+        io::ErrorKind::ConnectionRefused
+            | io::ErrorKind::AddrNotAvailable
+            | io::ErrorKind::NetworkUnreachable
+    )
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests
+//--------------------------------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use tokio::net::TcpListener;
+
+    use super::*;
+    use crate::conn::ProxyConnectStatus;
+
+    #[tokio::test]
+    async fn connect_falls_back_from_ipv6_to_ipv4_loopback() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let fallback = SocketAddr::new("127.0.0.1".parse().unwrap(), port);
+        let primary = SocketAddr::new("::1".parse().unwrap(), port);
+        let target = UpstreamTcpTarget::with_fallback(primary, fallback);
+        let proxy_connect = ProxyConnectState::new();
+        let shared = SharedState::new(4);
+
+        let stream = target
+            .connect(&proxy_connect, &shared)
+            .await
+            .expect("IPv4 loopback fallback should connect");
+
+        assert_eq!(stream.peer_addr().unwrap(), fallback);
+        assert_eq!(proxy_connect.status(), ProxyConnectStatus::Connected);
+        let _accepted = listener.accept().await.unwrap();
+    }
+}

--- a/crates/network/lib/stack.rs
+++ b/crates/network/lib/stack.rs
@@ -31,7 +31,7 @@ use crate::dns::{
 };
 use crate::icmp_relay::IcmpRelay;
 use crate::policy::{EgressEvaluation, HostnameSource, NetworkPolicy, Protocol};
-use crate::proxy;
+use crate::proxy::{self, upstream::UpstreamTcpTarget};
 use crate::publisher::PortPublisher;
 use crate::secrets::handle::SecretsHandle;
 use crate::shared::SharedState;
@@ -523,11 +523,11 @@ pub fn smoltcp_poll_loop(
                     .contains(&conn.dst.port())
             {
                 // TLS-intercepted port — spawn TLS MITM proxy.
-                let connect_dst = resolve_host_dst(conn.dst, config.gateway);
+                let connect_target = resolve_tcp_host_target(conn.dst, config.gateway);
                 tls_proxy::spawn_tls_proxy(
                     &tokio_handle,
                     conn.dst,
-                    connect_dst,
+                    connect_target,
                     conn.from_smoltcp,
                     conn.to_smoltcp,
                     shared.clone(),
@@ -588,11 +588,11 @@ pub fn smoltcp_poll_loop(
                 continue;
             }
             // Plain TCP proxy.
-            let connect_dst = resolve_host_dst(conn.dst, config.gateway);
-            proxy::spawn_tcp_proxy(
+            let connect_target = resolve_tcp_host_target(conn.dst, config.gateway);
+            proxy::spawn_tcp_proxy_with_target(
                 &tokio_handle,
                 conn.dst,
-                connect_dst,
+                connect_target,
                 conn.from_smoltcp,
                 conn.to_smoltcp,
                 shared.clone(),
@@ -796,10 +796,30 @@ fn handle_reassembled_udp_datagram(
     device.drop_staged_frame();
 }
 
-/// Map a guest-wire destination to its host-socket equivalent.
+/// Resolve host-side TCP destination candidates for a guest connection.
+///
+/// A guest connection to either gateway family first dials the matching host
+/// loopback address, then may fall back to the other loopback family. Regular
+/// outbound destinations have no fallback.
+fn resolve_tcp_host_target(dst: SocketAddr, gateway: GatewayIps) -> UpstreamTcpTarget {
+    let port = dst.port();
+    match dst.ip() {
+        IpAddr::V4(v4) if gateway.ipv4 == Some(v4) => UpstreamTcpTarget::with_fallback(
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), port),
+            SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), port),
+        ),
+        IpAddr::V6(v6) if gateway.ipv6 == Some(v6) => UpstreamTcpTarget::with_fallback(
+            SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), port),
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), port),
+        ),
+        _ => UpstreamTcpTarget::direct(dst),
+    }
+}
+
+/// Map a guest-wire UDP destination to its host-socket equivalent.
 ///
 /// Gateway IPs rewrite to loopback (`127.0.0.1` / `::1`); everything else
-/// passes through. Shared by the TCP proxy dispatch and the UDP relay.
+/// passes through.
 ///
 /// # Arguments
 ///
@@ -1540,6 +1560,44 @@ mod tests {
             ipv4: Some(Ipv4Addr::new(100, 96, 0, 1)),
             ipv6: Some("fd42:6d73:62::1".parse().unwrap()),
         }
+    }
+
+    #[test]
+    fn resolve_tcp_host_target_ipv4_can_fall_back_to_ipv6() {
+        let gw = test_gateway();
+        let dst = SocketAddr::new(IpAddr::V4(gw.ipv4.unwrap()), 8080);
+
+        assert_eq!(
+            resolve_tcp_host_target(dst, gw),
+            UpstreamTcpTarget::with_fallback(
+                SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 8080),
+                SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), 8080),
+            )
+        );
+    }
+
+    #[test]
+    fn resolve_tcp_host_target_ipv6_can_fall_back_to_ipv4() {
+        let gw = test_gateway();
+        let dst = SocketAddr::new(IpAddr::V6(gw.ipv6.unwrap()), 8080);
+
+        assert_eq!(
+            resolve_tcp_host_target(dst, gw),
+            UpstreamTcpTarget::with_fallback(
+                SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), 8080),
+                SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 8080),
+            )
+        );
+    }
+
+    #[test]
+    fn resolve_tcp_host_target_external_has_no_fallback() {
+        let dst = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8)), 443);
+
+        assert_eq!(
+            resolve_tcp_host_target(dst, test_gateway()),
+            UpstreamTcpTarget::direct(dst)
+        );
     }
 
     #[test]

--- a/crates/network/lib/tls/proxy.rs
+++ b/crates/network/lib/tls/proxy.rs
@@ -19,7 +19,7 @@ use super::sni;
 use super::state::TlsState;
 use crate::conn::ProxyConnectState;
 use crate::policy::{EgressEvaluation, HostnameSource, NetworkPolicy, Protocol};
-use crate::proxy::connect_upstream;
+use crate::proxy::upstream::UpstreamTcpTarget;
 use crate::secrets::config::ViolationAction;
 use crate::secrets::handler::SecretsHandler;
 use crate::shared::SharedState;
@@ -40,12 +40,12 @@ const RELAY_BUF_SIZE: usize = 16384;
 
 pub(crate) struct TlsProxyContext {
     pub(crate) guest_dst: SocketAddr,
-    pub(crate) connect_dst: SocketAddr,
+    pub(crate) connect_target: UpstreamTcpTarget,
     pub(crate) shared: Arc<SharedState>,
     pub(crate) tls_state: Arc<TlsState>,
     pub(crate) network_policy: Arc<NetworkPolicy>,
     pub(crate) proxy_connect: Arc<ProxyConnectState>,
-    /// Pre-connected upstream; when `Some`, skips dialing `connect_dst`.
+    /// Pre-connected upstream; when `Some`, skips dialing `connect_target`.
     pub(crate) upstream_stream: Option<TcpStream>,
     /// Hostname from a CONNECT authority that must match the ClientHello SNI.
     pub(crate) expected_sni: Option<String>,
@@ -62,10 +62,10 @@ pub(crate) struct TlsProxyContext {
 /// See [`crate::proxy::spawn_tcp_proxy`] for the `proxy_connect`
 /// contract.
 #[allow(clippy::too_many_arguments)]
-pub fn spawn_tls_proxy(
+pub(crate) fn spawn_tls_proxy(
     handle: &tokio::runtime::Handle,
     guest_dst: SocketAddr,
-    connect_dst: SocketAddr,
+    connect_target: UpstreamTcpTarget,
     from_smoltcp: mpsc::Receiver<Bytes>,
     to_smoltcp: mpsc::Sender<Bytes>,
     shared: Arc<SharedState>,
@@ -76,7 +76,7 @@ pub fn spawn_tls_proxy(
     handle.spawn(async move {
         let context = TlsProxyContext {
             guest_dst,
-            connect_dst,
+            connect_target,
             shared,
             tls_state,
             network_policy,
@@ -87,7 +87,7 @@ pub fn spawn_tls_proxy(
         };
 
         if let Err(e) = tls_proxy_task(context, from_smoltcp, to_smoltcp, Vec::new()).await {
-            tracing::debug!(dst = %connect_dst, guest_dst = %guest_dst, error = %e, "TLS proxy task ended");
+            tracing::debug!(dst = %connect_target.primary(), guest_dst = %guest_dst, error = %e, "TLS proxy task ended");
         }
     });
 }
@@ -101,7 +101,7 @@ pub(crate) async fn tls_proxy_task(
 ) -> io::Result<()> {
     let TlsProxyContext {
         guest_dst,
-        connect_dst,
+        connect_target,
         shared,
         tls_state,
         network_policy,
@@ -110,6 +110,7 @@ pub(crate) async fn tls_proxy_task(
         expected_sni,
         via_connect,
     } = context;
+    let connect_dst = connect_target.primary();
 
     // Buffer initial data to extract SNI from ClientHello. Timeout prevents a
     // slow/malicious guest from holding a proxy slot indefinitely.
@@ -159,7 +160,7 @@ pub(crate) async fn tls_proxy_task(
     if tls_state.should_bypass(&sni_name) {
         tracing::debug!(sni = %sni_name, dst = %connect_dst, guest_dst = %guest_dst, "TLS bypass");
         bypass_relay(
-            connect_dst,
+            connect_target,
             initial_buf,
             from_smoltcp,
             to_smoltcp,
@@ -172,7 +173,7 @@ pub(crate) async fn tls_proxy_task(
         tracing::debug!(sni = %sni_name, dst = %connect_dst, guest_dst = %guest_dst, "TLS intercept");
         intercept_relay(
             guest_dst,
-            connect_dst,
+            connect_target,
             &sni_name,
             via_connect,
             initial_buf,
@@ -189,7 +190,7 @@ pub(crate) async fn tls_proxy_task(
 
 /// Bypass mode: plain TCP splice, no TLS termination.
 async fn bypass_relay(
-    dst: SocketAddr,
+    connect_target: UpstreamTcpTarget,
     initial_buf: Vec<u8>,
     mut from_smoltcp: mpsc::Receiver<Bytes>,
     to_smoltcp: mpsc::Sender<Bytes>,
@@ -199,7 +200,7 @@ async fn bypass_relay(
 ) -> io::Result<()> {
     let mut server = match upstream_stream {
         Some(s) => s,
-        None => connect_upstream(dst, &proxy_connect, &shared).await?,
+        None => connect_target.connect(&proxy_connect, &shared).await?,
     };
     server.write_all(&initial_buf).await?;
 
@@ -244,7 +245,7 @@ async fn bypass_relay(
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn intercept_relay(
     guest_dst: SocketAddr,
-    connect_dst: SocketAddr,
+    connect_target: UpstreamTcpTarget,
     sni_name: &str,
     via_connect: bool,
     initial_buf: Vec<u8>,
@@ -314,7 +315,7 @@ pub(crate) async fn intercept_relay(
     // Connect to real server with TLS.
     let server_stream = match upstream_stream {
         Some(s) => s,
-        None => connect_upstream(connect_dst, &proxy_connect, &shared).await?,
+        None => connect_target.connect(&proxy_connect, &shared).await?,
     };
     let server_name = ServerName::try_from(sni_name.to_string())
         .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?;

--- a/sdk/rust/tests/host_access.rs
+++ b/sdk/rust/tests/host_access.rs
@@ -1,7 +1,7 @@
 //! Integration tests for the `host.microsandbox.internal` alias.
 
 use std::io;
-use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr};
+use std::net::{Ipv4Addr, SocketAddr};
 use std::sync::Arc;
 
 use ipnetwork::{IpNetwork, Ipv4Network};
@@ -17,8 +17,9 @@ use tokio::task::JoinHandle;
 // Host HTTP fixture
 //--------------------------------------------------------------------------------------------------
 
-/// Minimal HTTP server bound to `127.0.0.1` and `::1` on the same port. Dual-family avoids
-/// flakes when the guest's happy-eyeballs picks v6 and the listener only lives on v4.
+/// Minimal HTTP server bound only to IPv4 loopback.
+///
+/// Host-alias access must work even when the guest selects its IPv6 gateway.
 struct HostHttp {
     port: u16,
     shutdown: Option<oneshot::Sender<()>>,
@@ -29,7 +30,6 @@ impl HostHttp {
     async fn start(body: &'static str) -> io::Result<Self> {
         let v4_listener = TcpListener::bind(SocketAddr::from((Ipv4Addr::LOCALHOST, 0))).await?;
         let port = v4_listener.local_addr()?.port();
-        let v6_listener = TcpListener::bind(SocketAddr::from((Ipv6Addr::LOCALHOST, port))).await?;
 
         let (shutdown_tx, shutdown_rx) = oneshot::channel();
         let body = Arc::new(body.to_owned());
@@ -40,7 +40,6 @@ impl HostHttp {
                 tokio::select! {
                     _ = &mut shutdown_rx => return,
                     accept = v4_listener.accept() => Self::handle_accept(accept, &body),
-                    accept = v6_listener.accept() => Self::handle_accept(accept, &body),
                 }
             }
         });
@@ -115,6 +114,17 @@ async fn read_gateway_ip(sb: &Sandbox) -> String {
         .shell("awk '/^nameserver /{print $2; exit}' /etc/resolv.conf")
         .await
         .expect("read resolv.conf");
+    out.stdout().expect("utf8").trim().to_owned()
+}
+
+/// Read the sandbox gateway IPv6 from the host-alias entry in `/etc/hosts`.
+async fn read_gateway_ipv6(sb: &Sandbox) -> String {
+    let out = sb
+        .shell(
+            "awk '$2 == \"host.microsandbox.internal\" && index($1, \":\") {print $1; exit}' /etc/hosts",
+        )
+        .await
+        .expect("read host alias IPv6");
     out.stdout().expect("utf8").trim().to_owned()
 }
 
@@ -206,6 +216,39 @@ async fn host_alias_reachable_by_hostname_and_gateway_ip() {
     assert!(
         hosts.contains(&gw),
         "expected gateway IPv4 {gw} in /etc/hosts, got:\n{hosts}"
+    );
+
+    teardown(sb, name).await;
+}
+
+/// An IPv6 host-alias choice must still reach a service bound only on IPv4 loopback.
+#[msb_test]
+async fn host_alias_ipv6_falls_back_to_ipv4_only_listener() {
+    let server = HostHttp::start("hello from ipv4")
+        .await
+        .expect("IPv4-only HTTP fixture");
+    let port = server.port();
+
+    let name = "host-alias-ipv6-to-ipv4";
+    let sb = spawn_sandbox(name, Some(NetworkPolicy::allow_all())).await;
+    let gateway_ipv6 = read_gateway_ipv6(&sb).await;
+    if gateway_ipv6.is_empty() {
+        eprintln!("skip: host has no IPv6 route — guest IPv6 gateway was not provisioned");
+        teardown(sb, name).await;
+        return;
+    }
+
+    let out = sb
+        .shell(format!(
+            "wget -qO- --timeout=10 'http://[{gateway_ipv6}]:{port}/'"
+        ))
+        .await
+        .expect("wget IPv6 gateway");
+    assert_eq!(
+        out.stdout().unwrap().trim(),
+        "hello from ipv4",
+        "IPv6-to-IPv4 fallback body mismatch (stderr: {})",
+        out.stderr().unwrap_or_default()
     );
 
     teardown(sb, name).await;


### PR DESCRIPTION
## TL;DR

Allow `host.microsandbox.internal` connections to reach host services bound to only one loopback address family. Fixes #1327.

## Description

- represent host-side TCP destinations as an ordered primary and optional fallback
- retry the alternate loopback family when the matching gateway-family connection is refused or unavailable
- share the connection path across plain TCP, CONNECT, and TLS proxy flows
- keep the proxy connection pending until all eligible loopback targets fail
- add unit coverage and an IPv6-gateway to IPv4-only-listener integration case

## Test Plan

- `cargo test -p microsandbox-network --lib`
- `cargo clippy -p microsandbox-network --lib --tests -- -D warnings`
- `cargo test -p microsandbox --test host_access --no-run`

<!-- greptile_comment -->

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  G[Guest connection] --> R[Resolve host TCP target]
  R --> P[Dial primary loopback]
  P -->|Success| X[Plain TCP, CONNECT, or TLS flow]
  P -->|Eligible failure| F[Dial fallback loopback]
  F -->|Success| X
  P -->|Ineligible failure| E[Mark upstream connection failed]
  F -->|Failure| E
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(network): report selected upstream e..."](https://github.com/superradcompany/microsandbox/commit/b5a1c0e6eacc2dd882a85e16673ab0abb19ed9c3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54071919)</sub>

<!-- /greptile_comment -->