### PR TITLE
refactor(network): move proxy tasks onto owning types

### DIFF
--- a/crates/network/lib/dns/interceptor.rs
+++ b/crates/network/lib/dns/interceptor.rs
@@ -136,18 +136,14 @@ impl DnsInterceptor {
             shared.clone(),
             gateway,
         );
-        let udp_forwarder_handle = forwarder_handle.clone();
-        tokio_handle.spawn(async move {
-            let Some(forwarder) = DnsForwarder::wait(udp_forwarder_handle).await else {
-                tracing::debug!(
-                    "dns/udp: upstream forwarder unavailable; UDP queries will be dropped"
-                );
-                return;
-            };
-            UdpProxy::new(query_rx, forwarder, shared, gateway_mac, guest_mac)
-                .run()
-                .await;
-        });
+        let proxy = UdpProxy::new(
+            query_rx,
+            forwarder_handle.clone(),
+            shared,
+            gateway_mac,
+            guest_mac,
+        );
+        tokio_handle.spawn(proxy.run());
 
         (
             Self {

--- a/crates/network/lib/dns/interceptor.rs
+++ b/crates/network/lib/dns/interceptor.rs
@@ -125,13 +125,8 @@ impl DnsInterceptor {
 
         let normalized = Arc::new(NormalizedDnsConfig::from_config(dns_config));
 
-        // Two spawns from the same construction site:
-        //   1. DnsForwarder::spawn — connects to the configured
-        //      upstream and publishes the shared handle.
-        //   2. UdpProxy::spawn — drains UDP queries from this
-        //      interceptor's channel and routes them through the
-        //      forwarder, mirroring how `tcp.rs` handles per-connection
-        //      TCP/53 traffic.
+        // Start the forwarder initializer, then schedule the UDP proxy
+        // that waits for its shared handle and drains intercepted queries.
         let forwarder_handle = DnsForwarder::spawn(
             tokio_handle,
             normalized,
@@ -141,14 +136,18 @@ impl DnsInterceptor {
             shared.clone(),
             gateway,
         );
-        UdpProxy::spawn(
-            tokio_handle,
-            query_rx,
-            forwarder_handle.clone(),
-            shared,
-            gateway_mac,
-            guest_mac,
-        );
+        let udp_forwarder_handle = forwarder_handle.clone();
+        tokio_handle.spawn(async move {
+            let Some(forwarder) = DnsForwarder::wait(udp_forwarder_handle).await else {
+                tracing::debug!(
+                    "dns/udp: upstream forwarder unavailable; UDP queries will be dropped"
+                );
+                return;
+            };
+            UdpProxy::new(query_rx, forwarder, shared, gateway_mac, guest_mac)
+                .run()
+                .await;
+        });
 
         (
             Self {

--- a/crates/network/lib/dns/proxies/dot.rs
+++ b/crates/network/lib/dns/proxies/dot.rs
@@ -37,7 +37,7 @@ use tokio::sync::mpsc;
 use tokio::time::timeout;
 
 use super::super::common::transport::Transport;
-use super::super::forwarder::DnsForwarder;
+use super::super::forwarder::{DnsForwarder, DnsForwarderHandle};
 use super::framing::{frame, take_message};
 use crate::netstack::shared::SharedState;
 use crate::tls::state::TlsState;
@@ -68,15 +68,24 @@ const RESPONSE_CHANNEL_CAPACITY: usize = 32;
 // Types
 //--------------------------------------------------------------------------------------------------
 
-/// Per-connection DoT proxy. Owns the guest-facing rustls session, the
-/// smoltcp byte-stream channels, scratch buffers, and the pieces needed
-/// to dispatch inner queries through the shared forwarder.
-///
-/// Construction via [`Self::new`] extracts SNI, builds the rustls
-/// session, and primes it with the ClientHello bytes already read.
-/// [`Self::run`] consumes the proxy and drives it to completion:
-/// handshake pump → framed DNS dispatch loop.
+/// Per-connection DoT proxy task.
 pub(crate) struct DotProxy {
+    /// The (resolver-IP, 853) the guest aimed at.
+    dst: SocketAddr,
+    /// Encrypted bytes from the smoltcp TCP stream.
+    from_smoltcp: mpsc::Receiver<Bytes>,
+    /// Encrypted bytes to the smoltcp TCP stream.
+    to_smoltcp: mpsc::Sender<Bytes>,
+    /// Handle that resolves to the shared DNS forwarder.
+    forwarder: DnsForwarderHandle,
+    /// TLS state used to build the guest-facing session.
+    tls_state: Arc<TlsState>,
+    /// Shared wake handle for poking the smoltcp poll loop after send.
+    shared: Arc<SharedState>,
+}
+
+/// Initialized DoT session owned by a running [`DotProxy`].
+struct DotSession {
     /// Guest-facing TLS session. Only touched from the proxy task so
     /// rustls' non-Send/non-Sync state stays on one thread.
     guest_tls: rustls::ServerConnection,
@@ -106,14 +115,71 @@ pub(crate) struct DotProxy {
 //--------------------------------------------------------------------------------------------------
 
 impl DotProxy {
-    /// Build a DoT proxy from a freshly accepted TCP/853 connection.
+    /// Build a DoT proxy task from a freshly accepted TCP/853 connection.
+    pub(crate) fn new(
+        dst: SocketAddr,
+        from_smoltcp: mpsc::Receiver<Bytes>,
+        to_smoltcp: mpsc::Sender<Bytes>,
+        forwarder: DnsForwarderHandle,
+        tls_state: Arc<TlsState>,
+        shared: Arc<SharedState>,
+    ) -> Self {
+        Self {
+            dst,
+            from_smoltcp,
+            to_smoltcp,
+            forwarder,
+            tls_state,
+            shared,
+        }
+    }
+
+    /// Run the DoT proxy task to completion.
+    pub(crate) async fn run(self) {
+        let Self {
+            dst,
+            from_smoltcp,
+            to_smoltcp,
+            forwarder,
+            tls_state,
+            shared,
+        } = self;
+
+        let Some(forwarder) = DnsForwarder::wait(forwarder).await else {
+            tracing::debug!(%dst, "DoT: forwarder unavailable; closing connection");
+            return;
+        };
+        let proxy = match DotSession::new(
+            dst,
+            from_smoltcp,
+            to_smoltcp,
+            forwarder,
+            tls_state,
+            shared,
+        )
+        .await
+        {
+            Ok(proxy) => proxy,
+            Err(error) => {
+                tracing::debug!(%dst, %error, "DoT proxy setup failed");
+                return;
+            }
+        };
+        if let Err(error) = proxy.run().await {
+            tracing::debug!(%dst, %error, "DoT proxy task ended");
+        }
+    }
+}
+
+impl DotSession {
+    /// Initialize a DoT session from a freshly accepted TCP/853 connection.
     ///
     /// Buffers guest bytes until the ClientHello is available, picks a
     /// server name (or falls back to the dst IP), builds the
     /// guest-facing rustls session with the per-domain intercept cert,
     /// and primes the rustls state machine with the ClientHello bytes
     /// so [`Self::run`] starts at a clean handshake-pump entry.
-    pub(crate) async fn new(
+    async fn new(
         dst: SocketAddr,
         mut from_smoltcp: mpsc::Receiver<Bytes>,
         to_smoltcp: mpsc::Sender<Bytes>,
@@ -160,7 +226,7 @@ impl DotProxy {
 
     /// Drive the proxy to completion. Consumes `self`: the guest-facing
     /// rustls session is owned by this task for its lifetime.
-    pub(crate) async fn run(mut self) -> io::Result<()> {
+    async fn run(mut self) -> io::Result<()> {
         self.drive_handshake().await?;
         self.dispatch_loop().await
     }
@@ -412,7 +478,7 @@ mod tests {
             RecordType::A,
         ));
 
-        let mut proxy = DotProxy {
+        let mut proxy = DotSession {
             guest_tls,
             from_smoltcp,
             to_smoltcp,

--- a/crates/network/lib/dns/proxies/dot.rs
+++ b/crates/network/lib/dns/proxies/dot.rs
@@ -37,7 +37,7 @@ use tokio::sync::mpsc;
 use tokio::time::timeout;
 
 use super::super::common::transport::Transport;
-use super::super::forwarder::{DnsForwarder, DnsForwarderHandle};
+use super::super::forwarder::DnsForwarder;
 use super::framing::{frame, take_message};
 use crate::netstack::shared::SharedState;
 use crate::tls::state::TlsState;
@@ -106,43 +106,6 @@ pub(crate) struct DotProxy {
 //--------------------------------------------------------------------------------------------------
 
 impl DotProxy {
-    /// Spawn a DoT proxy task for a newly established TCP/853
-    /// connection. Waits for the forwarder, constructs a [`DotProxy`],
-    /// and drives it to completion.
-    ///
-    /// `dst` is the `(resolver-IP, 853)` the guest aimed at — passed
-    /// to the forwarder so upstream selection can route to the
-    /// configured upstream (gateway IP) or forward over DoT
-    /// (non-gateway `@target`).
-    pub(crate) fn spawn(
-        handle: &tokio::runtime::Handle,
-        dst: SocketAddr,
-        from_smoltcp: mpsc::Receiver<Bytes>,
-        to_smoltcp: mpsc::Sender<Bytes>,
-        forwarder: DnsForwarderHandle,
-        tls_state: Arc<TlsState>,
-        shared: Arc<SharedState>,
-    ) {
-        handle.spawn(async move {
-            let Some(forwarder) = DnsForwarder::wait(forwarder).await else {
-                tracing::debug!(%dst, "DoT: forwarder unavailable; closing connection");
-                return;
-            };
-            let proxy = match Self::new(dst, from_smoltcp, to_smoltcp, forwarder, tls_state, shared)
-                .await
-            {
-                Ok(p) => p,
-                Err(e) => {
-                    tracing::debug!(%dst, error = %e, "DoT proxy setup failed");
-                    return;
-                }
-            };
-            if let Err(e) = proxy.run().await {
-                tracing::debug!(%dst, error = %e, "DoT proxy task ended");
-            }
-        });
-    }
-
     /// Build a DoT proxy from a freshly accepted TCP/853 connection.
     ///
     /// Buffers guest bytes until the ClientHello is available, picks a
@@ -150,7 +113,7 @@ impl DotProxy {
     /// guest-facing rustls session with the per-domain intercept cert,
     /// and primes the rustls state machine with the ClientHello bytes
     /// so [`Self::run`] starts at a clean handshake-pump entry.
-    async fn new(
+    pub(crate) async fn new(
         dst: SocketAddr,
         mut from_smoltcp: mpsc::Receiver<Bytes>,
         to_smoltcp: mpsc::Sender<Bytes>,
@@ -197,7 +160,7 @@ impl DotProxy {
 
     /// Drive the proxy to completion. Consumes `self`: the guest-facing
     /// rustls session is owned by this task for its lifetime.
-    async fn run(mut self) -> io::Result<()> {
+    pub(crate) async fn run(mut self) -> io::Result<()> {
         self.drive_handshake().await?;
         self.dispatch_loop().await
     }

--- a/crates/network/lib/dns/proxies/tcp.rs
+++ b/crates/network/lib/dns/proxies/tcp.rs
@@ -25,7 +25,7 @@ use tokio::sync::mpsc;
 use tokio::time::timeout;
 
 use super::super::common::transport::Transport;
-use super::super::forwarder::DnsForwarder;
+use super::super::forwarder::{DnsForwarder, DnsForwarderHandle};
 use super::framing::{take_message, write_framed};
 use crate::netstack::shared::SharedState;
 
@@ -56,8 +56,8 @@ pub(crate) struct DnsTcpProxy {
     to_smoltcp: mpsc::Sender<Bytes>,
     /// Framing buffer: incoming bytes pending message extraction.
     frame_buf: Vec<u8>,
-    /// Shared forwarder handle used by every inner query.
-    forwarder: Arc<DnsForwarder>,
+    /// Handle that resolves to the shared forwarder used by every inner query.
+    forwarder: DnsForwarderHandle,
     /// Shared wake handle for poking the smoltcp poll loop after send.
     shared: Arc<SharedState>,
 }
@@ -77,7 +77,7 @@ impl DnsTcpProxy {
         dst: SocketAddr,
         from_smoltcp: mpsc::Receiver<Bytes>,
         to_smoltcp: mpsc::Sender<Bytes>,
-        forwarder: Arc<DnsForwarder>,
+        forwarder: DnsForwarderHandle,
         shared: Arc<SharedState>,
     ) -> Self {
         Self {
@@ -92,27 +92,44 @@ impl DnsTcpProxy {
 
     /// Drive the proxy to completion. Consumes `self`: the framing
     /// buffer and channels are owned by this task for its lifetime.
-    pub(crate) async fn run(mut self) {
-        let original_dst = Some(self.dst.ip());
+    pub(crate) async fn run(self) {
+        let Self {
+            dst,
+            mut from_smoltcp,
+            to_smoltcp,
+            mut frame_buf,
+            forwarder,
+            shared,
+        } = self;
+
+        let Some(forwarder) = DnsForwarder::wait(forwarder).await else {
+            tracing::debug!(
+                %dst,
+                "dns/tcp: upstream forwarder unavailable; closing connection",
+            );
+            return;
+        };
+
+        let original_dst = Some(dst.ip());
         loop {
-            let next = match timeout(IDLE_TIMEOUT, self.from_smoltcp.recv()).await {
+            let next = match timeout(IDLE_TIMEOUT, from_smoltcp.recv()).await {
                 Ok(Some(chunk)) => chunk,
                 Ok(None) => return, // guest closed
                 Err(_) => {
-                    tracing::debug!(dst = %self.dst, "dns/tcp: idle timeout, closing connection");
+                    tracing::debug!(%dst, "dns/tcp: idle timeout, closing connection");
                     return;
                 }
             };
-            self.frame_buf.extend_from_slice(&next);
+            frame_buf.extend_from_slice(&next);
 
             // Drain all complete messages currently in the buffer. Each
             // query is forwarded in its own task so a slow upstream
             // doesn't block subsequent pipelined queries on the same
             // connection.
-            while let Some(query) = take_message(&mut self.frame_buf) {
-                let forwarder = self.forwarder.clone();
-                let to_smoltcp = self.to_smoltcp.clone();
-                let shared = self.shared.clone();
+            while let Some(query) = take_message(&mut frame_buf) {
+                let forwarder = forwarder.clone();
+                let to_smoltcp = to_smoltcp.clone();
+                let shared = shared.clone();
                 tokio::spawn(async move {
                     let Some(response) = forwarder
                         .forward(&query, original_dst, Transport::Tcp, None)

--- a/crates/network/lib/dns/proxies/tcp.rs
+++ b/crates/network/lib/dns/proxies/tcp.rs
@@ -25,7 +25,7 @@ use tokio::sync::mpsc;
 use tokio::time::timeout;
 
 use super::super::common::transport::Transport;
-use super::super::forwarder::{DnsForwarder, DnsForwarderHandle};
+use super::super::forwarder::DnsForwarder;
 use super::framing::{take_message, write_framed};
 use crate::netstack::shared::SharedState;
 
@@ -67,35 +67,13 @@ pub(crate) struct DnsTcpProxy {
 //--------------------------------------------------------------------------------------------------
 
 impl DnsTcpProxy {
-    /// Spawn a DNS-over-TCP proxy task for a newly established TCP/53
-    /// connection. Waits for the forwarder, constructs a [`TcpProxy`],
-    /// and drives it to completion.
+    /// Build a DNS-over-TCP proxy from a freshly accepted TCP/53 connection.
     ///
     /// `dst` is the (resolver-IP, 53) the guest aimed at — passed to
     /// the forwarder so the per-query upstream selector can route to
     /// the right place (configured upstream if `dst.ip()` is a gateway
     /// IP, direct forward otherwise).
-    pub(crate) fn spawn(
-        handle: &tokio::runtime::Handle,
-        dst: SocketAddr,
-        from_smoltcp: mpsc::Receiver<Bytes>,
-        to_smoltcp: mpsc::Sender<Bytes>,
-        forwarder: DnsForwarderHandle,
-        shared: Arc<SharedState>,
-    ) {
-        handle.spawn(async move {
-            let Some(forwarder) = DnsForwarder::wait(forwarder).await else {
-                tracing::debug!(%dst, "dns/tcp: upstream forwarder unavailable; closing connection");
-                return;
-            };
-            Self::new(dst, from_smoltcp, to_smoltcp, forwarder, shared)
-                .run()
-                .await;
-        });
-    }
-
-    /// Build a TCP proxy from a freshly accepted TCP/53 connection.
-    fn new(
+    pub(crate) fn new(
         dst: SocketAddr,
         from_smoltcp: mpsc::Receiver<Bytes>,
         to_smoltcp: mpsc::Sender<Bytes>,
@@ -114,7 +92,7 @@ impl DnsTcpProxy {
 
     /// Drive the proxy to completion. Consumes `self`: the framing
     /// buffer and channels are owned by this task for its lifetime.
-    async fn run(mut self) {
+    pub(crate) async fn run(mut self) {
         let original_dst = Some(self.dst.ip());
         loop {
             let next = match timeout(IDLE_TIMEOUT, self.from_smoltcp.recv()).await {

--- a/crates/network/lib/dns/proxies/udp.rs
+++ b/crates/network/lib/dns/proxies/udp.rs
@@ -17,7 +17,7 @@ use smoltcp::wire::{EthernetAddress, IpEndpoint};
 use tokio::sync::mpsc;
 
 use super::super::common::transport::Transport;
-use super::super::forwarder::{DnsForwarder, DnsForwarderHandle};
+use super::super::forwarder::DnsForwarder;
 use super::super::interceptor::DnsQuery;
 use crate::netstack::shared::SharedState;
 use crate::udp::relay::construct_udp_response;
@@ -54,31 +54,8 @@ pub(crate) struct UdpProxy {
 //--------------------------------------------------------------------------------------------------
 
 impl UdpProxy {
-    /// Spawn the DNS-over-UDP proxy task. Waits for the forwarder,
-    /// constructs a [`UdpProxy`], and drives it to completion.
-    pub(crate) fn spawn(
-        handle: &tokio::runtime::Handle,
-        query_rx: mpsc::Receiver<DnsQuery>,
-        forwarder: DnsForwarderHandle,
-        shared: Arc<SharedState>,
-        gateway_mac: [u8; 6],
-        guest_mac: [u8; 6],
-    ) {
-        handle.spawn(async move {
-            let Some(forwarder) = DnsForwarder::wait(forwarder).await else {
-                tracing::debug!(
-                    "dns/udp: upstream forwarder unavailable; UDP queries will be dropped"
-                );
-                return;
-            };
-            Self::new(query_rx, forwarder, shared, gateway_mac, guest_mac)
-                .run()
-                .await;
-        });
-    }
-
-    /// Build a UDP proxy bound to the interceptor's channel pair.
-    fn new(
+    /// Build a DNS-over-UDP proxy bound to the interceptor's channel pair.
+    pub(crate) fn new(
         query_rx: mpsc::Receiver<DnsQuery>,
         forwarder: Arc<DnsForwarder>,
         shared: Arc<SharedState>,
@@ -96,7 +73,7 @@ impl UdpProxy {
 
     /// Drive the per-query dispatch loop. Consumes `self`: the channels
     /// are owned by this task for its lifetime.
-    async fn run(mut self) {
+    pub(crate) async fn run(mut self) {
         while let Some(query) = self.query_rx.recv().await {
             let shared = self.shared.clone();
             let forwarder = self.forwarder.clone();

--- a/crates/network/lib/dns/proxies/udp.rs
+++ b/crates/network/lib/dns/proxies/udp.rs
@@ -17,7 +17,7 @@ use smoltcp::wire::{EthernetAddress, IpEndpoint};
 use tokio::sync::mpsc;
 
 use super::super::common::transport::Transport;
-use super::super::forwarder::DnsForwarder;
+use super::super::forwarder::{DnsForwarder, DnsForwarderHandle};
 use super::super::interceptor::DnsQuery;
 use crate::netstack::shared::SharedState;
 use crate::udp::relay::construct_udp_response;
@@ -39,8 +39,8 @@ const DNS_PORT: u16 = 53;
 pub(crate) struct UdpProxy {
     /// Queries pushed by the interceptor's smoltcp read loop.
     query_rx: mpsc::Receiver<DnsQuery>,
-    /// Shared forwarder handle used by every inner query.
-    forwarder: Arc<DnsForwarder>,
+    /// Handle that resolves to the shared forwarder used by every inner query.
+    forwarder: DnsForwarderHandle,
     /// Shared rings and wake handles for guest delivery.
     shared: Arc<SharedState>,
     /// Source MAC on synthesized response frames.
@@ -57,7 +57,7 @@ impl UdpProxy {
     /// Build a DNS-over-UDP proxy bound to the interceptor's channel pair.
     pub(crate) fn new(
         query_rx: mpsc::Receiver<DnsQuery>,
-        forwarder: Arc<DnsForwarder>,
+        forwarder: DnsForwarderHandle,
         shared: Arc<SharedState>,
         gateway_mac: [u8; 6],
         guest_mac: [u8; 6],
@@ -73,12 +73,23 @@ impl UdpProxy {
 
     /// Drive the per-query dispatch loop. Consumes `self`: the channels
     /// are owned by this task for its lifetime.
-    pub(crate) async fn run(mut self) {
-        while let Some(query) = self.query_rx.recv().await {
-            let shared = self.shared.clone();
-            let forwarder = self.forwarder.clone();
-            let gateway_mac = self.gateway_mac;
-            let guest_mac = self.guest_mac;
+    pub(crate) async fn run(self) {
+        let Self {
+            mut query_rx,
+            forwarder,
+            shared,
+            gateway_mac,
+            guest_mac,
+        } = self;
+
+        let Some(forwarder) = DnsForwarder::wait(forwarder).await else {
+            tracing::debug!("dns/udp: upstream forwarder unavailable; UDP queries will be dropped");
+            return;
+        };
+
+        while let Some(query) = query_rx.recv().await {
+            let shared = shared.clone();
+            let forwarder = forwarder.clone();
             // Two views of the same address: smoltcp's IpAddress for
             // the outgoing source-IP stamp on the response, and std's
             // IpAddr for the forwarder's policy lookup.

--- a/crates/network/lib/netstack/poll.rs
+++ b/crates/network/lib/netstack/poll.rs
@@ -24,7 +24,6 @@ use smoltcp::wire::{
 use crate::config::{DnsConfig, PublishedPort};
 use crate::dns::common::ports::DnsPortType;
 use crate::dns::{
-    forwarder::DnsForwarder,
     interceptor::DnsInterceptor,
     proxies::{dot::DotProxy, tcp::DnsTcpProxy},
 };
@@ -524,7 +523,6 @@ pub fn smoltcp_poll_loop(
             {
                 // TLS-intercepted port — spawn TLS MITM proxy.
                 let connect_target = resolve_tcp_host_target(conn.dst, config.gateway);
-                let guest_dst = conn.dst;
                 let proxy = TlsProxy::new(
                     conn.dst,
                     connect_target,
@@ -535,16 +533,7 @@ pub fn smoltcp_poll_loop(
                     network_policy.clone(),
                     conn.proxy_connect,
                 );
-                tokio_handle.spawn(async move {
-                    if let Err(error) = proxy.run().await {
-                        tracing::debug!(
-                            dst = %connect_target.primary(),
-                            %guest_dst,
-                            %error,
-                            "TLS proxy task ended",
-                        );
-                    }
-                });
+                tokio_handle.spawn(proxy.run());
                 continue;
             }
             if conn.dst.port() == 53 {
@@ -565,21 +554,14 @@ pub fn smoltcp_poll_loop(
                 // otherwise. No gateway→loopback rewrite here: the
                 // forwarder dials the configured upstream, not the
                 // gateway.
-                let dst = conn.dst;
-                let forwarder_handle = dns_forwarder_handle.clone();
-                let shared = shared.clone();
-                tokio_handle.spawn(async move {
-                    let Some(forwarder) = DnsForwarder::wait(forwarder_handle).await else {
-                        tracing::debug!(
-                            %dst,
-                            "dns/tcp: upstream forwarder unavailable; closing connection",
-                        );
-                        return;
-                    };
-                    DnsTcpProxy::new(dst, conn.from_smoltcp, conn.to_smoltcp, forwarder, shared)
-                        .run()
-                        .await;
-                });
+                let proxy = DnsTcpProxy::new(
+                    conn.dst,
+                    conn.from_smoltcp,
+                    conn.to_smoltcp,
+                    dns_forwarder_handle.clone(),
+                    shared.clone(),
+                );
+                tokio_handle.spawn(proxy.run());
                 continue;
             }
             if conn.dst.port() == 853
@@ -593,40 +575,19 @@ pub fn smoltcp_poll_loop(
                 // same forwarder plain DNS uses. Policy for the
                 // chosen `@target` resolver is applied per-query by
                 // the forwarder (block list + rebind + egress).
-                let dst = conn.dst;
-                let forwarder_handle = dns_forwarder_handle.clone();
-                let tls_state = tls_state.clone();
-                let shared = shared.clone();
-                tokio_handle.spawn(async move {
-                    let Some(forwarder) = DnsForwarder::wait(forwarder_handle).await else {
-                        tracing::debug!(%dst, "DoT: forwarder unavailable; closing connection");
-                        return;
-                    };
-                    let proxy = match DotProxy::new(
-                        dst,
-                        conn.from_smoltcp,
-                        conn.to_smoltcp,
-                        forwarder,
-                        tls_state,
-                        shared,
-                    )
-                    .await
-                    {
-                        Ok(proxy) => proxy,
-                        Err(error) => {
-                            tracing::debug!(%dst, %error, "DoT proxy setup failed");
-                            return;
-                        }
-                    };
-                    if let Err(error) = proxy.run().await {
-                        tracing::debug!(%dst, %error, "DoT proxy task ended");
-                    }
-                });
+                let proxy = DotProxy::new(
+                    conn.dst,
+                    conn.from_smoltcp,
+                    conn.to_smoltcp,
+                    dns_forwarder_handle.clone(),
+                    tls_state.clone(),
+                    shared.clone(),
+                );
+                tokio_handle.spawn(proxy.run());
                 continue;
             }
             // Plain TCP proxy.
             let connect_target = resolve_tcp_host_target(conn.dst, config.gateway);
-            let guest_dst = conn.dst;
             let proxy = TcpProxy::new(
                 conn.dst,
                 connect_target,
@@ -640,16 +601,7 @@ pub fn smoltcp_poll_loop(
                 tls_state.clone(),
                 conn.proxy_connect,
             );
-            tokio_handle.spawn(async move {
-                if let Err(error) = proxy.run().await {
-                    tracing::debug!(
-                        dst = %connect_target.primary(),
-                        %guest_dst,
-                        %error,
-                        "TCP proxy task ended",
-                    );
-                }
-            });
+            tokio_handle.spawn(proxy.run());
         }
 
         // Rate-limited cleanup: TIME_WAIT is 60s, session timeout is 60s,

--- a/crates/network/lib/netstack/poll.rs
+++ b/crates/network/lib/netstack/poll.rs
@@ -523,19 +523,17 @@ pub fn smoltcp_poll_loop(
             {
                 // TLS-intercepted port — spawn TLS MITM proxy.
                 let connect_target = resolve_tcp_host_target(conn.dst, config.gateway);
-                std::mem::drop(
-                    TlsProxy::new(
-                        conn.dst,
-                        connect_target,
-                        conn.from_smoltcp,
-                        conn.to_smoltcp,
-                        shared.clone(),
-                        tls_state.clone(),
-                        network_policy.clone(),
-                        conn.proxy_connect,
-                    )
-                    .spawn(&tokio_handle),
-                );
+                TlsProxy::new(
+                    conn.dst,
+                    connect_target,
+                    conn.from_smoltcp,
+                    conn.to_smoltcp,
+                    shared.clone(),
+                    tls_state.clone(),
+                    network_policy.clone(),
+                    conn.proxy_connect,
+                )
+                .spawn(&tokio_handle);
                 continue;
             }
             if conn.dst.port() == 53 {
@@ -590,22 +588,20 @@ pub fn smoltcp_poll_loop(
             }
             // Plain TCP proxy.
             let connect_target = resolve_tcp_host_target(conn.dst, config.gateway);
-            std::mem::drop(
-                TcpProxy::new(
-                    conn.dst,
-                    connect_target,
-                    conn.from_smoltcp,
-                    conn.to_smoltcp,
-                    shared.clone(),
-                    network_policy.clone(),
-                    // Load the current snapshot per connection so live secret
-                    // updates apply to traffic the guest starts afterwards.
-                    secrets.load(),
-                    tls_state.clone(),
-                    conn.proxy_connect,
-                )
-                .spawn(&tokio_handle),
-            );
+            TcpProxy::new(
+                conn.dst,
+                connect_target,
+                conn.from_smoltcp,
+                conn.to_smoltcp,
+                shared.clone(),
+                network_policy.clone(),
+                // Load the current snapshot per connection so live secret
+                // updates apply to traffic the guest starts afterwards.
+                secrets.load(),
+                tls_state.clone(),
+                conn.proxy_connect,
+            )
+            .spawn(&tokio_handle);
         }
 
         // Rate-limited cleanup: TIME_WAIT is 60s, session timeout is 60s,

--- a/crates/network/lib/netstack/poll.rs
+++ b/crates/network/lib/netstack/poll.rs
@@ -24,6 +24,7 @@ use smoltcp::wire::{
 use crate::config::{DnsConfig, PublishedPort};
 use crate::dns::common::ports::DnsPortType;
 use crate::dns::{
+    forwarder::DnsForwarder,
     interceptor::DnsInterceptor,
     proxies::{dot::DotProxy, tcp::DnsTcpProxy},
 };
@@ -523,7 +524,8 @@ pub fn smoltcp_poll_loop(
             {
                 // TLS-intercepted port — spawn TLS MITM proxy.
                 let connect_target = resolve_tcp_host_target(conn.dst, config.gateway);
-                TlsProxy::new(
+                let guest_dst = conn.dst;
+                let proxy = TlsProxy::new(
                     conn.dst,
                     connect_target,
                     conn.from_smoltcp,
@@ -532,8 +534,17 @@ pub fn smoltcp_poll_loop(
                     tls_state.clone(),
                     network_policy.clone(),
                     conn.proxy_connect,
-                )
-                .spawn(&tokio_handle);
+                );
+                tokio_handle.spawn(async move {
+                    if let Err(error) = proxy.run().await {
+                        tracing::debug!(
+                            dst = %connect_target.primary(),
+                            %guest_dst,
+                            %error,
+                            "TLS proxy task ended",
+                        );
+                    }
+                });
                 continue;
             }
             if conn.dst.port() == 53 {
@@ -554,14 +565,21 @@ pub fn smoltcp_poll_loop(
                 // otherwise. No gateway→loopback rewrite here: the
                 // forwarder dials the configured upstream, not the
                 // gateway.
-                DnsTcpProxy::spawn(
-                    &tokio_handle,
-                    conn.dst,
-                    conn.from_smoltcp,
-                    conn.to_smoltcp,
-                    dns_forwarder_handle.clone(),
-                    shared.clone(),
-                );
+                let dst = conn.dst;
+                let forwarder_handle = dns_forwarder_handle.clone();
+                let shared = shared.clone();
+                tokio_handle.spawn(async move {
+                    let Some(forwarder) = DnsForwarder::wait(forwarder_handle).await else {
+                        tracing::debug!(
+                            %dst,
+                            "dns/tcp: upstream forwarder unavailable; closing connection",
+                        );
+                        return;
+                    };
+                    DnsTcpProxy::new(dst, conn.from_smoltcp, conn.to_smoltcp, forwarder, shared)
+                        .run()
+                        .await;
+                });
                 continue;
             }
             if conn.dst.port() == 853
@@ -575,20 +593,41 @@ pub fn smoltcp_poll_loop(
                 // same forwarder plain DNS uses. Policy for the
                 // chosen `@target` resolver is applied per-query by
                 // the forwarder (block list + rebind + egress).
-                DotProxy::spawn(
-                    &tokio_handle,
-                    conn.dst,
-                    conn.from_smoltcp,
-                    conn.to_smoltcp,
-                    dns_forwarder_handle.clone(),
-                    tls_state.clone(),
-                    shared.clone(),
-                );
+                let dst = conn.dst;
+                let forwarder_handle = dns_forwarder_handle.clone();
+                let tls_state = tls_state.clone();
+                let shared = shared.clone();
+                tokio_handle.spawn(async move {
+                    let Some(forwarder) = DnsForwarder::wait(forwarder_handle).await else {
+                        tracing::debug!(%dst, "DoT: forwarder unavailable; closing connection");
+                        return;
+                    };
+                    let proxy = match DotProxy::new(
+                        dst,
+                        conn.from_smoltcp,
+                        conn.to_smoltcp,
+                        forwarder,
+                        tls_state,
+                        shared,
+                    )
+                    .await
+                    {
+                        Ok(proxy) => proxy,
+                        Err(error) => {
+                            tracing::debug!(%dst, %error, "DoT proxy setup failed");
+                            return;
+                        }
+                    };
+                    if let Err(error) = proxy.run().await {
+                        tracing::debug!(%dst, %error, "DoT proxy task ended");
+                    }
+                });
                 continue;
             }
             // Plain TCP proxy.
             let connect_target = resolve_tcp_host_target(conn.dst, config.gateway);
-            TcpProxy::new(
+            let guest_dst = conn.dst;
+            let proxy = TcpProxy::new(
                 conn.dst,
                 connect_target,
                 conn.from_smoltcp,
@@ -600,8 +639,17 @@ pub fn smoltcp_poll_loop(
                 secrets.load(),
                 tls_state.clone(),
                 conn.proxy_connect,
-            )
-            .spawn(&tokio_handle);
+            );
+            tokio_handle.spawn(async move {
+                if let Err(error) = proxy.run().await {
+                    tracing::debug!(
+                        dst = %connect_target.primary(),
+                        %guest_dst,
+                        %error,
+                        "TCP proxy task ended",
+                    );
+                }
+            });
         }
 
         // Rate-limited cleanup: TIME_WAIT is 60s, session timeout is 60s,

--- a/crates/network/lib/netstack/poll.rs
+++ b/crates/network/lib/netstack/poll.rs
@@ -31,8 +31,8 @@ use crate::icmp::relay::IcmpRelay;
 use crate::policy::{EgressEvaluation, HostnameSource, NetworkPolicy, Protocol};
 use crate::ports::PortPublisher;
 use crate::secrets::handle::SecretsHandle;
-use crate::tcp::{connection::ConnectionTracker, proxy, upstream::UpstreamTcpTarget};
-use crate::tls::{proxy as tls_proxy, state::TlsState};
+use crate::tcp::{connection::ConnectionTracker, proxy::TcpProxy, upstream::UpstreamTcpTarget};
+use crate::tls::{proxy::TlsProxy, state::TlsState};
 use crate::udp::fragments::{
     Ipv4UdpFragmentReassembler, Ipv6UdpFragmentReassembler, ReassembledUdpDatagram,
     is_ipv4_udp_fragment, is_ipv6_fragment, is_ipv6_udp_fragment,
@@ -523,16 +523,18 @@ pub fn smoltcp_poll_loop(
             {
                 // TLS-intercepted port — spawn TLS MITM proxy.
                 let connect_target = resolve_tcp_host_target(conn.dst, config.gateway);
-                tls_proxy::spawn_tls_proxy(
-                    &tokio_handle,
-                    conn.dst,
-                    connect_target,
-                    conn.from_smoltcp,
-                    conn.to_smoltcp,
-                    shared.clone(),
-                    tls_state.clone(),
-                    network_policy.clone(),
-                    conn.proxy_connect,
+                std::mem::drop(
+                    TlsProxy::new(
+                        conn.dst,
+                        connect_target,
+                        conn.from_smoltcp,
+                        conn.to_smoltcp,
+                        shared.clone(),
+                        tls_state.clone(),
+                        network_policy.clone(),
+                        conn.proxy_connect,
+                    )
+                    .spawn(&tokio_handle),
                 );
                 continue;
             }
@@ -588,19 +590,21 @@ pub fn smoltcp_poll_loop(
             }
             // Plain TCP proxy.
             let connect_target = resolve_tcp_host_target(conn.dst, config.gateway);
-            proxy::spawn_tcp_proxy_with_target(
-                &tokio_handle,
-                conn.dst,
-                connect_target,
-                conn.from_smoltcp,
-                conn.to_smoltcp,
-                shared.clone(),
-                network_policy.clone(),
-                // Load the current snapshot per connection so live secret
-                // updates apply to traffic the guest starts afterwards.
-                secrets.load(),
-                tls_state.clone(),
-                conn.proxy_connect,
+            std::mem::drop(
+                TcpProxy::new(
+                    conn.dst,
+                    connect_target,
+                    conn.from_smoltcp,
+                    conn.to_smoltcp,
+                    shared.clone(),
+                    network_policy.clone(),
+                    // Load the current snapshot per connection so live secret
+                    // updates apply to traffic the guest starts afterwards.
+                    secrets.load(),
+                    tls_state.clone(),
+                    conn.proxy_connect,
+                )
+                .spawn(&tokio_handle),
             );
         }
 

--- a/crates/network/lib/tcp/proxy.rs
+++ b/crates/network/lib/tcp/proxy.rs
@@ -152,8 +152,23 @@ impl TcpProxy {
         }
     }
 
-    /// Drive the TCP proxy to completion.
-    pub(crate) async fn run(self) -> io::Result<()> {
+    /// Run the TCP proxy task to completion.
+    pub(crate) async fn run(self) {
+        let guest_dst = self.guest_dst;
+        let connect_dst = self.connect_target.primary();
+
+        if let Err(error) = self.try_run().await {
+            tracing::debug!(
+                dst = %connect_dst,
+                %guest_dst,
+                %error,
+                "TCP proxy task ended",
+            );
+        }
+    }
+
+    /// Drive the TCP proxy to completion, returning operational failures.
+    async fn try_run(self) -> io::Result<()> {
         let Self {
             guest_dst,
             connect_target,
@@ -476,11 +491,7 @@ pub fn spawn_tcp_proxy(
         proxy_connect,
     );
 
-    handle.spawn(async move {
-        if let Err(error) = proxy.run().await {
-            tracing::debug!(dst = %connect_dst, %guest_dst, %error, "TCP proxy task ended");
-        }
-    });
+    handle.spawn(proxy.run());
 }
 
 /// Forward an HTTP CONNECT tunnel: dial the proxy, splice the handshake,
@@ -603,7 +614,7 @@ async fn handle_connect_tunnel(
     .with_upstream(proxy_stream)
     .with_expected_sni(expected_sni)
     .with_initial_buf(tls_seed)
-    .run()
+    .try_run()
     .await
 }
 
@@ -1686,7 +1697,7 @@ mod tests {
             None,
             proxy_connect,
         )
-        .run()
+        .try_run()
         .await
         .unwrap();
 
@@ -1727,7 +1738,7 @@ mod tests {
             None,
             proxy_connect,
         )
-        .run()
+        .try_run()
         .await
         .unwrap();
 
@@ -1798,7 +1809,7 @@ mod tests {
             None,
             proxy_connect,
         )
-        .run()
+        .try_run()
         .await
         .unwrap();
 
@@ -1899,7 +1910,7 @@ mod tests {
             None,
             proxy_connect,
         )
-        .run()
+        .try_run()
         .await
         .unwrap();
 

--- a/crates/network/lib/tcp/proxy.rs
+++ b/crates/network/lib/tcp/proxy.rs
@@ -15,6 +15,7 @@ use bytes::Bytes;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpStream;
 use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
 
 use super::connection::ProxyConnectState;
 use super::upstream::UpstreamTcpTarget;
@@ -24,7 +25,7 @@ use crate::secrets::config::{SecretsConfig, SecretsConfigExt, ViolationAction};
 use crate::secrets::handler::{
     SecretsHandler, first_line_is_not_http_request, looks_like_http_request_prefix,
 };
-use crate::tls::proxy::{TlsProxyContext, tls_proxy_task};
+use crate::tls::proxy::TlsProxy;
 use crate::tls::sni;
 use crate::tls::state::TlsState;
 
@@ -61,6 +62,19 @@ struct ConnectTarget {
     host: String,
     port: u16,
     expected_sni: Option<String>,
+}
+
+/// Per-connection TCP proxy task and the state it owns.
+pub(crate) struct TcpProxy {
+    guest_dst: SocketAddr,
+    connect_target: UpstreamTcpTarget,
+    from_smoltcp: mpsc::Receiver<Bytes>,
+    to_smoltcp: mpsc::Sender<Bytes>,
+    shared: Arc<SharedState>,
+    network_policy: Arc<NetworkPolicy>,
+    secrets: Arc<SecretsConfig>,
+    tls_state: Option<Arc<TlsState>>,
+    proxy_connect: Arc<ProxyConnectState>,
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -112,6 +126,337 @@ impl ConnectTarget {
     }
 }
 
+impl TcpProxy {
+    /// Build a proxy for a newly established guest TCP connection.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn new(
+        guest_dst: SocketAddr,
+        connect_target: UpstreamTcpTarget,
+        from_smoltcp: mpsc::Receiver<Bytes>,
+        to_smoltcp: mpsc::Sender<Bytes>,
+        shared: Arc<SharedState>,
+        network_policy: Arc<NetworkPolicy>,
+        secrets: Arc<SecretsConfig>,
+        tls_state: Option<Arc<TlsState>>,
+        proxy_connect: Arc<ProxyConnectState>,
+    ) -> Self {
+        Self {
+            guest_dst,
+            connect_target,
+            from_smoltcp,
+            to_smoltcp,
+            shared,
+            network_policy,
+            secrets,
+            tls_state,
+            proxy_connect,
+        }
+    }
+
+    /// Spawn this proxy on the networking runtime.
+    pub(crate) fn spawn(self, handle: &tokio::runtime::Handle) -> JoinHandle<()> {
+        let guest_dst = self.guest_dst;
+        let connect_target = self.connect_target;
+
+        handle.spawn(async move {
+            if let Err(error) = self.run().await {
+                tracing::debug!(
+                    dst = %connect_target.primary(),
+                    %guest_dst,
+                    %error,
+                    "TCP proxy task ended",
+                );
+            }
+        })
+    }
+
+    /// Drive the TCP proxy to completion.
+    async fn run(self) -> io::Result<()> {
+        let Self {
+            guest_dst,
+            connect_target,
+            mut from_smoltcp,
+            to_smoltcp,
+            shared,
+            network_policy,
+            secrets,
+            tls_state,
+            proxy_connect,
+        } = self;
+
+        // Pre-connect peek is only for domain policy: the hostname has to be known
+        // before we dial upstream so a Deny never opens a connection. Secrets do
+        // *not* gate the connect, so they no longer force a peek here — that work is
+        // deferred to `classify_first_flight` after the socket is open, where it can
+        // run without stalling server-first protocols (see below).
+        let (mut initial_buf, sni) = if network_policy.has_domain_rules() {
+            peek_for_sni(&mut from_smoltcp, PEEK_BUF_SIZE, PEEK_BUDGET).await
+        } else {
+            (Vec::new(), None)
+        };
+
+        // Re-evaluate egress against the *guest* dst — the address the
+        // guest dialed, not the post-rewrite host-side address. SNI
+        // refines over-allow when the cache matched a shared CDN IP;
+        // CacheOnly is the non-TLS fallback path so Domain rules still
+        // gate plain HTTP / SSH / etc.
+        if network_policy.has_domain_rules() {
+            let source = match sni.as_deref() {
+                Some(name) => HostnameSource::Sni(name),
+                None => HostnameSource::CacheOnly,
+            };
+            match network_policy.evaluate_egress_with_source(
+                guest_dst,
+                Protocol::Tcp,
+                &shared,
+                source,
+            ) {
+                EgressEvaluation::Allow => {}
+                EgressEvaluation::Deny => {
+                    tracing::debug!(
+                        dst = %guest_dst,
+                        source = source.label(),
+                        "TCP egress denied by domain policy",
+                    );
+                    proxy_connect.mark_policy_denied();
+                    shared.proxy_wake.wake();
+                    return Ok(());
+                }
+                EgressEvaluation::DeferUntilHostname => {
+                    debug_assert!(false, "DeferUntilHostname leaked into TCP proxy task");
+                    proxy_connect.mark_policy_denied();
+                    shared.proxy_wake.wake();
+                    return Ok(());
+                }
+            }
+        }
+
+        // Peek for HTTP CONNECT before dialing upstream; hand off if detected.
+        if let Some(tls_state) = tls_state.clone() {
+            if initial_buf.is_empty() {
+                let (peeked, _) = peek_for_sni(&mut from_smoltcp, PEEK_BUF_SIZE, PEEK_BUDGET).await;
+                initial_buf = peeked;
+            }
+            if could_be_connect_request(&initial_buf) {
+                return handle_connect_tunnel(
+                    guest_dst,
+                    connect_target,
+                    initial_buf,
+                    from_smoltcp,
+                    to_smoltcp,
+                    shared,
+                    network_policy,
+                    tls_state,
+                    proxy_connect,
+                    None,
+                )
+                .await;
+            }
+        }
+
+        // Connect upstream *before* finishing the secrets-side classification. A
+        // server-first protocol (SSH, SMTP, a database) sends nothing until it has
+        // seen the server's banner; with the socket already open we can relay that
+        // banner while we wait, instead of burning the peek budget pre-connect.
+        let stream = connect_target.connect(&proxy_connect, &shared).await?;
+        let connect_dst = stream.peer_addr().unwrap_or(connect_target.primary());
+        let (mut server_rx, mut server_tx) = stream.into_split();
+
+        // Finish classifying the first flight (TLS vs plain HTTP) and, for
+        // plain-HTTP candidates, gather a full header block — without blocking the
+        // server→guest direction. When domain rules already peeked, `initial_buf`
+        // is reused and this is cheap; with no secrets it is skipped entirely
+        // (`is_tls` only matters for deciding whether to build the handler).
+        let want_headers = secrets.has_plain_http_candidates() || secrets.has_host_scoped_secrets();
+        let (initial_buf, is_tls) = if !secrets.secrets.is_empty() {
+            classify_first_flight(
+                initial_buf,
+                &mut from_smoltcp,
+                &mut server_rx,
+                &to_smoltcp,
+                &shared,
+                want_headers,
+                PEEK_BUF_SIZE,
+                PEEK_BUDGET,
+            )
+            .await?
+        } else {
+            (initial_buf, false)
+        };
+
+        if let Some(tls_state) = tls_state.clone()
+            && could_be_connect_request(&initial_buf)
+        {
+            // The pre-connect CONNECT peek can miss a client whose first bytes arrive
+            // after we dial upstream. Once classify_first_flight has captured that
+            // request, rejoin the already-open proxy socket and use the CONNECT path
+            // so intercepted tunnels still get TLS substitution and policy checks.
+            let proxy_stream = server_rx
+                .reunite(server_tx)
+                .map_err(|_| io::Error::other("failed to reunite proxy stream halves"))?;
+            return handle_connect_tunnel(
+                guest_dst,
+                connect_target,
+                initial_buf,
+                from_smoltcp,
+                to_smoltcp,
+                shared,
+                network_policy,
+                tls_state,
+                proxy_connect,
+                Some(proxy_stream),
+            )
+            .await;
+        }
+
+        let mut late_connect_state = tls_state;
+        let mut secrets_handler: Option<SecretsHandler> = if !secrets.secrets.is_empty() && !is_tls
+        {
+            Some(match extract_http_host(&initial_buf) {
+                Some(host) => {
+                    SecretsHandler::new_plain_http(&secrets, &host, guest_dst.ip(), &shared)
+                }
+                None => SecretsHandler::new_plain_http_invalid_host(&secrets),
+            })
+        } else {
+            None
+        };
+
+        // Replay the buffered first flight — run through secrets handler first.
+        if !initial_buf.is_empty() {
+            let out: Cow<[u8]> = match secrets_handler.as_mut() {
+                Some(h) => match h.substitute(&initial_buf) {
+                    // Borrow the input when nothing was substituted; only a chunk
+                    // that actually carries a placeholder is reallocated.
+                    Ok(cow) => cow,
+                    Err(action) => {
+                        tracing::warn!(dst = %connect_dst, violation = ?action, "secret violation in first flight");
+                        if matches!(action, ViolationAction::BlockAndTerminate) {
+                            shared.trigger_termination();
+                        }
+                        return Ok(());
+                    }
+                },
+                None => Cow::Borrowed(&initial_buf),
+            };
+            if !out.is_empty() {
+                if let Err(e) = server_tx.write_all(&out).await {
+                    tracing::debug!(dst = %connect_dst, error = %e, "replay of buffered first flight failed");
+                    return Ok(());
+                }
+                if let Err(e) = server_tx.flush().await {
+                    tracing::debug!(dst = %connect_dst, error = %e, "flush after first flight failed");
+                    return Ok(());
+                }
+            }
+        }
+
+        let mut server_buf = vec![0u8; SERVER_READ_BUF_SIZE];
+
+        // Bidirectional relay using tokio::select!.
+        //
+        // guest → server: receive from channel, write to server socket.
+        // server → guest: read from server socket, send via channel + wake poll.
+        let mut guest_eof = false;
+        loop {
+            tokio::select! {
+                // Guest → server: substitute placeholders before forwarding.
+                data = from_smoltcp.recv(), if !guest_eof => {
+                    match data {
+                        Some(bytes) => {
+                            if let Some(tls_state) = late_connect_state.take()
+                                && could_be_connect_request(&bytes)
+                            {
+                                // The first guest bytes can arrive after both peek
+                                // windows have completed. Nothing has been written
+                                // to the proxy socket yet, so this is still a valid
+                                // point to switch into CONNECT tunnel handling.
+                                let proxy_stream = server_rx
+                                    .reunite(server_tx)
+                                    .map_err(|_| io::Error::other("failed to reunite proxy stream halves"))?;
+                                return handle_connect_tunnel(
+                                    guest_dst,
+                                    connect_target,
+                                    bytes.to_vec(),
+                                    from_smoltcp,
+                                    to_smoltcp,
+                                    shared,
+                                    network_policy,
+                                    tls_state,
+                                    proxy_connect,
+                                    Some(proxy_stream),
+                                )
+                                .await;
+                            }
+                            // No handler (no secrets / TLS) is the common path: forward
+                            // the chunk borrowed, with no per-chunk allocation or copy.
+                            let out: Cow<[u8]> = match secrets_handler.as_mut() {
+                                Some(h) => match h.substitute(&bytes) {
+                                    Ok(cow) => cow,
+                                    Err(action) => {
+                                        tracing::warn!(dst = %connect_dst, violation = ?action, "secret violation");
+                                        if matches!(action, ViolationAction::BlockAndTerminate) {
+                                            shared.trigger_termination();
+                                        }
+                                        break;
+                                    }
+                                },
+                                None => Cow::Borrowed(&bytes),
+                            };
+                            if !out.is_empty() {
+                                if let Err(e) = server_tx.write_all(&out).await {
+                                    tracing::debug!(dst = %connect_dst, error = %e, "write to server failed");
+                                    break;
+                                }
+                                if let Err(e) = server_tx.flush().await {
+                                    tracing::debug!(dst = %connect_dst, error = %e, "flush to server failed");
+                                    break;
+                                }
+                            }
+                        }
+                        // Channel closed — the guest half-closed (FIN) or the
+                        // connection was torn down. Propagate the half-close:
+                        // stop sending upstream but keep relaying server →
+                        // guest until the server closes.
+                        None => {
+                            guest_eof = true;
+                            if server_tx.shutdown().await.is_err() {
+                                break;
+                            }
+                        }
+                    }
+                }
+
+                // Server → guest: no substitution — server never sends placeholders.
+                result = server_rx.read(&mut server_buf) => {
+                    match result {
+                        Ok(0) => break, // Server closed connection.
+                        Ok(n) => {
+                            // A server-first byte means this is not an HTTP CONNECT
+                            // tunnel to a proxy. Keep relaying normally afterward.
+                            late_connect_state = None;
+                            let data = Bytes::copy_from_slice(&server_buf[..n]);
+                            if to_smoltcp.send(data).await.is_err() {
+                                // Channel closed — poll loop dropped the receiver.
+                                break;
+                            }
+                            // Wake the poll thread so it writes data to the
+                            // smoltcp socket.
+                            shared.proxy_wake.wake();
+                        }
+                        Err(e) => {
+                            tracing::debug!(dst = %connect_dst, error = %e, "read from server failed");
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
 //--------------------------------------------------------------------------------------------------
 // Functions
 //--------------------------------------------------------------------------------------------------
@@ -137,38 +482,10 @@ pub fn spawn_tcp_proxy(
     tls_state: Option<Arc<TlsState>>,
     proxy_connect: Arc<ProxyConnectState>,
 ) {
-    spawn_tcp_proxy_with_target(
-        handle,
-        guest_dst,
-        UpstreamTcpTarget::direct(connect_dst),
-        from_smoltcp,
-        to_smoltcp,
-        shared,
-        network_policy,
-        secrets,
-        tls_state,
-        proxy_connect,
-    );
-}
-
-/// Spawn a TCP proxy with an optional alternate host-loopback destination.
-#[allow(clippy::too_many_arguments)]
-pub(crate) fn spawn_tcp_proxy_with_target(
-    handle: &tokio::runtime::Handle,
-    guest_dst: SocketAddr,
-    connect_target: UpstreamTcpTarget,
-    from_smoltcp: mpsc::Receiver<Bytes>,
-    to_smoltcp: mpsc::Sender<Bytes>,
-    shared: Arc<SharedState>,
-    network_policy: Arc<NetworkPolicy>,
-    secrets: Arc<SecretsConfig>,
-    tls_state: Option<Arc<TlsState>>,
-    proxy_connect: Arc<ProxyConnectState>,
-) {
-    handle.spawn(async move {
-        if let Err(e) = tcp_proxy_task(
+    std::mem::drop(
+        TcpProxy::new(
             guest_dst,
-            connect_target,
+            UpstreamTcpTarget::direct(connect_dst),
             from_smoltcp,
             to_smoltcp,
             shared,
@@ -177,294 +494,12 @@ pub(crate) fn spawn_tcp_proxy_with_target(
             tls_state,
             proxy_connect,
         )
-        .await
-        {
-            tracing::debug!(dst = %connect_target.primary(), error = %e, "TCP proxy task ended");
-        }
-    });
-}
-
-/// Core TCP proxy: peek for SNI, evaluate egress policy, then either
-/// connect and relay or drop the channels.
-#[allow(clippy::too_many_arguments)]
-async fn tcp_proxy_task(
-    guest_dst: SocketAddr,
-    connect_target: UpstreamTcpTarget,
-    mut from_smoltcp: mpsc::Receiver<Bytes>,
-    to_smoltcp: mpsc::Sender<Bytes>,
-    shared: Arc<SharedState>,
-    network_policy: Arc<NetworkPolicy>,
-    secrets: Arc<SecretsConfig>,
-    tls_state: Option<Arc<TlsState>>,
-    proxy_connect: Arc<ProxyConnectState>,
-) -> io::Result<()> {
-    // Pre-connect peek is only for domain policy: the hostname has to be known
-    // before we dial upstream so a Deny never opens a connection. Secrets do
-    // *not* gate the connect, so they no longer force a peek here — that work is
-    // deferred to `classify_first_flight` after the socket is open, where it can
-    // run without stalling server-first protocols (see below).
-    let (mut initial_buf, sni) = if network_policy.has_domain_rules() {
-        peek_for_sni(&mut from_smoltcp, PEEK_BUF_SIZE, PEEK_BUDGET).await
-    } else {
-        (Vec::new(), None)
-    };
-
-    // Re-evaluate egress against the *guest* dst — the address the
-    // guest dialed, not the post-rewrite host-side address. SNI
-    // refines over-allow when the cache matched a shared CDN IP;
-    // CacheOnly is the non-TLS fallback path so Domain rules still
-    // gate plain HTTP / SSH / etc.
-    if network_policy.has_domain_rules() {
-        let source = match sni.as_deref() {
-            Some(name) => HostnameSource::Sni(name),
-            None => HostnameSource::CacheOnly,
-        };
-        match network_policy.evaluate_egress_with_source(guest_dst, Protocol::Tcp, &shared, source)
-        {
-            EgressEvaluation::Allow => {}
-            EgressEvaluation::Deny => {
-                tracing::debug!(
-                    dst = %guest_dst,
-                    source = source.label(),
-                    "TCP egress denied by domain policy",
-                );
-                proxy_connect.mark_policy_denied();
-                shared.proxy_wake.wake();
-                return Ok(());
-            }
-            EgressEvaluation::DeferUntilHostname => {
-                debug_assert!(false, "DeferUntilHostname leaked into TCP proxy task");
-                proxy_connect.mark_policy_denied();
-                shared.proxy_wake.wake();
-                return Ok(());
-            }
-        }
-    }
-
-    // Peek for HTTP CONNECT before dialing upstream; hand off if detected.
-    if let Some(tls_state) = tls_state.clone() {
-        if initial_buf.is_empty() {
-            let (peeked, _) = peek_for_sni(&mut from_smoltcp, PEEK_BUF_SIZE, PEEK_BUDGET).await;
-            initial_buf = peeked;
-        }
-        if could_be_connect_request(&initial_buf) {
-            return handle_connect_tunnel(
-                guest_dst,
-                connect_target,
-                initial_buf,
-                from_smoltcp,
-                to_smoltcp,
-                shared,
-                network_policy,
-                tls_state,
-                proxy_connect,
-                None,
-            )
-            .await;
-        }
-    }
-
-    // Connect upstream *before* finishing the secrets-side classification. A
-    // server-first protocol (SSH, SMTP, a database) sends nothing until it has
-    // seen the server's banner; with the socket already open we can relay that
-    // banner while we wait, instead of burning the peek budget pre-connect.
-    let stream = connect_target.connect(&proxy_connect, &shared).await?;
-    let connect_dst = stream.peer_addr().unwrap_or(connect_target.primary());
-    let (mut server_rx, mut server_tx) = stream.into_split();
-
-    // Finish classifying the first flight (TLS vs plain HTTP) and, for
-    // plain-HTTP candidates, gather a full header block — without blocking the
-    // server→guest direction. When domain rules already peeked, `initial_buf`
-    // is reused and this is cheap; with no secrets it is skipped entirely
-    // (`is_tls` only matters for deciding whether to build the handler).
-    let want_headers = secrets.has_plain_http_candidates() || secrets.has_host_scoped_secrets();
-    let (initial_buf, is_tls) = if !secrets.secrets.is_empty() {
-        classify_first_flight(
-            initial_buf,
-            &mut from_smoltcp,
-            &mut server_rx,
-            &to_smoltcp,
-            &shared,
-            want_headers,
-            PEEK_BUF_SIZE,
-            PEEK_BUDGET,
-        )
-        .await?
-    } else {
-        (initial_buf, false)
-    };
-
-    if let Some(tls_state) = tls_state.clone()
-        && could_be_connect_request(&initial_buf)
-    {
-        // The pre-connect CONNECT peek can miss a client whose first bytes arrive
-        // after we dial upstream. Once classify_first_flight has captured that
-        // request, rejoin the already-open proxy socket and use the CONNECT path
-        // so intercepted tunnels still get TLS substitution and policy checks.
-        let proxy_stream = server_rx
-            .reunite(server_tx)
-            .map_err(|_| io::Error::other("failed to reunite proxy stream halves"))?;
-        return handle_connect_tunnel(
-            guest_dst,
-            connect_target,
-            initial_buf,
-            from_smoltcp,
-            to_smoltcp,
-            shared,
-            network_policy,
-            tls_state,
-            proxy_connect,
-            Some(proxy_stream),
-        )
-        .await;
-    }
-
-    let mut late_connect_state = tls_state;
-    let mut secrets_handler: Option<SecretsHandler> = if !secrets.secrets.is_empty() && !is_tls {
-        Some(match extract_http_host(&initial_buf) {
-            Some(host) => SecretsHandler::new_plain_http(&secrets, &host, guest_dst.ip(), &shared),
-            None => SecretsHandler::new_plain_http_invalid_host(&secrets),
-        })
-    } else {
-        None
-    };
-
-    // Replay the buffered first flight — run through secrets handler first.
-    if !initial_buf.is_empty() {
-        let out: Cow<[u8]> = match secrets_handler.as_mut() {
-            Some(h) => match h.substitute(&initial_buf) {
-                // Borrow the input when nothing was substituted; only a chunk
-                // that actually carries a placeholder is reallocated.
-                Ok(cow) => cow,
-                Err(action) => {
-                    tracing::warn!(dst = %connect_dst, violation = ?action, "secret violation in first flight");
-                    if matches!(action, ViolationAction::BlockAndTerminate) {
-                        shared.trigger_termination();
-                    }
-                    return Ok(());
-                }
-            },
-            None => Cow::Borrowed(&initial_buf),
-        };
-        if !out.is_empty() {
-            if let Err(e) = server_tx.write_all(&out).await {
-                tracing::debug!(dst = %connect_dst, error = %e, "replay of buffered first flight failed");
-                return Ok(());
-            }
-            if let Err(e) = server_tx.flush().await {
-                tracing::debug!(dst = %connect_dst, error = %e, "flush after first flight failed");
-                return Ok(());
-            }
-        }
-    }
-
-    let mut server_buf = vec![0u8; SERVER_READ_BUF_SIZE];
-
-    // Bidirectional relay using tokio::select!.
-    //
-    // guest → server: receive from channel, write to server socket.
-    // server → guest: read from server socket, send via channel + wake poll.
-    let mut guest_eof = false;
-    loop {
-        tokio::select! {
-            // Guest → server: substitute placeholders before forwarding.
-            data = from_smoltcp.recv(), if !guest_eof => {
-                match data {
-                    Some(bytes) => {
-                        if let Some(tls_state) = late_connect_state.take()
-                            && could_be_connect_request(&bytes)
-                        {
-                            // The first guest bytes can arrive after both peek
-                            // windows have completed. Nothing has been written
-                            // to the proxy socket yet, so this is still a valid
-                            // point to switch into CONNECT tunnel handling.
-                            let proxy_stream = server_rx
-                                .reunite(server_tx)
-                                .map_err(|_| io::Error::other("failed to reunite proxy stream halves"))?;
-                            return handle_connect_tunnel(
-                                guest_dst,
-                                connect_target,
-                                bytes.to_vec(),
-                                from_smoltcp,
-                                to_smoltcp,
-                                shared,
-                                network_policy,
-                                tls_state,
-                                proxy_connect,
-                                Some(proxy_stream),
-                            )
-                            .await;
-                        }
-                        // No handler (no secrets / TLS) is the common path: forward
-                        // the chunk borrowed, with no per-chunk allocation or copy.
-                        let out: Cow<[u8]> = match secrets_handler.as_mut() {
-                            Some(h) => match h.substitute(&bytes) {
-                                Ok(cow) => cow,
-                                Err(action) => {
-                                    tracing::warn!(dst = %connect_dst, violation = ?action, "secret violation");
-                                    if matches!(action, ViolationAction::BlockAndTerminate) {
-                                        shared.trigger_termination();
-                                    }
-                                    break;
-                                }
-                            },
-                            None => Cow::Borrowed(&bytes),
-                        };
-                        if !out.is_empty() {
-                            if let Err(e) = server_tx.write_all(&out).await {
-                                tracing::debug!(dst = %connect_dst, error = %e, "write to server failed");
-                                break;
-                            }
-                            if let Err(e) = server_tx.flush().await {
-                                tracing::debug!(dst = %connect_dst, error = %e, "flush to server failed");
-                                break;
-                            }
-                        }
-                    }
-                    // Channel closed — the guest half-closed (FIN) or the
-                    // connection was torn down. Propagate the half-close:
-                    // stop sending upstream but keep relaying server →
-                    // guest until the server closes.
-                    None => {
-                        guest_eof = true;
-                        if server_tx.shutdown().await.is_err() {
-                            break;
-                        }
-                    }
-                }
-            }
-
-            // Server → guest: no substitution — server never sends placeholders.
-            result = server_rx.read(&mut server_buf) => {
-                match result {
-                    Ok(0) => break, // Server closed connection.
-                    Ok(n) => {
-                        // A server-first byte means this is not an HTTP CONNECT
-                        // tunnel to a proxy. Keep relaying normally afterward.
-                        late_connect_state = None;
-                        let data = Bytes::copy_from_slice(&server_buf[..n]);
-                        if to_smoltcp.send(data).await.is_err() {
-                            // Channel closed — poll loop dropped the receiver.
-                            break;
-                        }
-                        // Wake the poll thread so it writes data to the
-                        // smoltcp socket.
-                        shared.proxy_wake.wake();
-                    }
-                    Err(e) => {
-                        tracing::debug!(dst = %connect_dst, error = %e, "read from server failed");
-                        break;
-                    }
-                }
-            }
-        }
-    }
-
-    Ok(())
+        .spawn(handle),
+    );
 }
 
 /// Forward an HTTP CONNECT tunnel: dial the proxy, splice the handshake,
-/// then hand the established stream to `tls_proxy_task` for TLS MITM.
+/// then hand the established stream to [`TlsProxy`] for TLS MITM.
 ///
 /// `guest_dst` is what the guest dialed; `proxy_target` contains the rewritten
 /// loopback address the gateway actually connects to and its optional fallback.
@@ -570,22 +605,20 @@ async fn handle_connect_tunnel(
     let tls_guest_dst = connect_req.target.guest_dst(guest_dst, &shared);
     let expected_sni = connect_req.target.expected_sni.clone();
 
-    tls_proxy_task(
-        TlsProxyContext {
-            guest_dst: tls_guest_dst,
-            connect_target: proxy_target,
-            shared,
-            tls_state,
-            network_policy,
-            proxy_connect,
-            upstream_stream: Some(proxy_stream),
-            via_connect: expected_sni.is_some(),
-            expected_sni,
-        },
+    TlsProxy::new(
+        tls_guest_dst,
+        proxy_target,
         from_smoltcp,
         to_smoltcp,
-        tls_seed,
+        shared,
+        tls_state,
+        network_policy,
+        proxy_connect,
     )
+    .with_upstream(proxy_stream)
+    .with_expected_sni(expected_sni)
+    .with_initial_buf(tls_seed)
+    .run()
     .await
 }
 
@@ -1657,7 +1690,7 @@ mod tests {
         from_tx.send(Bytes::from(request)).await.unwrap();
         drop(from_tx);
 
-        tcp_proxy_task(
+        TcpProxy::new(
             server_addr,
             UpstreamTcpTarget::direct(server_addr),
             from_rx,
@@ -1668,6 +1701,7 @@ mod tests {
             None,
             proxy_connect,
         )
+        .run()
         .await
         .unwrap();
 
@@ -1697,7 +1731,7 @@ mod tests {
             .unwrap();
         drop(from_tx);
 
-        tcp_proxy_task(
+        TcpProxy::new(
             addr,
             UpstreamTcpTarget::direct(addr),
             from_rx,
@@ -1708,6 +1742,7 @@ mod tests {
             None,
             proxy_connect,
         )
+        .run()
         .await
         .unwrap();
 
@@ -1767,7 +1802,7 @@ mod tests {
             .unwrap();
         drop(from_tx);
 
-        tcp_proxy_task(
+        TcpProxy::new(
             addr,
             UpstreamTcpTarget::direct(addr),
             from_rx,
@@ -1778,6 +1813,7 @@ mod tests {
             None,
             proxy_connect,
         )
+        .run()
         .await
         .unwrap();
 
@@ -1867,7 +1903,7 @@ mod tests {
             .unwrap();
         drop(from_tx);
 
-        tcp_proxy_task(
+        TcpProxy::new(
             addr,
             UpstreamTcpTarget::direct(addr),
             from_rx,
@@ -1878,6 +1914,7 @@ mod tests {
             None,
             proxy_connect,
         )
+        .run()
         .await
         .unwrap();
 

--- a/crates/network/lib/tcp/proxy.rs
+++ b/crates/network/lib/tcp/proxy.rs
@@ -15,7 +15,6 @@ use bytes::Bytes;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpStream;
 use tokio::sync::mpsc;
-use tokio::task::JoinHandle;
 
 use super::connection::ProxyConnectState;
 use super::upstream::UpstreamTcpTarget;
@@ -154,7 +153,7 @@ impl TcpProxy {
     }
 
     /// Spawn this proxy on the networking runtime.
-    pub(crate) fn spawn(self, handle: &tokio::runtime::Handle) -> JoinHandle<()> {
+    pub(crate) fn spawn(self, handle: &tokio::runtime::Handle) {
         let guest_dst = self.guest_dst;
         let connect_target = self.connect_target;
 
@@ -167,7 +166,7 @@ impl TcpProxy {
                     "TCP proxy task ended",
                 );
             }
-        })
+        });
     }
 
     /// Drive the TCP proxy to completion.
@@ -482,20 +481,18 @@ pub fn spawn_tcp_proxy(
     tls_state: Option<Arc<TlsState>>,
     proxy_connect: Arc<ProxyConnectState>,
 ) {
-    std::mem::drop(
-        TcpProxy::new(
-            guest_dst,
-            UpstreamTcpTarget::direct(connect_dst),
-            from_smoltcp,
-            to_smoltcp,
-            shared,
-            network_policy,
-            secrets,
-            tls_state,
-            proxy_connect,
-        )
-        .spawn(handle),
-    );
+    TcpProxy::new(
+        guest_dst,
+        UpstreamTcpTarget::direct(connect_dst),
+        from_smoltcp,
+        to_smoltcp,
+        shared,
+        network_policy,
+        secrets,
+        tls_state,
+        proxy_connect,
+    )
+    .spawn(handle);
 }
 
 /// Forward an HTTP CONNECT tunnel: dial the proxy, splice the handshake,

--- a/crates/network/lib/tcp/proxy.rs
+++ b/crates/network/lib/tcp/proxy.rs
@@ -152,25 +152,8 @@ impl TcpProxy {
         }
     }
 
-    /// Spawn this proxy on the networking runtime.
-    pub(crate) fn spawn(self, handle: &tokio::runtime::Handle) {
-        let guest_dst = self.guest_dst;
-        let connect_target = self.connect_target;
-
-        handle.spawn(async move {
-            if let Err(error) = self.run().await {
-                tracing::debug!(
-                    dst = %connect_target.primary(),
-                    %guest_dst,
-                    %error,
-                    "TCP proxy task ended",
-                );
-            }
-        });
-    }
-
     /// Drive the TCP proxy to completion.
-    async fn run(self) -> io::Result<()> {
+    pub(crate) async fn run(self) -> io::Result<()> {
         let Self {
             guest_dst,
             connect_target,
@@ -481,7 +464,7 @@ pub fn spawn_tcp_proxy(
     tls_state: Option<Arc<TlsState>>,
     proxy_connect: Arc<ProxyConnectState>,
 ) {
-    TcpProxy::new(
+    let proxy = TcpProxy::new(
         guest_dst,
         UpstreamTcpTarget::direct(connect_dst),
         from_smoltcp,
@@ -491,8 +474,13 @@ pub fn spawn_tcp_proxy(
         secrets,
         tls_state,
         proxy_connect,
-    )
-    .spawn(handle);
+    );
+
+    handle.spawn(async move {
+        if let Err(error) = proxy.run().await {
+            tracing::debug!(dst = %connect_dst, %guest_dst, %error, "TCP proxy task ended");
+        }
+    });
 }
 
 /// Forward an HTTP CONNECT tunnel: dial the proxy, splice the handshake,

--- a/crates/network/lib/tls/proxy.rs
+++ b/crates/network/lib/tls/proxy.rs
@@ -109,27 +109,10 @@ impl TlsProxy {
         self
     }
 
-    /// Spawn this proxy on the networking runtime.
+    /// Drive the TLS proxy to completion.
     ///
     /// See [`crate::tcp::proxy::spawn_tcp_proxy`] for the `proxy_connect`
     /// contract.
-    pub(crate) fn spawn(self, handle: &tokio::runtime::Handle) {
-        let guest_dst = self.guest_dst;
-        let connect_target = self.connect_target;
-
-        handle.spawn(async move {
-            if let Err(error) = self.run().await {
-                tracing::debug!(
-                    dst = %connect_target.primary(),
-                    %guest_dst,
-                    %error,
-                    "TLS proxy task ended",
-                );
-            }
-        });
-    }
-
-    /// Drive the TLS proxy to completion.
     pub(crate) async fn run(self) -> io::Result<()> {
         let Self {
             guest_dst,

--- a/crates/network/lib/tls/proxy.rs
+++ b/crates/network/lib/tls/proxy.rs
@@ -14,7 +14,6 @@ use rustls::pki_types::ServerName;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpStream;
 use tokio::sync::mpsc;
-use tokio::task::JoinHandle;
 
 use super::sni;
 use super::state::TlsState;
@@ -114,7 +113,7 @@ impl TlsProxy {
     ///
     /// See [`crate::tcp::proxy::spawn_tcp_proxy`] for the `proxy_connect`
     /// contract.
-    pub(crate) fn spawn(self, handle: &tokio::runtime::Handle) -> JoinHandle<()> {
+    pub(crate) fn spawn(self, handle: &tokio::runtime::Handle) {
         let guest_dst = self.guest_dst;
         let connect_target = self.connect_target;
 
@@ -127,7 +126,7 @@ impl TlsProxy {
                     "TLS proxy task ended",
                 );
             }
-        })
+        });
     }
 
     /// Drive the TLS proxy to completion.

--- a/crates/network/lib/tls/proxy.rs
+++ b/crates/network/lib/tls/proxy.rs
@@ -109,11 +109,26 @@ impl TlsProxy {
         self
     }
 
-    /// Drive the TLS proxy to completion.
+    /// Run the TLS proxy task to completion.
     ///
     /// See [`crate::tcp::proxy::spawn_tcp_proxy`] for the `proxy_connect`
     /// contract.
-    pub(crate) async fn run(self) -> io::Result<()> {
+    pub(crate) async fn run(self) {
+        let guest_dst = self.guest_dst;
+        let connect_dst = self.connect_target.primary();
+
+        if let Err(error) = self.try_run().await {
+            tracing::debug!(
+                dst = %connect_dst,
+                %guest_dst,
+                %error,
+                "TLS proxy task ended",
+            );
+        }
+    }
+
+    /// Drive the TLS proxy to completion, returning operational failures.
+    pub(crate) async fn try_run(self) -> io::Result<()> {
         let Self {
             guest_dst,
             connect_target,

--- a/crates/network/lib/tls/proxy.rs
+++ b/crates/network/lib/tls/proxy.rs
@@ -14,6 +14,7 @@ use rustls::pki_types::ServerName;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpStream;
 use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
 
 use super::sni;
 use super::state::TlsState;
@@ -37,32 +38,8 @@ const RELAY_BUF_SIZE: usize = 16384;
 // Types
 //--------------------------------------------------------------------------------------------------
 
-pub(crate) struct TlsProxyContext {
-    pub(crate) guest_dst: SocketAddr,
-    pub(crate) connect_target: UpstreamTcpTarget,
-    pub(crate) shared: Arc<SharedState>,
-    pub(crate) tls_state: Arc<TlsState>,
-    pub(crate) network_policy: Arc<NetworkPolicy>,
-    pub(crate) proxy_connect: Arc<ProxyConnectState>,
-    /// Pre-connected upstream; when `Some`, skips dialing `connect_target`.
-    pub(crate) upstream_stream: Option<TcpStream>,
-    /// Hostname from a CONNECT authority that must match the ClientHello SNI.
-    pub(crate) expected_sni: Option<String>,
-    /// `true` when the connection arrived via HTTP CONNECT; skips the DNS-cache pin check.
-    pub(crate) via_connect: bool,
-}
-
-//--------------------------------------------------------------------------------------------------
-// Functions
-//--------------------------------------------------------------------------------------------------
-
-/// Spawn a TLS proxy task for a connection to an intercepted port.
-///
-/// See [`crate::tcp::proxy::spawn_tcp_proxy`] for the `proxy_connect`
-/// contract.
-#[allow(clippy::too_many_arguments)]
-pub(crate) fn spawn_tls_proxy(
-    handle: &tokio::runtime::Handle,
+/// Per-connection TLS proxy task and the state it owns.
+pub(crate) struct TlsProxy {
     guest_dst: SocketAddr,
     connect_target: UpstreamTcpTarget,
     from_smoltcp: mpsc::Receiver<Bytes>,
@@ -71,11 +48,38 @@ pub(crate) fn spawn_tls_proxy(
     tls_state: Arc<TlsState>,
     network_policy: Arc<NetworkPolicy>,
     proxy_connect: Arc<ProxyConnectState>,
-) {
-    handle.spawn(async move {
-        let context = TlsProxyContext {
+    /// Pre-connected upstream; when `Some`, skips dialing `connect_target`.
+    upstream_stream: Option<TcpStream>,
+    /// Hostname from a CONNECT authority that must match the ClientHello SNI.
+    expected_sni: Option<String>,
+    /// `true` when the connection arrived via HTTP CONNECT; skips the DNS-cache pin check.
+    via_connect: bool,
+    /// ClientHello bytes already consumed from the guest stream.
+    initial_buf: Vec<u8>,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Methods
+//--------------------------------------------------------------------------------------------------
+
+impl TlsProxy {
+    /// Build a proxy for a newly established guest TLS connection.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn new(
+        guest_dst: SocketAddr,
+        connect_target: UpstreamTcpTarget,
+        from_smoltcp: mpsc::Receiver<Bytes>,
+        to_smoltcp: mpsc::Sender<Bytes>,
+        shared: Arc<SharedState>,
+        tls_state: Arc<TlsState>,
+        network_policy: Arc<NetworkPolicy>,
+        proxy_connect: Arc<ProxyConnectState>,
+    ) -> Self {
+        Self {
             guest_dst,
             connect_target,
+            from_smoltcp,
+            to_smoltcp,
             shared,
             tls_state,
             network_policy,
@@ -83,109 +87,147 @@ pub(crate) fn spawn_tls_proxy(
             upstream_stream: None,
             expected_sni: None,
             via_connect: false,
-        };
-
-        if let Err(e) = tls_proxy_task(context, from_smoltcp, to_smoltcp, Vec::new()).await {
-            tracing::debug!(dst = %connect_target.primary(), guest_dst = %guest_dst, error = %e, "TLS proxy task ended");
+            initial_buf: Vec::new(),
         }
-    });
-}
-
-/// Core TLS proxy task.
-pub(crate) async fn tls_proxy_task(
-    context: TlsProxyContext,
-    mut from_smoltcp: mpsc::Receiver<Bytes>,
-    to_smoltcp: mpsc::Sender<Bytes>,
-    tls_initial_buf: Vec<u8>,
-) -> io::Result<()> {
-    let TlsProxyContext {
-        guest_dst,
-        connect_target,
-        shared,
-        tls_state,
-        network_policy,
-        proxy_connect,
-        upstream_stream,
-        expected_sni,
-        via_connect,
-    } = context;
-    let connect_dst = connect_target.primary();
-
-    // Buffer initial data to extract SNI from ClientHello. Timeout prevents a
-    // slow/malicious guest from holding a proxy slot indefinitely.
-    let sni_name = tokio::time::timeout(
-        std::time::Duration::from_secs(10),
-        extract_sni_from_channel(&mut from_smoltcp, tls_initial_buf),
-    )
-    .await
-    .map_err(|_| io::Error::new(io::ErrorKind::TimedOut, "SNI extraction timed out"))?;
-    let (sni_name, initial_buf) = sni_name?;
-
-    // Canonicalize so byte equality against rule destinations works.
-    let sni_name = sni_name.trim_end_matches('.').to_ascii_lowercase();
-
-    if let Some(expected) = expected_sni.as_deref()
-        && !sni_name.eq_ignore_ascii_case(expected.trim_end_matches('.'))
-    {
-        tracing::debug!(
-            sni = %sni_name,
-            expected = %expected,
-            dst = %connect_dst,
-            "TLS SNI did not match CONNECT authority",
-        );
-        proxy_connect.mark_policy_denied();
-        shared.proxy_wake.wake();
-        return Ok(());
     }
 
-    // Apply Domain / DomainSuffix rules against the SNI.
-    let eval = network_policy.evaluate_egress_with_source(
-        guest_dst,
-        Protocol::Tcp,
-        &shared,
-        HostnameSource::Sni(&sni_name),
-    );
-    if !matches!(eval, EgressEvaluation::Allow) {
-        tracing::debug!(
-            sni = %sni_name,
-            dst = %guest_dst,
-            "TLS egress denied by domain policy",
-        );
-        proxy_connect.mark_policy_denied();
-        shared.proxy_wake.wake();
-        return Ok(());
+    /// Reuse an already connected upstream stream.
+    pub(crate) fn with_upstream(mut self, upstream_stream: TcpStream) -> Self {
+        self.upstream_stream = Some(upstream_stream);
+        self
     }
 
-    if tls_state.should_bypass(&sni_name) {
-        tracing::debug!(sni = %sni_name, dst = %connect_dst, guest_dst = %guest_dst, "TLS bypass");
-        bypass_relay(
-            connect_target,
-            initial_buf,
-            from_smoltcp,
-            to_smoltcp,
-            shared,
-            proxy_connect,
-            upstream_stream,
-        )
-        .await
-    } else {
-        tracing::debug!(sni = %sni_name, dst = %connect_dst, guest_dst = %guest_dst, "TLS intercept");
-        intercept_relay(
+    /// Require the ClientHello SNI to match an HTTP CONNECT authority.
+    pub(crate) fn with_expected_sni(mut self, expected_sni: Option<String>) -> Self {
+        self.via_connect = expected_sni.is_some();
+        self.expected_sni = expected_sni;
+        self
+    }
+
+    /// Seed the proxy with ClientHello bytes already read from the guest.
+    pub(crate) fn with_initial_buf(mut self, initial_buf: Vec<u8>) -> Self {
+        self.initial_buf = initial_buf;
+        self
+    }
+
+    /// Spawn this proxy on the networking runtime.
+    ///
+    /// See [`crate::tcp::proxy::spawn_tcp_proxy`] for the `proxy_connect`
+    /// contract.
+    pub(crate) fn spawn(self, handle: &tokio::runtime::Handle) -> JoinHandle<()> {
+        let guest_dst = self.guest_dst;
+        let connect_target = self.connect_target;
+
+        handle.spawn(async move {
+            if let Err(error) = self.run().await {
+                tracing::debug!(
+                    dst = %connect_target.primary(),
+                    %guest_dst,
+                    %error,
+                    "TLS proxy task ended",
+                );
+            }
+        })
+    }
+
+    /// Drive the TLS proxy to completion.
+    pub(crate) async fn run(self) -> io::Result<()> {
+        let Self {
             guest_dst,
             connect_target,
-            &sni_name,
-            via_connect,
-            initial_buf,
-            from_smoltcp,
+            mut from_smoltcp,
             to_smoltcp,
             shared,
             tls_state,
+            network_policy,
             proxy_connect,
             upstream_stream,
+            expected_sni,
+            via_connect,
+            initial_buf,
+        } = self;
+        let connect_dst = connect_target.primary();
+
+        // Buffer initial data to extract SNI from ClientHello. Timeout prevents a
+        // slow/malicious guest from holding a proxy slot indefinitely.
+        let sni_name = tokio::time::timeout(
+            std::time::Duration::from_secs(10),
+            extract_sni_from_channel(&mut from_smoltcp, initial_buf),
         )
         .await
+        .map_err(|_| io::Error::new(io::ErrorKind::TimedOut, "SNI extraction timed out"))?;
+        let (sni_name, initial_buf) = sni_name?;
+
+        // Canonicalize so byte equality against rule destinations works.
+        let sni_name = sni_name.trim_end_matches('.').to_ascii_lowercase();
+
+        if let Some(expected) = expected_sni.as_deref()
+            && !sni_name.eq_ignore_ascii_case(expected.trim_end_matches('.'))
+        {
+            tracing::debug!(
+                sni = %sni_name,
+                expected = %expected,
+                dst = %connect_dst,
+                "TLS SNI did not match CONNECT authority",
+            );
+            proxy_connect.mark_policy_denied();
+            shared.proxy_wake.wake();
+            return Ok(());
+        }
+
+        // Apply Domain / DomainSuffix rules against the SNI.
+        let eval = network_policy.evaluate_egress_with_source(
+            guest_dst,
+            Protocol::Tcp,
+            &shared,
+            HostnameSource::Sni(&sni_name),
+        );
+        if !matches!(eval, EgressEvaluation::Allow) {
+            tracing::debug!(
+                sni = %sni_name,
+                dst = %guest_dst,
+                "TLS egress denied by domain policy",
+            );
+            proxy_connect.mark_policy_denied();
+            shared.proxy_wake.wake();
+            return Ok(());
+        }
+
+        if tls_state.should_bypass(&sni_name) {
+            tracing::debug!(sni = %sni_name, dst = %connect_dst, guest_dst = %guest_dst, "TLS bypass");
+            bypass_relay(
+                connect_target,
+                initial_buf,
+                from_smoltcp,
+                to_smoltcp,
+                shared,
+                proxy_connect,
+                upstream_stream,
+            )
+            .await
+        } else {
+            tracing::debug!(sni = %sni_name, dst = %connect_dst, guest_dst = %guest_dst, "TLS intercept");
+            intercept_relay(
+                guest_dst,
+                connect_target,
+                &sni_name,
+                via_connect,
+                initial_buf,
+                from_smoltcp,
+                to_smoltcp,
+                shared,
+                tls_state,
+                proxy_connect,
+                upstream_stream,
+            )
+            .await
+        }
     }
 }
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
 
 /// Bypass mode: plain TCP splice, no TLS termination.
 async fn bypass_relay(


### PR DESCRIPTION
## TL;DR

Represent network proxies as owned values with runtime-agnostic `run()` futures. Runtime call sites now construct a proxy and schedule `proxy.run()`, while each proxy module retains its initialization, long-running task body, and task-level diagnostics.

## Description

- add owned `TcpProxy` and `TlsProxy` types for per-connection state
- give TCP, TLS, DNS-over-TCP, DNS-over-TLS, and DNS-over-UDP proxies self-contained `run()` lifecycles
- keep fallible inner execution methods private to direct proxy handoffs and tests
- reduce the netstack poll loop and DNS interceptor to constructing proxies and scheduling their futures
- keep DNS forwarder initialization separate because it creates and publishes the shared forwarder handle
- preserve the existing `spawn_tcp_proxy` compatibility entry point while delegating its task body to `TcpProxy::run()`

## Test Plan

- `cargo fmt --all -- --check`
- `cargo test -p microsandbox-network`
- `cargo clippy -p microsandbox-network --all-targets -- -D warnings`
- `cargo test --workspace --no-run`

<!-- greptile_comment -->

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    A[Netstack poll loop] --> B[Construct owned proxy]
    B --> C[Tokio Handle spawn proxy.run]
    C --> D{Proxy type}
    D -->|TCP| E[TcpProxy try_run]
    D -->|TLS| F[TlsProxy try_run]
    D -->|DNS TCP or DoT| G[Wait for shared DNS forwarder]
    H[DNS interceptor] --> I[Initialize and publish DNS forwarder]
    H --> J[Construct UDP proxy]
    J --> K[Spawn UdpProxy run]
    I --> G
    I --> K
```
</details>

<sub>Reviews (1): Last reviewed commit: ["refactor(network): keep proxy task bodie..."](https://github.com/superradcompany/microsandbox/commit/3571bd91393e5b27ef761367cd3f765e32e889c7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54196583)</sub>

<!-- /greptile_comment -->