### PR TITLE
perf(agent): add single-socket shared arenas

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3787,6 +3787,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "memmap2"
+version = "0.9.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "memoffset"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3869,8 +3878,12 @@ dependencies = [
 name = "microsandbox-agent-client"
 version = "0.6.15"
 dependencies = [
+ "bytes",
  "ciborium",
+ "libc",
+ "memmap2",
  "microsandbox-protocol",
+ "nix 0.31.3",
  "serde",
  "tempfile",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,6 +121,7 @@ httlib-hpack = "0.1.3"
 indicatif = "0.18"
 ipnetwork = { version = "0.21.0", features = ["serde"] }
 libc = "0.2"
+memmap2 = "0.9"
 nix = "0.31"
 notify = "8"
 oci-client = "0.17"

--- a/crates/agentd/lib/agent.rs
+++ b/crates/agentd/lib/agent.rs
@@ -11,7 +11,7 @@ use std::time::Instant;
 use bytes::BytesMut;
 use chrono::Utc;
 use tokio::io::unix::AsyncFd;
-use tokio::sync::watch;
+use tokio::sync::{OwnedSemaphorePermit, Semaphore, watch};
 use tokio::time::{self, Duration};
 
 use microsandbox_protocol::AGENT_TRANSPORT_DUAL_PORT_CMDLINE;
@@ -112,6 +112,9 @@ const BULK_READER_MAX_BYTES_PER_TURN: usize = 1024 * 1024;
 const FS_BULK_INPUT_ITEM_CAPACITY: usize =
     DEFAULT_BULK_WINDOW as usize / MIN_BULK_RECORD_PAYLOAD as usize;
 
+/// Aggregate host-to-guest payload retained across every relay client and bulk destination.
+const BULK_INPUT_BYTE_CAPACITY: usize = 32 * 1024 * 1024;
+
 /// Filesystem activity bytes coalesced before publishing an otherwise empty worker event.
 const FS_ACTIVITY_BATCH_BYTES: usize = 4 * 1024 * 1024;
 
@@ -129,9 +132,9 @@ const BULK_FAILURE_FLUSH_TIMEOUT: Duration = Duration::from_secs(2);
 // Types
 //--------------------------------------------------------------------------------------------------
 
-#[derive(Default)]
 struct AgentState {
     client_incarnations: HashMap<u32, ClientIncarnation>,
+    bulk_input_budget: Arc<Semaphore>,
     sessions: HashMap<u32, ExecSession>,
     write_sessions: HashMap<u32, FsWriteSession>,
     bulk_write_workers: HashMap<u32, FsBulkWriteWorker>,
@@ -144,9 +147,22 @@ struct AgentState {
 
 /// Bounded command path for one filesystem bulk write, isolated from the control loop.
 struct FsBulkWriteWorker {
-    records: tokio::sync::mpsc::Sender<BulkRecord>,
+    records: tokio::sync::mpsc::Sender<AdmittedBulkRecord>,
     finish: tokio::sync::mpsc::Sender<BulkFinish>,
     task: tokio::task::JoinHandle<()>,
+}
+
+/// One host-to-guest record whose global input capacity remains charged until the destination
+/// filesystem or TCP socket has consumed its payload.
+pub(crate) struct AdmittedBulkRecord {
+    record: BulkRecord,
+    _permit: OwnedSemaphorePermit,
+}
+
+/// Dedicated-lane input waiting for aggregate client capacity while the control actor stays live.
+struct PendingBulkInput {
+    frame: IncarnatedBulkFrame,
+    budget: Arc<Semaphore>,
 }
 
 struct ActivityTracker {
@@ -207,6 +223,46 @@ enum BulkOutputCleanup {
 //--------------------------------------------------------------------------------------------------
 // Methods
 //--------------------------------------------------------------------------------------------------
+
+impl Default for AgentState {
+    fn default() -> Self {
+        Self {
+            client_incarnations: HashMap::new(),
+            bulk_input_budget: Arc::new(Semaphore::new(BULK_INPUT_BYTE_CAPACITY)),
+            sessions: HashMap::new(),
+            write_sessions: HashMap::new(),
+            bulk_write_workers: HashMap::new(),
+            read_sessions: HashMap::new(),
+            tcp_sessions: HashMap::new(),
+            bulk_received_offsets: HashMap::new(),
+            pending_bulk_finishes: HashMap::new(),
+            fs: FsState::default(),
+        }
+    }
+}
+
+impl AdmittedBulkRecord {
+    pub(crate) fn record(&self) -> &BulkRecord {
+        &self.record
+    }
+
+    pub(crate) fn into_parts(self) -> (BulkRecord, OwnedSemaphorePermit) {
+        (self.record, self._permit)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn for_test(record: BulkRecord) -> Self {
+        let payload_len = record.payload.len();
+        let budget = Arc::new(Semaphore::new(payload_len));
+        let permit = budget
+            .try_acquire_many_owned(payload_len as u32)
+            .expect("test record fits its exact input budget");
+        Self {
+            record,
+            _permit: permit,
+        }
+    }
+}
 
 impl ActivityTracker {
     fn new() -> Self {
@@ -404,11 +460,25 @@ pub async fn run(
             }
         };
     let dual_port_active = bulk_input.is_some();
+    let mut pending_bulk_inputs = VecDeque::<PendingBulkInput>::new();
     let mut bulk_input_bytes_since_snapshot = 0usize;
     let mut last_bulk_input_snapshot = Instant::now();
 
     // Main loop.
     'agent: loop {
+        // A control-lane disconnect cancels the pending acquire future at the select boundary.
+        // Remove its stale record before rebuilding that future against the global budget.
+        pending_bulk_inputs.retain(|pending| {
+            client_incarnation_for_id(&state, pending.frame.record.id)
+                == Some(pending.frame.incarnation)
+        });
+        let pending_bulk_admission = pending_bulk_inputs.front().map(|pending| {
+            (
+                Arc::clone(&pending.budget),
+                pending.frame.record.payload.len(),
+            )
+        });
+        let has_pending_bulk_admission = pending_bulk_admission.is_some();
         tokio::select! {
             failure = process_manager_failure.changed() => {
                 let error = match failure {
@@ -442,6 +512,59 @@ pub async fn run(
                 publish_heartbeat_snapshot(&heartbeat_tx, &state, &activity);
             }
 
+            permit = acquire_bulk_input_permit(pending_bulk_admission), if has_pending_bulk_admission => {
+                let pending = pending_bulk_inputs
+                    .pop_front()
+                    .expect("guarded pending bulk input exists");
+                let permit = match permit {
+                    Ok(permit) => permit,
+                    Err(error) => {
+                        // The process-wide budget is never normally closed. Preserve the
+                        // ownership check so a future epoch-scoped budget can cancel stale waits
+                        // without allowing old bytes into a recycled correlation range.
+                        if validate_bulk_client_incarnation(
+                            &state,
+                            pending.frame.record.id,
+                            pending.frame.incarnation,
+                        )? {
+                            return Err(error);
+                        }
+                        continue;
+                    }
+                };
+                if !validate_bulk_client_incarnation(
+                    &state,
+                    pending.frame.record.id,
+                    pending.frame.incarnation,
+                )? {
+                    continue;
+                }
+                let payload_len = pending.frame.record.payload.len();
+                let bulk_session_tx = session_tx.with_incarnation(Some(pending.frame.incarnation));
+                handle_bulk_record(
+                    AdmittedBulkRecord {
+                        record: pending.frame.record,
+                        _permit: permit,
+                    },
+                    &mut state,
+                    &mut activity,
+                    &mut serial_out_buf,
+                    &bulk_session_tx,
+                ).await?;
+                bulk_input_bytes_since_snapshot =
+                    bulk_input_bytes_since_snapshot.saturating_add(payload_len);
+                if bulk_input_bytes_since_snapshot >= BULK_ACTIVITY_PUBLISH_BYTES
+                    || last_bulk_input_snapshot.elapsed() >= BULK_ACTIVITY_PUBLISH_INTERVAL
+                {
+                    publish_heartbeat_snapshot(&heartbeat_tx, &state, &activity);
+                    bulk_input_bytes_since_snapshot = 0;
+                    last_bulk_input_snapshot = Instant::now();
+                }
+                if !serial_out_buf.is_empty() {
+                    flush_write_buf(&async_port, &mut serial_out_buf).await?;
+                }
+            }
+
             Some(envelope) = recv_optional(&mut combined_bulk_rx) => {
                 if envelope.incarnation.is_some()
                     && client_incarnation_for_id(&state, envelope.id) != envelope.incarnation
@@ -467,7 +590,7 @@ pub async fn run(
                     .expect("guarded dedicated bulk input")
                     .read_turn()
                     .await
-            }, if bulk_input.is_some() => {
+            }, if bulk_input.is_some() && pending_bulk_inputs.is_empty() => {
                 let frames = match turn {
                     Ok(frames) => frames,
                     Err(error) => {
@@ -486,6 +609,7 @@ pub async fn run(
                         )));
                     }
                 };
+                let mut capacity_deferred = false;
                 for frame in frames {
                     if !validate_bulk_client_incarnation(
                         &state,
@@ -496,10 +620,34 @@ pub async fn run(
                         // the other physical lane. They must not affect the new owner's ID.
                         continue;
                     }
+                    let budget = Arc::clone(&state.bulk_input_budget);
+                    if capacity_deferred {
+                        pending_bulk_inputs.push_back(PendingBulkInput { frame, budget });
+                        continue;
+                    }
                     let payload_len = frame.record.payload.len();
+                    let charged = u32::try_from(payload_len).map_err(|_| {
+                        AgentdError::ExecSession("bulk input payload budget overflow".into())
+                    })?;
+                    let permit = match Arc::clone(&budget).try_acquire_many_owned(charged) {
+                        Ok(permit) => permit,
+                        Err(_) if !budget.is_closed() => {
+                            capacity_deferred = true;
+                            pending_bulk_inputs.push_back(PendingBulkInput { frame, budget });
+                            continue;
+                        }
+                        Err(error) => {
+                            return Err(AgentdError::ExecSession(format!(
+                                "bulk input budget closed unexpectedly: {error}"
+                            )));
+                        }
+                    };
                     let bulk_session_tx = session_tx.with_incarnation(Some(frame.incarnation));
                     handle_bulk_record(
-                        frame.record,
+                        AdmittedBulkRecord {
+                            record: frame.record,
+                            _permit: permit,
+                        },
                         &mut state,
                         &mut activity,
                         &mut serial_out_buf,
@@ -584,8 +732,16 @@ pub async fn run(
                                         client_incarnation_for_id(&state, record.id),
                                     );
                                     let payload_len = record.payload.len();
+                                    let budget = Arc::clone(&state.bulk_input_budget);
+                                    let permit = acquire_bulk_input_permit(Some((
+                                        budget,
+                                        payload_len,
+                                    ))).await?;
                                     handle_bulk_record(
-                                        record,
+                                        AdmittedBulkRecord {
+                                            record,
+                                            _permit: permit,
+                                        },
                                         &mut state,
                                         &mut activity,
                                         &mut serial_out_buf,
@@ -1286,7 +1442,7 @@ fn ensure_fs_bulk_write_worker(
 
 fn enqueue_fs_bulk_record(
     id: u32,
-    record: BulkRecord,
+    record: AdmittedBulkRecord,
     state: &mut AgentState,
     session_tx: &SessionOutputSender,
 ) -> Result<(), String> {
@@ -1331,7 +1487,7 @@ fn finish_fs_bulk_write(
 async fn run_fs_bulk_write_worker(
     id: u32,
     mut session: FsWriteSession,
-    mut record_rx: tokio::sync::mpsc::Receiver<BulkRecord>,
+    mut record_rx: tokio::sync::mpsc::Receiver<AdmittedBulkRecord>,
     mut finish_rx: tokio::sync::mpsc::Receiver<BulkFinish>,
     output_tx: SessionOutputSender,
 ) {
@@ -1398,18 +1554,23 @@ async fn run_fs_bulk_write_worker(
         let mut records = Vec::with_capacity(
             FS_BULK_WRITE_COALESCE_BYTES.div_ceil(DEFAULT_FILESYSTEM_BULK_RECORD_PAYLOAD as usize),
         );
-        let mut payload_len = record.payload.len();
+        let mut retained_permits = Vec::with_capacity(records.capacity());
+        let mut payload_len = record.record().payload.len();
+        let (record, permit) = record.into_parts();
         records.push(record);
+        retained_permits.push(permit);
         while payload_len < FS_BULK_WRITE_COALESCE_BYTES {
             match record_rx.try_recv() {
                 Ok(record) => {
-                    let next_len = payload_len.saturating_add(record.payload.len());
+                    let next_len = payload_len.saturating_add(record.record().payload.len());
                     if next_len > FS_BULK_WRITE_COALESCE_BYTES {
                         pending_record = Some(record);
                         break;
                     }
+                    let (record, permit) = record.into_parts();
                     payload_len = next_len;
                     records.push(record);
+                    retained_permits.push(permit);
                 }
                 Err(tokio::sync::mpsc::error::TryRecvError::Empty) => break,
                 Err(tokio::sync::mpsc::error::TryRecvError::Disconnected) => break,
@@ -1439,6 +1600,9 @@ async fn run_fs_bulk_write_worker(
                     true
                 }
             };
+        // Filesystem effects have consumed every payload in this batch. Release aggregate input
+        // capacity before potentially waiting to publish credit or heartbeat output.
+        drop(retained_permits);
 
         if !completed
             && pending_finish
@@ -1481,29 +1645,32 @@ async fn run_fs_bulk_write_worker(
 
 /// Handles a single incoming message from the host.
 async fn handle_bulk_record(
-    record: BulkRecord,
+    record: AdmittedBulkRecord,
     state: &mut AgentState,
     activity: &mut ActivityTracker,
     out_buf: &mut Vec<u8>,
     session_tx: &SessionOutputSender,
 ) -> AgentdResult<()> {
     activity.record_host_message();
-    let id = record.id;
+    let id = record.record().id;
     let record_end = record
+        .record()
         .offset
-        .checked_add(record.payload.len() as u64)
+        .checked_add(record.record().payload.len() as u64)
         .ok_or_else(|| AgentdError::ExecSession("bulk record offset overflow".into()))?;
-    let record_payload_len = record.payload.len();
+    let record_payload_len = record.record().payload.len();
+    let kind = record.record().kind;
+    let flow = record.record().flow;
     let mut accepted = false;
-    match record.kind {
+    match kind {
         BulkKind::Filesystem => {
-            if record.flow != BulkFlow::HostToGuest {
+            if flow != BulkFlow::HostToGuest {
                 encode_bulk_fs_failure(
-                    record.id,
+                    id,
                     "host sent a filesystem record in the guest-to-host flow".into(),
                     out_buf,
                 )?;
-                cancel_bulk_correlation(record.id, BulkKind::Filesystem, state, session_tx);
+                cancel_bulk_correlation(id, BulkKind::Filesystem, state, session_tx);
                 return Ok(());
             }
 
@@ -1515,13 +1682,13 @@ async fn handle_bulk_record(
             }
         }
         BulkKind::Tcp => {
-            if record.flow != BulkFlow::HostToGuest {
+            if flow != BulkFlow::HostToGuest {
                 encode_bulk_tcp_failure(
-                    record.id,
+                    id,
                     "host sent a TCP record in the guest-to-host flow".into(),
                     out_buf,
                 )?;
-                cancel_bulk_correlation(record.id, BulkKind::Tcp, state, session_tx);
+                cancel_bulk_correlation(id, BulkKind::Tcp, state, session_tx);
                 return Ok(());
             }
             let result = match state.tcp_sessions.get(&id) {
@@ -1761,6 +1928,18 @@ fn validate_bulk_client_incarnation(
         )));
     }
     Ok(false)
+}
+
+async fn acquire_bulk_input_permit(
+    admission: Option<(Arc<Semaphore>, usize)>,
+) -> AgentdResult<OwnedSemaphorePermit> {
+    let (budget, payload_len) = admission.expect("bulk admission future is guarded by queue state");
+    let charged = u32::try_from(payload_len)
+        .map_err(|_| AgentdError::ExecSession("bulk input payload budget overflow".into()))?;
+    budget
+        .acquire_many_owned(charged)
+        .await
+        .map_err(|error| AgentdError::ExecSession(format!("bulk input budget closed: {error}")))
 }
 
 /// Validate that an internal lifecycle message names one complete relay-owned range.
@@ -3305,6 +3484,19 @@ mod tests {
     }
 
     #[test]
+    fn aggregate_bulk_input_budget_is_bounded_and_recoverable() {
+        let state = AgentState::default();
+        let budget = state.bulk_input_budget;
+        let held = Arc::clone(&budget)
+            .try_acquire_many_owned(BULK_INPUT_BYTE_CAPACITY as u32)
+            .unwrap();
+
+        assert!(Arc::clone(&budget).try_acquire_owned().is_err());
+        drop(held);
+        assert_eq!(budget.available_permits(), BULK_INPUT_BYTE_CAPACITY);
+    }
+
+    #[test]
     fn disconnect_ack_does_not_refresh_idle_activity() {
         let ack = encode_relay_client_disconnected_ack(RelayClientDisconnectedAck {
             id_start: 1,
@@ -3478,13 +3670,13 @@ mod tests {
         for index in 0..FS_BULK_INPUT_ITEM_CAPACITY {
             worker
                 .records
-                .try_send(BulkRecord {
+                .try_send(AdmittedBulkRecord::for_test(BulkRecord {
                     id: 17,
                     kind: BulkKind::Filesystem,
                     flow: BulkFlow::HostToGuest,
                     offset: (index * MIN_BULK_RECORD_PAYLOAD as usize) as u64,
                     payload: payload.clone(),
-                })
+                }))
                 .unwrap();
         }
         assert_eq!(worker.records.capacity(), 0);

--- a/crates/agentd/lib/agent.rs
+++ b/crates/agentd/lib/agent.rs
@@ -380,6 +380,9 @@ pub async fn run(
                 .as_ref()
                 .map(|port| BulkTransportReady::dual_port_v1(port.connection_id)),
             relay_lease: Some(RelayLeaseReady::range_lease_v1()),
+            // Shared arenas are negotiated only on the local SDK-to-runtime hop. Agentd speaks to
+            // the runtime over the guest consoles, so the runtime injects this capability later.
+            local_transport: None,
         },
     )
     .map_err(|e| AgentdError::ExecSession(format!("encode ready: {e}")))?;

--- a/crates/agentd/lib/tcp.rs
+++ b/crates/agentd/lib/tcp.rs
@@ -8,7 +8,7 @@ use std::time::Duration;
 use bytes::Bytes;
 use tokio::io::{AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use tokio::net::TcpStream;
-use tokio::sync::{mpsc, watch};
+use tokio::sync::{OwnedSemaphorePermit, mpsc, watch};
 use tokio::task::JoinHandle;
 
 use microsandbox_protocol::bulk::{
@@ -20,6 +20,7 @@ use microsandbox_protocol::codec;
 use microsandbox_protocol::message::{Message, MessageType};
 use microsandbox_protocol::tcp::{TcpClosed, TcpConnect, TcpConnected, TcpData, TcpEof, TcpFailed};
 
+use crate::agent::AdmittedBulkRecord;
 #[cfg(test)]
 use crate::session::SessionOutputEnvelope;
 use crate::session::{
@@ -65,7 +66,7 @@ pub struct TcpSession {
 enum TcpCommand {
     Data(Vec<u8>),
     Eof,
-    BulkRecord(BulkRecord),
+    BulkRecord(AdmittedBulkRecord),
 }
 
 /// Coalescing lifecycle channels that cannot be starved by a full TCP data queue.
@@ -90,6 +91,7 @@ struct PendingTcpWrite {
     payload: Bytes,
     written: usize,
     bulk_end: Option<u64>,
+    _bulk_input_permit: Option<OwnedSemaphorePermit>,
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -131,7 +133,7 @@ impl TcpSession {
     }
 
     /// Queue one host-to-guest raw bulk record.
-    pub async fn write_bulk(&self, record: BulkRecord) -> Result<(), String> {
+    pub(crate) async fn write_bulk(&self, record: AdmittedBulkRecord) -> Result<(), String> {
         if !self.bulk {
             return Err("raw bulk record sent to a generation-6 TCP stream".into());
         }
@@ -642,7 +644,11 @@ async fn relay_tcp_session(
                         }
 
                         let completed = pending_write.take().expect("completed TCP write exists");
-                        if let Some(end) = completed.bulk_end {
+                        let bulk_end = completed.bulk_end;
+                        // The destination socket has consumed the full payload. Release aggregate
+                        // input capacity before an outbound credit waits on the opposite lane.
+                        drop(completed._bulk_input_permit);
+                        if let Some(end) = bulk_end {
                             let Some(state) = bulk.as_mut() else {
                                 terminal_sent = send_tcp_failure(
                                     id,
@@ -729,6 +735,7 @@ async fn relay_tcp_session(
                             payload: Bytes::from(data),
                             written: 0,
                             bulk_end: None,
+                            _bulk_input_permit: None,
                         });
                     }
                     Some(TcpCommand::Eof) => {
@@ -770,7 +777,7 @@ async fn relay_tcp_session(
                             .await;
                             break;
                         };
-                        let end = match state.receive.accept_record(&record) {
+                        let end = match state.receive.accept_record(record.record()) {
                             Ok(end) => end,
                             Err(error) => {
                                 terminal_sent = send_tcp_failure(
@@ -782,10 +789,12 @@ async fn relay_tcp_session(
                                 break;
                             }
                         };
+                        let (record, permit) = record.into_parts();
                         pending_write = Some(PendingTcpWrite {
                             payload: record.payload,
                             written: 0,
                             bulk_end: Some(end),
+                            _bulk_input_permit: Some(permit),
                         });
                     }
                 }
@@ -1036,13 +1045,13 @@ mod tests {
 
         let host_payload = Bytes::from_static(b"from-host");
         session
-            .write_bulk(BulkRecord {
+            .write_bulk(AdmittedBulkRecord::for_test(BulkRecord {
                 id: 13,
                 kind: BulkKind::Tcp,
                 flow: BulkFlow::HostToGuest,
                 offset: 0,
                 payload: host_payload.clone(),
-            })
+            }))
             .await
             .unwrap();
         session
@@ -1116,13 +1125,13 @@ mod tests {
         );
 
         session
-            .write_bulk(BulkRecord {
+            .write_bulk(AdmittedBulkRecord::for_test(BulkRecord {
                 id: 17,
                 kind: BulkKind::Tcp,
                 flow: BulkFlow::HostToGuest,
                 offset: 0,
                 payload: host_payload,
-            })
+            }))
             .await
             .unwrap();
 
@@ -1167,13 +1176,13 @@ mod tests {
 
         for index in 0..TCP_COMMAND_CAPACITY {
             session
-                .write_bulk(BulkRecord {
+                .write_bulk(AdmittedBulkRecord::for_test(BulkRecord {
                     id: 29,
                     kind: BulkKind::Tcp,
                     flow: BulkFlow::HostToGuest,
                     offset: (index * MIN_BULK_RECORD_PAYLOAD as usize) as u64,
                     payload: payload.clone(),
-                })
+                }))
                 .await
                 .unwrap();
         }

--- a/crates/protocol/lib/core.rs
+++ b/crates/protocol/lib/core.rs
@@ -2,7 +2,7 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::transport::{BulkTransportReady, RelayLeaseReady};
+use crate::transport::{BulkTransportReady, LocalTransportReady, RelayLeaseReady};
 
 //--------------------------------------------------------------------------------------------------
 // Types
@@ -44,6 +44,12 @@ pub struct Ready {
     /// Optional topology-independent relay correlation-range lease capability.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub relay_lease: Option<RelayLeaseReady>,
+
+    /// Optional SDK-to-runtime transport capability injected by a local Unix relay.
+    ///
+    /// Agentd leaves this absent because local shared memory is below the guest protocol.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub local_transport: Option<LocalTransportReady>,
 }
 
 /// Payload for `core.clock.sync` messages.
@@ -213,6 +219,7 @@ mod tests {
             agent_version: legacy.agent_version.clone(),
             bulk_transport: None,
             relay_lease: None,
+            local_transport: None,
         };
         let mut legacy_bytes = Vec::new();
         ciborium::into_writer(&legacy, &mut legacy_bytes).unwrap();
@@ -223,6 +230,7 @@ mod tests {
         let decoded: Ready = ciborium::from_reader(legacy_bytes.as_slice()).unwrap();
         assert!(decoded.bulk_transport.is_none());
         assert!(decoded.relay_lease.is_none());
+        assert!(decoded.local_transport.is_none());
     }
 
     #[test]

--- a/crates/protocol/lib/transport.rs
+++ b/crates/protocol/lib/transport.rs
@@ -32,6 +32,9 @@ pub const RELAY_CLIENT_LEASE_SIZE: usize = 41;
 /// First backwards-readable range-lease record format.
 pub const RELAY_LEASE_FORMAT_V1: u8 = 1;
 
+/// First backwards-readable SDK-to-runtime shared-arena format.
+pub const LOCAL_SHM_FORMAT_V1: u8 = 1;
+
 const BULK_HELLO_MAGIC: [u8; 4] = *b"MSBB";
 const BULK_ACK_MAGIC: [u8; 4] = *b"MSBA";
 const RELAY_CLIENT_MAGIC: [u8; 4] = *b"MSBL";
@@ -62,6 +65,16 @@ pub type ClientIncarnation = [u8; CLIENT_INCARNATION_SIZE];
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RelayLeaseReady {
     /// Highest fixed MSBL record format this agent can read.
+    pub max_format: u8,
+}
+
+/// Unix-local SDK-to-runtime transport formats supported by the relay.
+///
+/// This is an additive Ready capability rather than a guest protocol generation. The guest does
+/// not allocate, map, or interpret these arenas.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LocalTransportReady {
+    /// Highest backwards-readable shared-arena format.
     pub max_format: u8,
 }
 
@@ -148,6 +161,21 @@ impl RelayLeaseReady {
     pub fn select_supported(&self, host_max: u8) -> Option<u8> {
         let selected = self.max_format.min(host_max);
         (selected >= RELAY_LEASE_FORMAT_V1).then_some(selected)
+    }
+}
+
+impl LocalTransportReady {
+    /// Advertise support for the first single-socket shared-arena format.
+    pub fn shared_arena_v1() -> Self {
+        Self {
+            max_format: LOCAL_SHM_FORMAT_V1,
+        }
+    }
+
+    /// Select the highest mutually supported backwards-readable format.
+    pub fn select_supported(&self, client_max: u8) -> Option<u8> {
+        let selected = self.max_format.min(client_max);
+        (selected >= LOCAL_SHM_FORMAT_V1).then_some(selected)
     }
 }
 
@@ -443,6 +471,17 @@ mod tests {
         BulkTransportReady::dual_port_v1(id)
             .validate_dual_port_v1(id)
             .unwrap();
+    }
+
+    #[test]
+    fn local_transport_selects_only_a_mutually_supported_format() {
+        let capability = LocalTransportReady::shared_arena_v1();
+        assert_eq!(capability.select_supported(LOCAL_SHM_FORMAT_V1), Some(1));
+        assert_eq!(capability.select_supported(0), None);
+        assert_eq!(
+            LocalTransportReady { max_format: 9 }.select_supported(LOCAL_SHM_FORMAT_V1),
+            Some(1)
+        );
     }
 
     #[test]

--- a/crates/runtime/lib/runner/relay.rs
+++ b/crates/runtime/lib/runner/relay.rs
@@ -11,17 +11,25 @@
 
 use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
 use std::io::IoSlice;
+#[cfg(unix)]
+use std::os::fd::{AsFd, AsRawFd, OwnedFd};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 
 use bytes::{Buf, Bytes, BytesMut};
 #[cfg(unix)]
+use microsandbox_agent_client::local_shm::{
+    LocalBulkRelease, LocalShmError, LocalShmFrame, LocalShmServer, PreparedLocalBulk,
+    SharedArenaProducer, decode_local_body, encode_local_bulk_ref, encode_local_bulk_release,
+    send_local_shm_upgrade_fd,
+};
+#[cfg(unix)]
 use microsandbox_filesystem::{BindIdentityMap, BindIdentityMapHandle};
 use microsandbox_protocol::AGENT_RELAY_MAX_CLIENTS;
 use microsandbox_protocol::bulk::{
     BULK_FLOW_MASK_GUEST_TO_HOST, BULK_HEADER_SIZE, BulkAccepted, BulkCancel, BulkCancelReason,
-    BulkFinish, BulkFlow, BulkKind, MAX_BULK_RECORD_PAYLOAD,
+    BulkFinish, BulkFlow, BulkKind, BulkRecord, MAX_BULK_RECORD_PAYLOAD,
 };
 use microsandbox_protocol::codec::{self, MAX_FRAME_SIZE, MAX_WIRE_FRAME};
 use microsandbox_protocol::core::{InitAck, InitResolved, Ready, RelayClientDisconnected};
@@ -33,9 +41,9 @@ use microsandbox_protocol::message::{
 };
 use microsandbox_protocol::tcp::TcpConnect;
 use microsandbox_protocol::transport::{
-    BULK_BINDING_SIZE, CLIENT_INCARNATION_SIZE, ClientIncarnation, RELAY_LEASE_FORMAT_V1,
-    decode_bulk_hello, encode_bulk_ack, encode_relay_client_connected, relay_client_id_range,
-    relay_client_slot, try_decode_incarnated_bulk_from_bytes,
+    BULK_BINDING_SIZE, CLIENT_INCARNATION_SIZE, ClientIncarnation, LocalTransportReady,
+    RELAY_LEASE_FORMAT_V1, decode_bulk_hello, encode_bulk_ack, encode_relay_client_connected,
+    relay_client_id_range, relay_client_slot, try_decode_incarnated_bulk_from_bytes,
     try_decode_relay_client_disconnected_ack_from_bytes,
 };
 use microsandbox_protocol::transport::{RelayClientConnected, RelayClientDisconnectedAck};
@@ -163,6 +171,10 @@ struct ClientState {
 
     /// Requests teardown when this client's bounded output path stops making progress.
     disconnect_tx: watch::Sender<bool>,
+
+    /// Runtime-to-SDK arena producer after this client accepts local-shm-v1.
+    #[cfg(unix)]
+    local_outbound: Option<SharedArenaProducer>,
 }
 
 /// One ordered control-lane write, optionally acknowledged after physical ring admission.
@@ -207,11 +219,22 @@ struct RingReaderContext {
 
 /// A client-bound frame whose aggregate capacity lives until the socket accepts it.
 struct ClientWrite {
-    data: Bytes,
+    data: ClientWriteData,
     /// Aggregate physical-lane admission, retained until the SDK socket consumes the frame.
     _lane_permit: tokio::sync::OwnedSemaphorePermit,
     /// Per-client admission, retained for the same lifetime as the aggregate permit.
     _client_permit: tokio::sync::OwnedSemaphorePermit,
+}
+
+/// One item in the canonical guest-to-SDK output order.
+///
+/// Shared-arena descriptors deliberately live in the same mailbox as in-band frames. Keeping
+/// them on a separate priority channel can let a later bulk descriptor overtake an earlier
+/// terminal control frame (or vice versa), which truncates otherwise valid full-duplex streams.
+enum ClientWriteData {
+    Inline(Bytes),
+    #[cfg(unix)]
+    LocalBulk(PreparedLocalBulk),
 }
 
 /// Nonblocking handles cloned from one live client owner before guest-output routing.
@@ -219,18 +242,40 @@ struct ClientRoute {
     write_tx: mpsc::UnboundedSender<ClientWrite>,
     write_budget: Arc<Semaphore>,
     disconnect_tx: watch::Sender<bool>,
+    #[cfg(unix)]
+    local_outbound: Option<SharedArenaProducer>,
+}
+
+/// Small priority writes that never carry bulk payload bytes through `agent.sock`.
+#[cfg(unix)]
+enum LocalClientWrite {
+    Upgrade {
+        server: Arc<LocalShmServer>,
+        completion: oneshot::Sender<Result<(), String>>,
+    },
+    Release(LocalBulkRelease),
 }
 
 /// Client-originated raw frame retained until the bulk console ring accepts it.
 struct BulkWrite {
     id: u32,
     incarnation: ClientIncarnation,
-    data: Bytes,
+    data: BulkWriteData,
     /// Validated direction carried from the client boundary.
     flow: BulkFlow,
     /// Validated payload length carried through scheduling to avoid reparsing the wire header.
     payload_len: usize,
     _permit: tokio::sync::OwnedSemaphorePermit,
+}
+
+/// One in-band frame or shared payload split into its unchanged wire header and body.
+enum BulkWriteData {
+    Inline(Bytes),
+    #[cfg(unix)]
+    Shared {
+        header: Bytes,
+        payload: Bytes,
+    },
 }
 
 /// Commands processed in-order by the host-to-guest bulk scheduler.
@@ -894,7 +939,7 @@ impl AgentRelay {
                                 .into(),
                         ));
                     }
-                    let ready: Ready = msg.payload().map_err(|error| {
+                    let mut ready: Ready = msg.payload().map_err(|error| {
                         RuntimeError::Custom(format!("decode core.ready payload: {error}"))
                     })?;
                     self.select_ready_transport(&ready)?;
@@ -902,7 +947,31 @@ impl AgentRelay {
                         dual_port = self.dual_port_active,
                         "agent relay: received core.ready from agentd"
                     );
-                    self.ready_frame = Some(frame.data.to_vec());
+                    #[cfg(unix)]
+                    {
+                        // This capability describes only the already authenticated local SDK
+                        // hop. Agentd remains unaware of shared mappings and the guest generation
+                        // stays unchanged.
+                        ready.local_transport = Some(LocalTransportReady::shared_arena_v1());
+                    }
+                    let mut client_ready =
+                        Message::with_payload(MessageType::Ready, msg.id, &ready).map_err(
+                            |error| {
+                                RuntimeError::Custom(format!(
+                                    "encode SDK-facing core.ready payload: {error}"
+                                ))
+                            },
+                        )?;
+                    client_ready.v = msg.v;
+                    let mut client_ready_frame = Vec::new();
+                    codec::encode_to_buf(&client_ready, &mut client_ready_frame).map_err(
+                        |error| {
+                            RuntimeError::Custom(format!(
+                                "encode SDK-facing core.ready frame: {error}"
+                            ))
+                        },
+                    )?;
+                    self.ready_frame = Some(client_ready_frame);
                     // Now that agentd has signalled readiness, mark the
                     // exec.log lifecycle. Doing this here (rather than
                     // in `with_log_writer`) means the marker only shows
@@ -1197,6 +1266,16 @@ impl AgentRelay {
 
                             // Perform handshake: send
                             // [id_start: u32 BE][id_end_exclusive: u32 BE][ready_frame_bytes...].
+                            #[cfg(unix)]
+                            let ancillary_fd = match stream.as_fd().try_clone_to_owned() {
+                                Ok(fd) => fd,
+                                Err(error) => {
+                                    tracing::error!(%error, "agent relay: duplicate client socket for local transport failed");
+                                    used_slots.lock().await.remove(&slot);
+                                    drop(stream);
+                                    continue;
+                                }
+                            };
                             let (reader_half, mut writer_half) = tokio::io::split(stream);
                             let (disconnect_tx, disconnect_rx) = watch::channel(false);
 
@@ -1249,12 +1328,19 @@ impl AgentRelay {
                             // every entry. This keeps routing nonblocking without allowing a burst
                             // of three frames to be mistaken for a stalled SDK client.
                             let (write_tx, write_rx) = mpsc::unbounded_channel::<ClientWrite>();
+                            #[cfg(unix)]
+                            let (local_write_tx, local_write_rx) =
+                                mpsc::unbounded_channel::<LocalClientWrite>();
                             let writer_disconnect_tx = disconnect_tx.clone();
                             tokio::spawn(client_writer_task(
                                 slot,
                                 writer_half,
                                 write_rx,
                                 writer_disconnect_tx,
+                                #[cfg(unix)]
+                                local_write_rx,
+                                #[cfg(unix)]
+                                ancillary_fd,
                             ));
 
                             let active_bulk = Arc::new(std::sync::Mutex::new(HashMap::new()));
@@ -1271,6 +1357,8 @@ impl AgentRelay {
                                         CLIENT_OUTPUT_PER_CLIENT_BYTE_CAPACITY,
                                     )),
                                     disconnect_tx,
+                                    #[cfg(unix)]
+                                    local_outbound: None,
                                 });
                             }
 
@@ -1304,6 +1392,8 @@ impl AgentRelay {
                                 incarnation,
                                 active_bulk,
                                 disconnect_rx,
+                                #[cfg(unix)]
+                                local_write_tx,
                             ));
                         }
                         Err(e) => {
@@ -1527,36 +1617,110 @@ fn decode_frame(buf: &[u8]) -> RuntimeResult<Message> {
     codec::decode_message_frame(buf).map_err(|e| RuntimeError::Custom(format!("decode frame: {e}")))
 }
 
-/// Drain one client's byte-bounded mailbox through a single batching writer.
+/// Drain one client's priority local commands and ordinary frame batches through one writer.
 async fn client_writer_task<W>(
     slot: u32,
     mut writer: W,
     mut write_rx: mpsc::UnboundedReceiver<ClientWrite>,
     disconnect_tx: watch::Sender<bool>,
+    #[cfg(unix)] mut local_write_rx: mpsc::UnboundedReceiver<LocalClientWrite>,
+    #[cfg(unix)] ancillary_fd: OwnedFd,
 ) where
     W: AsyncWrite + Unpin,
 {
     let mut batch = VecDeque::new();
     let mut deferred = None;
+    #[cfg(unix)]
+    let mut local_commands_open = true;
     loop {
+        #[cfg(unix)]
+        if local_commands_open {
+            match local_write_rx.try_recv() {
+                Ok(command) => {
+                    if let Err(error) =
+                        write_local_client_command(&mut writer, &ancillary_fd, command).await
+                    {
+                        tracing::error!(
+                            "agent relay: local client writer slot={slot} failed: {error}"
+                        );
+                        let _ = disconnect_tx.send(true);
+                        break;
+                    }
+                    continue;
+                }
+                Err(mpsc::error::TryRecvError::Empty) => {}
+                Err(mpsc::error::TryRecvError::Disconnected) => local_commands_open = false,
+            }
+        }
+
         let write = match deferred.take() {
             Some(write) => write,
-            None => match write_rx.recv().await {
-                Some(write) => write,
-                None => break,
-            },
+            None => {
+                #[cfg(unix)]
+                {
+                    tokio::select! {
+                        biased;
+                        command = local_write_rx.recv(), if local_commands_open => {
+                            let Some(command) = command else {
+                                // Once the reader side is gone, stop polling a permanently-ready
+                                // closed priority channel so the ordinary writer can drain and exit.
+                                local_commands_open = false;
+                                continue;
+                            };
+                            if let Err(error) = write_local_client_command(
+                                &mut writer,
+                                &ancillary_fd,
+                                command,
+                            ).await {
+                                tracing::error!("agent relay: local client writer slot={slot} failed: {error}");
+                                let _ = disconnect_tx.send(true);
+                                break;
+                            }
+                            continue;
+                        }
+                        write = write_rx.recv() => {
+                            let Some(write) = write else { break; };
+                            write
+                        }
+                    }
+                }
+                #[cfg(not(unix))]
+                {
+                    let Some(write) = write_rx.recv().await else {
+                        break;
+                    };
+                    write
+                }
+            }
         };
-        let mut batch_bytes = write.data.len();
+        let mut batch_bytes = match &write.data {
+            ClientWriteData::Inline(data) => data.len(),
+            #[cfg(unix)]
+            ClientWriteData::LocalBulk(_) => {
+                if let Err(error) = write_ordered_local_bulk(&mut writer, write).await {
+                    tracing::error!("agent relay: local bulk writer slot={slot} failed: {error}");
+                    let _ = disconnect_tx.send(true);
+                    break;
+                }
+                continue;
+            }
+        };
         batch.push_back(write);
         while batch.len() < CLIENT_WRITE_BATCH_FRAMES && batch_bytes < CLIENT_WRITE_BATCH_BYTES {
             let Ok(write) = write_rx.try_recv() else {
                 break;
             };
-            if batch_bytes.saturating_add(write.data.len()) > CLIENT_WRITE_BATCH_BYTES {
+            let ClientWriteData::Inline(data) = &write.data else {
+                // A local descriptor is an ordering barrier: flush every preceding in-band frame
+                // before publishing its arena slot to the SDK.
+                deferred = Some(write);
+                break;
+            };
+            if batch_bytes.saturating_add(data.len()) > CLIENT_WRITE_BATCH_BYTES {
                 deferred = Some(write);
                 break;
             }
-            batch_bytes = batch_bytes.saturating_add(write.data.len());
+            batch_bytes = batch_bytes.saturating_add(data.len());
             batch.push_back(write);
         }
 
@@ -1568,6 +1732,72 @@ async fn client_writer_task<W>(
     }
 }
 
+#[cfg(unix)]
+async fn write_local_client_command<W: AsyncWrite + Unpin>(
+    writer: &mut W,
+    ancillary_fd: &OwnedFd,
+    command: LocalClientWrite,
+) -> Result<(), String> {
+    match command {
+        LocalClientWrite::Upgrade { server, completion } => {
+            let result = async {
+                tokio::time::timeout(CLIENT_OUTPUT_STALL_GRACE, writer.flush())
+                    .await
+                    .map_err(|_| "flush before shared-arena acknowledgement timed out".to_string())?
+                    .map_err(|error| error.to_string())?;
+                tokio::time::timeout(
+                    CLIENT_OUTPUT_STALL_GRACE,
+                    send_local_shm_upgrade_fd(ancillary_fd.as_raw_fd(), Some(server.client_fds())),
+                )
+                .await
+                .map_err(|_| "shared-arena descriptor send timed out".to_string())?
+                .map_err(|error| error.to_string())
+            }
+            .await;
+            let failed = result.as_ref().err().cloned();
+            let _ = completion.send(result);
+            if let Some(error) = failed {
+                return Err(error);
+            }
+        }
+        LocalClientWrite::Release(release) => {
+            let wire = encode_local_bulk_release(release).map_err(|e| e.to_string())?;
+            write_local_client_bytes(writer, &wire).await?;
+        }
+    }
+    Ok(())
+}
+
+/// Publish one shared-arena descriptor at its exact position in the merged guest output stream.
+#[cfg(unix)]
+async fn write_ordered_local_bulk<W: AsyncWrite + Unpin>(
+    writer: &mut W,
+    write: ClientWrite,
+) -> Result<(), String> {
+    let ClientWriteData::LocalBulk(mut prepared) = write.data else {
+        return Err("ordered local bulk writer received an in-band frame".to_string());
+    };
+    let wire = encode_local_bulk_ref(prepared.descriptor()).map_err(|e| e.to_string())?;
+    write_local_client_bytes(writer, &wire).await?;
+    prepared.commit();
+    Ok(())
+}
+
+#[cfg(unix)]
+async fn write_local_client_bytes<W: AsyncWrite + Unpin>(
+    writer: &mut W,
+    bytes: &[u8],
+) -> Result<(), String> {
+    tokio::time::timeout(CLIENT_OUTPUT_STALL_GRACE, writer.write_all(bytes))
+        .await
+        .map_err(|_| "local descriptor write timed out".to_string())?
+        .map_err(|error| error.to_string())?;
+    tokio::time::timeout(CLIENT_OUTPUT_STALL_GRACE, writer.flush())
+        .await
+        .map_err(|_| "local descriptor flush timed out".to_string())?
+        .map_err(|error| error.to_string())
+}
+
 /// Write a client batch with cursor advancement so short writes never compact frame tails.
 async fn write_client_batch<W: AsyncWrite + Unpin>(
     writer: &mut W,
@@ -1577,7 +1807,12 @@ async fn write_client_batch<W: AsyncWrite + Unpin>(
         let slices: Vec<IoSlice<'_>> = batch
             .iter()
             .take(CLIENT_WRITE_BATCH_FRAMES)
-            .map(|write| IoSlice::new(&write.data))
+            .map(|write| {
+                let ClientWriteData::Inline(data) = &write.data else {
+                    unreachable!("local bulk descriptors are ordering barriers, never batch data")
+                };
+                IoSlice::new(data)
+            })
             .collect();
         let written =
             tokio::time::timeout(CLIENT_OUTPUT_STALL_GRACE, writer.write_vectored(&slices))
@@ -1595,11 +1830,14 @@ async fn write_client_batch<W: AsyncWrite + Unpin>(
         let mut remaining = written;
         while remaining != 0 {
             let front = batch.front_mut().expect("non-empty batch after write");
-            if remaining < front.data.len() {
-                front.data.advance(remaining);
+            let ClientWriteData::Inline(data) = &mut front.data else {
+                unreachable!("local bulk descriptors are ordering barriers, never batch data")
+            };
+            if remaining < data.len() {
+                data.advance(remaining);
                 remaining = 0;
             } else {
-                remaining -= front.data.len();
+                remaining -= data.len();
                 batch.pop_front();
             }
         }
@@ -2014,13 +2252,24 @@ async fn push_bulk_write(
     {
         return false;
     }
-    push_bulk_fragment(
-        shared,
-        write.data,
+    match write.data {
+        BulkWriteData::Inline(data) => {
+            push_bulk_fragment(
+                shared,
+                data,
+                #[cfg(unix)]
+                capacity_fd,
+            )
+            .await
+        }
         #[cfg(unix)]
-        capacity_fd,
-    )
-    .await
+        BulkWriteData::Shared { header, payload } => {
+            if !push_bulk_fragment(shared, header, capacity_fd).await {
+                return false;
+            }
+            push_bulk_fragment(shared, payload, capacity_fd).await
+        }
+    }
 }
 
 async fn push_bulk_fragment(
@@ -2354,6 +2603,8 @@ async fn route_guest_lane_frame(
                 write_tx: client.write_tx.clone(),
                 write_budget: Arc::clone(&client.write_budget),
                 disconnect_tx: client.disconnect_tx.clone(),
+                #[cfg(unix)]
+                local_outbound: client.local_outbound.clone(),
             })
         } else {
             Err(frame.id)
@@ -2388,8 +2639,49 @@ async fn route_guest_lane_frame(
                 ))
             })?;
 
+            // The shared arena is a local optimization only. If all fitting slots are leased,
+            // preserve forward progress by sending this record through the original socket path.
+            // Any error other than temporary capacity means the negotiated local transport is
+            // corrupt and must fail closed instead of silently changing its interpretation.
+            #[cfg(unix)]
+            if frame.flags == FLAG_BULK
+                && let Some(producer) = route.local_outbound
+            {
+                let (kind, flow, offset, payload_len) = bulk_wire_metadata(&frame.data)?;
+                let payload_start = LEN_PREFIX_SIZE + FRAME_HEADER_SIZE + BULK_HEADER_SIZE;
+                let record = BulkRecord {
+                    id: frame.id,
+                    kind,
+                    flow,
+                    offset,
+                    payload: frame.data.slice(payload_start..payload_start + payload_len),
+                };
+                match producer.try_prepare(&record) {
+                    Ok(prepared) => {
+                        if let Err(error) = route.write_tx.send(ClientWrite {
+                            data: ClientWriteData::LocalBulk(prepared),
+                            _lane_permit: lane_permit,
+                            _client_permit: client_permit,
+                        }) {
+                            tracing::warn!(
+                                %error,
+                                "agent relay: disconnecting slot={client_slot}; local client writer stopped"
+                            );
+                            let _ = route.disconnect_tx.send(true);
+                        }
+                        return Ok(());
+                    }
+                    Err(LocalShmError::Full(_)) => {}
+                    Err(error) => {
+                        return Err(RuntimeError::Custom(format!(
+                            "agent relay: local shared-arena output failed: {error}"
+                        )));
+                    }
+                }
+            }
+
             if let Err(error) = route.write_tx.send(ClientWrite {
-                data: frame.data,
+                data: ClientWriteData::Inline(frame.data),
                 _lane_permit: lane_permit,
                 _client_permit: client_permit,
             }) {
@@ -2697,9 +2989,42 @@ async fn client_reader_task(
     incarnation: Option<ClientIncarnation>,
     active_bulk: Arc<std::sync::Mutex<HashMap<u32, BulkKind>>>,
     mut disconnect_rx: watch::Receiver<bool>,
+    #[cfg(unix)] local_write_tx: mpsc::UnboundedSender<LocalClientWrite>,
 ) {
+    #[cfg(unix)]
+    let (local_release_tx, mut local_release_rx) = mpsc::unbounded_channel();
+    #[cfg(unix)]
+    let mut local_server: Option<Arc<LocalShmServer>> = None;
+    #[cfg(unix)]
+    let mut ordinary_frame_seen = false;
+
     loop {
-        let frame = tokio::select! {
+        #[cfg(unix)]
+        let mut frame = tokio::select! {
+            result = read_raw_frame(&mut reader) => match result {
+                Ok(frame) => frame,
+                Err(error) => {
+                    tracing::info!(%error, "agent relay: client disconnected slot={slot}");
+                    break;
+                }
+            },
+            changed = disconnect_rx.changed() => {
+                if changed.is_err() || *disconnect_rx.borrow() {
+                    tracing::info!("agent relay: disconnecting stalled client slot={slot}");
+                    break;
+                }
+                continue;
+            }
+            release = local_release_rx.recv() => {
+                let Some(release) = release else { continue; };
+                if local_write_tx.send(LocalClientWrite::Release(release)).is_err() {
+                    break;
+                }
+                continue;
+            }
+        };
+        #[cfg(not(unix))]
+        let mut frame = tokio::select! {
             result = read_raw_frame(&mut reader) => match result {
                 Ok(frame) => frame,
                 Err(error) => {
@@ -2715,6 +3040,111 @@ async fn client_reader_task(
                 continue;
             }
         };
+
+        #[cfg(unix)]
+        let mut shared_bulk = None;
+        #[cfg(unix)]
+        if frame.id == 0 && frame.flags == 0 {
+            let local = if frame.data.len() >= LEN_PREFIX_SIZE + FRAME_HEADER_SIZE {
+                decode_local_body(&frame.data[LEN_PREFIX_SIZE + FRAME_HEADER_SIZE..])
+            } else {
+                Err(
+                    microsandbox_agent_client::local_shm::LocalShmError::Protocol(
+                        "local frame is shorter than its outer header".into(),
+                    ),
+                )
+            };
+            let local = match local {
+                Ok(local) => local,
+                Err(error) => {
+                    tracing::warn!(%error, "agent relay: malformed local client frame slot={slot}");
+                    break;
+                }
+            };
+            match local {
+                LocalShmFrame::UpgradeRequest => {
+                    if ordinary_frame_seen || local_server.is_some() {
+                        tracing::warn!(
+                            "agent relay: repeated or late local transport upgrade slot={slot}"
+                        );
+                        break;
+                    }
+                    let server = match LocalShmServer::create() {
+                        Ok(server) => Arc::new(server),
+                        Err(error) => {
+                            tracing::warn!(%error, "agent relay: create local arenas failed slot={slot}");
+                            break;
+                        }
+                    };
+                    let (completion, completed) = oneshot::channel();
+                    if local_write_tx
+                        .send(LocalClientWrite::Upgrade {
+                            server: Arc::clone(&server),
+                            completion,
+                        })
+                        .is_err()
+                    {
+                        break;
+                    }
+                    match completed.await {
+                        Ok(Ok(())) => {}
+                        Ok(Err(error)) => {
+                            tracing::warn!(%error, "agent relay: local arena acknowledgement failed slot={slot}");
+                            break;
+                        }
+                        Err(_) => break,
+                    }
+                    {
+                        let mut map = clients.lock().await;
+                        let Some(client) = map.get_mut(&slot) else {
+                            break;
+                        };
+                        client.local_outbound = Some(server.outbound.clone());
+                    }
+                    local_server = Some(server);
+                    tracing::info!(slot, local_shm = true, "agent relay: selected local-shm-v1");
+                    continue;
+                }
+                LocalShmFrame::BulkRelease(release) => {
+                    let Some(server) = local_server.as_ref() else {
+                        tracing::warn!("agent relay: local release before upgrade slot={slot}");
+                        break;
+                    };
+                    if let Err(error) = server.outbound.release(release) {
+                        tracing::warn!(%error, "agent relay: rejected local release slot={slot}");
+                        break;
+                    }
+                    continue;
+                }
+                LocalShmFrame::BulkRef(descriptor) => {
+                    ordinary_frame_seen = true;
+                    let Some(server) = local_server.as_ref() else {
+                        tracing::warn!(
+                            "agent relay: local bulk reference before upgrade slot={slot}"
+                        );
+                        break;
+                    };
+                    let record = match server.inbound.receive(descriptor, local_release_tx.clone())
+                    {
+                        Ok(record) => record,
+                        Err(error) => {
+                            tracing::warn!(%error, "agent relay: rejected local bulk reference slot={slot}");
+                            break;
+                        }
+                    };
+                    frame = RawFrame {
+                        data: Bytes::new(),
+                        id: record.id,
+                        flags: FLAG_BULK,
+                    };
+                    shared_bulk = Some(record);
+                }
+            }
+        }
+        #[cfg(unix)]
+        if shared_bulk.is_none() {
+            ordinary_frame_seen = true;
+        }
 
         if !has_valid_frame_flags(frame.flags) {
             tracing::warn!(
@@ -2798,11 +3228,29 @@ async fn client_reader_task(
         }
 
         let bulk_metadata = if frame.flags == FLAG_BULK {
-            let Ok(metadata) = bulk_wire_metadata(&frame.data) else {
-                tracing::error!(id = frame.id, "agent relay: malformed client bulk record");
-                break;
-            };
-            Some(metadata)
+            #[cfg(unix)]
+            if let Some(record) = shared_bulk.as_ref() {
+                Some((
+                    record.kind,
+                    record.flow,
+                    record.offset,
+                    record.payload.len(),
+                ))
+            } else {
+                let Ok(metadata) = bulk_wire_metadata(&frame.data) else {
+                    tracing::error!(id = frame.id, "agent relay: malformed client bulk record");
+                    break;
+                };
+                Some(metadata)
+            }
+            #[cfg(not(unix))]
+            {
+                let Ok(metadata) = bulk_wire_metadata(&frame.data) else {
+                    tracing::error!(id = frame.id, "agent relay: malformed client bulk record");
+                    break;
+                };
+                Some(metadata)
+            }
         } else {
             None
         };
@@ -2926,6 +3374,11 @@ async fn client_reader_task(
             let incarnation = incarnation.expect("dual-port client has an incarnation");
             let (_, flow, _, payload_len) =
                 bulk_metadata.expect("bulk frame metadata was validated");
+            #[cfg(unix)]
+            let wire_len = shared_bulk.as_ref().map_or(frame.data.len(), |record| {
+                LEN_PREFIX_SIZE + FRAME_HEADER_SIZE + BULK_HEADER_SIZE + record.payload.len()
+            });
+            #[cfg(not(unix))]
             let wire_len = frame.data.len();
             let Ok(charged) = u32::try_from(wire_len.saturating_add(CLIENT_INCARNATION_SIZE))
             else {
@@ -2936,11 +3389,29 @@ async fn client_reader_task(
                 Ok(permit) => permit,
                 Err(_) => break,
             };
+            #[cfg(unix)]
+            let data = if let Some(record) = shared_bulk.take() {
+                let header = match codec::encode_bulk_header(&record) {
+                    Ok(header) => Bytes::copy_from_slice(&header),
+                    Err(error) => {
+                        tracing::error!(%error, "agent relay: encode shared bulk header failed");
+                        break;
+                    }
+                };
+                BulkWriteData::Shared {
+                    header,
+                    payload: record.payload,
+                }
+            } else {
+                BulkWriteData::Inline(frame.data)
+            };
+            #[cfg(not(unix))]
+            let data = BulkWriteData::Inline(frame.data);
             if bulk_tx
                 .send(BulkWriterCommand::Write(BulkWrite {
                     id: frame.id,
                     incarnation,
-                    data: frame.data,
+                    data,
                     flow,
                     payload_len,
                     _permit: permit,
@@ -3412,6 +3883,10 @@ mod tests {
 
     use super::*;
 
+    #[cfg(unix)]
+    use microsandbox_agent_client::local_shm::{
+        LocalShmClient, LocalShmUpgrade, local_upgrade_request_frame, receive_local_shm_upgrade,
+    };
     use microsandbox_protocol::AGENT_RELAY_ID_RANGE_STEP;
     use microsandbox_protocol::bulk::{
         BULK_FORMAT_RAW_V1, BulkKind, BulkRecord, DEFAULT_BULK_RECORD_PAYLOAD, DEFAULT_BULK_WINDOW,
@@ -3485,6 +3960,232 @@ mod tests {
 
     fn encoded_host_raw(id: u32, offset: u64, payload: &'static [u8]) -> Vec<u8> {
         encoded_raw_flow(id, BulkFlow::HostToGuest, offset, payload)
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn guest_bulk_uses_local_descriptor_when_an_arena_is_selected() {
+        use std::os::fd::{BorrowedFd, OwnedFd};
+
+        let server = LocalShmServer::create().unwrap();
+        let raw_fds = server.client_fds();
+        // SAFETY: The server owns both live descriptors for the duration of these duplications.
+        let client_fds: [OwnedFd; 2] = unsafe {
+            [
+                BorrowedFd::borrow_raw(raw_fds[0])
+                    .try_clone_to_owned()
+                    .unwrap(),
+                BorrowedFd::borrow_raw(raw_fds[1])
+                    .try_clone_to_owned()
+                    .unwrap(),
+            ]
+        };
+        let client = LocalShmClient::from_fds(client_fds).unwrap();
+        let (write_tx, mut write_rx) = mpsc::unbounded_channel();
+        let (disconnect_tx, _disconnect_rx) = watch::channel(false);
+        let clients = Arc::new(Mutex::new(HashMap::from([(
+            0,
+            ClientState {
+                incarnation: Some(TEST_INCARNATION),
+                active_sessions: HashSet::new(),
+                active_bulk: Arc::new(std::sync::Mutex::new(HashMap::new())),
+                write_tx,
+                write_budget: Arc::new(Semaphore::new(CLIENT_OUTPUT_PER_CLIENT_BYTE_CAPACITY)),
+                disconnect_tx,
+                local_outbound: Some(server.outbound.clone()),
+            },
+        )])));
+        let payload_bytes = b"guest bytes stay off the local socket";
+        let payload = Bytes::from_static(payload_bytes);
+        let wire = encoded_raw_flow(1, BulkFlow::GuestToHost, 9, payload_bytes);
+        let lane_budget = Arc::new(Semaphore::new(CLIENT_OUTPUT_BYTE_CAPACITY));
+        let lane_permit = Arc::clone(&lane_budget)
+            .try_acquire_many_owned(wire.len() as u32)
+            .unwrap();
+
+        route_guest_lane_frame(
+            LaneFrame {
+                frame: RawFrame {
+                    data: Bytes::from(wire),
+                    id: 1,
+                    flags: FLAG_BULK,
+                },
+                incarnation: Some(TEST_INCARNATION),
+                _permit: lane_permit,
+            },
+            true,
+            &clients,
+            None,
+            &std::sync::Mutex::new(HashMap::new()),
+        )
+        .await
+        .unwrap();
+
+        let ClientWriteData::LocalBulk(mut prepared) = write_rx.recv().await.unwrap().data else {
+            panic!("guest bulk did not enter the local descriptor path");
+        };
+        let descriptor = prepared.descriptor();
+        prepared.commit();
+        let (release_tx, _release_rx) = mpsc::unbounded_channel();
+        let received = client.inbound.receive(descriptor, release_tx).unwrap();
+        assert_eq!(received.payload, payload);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn client_writer_preserves_local_bulk_and_terminal_order() {
+        let server = LocalShmServer::create().unwrap();
+        let record = BulkRecord {
+            id: 1,
+            kind: BulkKind::Tcp,
+            flow: BulkFlow::GuestToHost,
+            offset: 0,
+            payload: Bytes::from_static(b"last tcp bytes"),
+        };
+        let prepared = server.outbound.try_prepare(&record).unwrap();
+        let descriptor_wire = encode_local_bulk_ref(prepared.descriptor()).unwrap();
+        let terminal_wire = Bytes::from_static(b"terminal-after-data");
+
+        let (mut client_socket, server_socket) = tokio::net::UnixStream::pair().unwrap();
+        let ancillary_fd = server_socket.as_fd().try_clone_to_owned().unwrap();
+        let (_server_reader, server_writer) = tokio::io::split(server_socket);
+        let (write_tx, write_rx) = mpsc::unbounded_channel();
+        let (_local_write_tx, local_write_rx) = mpsc::unbounded_channel();
+        let (disconnect_tx, _disconnect_rx) = watch::channel(false);
+        let writer = tokio::spawn(client_writer_task(
+            0,
+            server_writer,
+            write_rx,
+            disconnect_tx,
+            local_write_rx,
+            ancillary_fd,
+        ));
+        let lane_budget = Arc::new(Semaphore::new(2));
+        let client_budget = Arc::new(Semaphore::new(2));
+
+        write_tx
+            .send(ClientWrite {
+                data: ClientWriteData::LocalBulk(prepared),
+                _lane_permit: Arc::clone(&lane_budget).acquire_owned().await.unwrap(),
+                _client_permit: Arc::clone(&client_budget).acquire_owned().await.unwrap(),
+            })
+            .unwrap();
+        write_tx
+            .send(ClientWrite {
+                data: ClientWriteData::Inline(terminal_wire.clone()),
+                _lane_permit: Arc::clone(&lane_budget).acquire_owned().await.unwrap(),
+                _client_permit: Arc::clone(&client_budget).acquire_owned().await.unwrap(),
+            })
+            .unwrap();
+
+        let mut received = vec![0; descriptor_wire.len() + terminal_wire.len()];
+        tokio::time::timeout(
+            Duration::from_secs(1),
+            client_socket.read_exact(&mut received),
+        )
+        .await
+        .unwrap()
+        .unwrap();
+        assert_eq!(&received[..descriptor_wire.len()], descriptor_wire);
+        assert_eq!(&received[descriptor_wire.len()..], terminal_wire);
+        writer.abort();
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn client_shared_descriptor_reaches_bulk_scheduler_without_socket_payload() {
+        let (mut client_socket, server_socket) = tokio::net::UnixStream::pair().unwrap();
+        let ancillary_fd = server_socket.as_fd().try_clone_to_owned().unwrap();
+        let (server_reader, server_writer) = tokio::io::split(server_socket);
+        let (write_tx, write_rx) = mpsc::unbounded_channel();
+        let (local_write_tx, local_write_rx) = mpsc::unbounded_channel();
+        let (disconnect_tx, disconnect_rx) = watch::channel(false);
+        let active_bulk = Arc::new(std::sync::Mutex::new(HashMap::from([(
+            1,
+            BulkKind::Filesystem,
+        )])));
+        let clients = Arc::new(Mutex::new(HashMap::from([(
+            0,
+            ClientState {
+                incarnation: Some(TEST_INCARNATION),
+                active_sessions: HashSet::new(),
+                active_bulk: Arc::clone(&active_bulk),
+                write_tx,
+                write_budget: Arc::new(Semaphore::new(CLIENT_OUTPUT_PER_CLIENT_BYTE_CAPACITY)),
+                disconnect_tx: disconnect_tx.clone(),
+                local_outbound: None,
+            },
+        )])));
+        let writer = tokio::spawn(client_writer_task(
+            0,
+            server_writer,
+            write_rx,
+            disconnect_tx,
+            local_write_rx,
+            ancillary_fd,
+        ));
+        let (agent_tx, _agent_rx) = mpsc::channel(1);
+        let used_slots = Arc::new(Mutex::new(HashSet::from([0])));
+        let (drain_tx, _drain_rx) = mpsc::channel(1);
+        let (bulk_tx, mut bulk_rx) = mpsc::channel(1);
+        let (merge_tx, _merge_rx) = mpsc::channel(1);
+        let pending_disconnects = Arc::new(Mutex::new(HashMap::new()));
+        let reader = tokio::spawn(client_reader_task(
+            0,
+            server_reader,
+            agent_tx,
+            Arc::clone(&clients),
+            used_slots,
+            drain_tx,
+            Arc::new(std::sync::Mutex::new(HashMap::new())),
+            Arc::new(AtomicU64::new(1)),
+            Some(bulk_tx),
+            Some(Arc::new(Semaphore::new(BULK_WRITE_BYTE_CAPACITY))),
+            merge_tx,
+            pending_disconnects,
+            1,
+            AGENT_RELAY_ID_RANGE_STEP,
+            Some(TEST_INCARNATION),
+            active_bulk,
+            disconnect_rx,
+            local_write_tx,
+        ));
+
+        codec::write_raw_frame(&mut client_socket, &local_upgrade_request_frame())
+            .await
+            .unwrap();
+        let LocalShmUpgrade::Accepted(fds) =
+            receive_local_shm_upgrade(&client_socket).await.unwrap()
+        else {
+            panic!("runtime rejected its advertised local transport");
+        };
+        let local = LocalShmClient::from_fds(fds).unwrap();
+        let record = BulkRecord {
+            id: 1,
+            kind: BulkKind::Filesystem,
+            flow: BulkFlow::HostToGuest,
+            offset: 17,
+            payload: Bytes::from_static(b"arena payload"),
+        };
+        let mut prepared = local.outbound.try_prepare(&record).unwrap();
+        let wire = encode_local_bulk_ref(prepared.descriptor()).unwrap();
+        client_socket.write_all(&wire).await.unwrap();
+        prepared.commit();
+
+        let command = tokio::time::timeout(Duration::from_secs(1), bulk_rx.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        let BulkWriterCommand::Write(write) = command else {
+            panic!("shared record did not enter the bulk scheduler");
+        };
+        let BulkWriteData::Shared { payload, .. } = write.data else {
+            panic!("runtime rebuilt shared input as an in-band socket frame");
+        };
+        assert_eq!(payload, record.payload);
+
+        reader.abort();
+        writer.abort();
     }
 
     fn lane_frame(bytes: Vec<u8>, budget: &Arc<Semaphore>) -> LaneFrame {
@@ -3636,6 +4337,8 @@ mod tests {
         drop(peer);
         let (agent_tx, mut agent_rx) = mpsc::channel(4);
         let (write_tx, _write_rx) = mpsc::unbounded_channel();
+        #[cfg(unix)]
+        let (local_write_tx, _local_write_rx) = mpsc::unbounded_channel();
         let (disconnect_tx, disconnect_rx) = watch::channel(false);
         let active_bulk = Arc::new(std::sync::Mutex::new(HashMap::new()));
         let clients = Arc::new(Mutex::new(HashMap::from([(
@@ -3647,6 +4350,8 @@ mod tests {
                 write_tx,
                 write_budget: Arc::new(Semaphore::new(CLIENT_OUTPUT_PER_CLIENT_BYTE_CAPACITY)),
                 disconnect_tx,
+                #[cfg(unix)]
+                local_outbound: None,
             },
         )])));
         let used_slots = Arc::new(Mutex::new(HashSet::from([slot])));
@@ -3672,6 +4377,8 @@ mod tests {
             Some(incarnation),
             active_bulk,
             disconnect_rx,
+            #[cfg(unix)]
+            local_write_tx,
         ));
 
         // Combined mode has no merger actor. Its ordered disconnect reaches agentd directly and
@@ -4045,7 +4752,7 @@ mod tests {
             BulkWriterCommand::Write(BulkWrite {
                 id: 1,
                 incarnation: TEST_INCARNATION,
-                data,
+                data: BulkWriteData::Inline(data),
                 flow: BulkFlow::HostToGuest,
                 payload_len: b"queued".len(),
                 _permit: permit,
@@ -4085,7 +4792,7 @@ mod tests {
             BulkWriterCommand::Write(BulkWrite {
                 id: 1,
                 incarnation: TEST_INCARNATION,
-                data: late_data,
+                data: BulkWriteData::Inline(late_data),
                 flow: BulkFlow::HostToGuest,
                 payload_len: b"late".len(),
                 _permit: late_permit,
@@ -4152,7 +4859,7 @@ mod tests {
             tx.send(BulkWriterCommand::Write(BulkWrite {
                 id: 1,
                 incarnation: TEST_INCARNATION,
-                data,
+                data: BulkWriteData::Inline(data),
                 flow: BulkFlow::HostToGuest,
                 payload_len: PAYLOAD.len(),
                 _permit: permit,
@@ -4168,7 +4875,7 @@ mod tests {
         tx.send(BulkWriterCommand::Write(BulkWrite {
             id: 2,
             incarnation: TEST_INCARNATION,
-            data,
+            data: BulkWriteData::Inline(data),
             flow: BulkFlow::HostToGuest,
             payload_len: PAYLOAD.len(),
             _permit: permit,
@@ -4224,7 +4931,7 @@ mod tests {
         tx.send(BulkWriterCommand::Write(BulkWrite {
             id: record.id,
             incarnation: TEST_INCARNATION,
-            data,
+            data: BulkWriteData::Inline(data),
             flow: record.flow,
             payload_len: record.payload.len(),
             _permit: permit,
@@ -4279,12 +4986,12 @@ mod tests {
             .unwrap();
         let mut batch = VecDeque::from([
             ClientWrite {
-                data: Bytes::from_static(b"abc"),
+                data: ClientWriteData::Inline(Bytes::from_static(b"abc")),
                 _lane_permit: first_lane,
                 _client_permit: first_client,
             },
             ClientWrite {
-                data: Bytes::from_static(b"defgh"),
+                data: ClientWriteData::Inline(Bytes::from_static(b"defgh")),
                 _lane_permit: second_lane,
                 _client_permit: second_client,
             },
@@ -4319,7 +5026,7 @@ mod tests {
                 .try_acquire_many_owned(FRAME_BYTES as u32)
                 .unwrap();
             tx.send(ClientWrite {
-                data: Bytes::from(vec![0u8; FRAME_BYTES]),
+                data: ClientWriteData::Inline(Bytes::from(vec![0u8; FRAME_BYTES])),
                 _lane_permit: lane_permit,
                 _client_permit: client_permit,
             })
@@ -4353,6 +5060,8 @@ mod tests {
                 write_tx,
                 write_budget: Arc::new(Semaphore::new(CLIENT_OUTPUT_PER_CLIENT_BYTE_CAPACITY)),
                 disconnect_tx,
+                #[cfg(unix)]
+                local_outbound: None,
             },
         )])));
         let frame = encoded_message_id(MessageType::Pong, 1, &microsandbox_protocol::core::Pong {});
@@ -4372,7 +5081,10 @@ mod tests {
             .expect("combined reader stalled")
             .expect("combined client writer stopped");
 
-        assert_eq!(output.data.as_ref(), frame);
+        let ClientWriteData::Inline(output) = output.data else {
+            panic!("combined control output unexpectedly used the local bulk path");
+        };
+        assert_eq!(output.as_ref(), frame);
         reader.abort();
     }
 
@@ -4485,7 +5197,15 @@ mod tests {
 
         relay.wait_ready().unwrap();
 
-        assert_eq!(relay.ready_frame.as_deref(), Some(ready.as_slice()));
+        let cached = relay.ready_frame.as_ref().expect("SDK-facing ready frame");
+        let cached_ready: Ready = decode_frame(cached).unwrap().payload().unwrap();
+        #[cfg(unix)]
+        assert_eq!(
+            cached_ready.local_transport,
+            Some(LocalTransportReady::shared_arena_v1())
+        );
+        #[cfg(not(unix))]
+        assert!(cached_ready.local_transport.is_none());
         assert!(
             shared.rx_ring.pop().is_none(),
             "no init context means no ack should be sent"

--- a/crates/runtime/lib/runner/relay.rs
+++ b/crates/runtime/lib/runner/relay.rs
@@ -27,23 +27,27 @@ use microsandbox_agent_client::local_shm::{
 #[cfg(unix)]
 use microsandbox_filesystem::{BindIdentityMap, BindIdentityMapHandle};
 use microsandbox_protocol::AGENT_RELAY_MAX_CLIENTS;
+#[cfg(unix)]
+use microsandbox_protocol::bulk::BulkRecord;
 use microsandbox_protocol::bulk::{
     BULK_FLOW_MASK_GUEST_TO_HOST, BULK_HEADER_SIZE, BulkAccepted, BulkCancel, BulkCancelReason,
-    BulkFinish, BulkFlow, BulkKind, BulkRecord, MAX_BULK_RECORD_PAYLOAD,
+    BulkFinish, BulkFlow, BulkKind, MAX_BULK_RECORD_PAYLOAD,
 };
 use microsandbox_protocol::codec::{self, MAX_FRAME_SIZE, MAX_WIRE_FRAME};
 use microsandbox_protocol::core::{InitAck, InitResolved, Ready, RelayClientDisconnected};
 use microsandbox_protocol::exec::{ExecRequest, ExecSignal, ExecStderr, ExecStdout};
-use microsandbox_protocol::fs::FsRequest;
+use microsandbox_protocol::fs::{FsRequest, FsResponse};
 use microsandbox_protocol::message::{
     FLAG_BULK, FLAG_SESSION_START, FLAG_SHUTDOWN, FLAG_TERMINAL, FRAME_HEADER_SIZE, Message,
     MessageType,
 };
-use microsandbox_protocol::tcp::TcpConnect;
+use microsandbox_protocol::tcp::{TcpConnect, TcpFailed};
+#[cfg(unix)]
+use microsandbox_protocol::transport::LocalTransportReady;
 use microsandbox_protocol::transport::{
-    BULK_BINDING_SIZE, CLIENT_INCARNATION_SIZE, ClientIncarnation, LocalTransportReady,
-    RELAY_LEASE_FORMAT_V1, decode_bulk_hello, encode_bulk_ack, encode_relay_client_connected,
-    relay_client_id_range, relay_client_slot, try_decode_incarnated_bulk_from_bytes,
+    BULK_BINDING_SIZE, CLIENT_INCARNATION_SIZE, ClientIncarnation, RELAY_LEASE_FORMAT_V1,
+    decode_bulk_hello, encode_bulk_ack, encode_relay_client_connected, relay_client_id_range,
+    relay_client_slot, try_decode_incarnated_bulk_from_bytes,
     try_decode_relay_client_disconnected_ack_from_bytes,
 };
 use microsandbox_protocol::transport::{RelayClientConnected, RelayClientDisconnectedAck};
@@ -220,8 +224,10 @@ struct RingReaderContext {
 /// A client-bound frame whose aggregate capacity lives until the socket accepts it.
 struct ClientWrite {
     data: ClientWriteData,
-    /// Aggregate physical-lane admission, retained until the SDK socket consumes the frame.
-    _lane_permit: tokio::sync::OwnedSemaphorePermit,
+    /// Aggregate physical-lane admission, retained until the SDK socket consumes a guest frame.
+    /// Runtime-generated terminal rejections have no guest-lane allocation and therefore carry
+    /// no permit here.
+    _lane_permit: Option<tokio::sync::OwnedSemaphorePermit>,
     /// Per-client admission, retained for the same lifetime as the aggregate permit.
     _client_permit: tokio::sync::OwnedSemaphorePermit,
 }
@@ -235,6 +241,31 @@ enum ClientWriteData {
     Inline(Bytes),
     #[cfg(unix)]
     LocalBulk(PreparedLocalBulk),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum BulkOpenAdmission {
+    Accepted,
+    Duplicate,
+    LimitReached,
+}
+
+impl ClientWriteData {
+    fn inline(&self) -> Option<&Bytes> {
+        match self {
+            Self::Inline(data) => Some(data),
+            #[cfg(unix)]
+            Self::LocalBulk(_) => None,
+        }
+    }
+
+    fn inline_mut(&mut self) -> Option<&mut Bytes> {
+        match self {
+            Self::Inline(data) => Some(data),
+            #[cfg(unix)]
+            Self::LocalBulk(_) => None,
+        }
+    }
 }
 
 /// Nonblocking handles cloned from one live client owner before guest-output routing.
@@ -939,7 +970,7 @@ impl AgentRelay {
                                 .into(),
                         ));
                     }
-                    let mut ready: Ready = msg.payload().map_err(|error| {
+                    let ready: Ready = msg.payload().map_err(|error| {
                         RuntimeError::Custom(format!("decode core.ready payload: {error}"))
                     })?;
                     self.select_ready_transport(&ready)?;
@@ -948,12 +979,14 @@ impl AgentRelay {
                         "agent relay: received core.ready from agentd"
                     );
                     #[cfg(unix)]
-                    {
+                    let ready = {
+                        let mut ready = ready;
                         // This capability describes only the already authenticated local SDK
                         // hop. Agentd remains unaware of shared mappings and the guest generation
                         // stays unchanged.
                         ready.local_transport = Some(LocalTransportReady::shared_arena_v1());
-                    }
+                        ready
+                    };
                     let mut client_ready =
                         Message::with_payload(MessageType::Ready, msg.id, &ready).map_err(
                             |error| {
@@ -1247,6 +1280,20 @@ impl AgentRelay {
                                 "agent relay: client connected slot={slot} id_start={id_start} id_end_exclusive={id_end_exclusive}"
                             );
 
+                            // Duplicate the descriptor before the guest learns this incarnation.
+                            // Once RelayClientConnected is admitted, every local failure must use
+                            // the acknowledged disconnect path before the slot can be recycled.
+                            #[cfg(unix)]
+                            let ancillary_fd = match stream.as_fd().try_clone_to_owned() {
+                                Ok(fd) => fd,
+                                Err(error) => {
+                                    tracing::error!(%error, "agent relay: duplicate client socket for local transport failed");
+                                    used_slots.lock().await.remove(&slot);
+                                    drop(stream);
+                                    continue;
+                                }
+                            };
+
                             // Establish the dual-port range owner on the ordered control lane before
                             // the SDK sees its handshake and can submit work on either physical lane.
                             if let Some(incarnation) = incarnation
@@ -1266,16 +1313,6 @@ impl AgentRelay {
 
                             // Perform handshake: send
                             // [id_start: u32 BE][id_end_exclusive: u32 BE][ready_frame_bytes...].
-                            #[cfg(unix)]
-                            let ancillary_fd = match stream.as_fd().try_clone_to_owned() {
-                                Ok(fd) => fd,
-                                Err(error) => {
-                                    tracing::error!(%error, "agent relay: duplicate client socket for local transport failed");
-                                    used_slots.lock().await.remove(&slot);
-                                    drop(stream);
-                                    continue;
-                                }
-                            };
                             let (reader_half, mut writer_half) = tokio::io::split(stream);
                             let (disconnect_tx, disconnect_rx) = watch::channel(false);
 
@@ -1344,6 +1381,9 @@ impl AgentRelay {
                             ));
 
                             let active_bulk = Arc::new(std::sync::Mutex::new(HashMap::new()));
+                            let write_budget = Arc::new(Semaphore::new(
+                                CLIENT_OUTPUT_PER_CLIENT_BYTE_CAPACITY,
+                            ));
 
                             // Register the client.
                             {
@@ -1352,10 +1392,8 @@ impl AgentRelay {
                                     incarnation,
                                     active_sessions: HashSet::new(),
                                     active_bulk: Arc::clone(&active_bulk),
-                                    write_tx,
-                                    write_budget: Arc::new(Semaphore::new(
-                                        CLIENT_OUTPUT_PER_CLIENT_BYTE_CAPACITY,
-                                    )),
+                                    write_tx: write_tx.clone(),
+                                    write_budget: Arc::clone(&write_budget),
                                     disconnect_tx,
                                     #[cfg(unix)]
                                     local_outbound: None,
@@ -1391,6 +1429,8 @@ impl AgentRelay {
                                 id_end_exclusive,
                                 incarnation,
                                 active_bulk,
+                                write_tx,
+                                write_budget,
                                 disconnect_rx,
                                 #[cfg(unix)]
                                 local_write_tx,
@@ -1710,7 +1750,7 @@ async fn client_writer_task<W>(
             let Ok(write) = write_rx.try_recv() else {
                 break;
             };
-            let ClientWriteData::Inline(data) = &write.data else {
+            let Some(data) = write.data.inline() else {
                 // A local descriptor is an ordering barrier: flush every preceding in-band frame
                 // before publishing its arena slot to the SDK.
                 deferred = Some(write);
@@ -1808,7 +1848,7 @@ async fn write_client_batch<W: AsyncWrite + Unpin>(
             .iter()
             .take(CLIENT_WRITE_BATCH_FRAMES)
             .map(|write| {
-                let ClientWriteData::Inline(data) = &write.data else {
+                let Some(data) = write.data.inline() else {
                     unreachable!("local bulk descriptors are ordering barriers, never batch data")
                 };
                 IoSlice::new(data)
@@ -1830,7 +1870,7 @@ async fn write_client_batch<W: AsyncWrite + Unpin>(
         let mut remaining = written;
         while remaining != 0 {
             let front = batch.front_mut().expect("non-empty batch after write");
-            let ClientWriteData::Inline(data) = &mut front.data else {
+            let Some(data) = front.data.inline_mut() else {
                 unreachable!("local bulk descriptors are ordering barriers, never batch data")
             };
             if remaining < data.len() {
@@ -2660,7 +2700,7 @@ async fn route_guest_lane_frame(
                     Ok(prepared) => {
                         if let Err(error) = route.write_tx.send(ClientWrite {
                             data: ClientWriteData::LocalBulk(prepared),
-                            _lane_permit: lane_permit,
+                            _lane_permit: Some(lane_permit),
                             _client_permit: client_permit,
                         }) {
                             tracing::warn!(
@@ -2682,7 +2722,7 @@ async fn route_guest_lane_frame(
 
             if let Err(error) = route.write_tx.send(ClientWrite {
                 data: ClientWriteData::Inline(frame.data),
-                _lane_permit: lane_permit,
+                _lane_permit: Some(lane_permit),
                 _client_permit: client_permit,
             }) {
                 tracing::warn!(
@@ -2961,6 +3001,71 @@ async fn read_raw_frame<R: AsyncReadExt + Unpin>(reader: &mut R) -> RuntimeResul
     })
 }
 
+fn admit_bulk_open(
+    active_bulk: &std::sync::Mutex<HashMap<u32, BulkKind>>,
+    id: u32,
+    kind: BulkKind,
+) -> BulkOpenAdmission {
+    let mut active = active_bulk.lock().unwrap();
+    if active.contains_key(&id) {
+        return BulkOpenAdmission::Duplicate;
+    }
+    if active.len() >= BULK_WRITE_MAX_FLOWS_PER_CLIENT {
+        return BulkOpenAdmission::LimitReached;
+    }
+    active.insert(id, kind);
+    BulkOpenAdmission::Accepted
+}
+
+fn queue_bulk_open_rejection(
+    write_tx: &mpsc::UnboundedSender<ClientWrite>,
+    write_budget: &Arc<Semaphore>,
+    version: u8,
+    id: u32,
+    kind: BulkKind,
+) -> RuntimeResult<()> {
+    let error = format!(
+        "client already has the maximum of {BULK_WRITE_MAX_FLOWS_PER_CLIENT} active bulk operations"
+    );
+    let mut message = match kind {
+        BulkKind::Filesystem => Message::with_payload(
+            MessageType::FsResponse,
+            id,
+            &FsResponse {
+                ok: false,
+                error: Some(error),
+                data: None,
+            },
+        ),
+        BulkKind::Tcp => Message::with_payload(MessageType::TcpFailed, id, &TcpFailed { error }),
+    }
+    .map_err(|error| RuntimeError::Custom(format!("encode bulk admission rejection: {error}")))?;
+    // Match the initiating request so an older compatible SDK can decode the terminal response.
+    message.v = version;
+    let mut wire = Vec::new();
+    codec::encode_to_buf(&message, &mut wire).map_err(|error| {
+        RuntimeError::Custom(format!("encode bulk admission rejection frame: {error}"))
+    })?;
+    let charged = wire
+        .len()
+        .div_ceil(OUTPUT_BUDGET_GRANULE)
+        .saturating_mul(OUTPUT_BUDGET_GRANULE);
+    let charged = u32::try_from(charged)
+        .map_err(|_| RuntimeError::Custom("bulk admission rejection budget overflow".into()))?;
+    let client_permit = Arc::clone(write_budget)
+        .try_acquire_many_owned(charged)
+        .map_err(|_| {
+            RuntimeError::Custom("client output full while rejecting a bulk operation".into())
+        })?;
+    write_tx
+        .send(ClientWrite {
+            data: ClientWriteData::Inline(Bytes::from(wire)),
+            _lane_permit: None,
+            _client_permit: client_permit,
+        })
+        .map_err(|_| RuntimeError::Custom("client writer stopped during bulk rejection".into()))
+}
+
 /// Background task that reads frames from a client and forwards them to the
 /// ring writer channel. Handles client disconnect with session cleanup.
 ///
@@ -2988,6 +3093,8 @@ async fn client_reader_task(
     id_end_exclusive: u32,
     incarnation: Option<ClientIncarnation>,
     active_bulk: Arc<std::sync::Mutex<HashMap<u32, BulkKind>>>,
+    write_tx: mpsc::UnboundedSender<ClientWrite>,
+    write_budget: Arc<Semaphore>,
     mut disconnect_rx: watch::Receiver<bool>,
     #[cfg(unix)] local_write_tx: mpsc::UnboundedSender<LocalClientWrite>,
 ) {
@@ -3024,7 +3131,7 @@ async fn client_reader_task(
             }
         };
         #[cfg(not(unix))]
-        let mut frame = tokio::select! {
+        let frame = tokio::select! {
             result = read_raw_frame(&mut reader) => match result {
                 Ok(frame) => frame,
                 Err(error) => {
@@ -3188,6 +3295,38 @@ async fn client_reader_task(
                 _ => None,
             });
 
+        if let Some(kind) = opened_bulk_kind {
+            match admit_bulk_open(&active_bulk, frame.id, kind) {
+                BulkOpenAdmission::Accepted => {}
+                BulkOpenAdmission::Duplicate => {
+                    tracing::error!(
+                        id = frame.id,
+                        "agent relay: client reused an active bulk correlation"
+                    );
+                    break;
+                }
+                BulkOpenAdmission::LimitReached => {
+                    let version = decoded_message
+                        .as_ref()
+                        .expect("bulk opening was decoded")
+                        .v;
+                    if let Err(error) =
+                        queue_bulk_open_rejection(&write_tx, &write_budget, version, frame.id, kind)
+                    {
+                        tracing::error!(
+                            %error,
+                            id = frame.id,
+                            "agent relay: failed to reject excess bulk operation"
+                        );
+                        break;
+                    }
+                    // The rejected operation never enters either guest lane, so it needs no
+                    // BulkCancel or merger cut. Its typed terminal is the complete lifecycle.
+                    continue;
+                }
+            }
+        }
+
         // The merger must know an operation exists before agentd can produce output for it. The
         // acknowledgement creates an actor-ordering cut across the command and physical lanes.
         if bulk_tx.is_some()
@@ -3208,20 +3347,12 @@ async fn client_reader_task(
                 .is_err()
                 || !matches!(completed.await, Ok(Ok(())))
             {
+                if opened_bulk_kind.is_some() {
+                    active_bulk.lock().unwrap().remove(&frame.id);
+                }
                 tracing::error!(
                     id = frame.id,
                     "agent relay: failed to register client operation"
-                );
-                break;
-            }
-        }
-
-        if let Some(kind) = opened_bulk_kind {
-            let duplicate = active_bulk.lock().unwrap().insert(frame.id, kind).is_some();
-            if duplicate {
-                tracing::error!(
-                    id = frame.id,
-                    "agent relay: client reused an active bulk correlation"
                 );
                 break;
             }
@@ -3432,6 +3563,10 @@ async fn client_reader_task(
     let active_sessions = {
         let mut map = clients.lock().await;
         if let Some(client) = map.remove(&slot) {
+            #[cfg(unix)]
+            if let Some(producer) = client.local_outbound.as_ref() {
+                producer.close();
+            }
             client.active_sessions
         } else {
             HashSet::new()
@@ -3938,7 +4073,7 @@ mod tests {
         frame
     }
 
-    fn encoded_raw_flow(id: u32, flow: BulkFlow, offset: u64, payload: &'static [u8]) -> Vec<u8> {
+    fn encoded_raw_flow(id: u32, flow: BulkFlow, offset: u64, payload: &[u8]) -> Vec<u8> {
         let mut frame = Vec::new();
         codec::encode_bulk_to_buf(
             &BulkRecord {
@@ -3946,7 +4081,7 @@ mod tests {
                 kind: BulkKind::Filesystem,
                 flow,
                 offset,
-                payload: Bytes::from_static(payload),
+                payload: Bytes::copy_from_slice(payload),
             },
             &mut frame,
         )
@@ -4066,14 +4201,14 @@ mod tests {
         write_tx
             .send(ClientWrite {
                 data: ClientWriteData::LocalBulk(prepared),
-                _lane_permit: Arc::clone(&lane_budget).acquire_owned().await.unwrap(),
+                _lane_permit: Some(Arc::clone(&lane_budget).acquire_owned().await.unwrap()),
                 _client_permit: Arc::clone(&client_budget).acquire_owned().await.unwrap(),
             })
             .unwrap();
         write_tx
             .send(ClientWrite {
                 data: ClientWriteData::Inline(terminal_wire.clone()),
-                _lane_permit: Arc::clone(&lane_budget).acquire_owned().await.unwrap(),
+                _lane_permit: Some(Arc::clone(&lane_budget).acquire_owned().await.unwrap()),
                 _client_permit: Arc::clone(&client_budget).acquire_owned().await.unwrap(),
             })
             .unwrap();
@@ -4100,6 +4235,7 @@ mod tests {
         let (write_tx, write_rx) = mpsc::unbounded_channel();
         let (local_write_tx, local_write_rx) = mpsc::unbounded_channel();
         let (disconnect_tx, disconnect_rx) = watch::channel(false);
+        let write_budget = Arc::new(Semaphore::new(CLIENT_OUTPUT_PER_CLIENT_BYTE_CAPACITY));
         let active_bulk = Arc::new(std::sync::Mutex::new(HashMap::from([(
             1,
             BulkKind::Filesystem,
@@ -4110,8 +4246,8 @@ mod tests {
                 incarnation: Some(TEST_INCARNATION),
                 active_sessions: HashSet::new(),
                 active_bulk: Arc::clone(&active_bulk),
-                write_tx,
-                write_budget: Arc::new(Semaphore::new(CLIENT_OUTPUT_PER_CLIENT_BYTE_CAPACITY)),
+                write_tx: write_tx.clone(),
+                write_budget: Arc::clone(&write_budget),
                 disconnect_tx: disconnect_tx.clone(),
                 local_outbound: None,
             },
@@ -4147,6 +4283,8 @@ mod tests {
             AGENT_RELAY_ID_RANGE_STEP,
             Some(TEST_INCARNATION),
             active_bulk,
+            write_tx,
+            write_budget,
             disconnect_rx,
             local_write_tx,
         ));
@@ -4340,6 +4478,7 @@ mod tests {
         #[cfg(unix)]
         let (local_write_tx, _local_write_rx) = mpsc::unbounded_channel();
         let (disconnect_tx, disconnect_rx) = watch::channel(false);
+        let write_budget = Arc::new(Semaphore::new(CLIENT_OUTPUT_PER_CLIENT_BYTE_CAPACITY));
         let active_bulk = Arc::new(std::sync::Mutex::new(HashMap::new()));
         let clients = Arc::new(Mutex::new(HashMap::from([(
             slot,
@@ -4347,8 +4486,8 @@ mod tests {
                 incarnation: Some(incarnation),
                 active_sessions: HashSet::new(),
                 active_bulk: Arc::clone(&active_bulk),
-                write_tx,
-                write_budget: Arc::new(Semaphore::new(CLIENT_OUTPUT_PER_CLIENT_BYTE_CAPACITY)),
+                write_tx: write_tx.clone(),
+                write_budget: Arc::clone(&write_budget),
                 disconnect_tx,
                 #[cfg(unix)]
                 local_outbound: None,
@@ -4376,6 +4515,8 @@ mod tests {
             id_end_exclusive,
             Some(incarnation),
             active_bulk,
+            write_tx,
+            write_budget,
             disconnect_rx,
             #[cfg(unix)]
             local_write_tx,
@@ -4987,12 +5128,12 @@ mod tests {
         let mut batch = VecDeque::from([
             ClientWrite {
                 data: ClientWriteData::Inline(Bytes::from_static(b"abc")),
-                _lane_permit: first_lane,
+                _lane_permit: Some(first_lane),
                 _client_permit: first_client,
             },
             ClientWrite {
                 data: ClientWriteData::Inline(Bytes::from_static(b"defgh")),
-                _lane_permit: second_lane,
+                _lane_permit: Some(second_lane),
                 _client_permit: second_client,
             },
         ]);
@@ -5027,7 +5168,7 @@ mod tests {
                 .unwrap();
             tx.send(ClientWrite {
                 data: ClientWriteData::Inline(Bytes::from(vec![0u8; FRAME_BYTES])),
-                _lane_permit: lane_permit,
+                _lane_permit: Some(lane_permit),
                 _client_permit: client_permit,
             })
             .unwrap();
@@ -5288,6 +5429,51 @@ mod tests {
 
         assert!(!relay.dual_port_active);
         assert!(bulk_shared.is_closed());
+    }
+
+    #[test]
+    fn bulk_open_admission_rejects_only_the_excess_operation() {
+        let active = std::sync::Mutex::new(HashMap::new());
+        for id in 1..=BULK_WRITE_MAX_FLOWS_PER_CLIENT as u32 {
+            assert_eq!(
+                admit_bulk_open(&active, id, BulkKind::Filesystem),
+                BulkOpenAdmission::Accepted
+            );
+        }
+
+        assert_eq!(
+            admit_bulk_open(&active, 1, BulkKind::Filesystem),
+            BulkOpenAdmission::Duplicate
+        );
+        assert_eq!(
+            admit_bulk_open(&active, 1000, BulkKind::Tcp),
+            BulkOpenAdmission::LimitReached
+        );
+        assert_eq!(
+            active.lock().unwrap().len(),
+            BULK_WRITE_MAX_FLOWS_PER_CLIENT
+        );
+    }
+
+    #[test]
+    fn bulk_open_rejection_is_typed_terminal_at_the_request_version() {
+        let (write_tx, mut write_rx) = mpsc::unbounded_channel();
+        let budget = Arc::new(Semaphore::new(CLIENT_OUTPUT_PER_CLIENT_BYTE_CAPACITY));
+        let version = microsandbox_protocol::message::PROTOCOL_VERSION - 1;
+
+        for (id, kind, expected_type) in [
+            (7, BulkKind::Filesystem, MessageType::FsResponse),
+            (8, BulkKind::Tcp, MessageType::TcpFailed),
+        ] {
+            queue_bulk_open_rejection(&write_tx, &budget, version, id, kind).unwrap();
+            let output = write_rx.try_recv().unwrap();
+            assert!(output._lane_permit.is_none());
+            let message = decode_frame(output.data.inline().unwrap()).unwrap();
+            assert_eq!(message.v, version);
+            assert_eq!(message.id, id);
+            assert_eq!(message.t, expected_type);
+            assert_eq!(message.flags, FLAG_TERMINAL);
+        }
     }
 
     #[derive(Default)]

--- a/packages/agent-client/rust/Cargo.toml
+++ b/packages/agent-client/rust/Cargo.toml
@@ -17,14 +17,19 @@ default = []
 # adapted to bytes). No extra dependencies.
 stream = []
 # Unix domain socket transport. Builds on the generic byte-stream path.
-uds = ["stream"]
+uds = ["stream", "dep:bytes", "dep:libc", "dep:memmap2", "dep:nix", "dep:tempfile"]
 # Windows named-pipe transport. Builds on the generic byte-stream path.
 named-pipe = ["stream"]
 
 [dependencies]
 ciborium.workspace = true
+bytes = { workspace = true, optional = true }
+libc = { workspace = true, optional = true }
+memmap2 = { workspace = true, optional = true }
 microsandbox-protocol.workspace = true
+nix = { workspace = true, features = ["socket", "uio"], optional = true }
 serde.workspace = true
+tempfile = { workspace = true, optional = true }
 thiserror.workspace = true
 tokio = { workspace = true, features = ["io-util", "net", "sync"] }
 tracing.workspace = true

--- a/packages/agent-client/rust/lib/client.rs
+++ b/packages/agent-client/rust/lib/client.rs
@@ -55,6 +55,13 @@ use tokio::task::JoinHandle;
 use tokio::time::Instant;
 
 use super::error::{AgentClientError, AgentClientResult};
+#[cfg(all(feature = "uds", unix))]
+use super::local_shm::{
+    LOCAL_SHM_FORMAT_V1, LocalBulkRelease, LocalShmClient, LocalShmFrame, LocalShmUpgrade,
+    PreparedLocalBulk, SharedArenaConsumer, SharedArenaProducer, decode_local_body,
+    encode_local_bulk_ref, encode_local_bulk_release, local_upgrade_request_frame,
+    receive_local_shm_upgrade,
+};
 
 //--------------------------------------------------------------------------------------------------
 // Constants
@@ -136,6 +143,9 @@ pub struct AgentClient {
     ready_body: Vec<u8>,
     /// Decoded `core.ready` payload from the relay handshake.
     ready: Ready,
+    /// Optional SDK-to-runtime arena producer selected on this Unix connection.
+    #[cfg(all(feature = "uds", unix))]
+    local_outbound: Option<SharedArenaProducer>,
 }
 
 #[cfg(feature = "stream")]
@@ -158,11 +168,20 @@ struct WriterCommand {
 enum WriterFrame {
     Control(RawFrame),
     Bulk(BulkRecord),
+    #[cfg(all(feature = "uds", unix))]
+    LocalBulk(PreparedLocalBulk),
+}
+
+/// One decoded transport item before the caller chooses its raw or typed API view.
+enum InboundFrame {
+    Raw(RawFrame),
+    #[cfg(all(feature = "uds", unix))]
+    Bulk(BulkRecord),
 }
 
 /// Local dispatch state retained through the terminal result of a cancellation.
 struct CorrelationRoute {
-    tx: mpsc::Sender<RawFrame>,
+    tx: mpsc::Sender<InboundFrame>,
     state: CorrelationState,
 }
 
@@ -193,6 +212,44 @@ impl AgentProtocol {
         match self {
             Self::Current => PROTOCOL_VERSION,
             Self::LegacyV1 => LEGACY_PROTOCOL_VERSION,
+        }
+    }
+}
+
+impl InboundFrame {
+    fn id(&self) -> u32 {
+        match self {
+            Self::Raw(frame) => frame.id,
+            #[cfg(all(feature = "uds", unix))]
+            Self::Bulk(record) => record.id,
+        }
+    }
+
+    fn flags(&self) -> u8 {
+        match self {
+            Self::Raw(frame) => frame.flags,
+            #[cfg(all(feature = "uds", unix))]
+            Self::Bulk(_) => FLAG_BULK,
+        }
+    }
+
+    fn into_raw_frame(self) -> AgentClientResult<RawFrame> {
+        match self {
+            Self::Raw(frame) => Ok(frame),
+            #[cfg(all(feature = "uds", unix))]
+            Self::Bulk(record) => {
+                let mut body = Vec::with_capacity(12 + record.payload.len());
+                body.push(record.kind as u8);
+                body.push(record.flow as u8);
+                body.extend_from_slice(&[0, 0]);
+                body.extend_from_slice(&record.offset.to_be_bytes());
+                body.extend_from_slice(&record.payload);
+                Ok(RawFrame {
+                    id: record.id,
+                    flags: FLAG_BULK,
+                    body,
+                })
+            }
         }
     }
 }
@@ -228,8 +285,26 @@ impl AgentClient {
         deadline: Instant,
     ) -> AgentClientResult<Self> {
         let sock_path = sock_path.as_ref();
-        let stream = connect_local_stream(sock_path, deadline).await?;
-        Self::connect_stream_with_deadline(stream, deadline).await
+        #[cfg(all(feature = "uds", unix))]
+        {
+            let stream = connect_local_stream(sock_path, deadline).await?;
+            match Self::connect_uds_stream_with_deadline(stream, deadline, true).await {
+                Ok(client) => Ok(client),
+                Err(AgentClientError::LocalTransport(error)) if Instant::now() < deadline => {
+                    // No operation exists yet, so a fresh connection is the only safe fallback
+                    // after a malformed or interrupted ancillary-data exchange.
+                    tracing::warn!(%error, "agent client: local shared-arena upgrade failed; reconnecting in-band");
+                    let stream = connect_local_stream(sock_path, deadline).await?;
+                    Self::connect_uds_stream_with_deadline(stream, deadline, false).await
+                }
+                Err(error) => Err(error),
+            }
+        }
+        #[cfg(all(feature = "named-pipe", windows))]
+        {
+            let stream = connect_local_stream(sock_path, deadline).await?;
+            Self::connect_stream_with_deadline(stream, deadline).await
+        }
     }
 
     /// Connect over an arbitrary byte-stream transport using the default 10s
@@ -278,43 +353,64 @@ impl AgentClient {
     {
         let (mut reader, writer) = tokio::io::split(stream);
         let handshake = perform_handshake(&mut reader, deadline).await?;
-
-        tracing::info!(
-            id_min = handshake.id_min,
-            id_max = handshake.id_max,
-            protocol = ?handshake.protocol,
-            ready_bytes = handshake.ready_body.len(),
-            boot_time_ns = handshake.ready.boot_time_ns,
-            "agent client: connected to relay"
-        );
-        if handshake.protocol == AgentProtocol::LegacyV1 {
-            // TODO(upgrade-0.6): Remove in 0.6.x or later once live-sandbox
-            // compatibility for versions before 0.5 is no longer supported.
-            tracing::warn!(
-                "agent client: connected to a sandbox started before microsandbox 0.5; exec compatibility is temporary and filesystem/SFTP require stop/start"
-            );
+        #[cfg(all(feature = "uds", unix))]
+        {
+            finish_connection(reader, writer, handshake, None).await
         }
+        #[cfg(not(all(feature = "uds", unix)))]
+        {
+            finish_connection(reader, writer, handshake).await
+        }
+    }
 
-        let pending: Arc<Mutex<HashMap<u32, CorrelationRoute>>> =
-            Arc::new(Mutex::new(HashMap::new()));
+    #[cfg(all(feature = "uds", unix))]
+    async fn connect_uds_stream_with_deadline(
+        mut stream: UnixStream,
+        deadline: Instant,
+        allow_local: bool,
+    ) -> AgentClientResult<Self> {
+        let handshake = perform_handshake(&mut stream, deadline).await?;
+        let selected = allow_local
+            && handshake
+                .ready
+                .local_transport
+                .as_ref()
+                .and_then(|capability| capability.select_supported(LOCAL_SHM_FORMAT_V1))
+                == Some(LOCAL_SHM_FORMAT_V1);
+        let local = if selected {
+            tokio::time::timeout_at(
+                deadline,
+                codec::write_raw_frame(&mut stream, &local_upgrade_request_frame()),
+            )
+            .await
+            .map_err(|_| {
+                AgentClientError::LocalTransport("upgrade request write timed out".into())
+            })?
+            .map_err(|error| AgentClientError::LocalTransport(error.to_string()))?;
+            match tokio::time::timeout_at(deadline, receive_local_shm_upgrade(&stream))
+                .await
+                .map_err(|_| {
+                    AgentClientError::LocalTransport("descriptor acknowledgement timed out".into())
+                })?
+                .map_err(|error| AgentClientError::LocalTransport(error.to_string()))?
+            {
+                LocalShmUpgrade::Accepted(fds) => Some(
+                    LocalShmClient::from_fds(fds)
+                        .map_err(|error| AgentClientError::LocalTransport(error.to_string()))?,
+                ),
+                LocalShmUpgrade::Rejected => None,
+            }
+        } else {
+            None
+        };
 
-        let (writer_tx, writer_rx) = mpsc::channel(WRITER_QUEUE_CAPACITY);
-        let reader_handle = tokio::spawn(reader_loop(reader, Arc::clone(&pending)));
-        let writer_handle = tokio::spawn(stream_writer_loop(writer, writer_rx));
-
-        Ok(Self {
-            writer: writer_tx,
-            next_id: AtomicU32::new(first_request_id(handshake.id_min)),
-            id_min: handshake.id_min,
-            id_max: handshake.id_max,
-            protocol: handshake.protocol,
-            negotiated_version: handshake.negotiated_version,
-            pending,
-            reader_handle,
-            writer_handle,
-            ready_body: handshake.ready_body,
-            ready: handshake.ready,
-        })
+        // Two descriptors for the same SOCK_STREAM allow independent Tokio read and write tasks
+        // while SCM_RIGHTS remains confined to the completed pre-task upgrade above.
+        let std_reader = stream.into_std()?;
+        let std_writer = std_reader.try_clone()?;
+        let reader = UnixStream::from_std(std_reader)?;
+        let writer = UnixStream::from_std(std_writer)?;
+        finish_connection(reader, writer, handshake, local).await
     }
 
     /// Close the connection. Drops the writer and aborts the reader task;
@@ -345,7 +441,11 @@ impl AgentClient {
             return Err(e);
         }
 
-        let frame = rx.recv().await.ok_or(AgentClientError::ReaderClosed(id))?;
+        let frame = rx
+            .recv()
+            .await
+            .ok_or(AgentClientError::ReaderClosed(id))?
+            .into_raw_frame()?;
         self.pending.lock().await.remove(&id);
         Ok(frame)
     }
@@ -362,6 +462,17 @@ impl AgentClient {
         flags: u8,
         body: Vec<u8>,
     ) -> AgentClientResult<(u32, mpsc::Receiver<RawFrame>)> {
+        let (id, inbound_rx) = self.open_inbound_stream(flags, body).await?;
+        let (tx, rx) = mpsc::channel(STREAM_QUEUE_CAPACITY);
+        tokio::spawn(materialize_raw_stream_task(inbound_rx, tx));
+        Ok((id, rx))
+    }
+
+    async fn open_inbound_stream(
+        &self,
+        flags: u8,
+        body: Vec<u8>,
+    ) -> AgentClientResult<(u32, mpsc::Receiver<InboundFrame>)> {
         let (tx, rx) = mpsc::channel(STREAM_QUEUE_CAPACITY);
         let id = self.reserve_id(tx).await?;
 
@@ -477,7 +588,7 @@ impl AgentClient {
         self.ensure_version_compat(t)?;
         let flags = t.flags();
         let body = encode_message_body(self.protocol.version(), t, payload)?;
-        let (id, raw_rx) = self.stream_raw(flags, body).await?;
+        let (id, raw_rx) = self.open_inbound_stream(flags, body).await?;
 
         let (tx, rx) = mpsc::channel(STREAM_QUEUE_CAPACITY);
         tokio::spawn(decode_stream_task(raw_rx, tx));
@@ -493,7 +604,7 @@ impl AgentClient {
         self.ensure_version_compat(t)?;
         let flags = t.flags();
         let body = encode_message_body(self.protocol.version(), t, payload)?;
-        let (id, raw_rx) = self.stream_raw(flags, body).await?;
+        let (id, raw_rx) = self.open_inbound_stream(flags, body).await?;
 
         let (tx, rx) = mpsc::channel(STREAM_QUEUE_CAPACITY);
         tokio::spawn(decode_frame_stream_task(raw_rx, tx));
@@ -515,6 +626,21 @@ impl AgentClient {
 
     /// Sends one generation-8 raw bulk record on an existing correlation.
     pub async fn send_bulk(&self, record: BulkRecord) -> AgentClientResult<()> {
+        self.ensure_bulk_supported()?;
+        #[cfg(all(feature = "uds", unix))]
+        if let Some(producer) = self.local_outbound.as_ref() {
+            let prepared = producer
+                .prepare(&record)
+                .await
+                .map_err(|error| AgentClientError::LocalTransport(error.to_string()))?;
+            return self
+                .write_writer_frame(WriterFrame::LocalBulk(prepared))
+                .await;
+        }
+        self.write_writer_frame(WriterFrame::Bulk(record)).await
+    }
+
+    fn ensure_bulk_supported(&self) -> AgentClientResult<()> {
         if self.negotiated_version < BULK_PROTOCOL_VERSION {
             return Err(AgentClientError::UnsupportedOperation {
                 msg_type: "raw bulk record",
@@ -522,13 +648,13 @@ impl AgentClient {
                 peer: self.negotiated_version,
             });
         }
+        Ok(())
+    }
 
+    async fn write_writer_frame(&self, frame: WriterFrame) -> AgentClientResult<()> {
         let (ack, written) = oneshot::channel();
         self.writer
-            .send(WriterCommand {
-                frame: WriterFrame::Bulk(record),
-                ack,
-            })
+            .send(WriterCommand { frame, ack })
             .await
             .map_err(|_| AgentClientError::Closed)?;
         written.await.map_err(|_| AgentClientError::Closed)?
@@ -557,7 +683,7 @@ impl AgentClient {
     ///
     /// IDs are single-use for this connection. Exhaustion requires reconnecting for a fresh range
     /// incarnation; wrap-around could relabel late raw records as a new operation.
-    async fn reserve_id(&self, tx: mpsc::Sender<RawFrame>) -> AgentClientResult<u32> {
+    async fn reserve_id(&self, tx: mpsc::Sender<InboundFrame>) -> AgentClientResult<u32> {
         let id = self
             .next_id
             .fetch_update(
@@ -648,6 +774,80 @@ fn is_retryable_named_pipe_connect_error(error: &std::io::Error) -> bool {
     const ERROR_PIPE_BUSY: i32 = 231;
 
     error.kind() == std::io::ErrorKind::NotFound || error.raw_os_error() == Some(ERROR_PIPE_BUSY)
+}
+
+#[cfg(feature = "stream")]
+async fn finish_connection<R, W>(
+    reader: R,
+    writer: W,
+    handshake: AgentHandshake,
+    #[cfg(all(feature = "uds", unix))] local: Option<LocalShmClient>,
+) -> AgentClientResult<AgentClient>
+where
+    R: AsyncRead + Unpin + Send + 'static,
+    W: AsyncWrite + Unpin + Send + 'static,
+{
+    #[cfg(all(feature = "uds", unix))]
+    let local_shm = local.is_some();
+    #[cfg(not(all(feature = "uds", unix)))]
+    let local_shm = false;
+    tracing::info!(
+        id_min = handshake.id_min,
+        id_max = handshake.id_max,
+        protocol = ?handshake.protocol,
+        ready_bytes = handshake.ready_body.len(),
+        boot_time_ns = handshake.ready.boot_time_ns,
+        local_shm,
+        "agent client: connected to relay"
+    );
+    if handshake.protocol == AgentProtocol::LegacyV1 {
+        // TODO(upgrade-0.6): Remove in 0.6.x or later once live-sandbox
+        // compatibility for versions before 0.5 is no longer supported.
+        tracing::warn!(
+            "agent client: connected to a sandbox started before microsandbox 0.5; exec compatibility is temporary and filesystem/SFTP require stop/start"
+        );
+    }
+
+    let pending: Arc<Mutex<HashMap<u32, CorrelationRoute>>> = Arc::new(Mutex::new(HashMap::new()));
+    let (writer_tx, writer_rx) = mpsc::channel(WRITER_QUEUE_CAPACITY);
+
+    #[cfg(all(feature = "uds", unix))]
+    let (local_release_tx, local_release_rx) = mpsc::unbounded_channel();
+    #[cfg(all(feature = "uds", unix))]
+    let (local_inbound, local_outbound) = match local {
+        Some(local) => (Some(local.inbound), Some(local.outbound)),
+        None => (None, None),
+    };
+    #[cfg(all(feature = "uds", unix))]
+    let reader_handle = tokio::spawn(reader_loop(
+        reader,
+        Arc::clone(&pending),
+        local_inbound,
+        local_outbound.clone(),
+        local_release_tx,
+    ));
+    #[cfg(not(all(feature = "uds", unix)))]
+    let reader_handle = tokio::spawn(reader_loop(reader, Arc::clone(&pending)));
+    #[cfg(all(feature = "uds", unix))]
+    let writer_handle = tokio::spawn(stream_writer_loop(writer, writer_rx, local_release_rx));
+    #[cfg(not(all(feature = "uds", unix)))]
+    let writer_handle = tokio::spawn(stream_writer_loop(writer, writer_rx));
+
+    Ok(AgentClient {
+        writer: writer_tx,
+        next_id: AtomicU32::new(first_request_id(handshake.id_min)),
+        id_min: handshake.id_min,
+        id_max: handshake.id_max,
+        protocol: handshake.protocol,
+        negotiated_version: handshake.negotiated_version,
+        pending,
+        reader_handle,
+        writer_handle,
+        ready_body: handshake.ready_body,
+        ready: handshake.ready,
+        #[cfg(all(feature = "uds", unix))]
+        local_outbound,
+    })
 }
 
 #[cfg(feature = "stream")]
@@ -838,30 +1038,94 @@ where
     }
 }
 
-#[cfg(feature = "stream")]
+#[cfg(all(feature = "stream", feature = "uds", unix))]
+async fn stream_writer_loop<W>(
+    mut writer: W,
+    mut rx: mpsc::Receiver<WriterCommand>,
+    mut local_release_rx: mpsc::UnboundedReceiver<LocalBulkRelease>,
+) where
+    W: tokio::io::AsyncWrite + Unpin,
+{
+    loop {
+        tokio::select! {
+            biased;
+            release = local_release_rx.recv() => {
+                let Some(release) = release else { continue; };
+                let result = async {
+                    let wire = encode_local_bulk_release(release)
+                        .map_err(|error| AgentClientError::LocalTransport(error.to_string()))?;
+                    tokio::io::AsyncWriteExt::write_all(&mut writer, &wire).await?;
+                    tokio::io::AsyncWriteExt::flush(&mut writer).await?;
+                    AgentClientResult::Ok(())
+                }.await;
+                if let Err(error) = result {
+                    tracing::debug!("agent client: local release writer error: {error}");
+                    break;
+                }
+            }
+            command = rx.recv() => {
+                let Some(mut command) = command else { break; };
+                let result = write_writer_command(&mut writer, &mut command).await;
+                if let Err(error) = result {
+                    tracing::debug!("agent client: stream writer error: {error}");
+                    let _ = command.ack.send(Err(error));
+                    break;
+                }
+                let _ = command.ack.send(Ok(()));
+            }
+        }
+    }
+}
+
+#[cfg(all(feature = "stream", not(all(feature = "uds", unix))))]
 async fn stream_writer_loop<W>(mut writer: W, mut rx: mpsc::Receiver<WriterCommand>)
 where
     W: tokio::io::AsyncWrite + Unpin,
 {
-    while let Some(command) = rx.recv().await {
-        let result = match &command.frame {
-            WriterFrame::Control(frame) => codec::write_raw_frame(&mut writer, frame).await,
-            WriterFrame::Bulk(record) => codec::write_bulk_record(&mut writer, record).await,
-        };
-        if let Err(e) = result {
-            tracing::debug!("agent client: stream writer error: {e}");
-            let _ = command.ack.send(Err(AgentClientError::Protocol(e)));
+    while let Some(mut command) = rx.recv().await {
+        let result = write_writer_command(&mut writer, &mut command).await;
+        if let Err(error) = result {
+            tracing::debug!("agent client: stream writer error: {error}");
+            let _ = command.ack.send(Err(error));
             break;
         }
         let _ = command.ack.send(Ok(()));
     }
 }
 
+#[cfg(feature = "stream")]
+async fn write_writer_command<W>(
+    writer: &mut W,
+    command: &mut WriterCommand,
+) -> AgentClientResult<()>
+where
+    W: tokio::io::AsyncWrite + Unpin,
+{
+    match &mut command.frame {
+        WriterFrame::Control(frame) => codec::write_raw_frame(writer, frame).await?,
+        WriterFrame::Bulk(record) => codec::write_bulk_record(writer, record).await?,
+        #[cfg(all(feature = "uds", unix))]
+        WriterFrame::LocalBulk(prepared) => {
+            let wire = encode_local_bulk_ref(prepared.descriptor())
+                .map_err(|error| AgentClientError::LocalTransport(error.to_string()))?;
+            tokio::io::AsyncWriteExt::write_all(writer, &wire).await?;
+            tokio::io::AsyncWriteExt::flush(writer).await?;
+            prepared.commit();
+        }
+    }
+    Ok(())
+}
+
 /// Background task that reads frames from the relay and dispatches them to
 /// pending channels by correlation ID. Operates on raw frames — no CBOR.
-#[cfg(feature = "stream")]
-async fn reader_loop<R>(mut reader: R, pending: Arc<Mutex<HashMap<u32, CorrelationRoute>>>)
-where
+#[cfg(all(feature = "stream", feature = "uds", unix))]
+async fn reader_loop<R>(
+    mut reader: R,
+    pending: Arc<Mutex<HashMap<u32, CorrelationRoute>>>,
+    local_inbound: Option<SharedArenaConsumer>,
+    local_outbound: Option<SharedArenaProducer>,
+    local_release_tx: mpsc::UnboundedSender<LocalBulkRelease>,
+) where
     R: tokio::io::AsyncRead + Unpin,
 {
     loop {
@@ -872,8 +1136,50 @@ where
                 break;
             }
         };
+        if frame.id == 0 && frame.flags == 0 {
+            let local = match decode_local_body(&frame.body) {
+                Ok(local) => local,
+                Err(error) => {
+                    tracing::debug!("agent client: malformed local frame: {error}");
+                    break;
+                }
+            };
+            match local {
+                LocalShmFrame::BulkRef(descriptor) => {
+                    let Some(consumer) = local_inbound.as_ref() else {
+                        tracing::debug!(
+                            "agent client: local bulk reference without negotiated arena"
+                        );
+                        break;
+                    };
+                    let record = match consumer.receive(descriptor, local_release_tx.clone()) {
+                        Ok(record) => record,
+                        Err(error) => {
+                            tracing::debug!("agent client: rejected local bulk reference: {error}");
+                            break;
+                        }
+                    };
+                    dispatch_frame(InboundFrame::Bulk(record), &pending).await;
+                }
+                LocalShmFrame::BulkRelease(release) => {
+                    let Some(producer) = local_outbound.as_ref() else {
+                        tracing::debug!("agent client: local release without negotiated arena");
+                        break;
+                    };
+                    if let Err(error) = producer.release(release) {
+                        tracing::debug!("agent client: rejected local bulk release: {error}");
+                        break;
+                    }
+                }
+                LocalShmFrame::UpgradeRequest => {
+                    tracing::debug!("agent client: relay sent an invalid upgrade request");
+                    break;
+                }
+            }
+            continue;
+        }
 
-        dispatch_frame(frame, &pending).await;
+        dispatch_frame(InboundFrame::Raw(frame), &pending).await;
     }
 
     // Reader exited — drop all senders so outstanding receivers wake up.
@@ -881,10 +1187,30 @@ where
     map.clear();
 }
 
+#[cfg(all(feature = "stream", not(all(feature = "uds", unix))))]
+async fn reader_loop<R>(mut reader: R, pending: Arc<Mutex<HashMap<u32, CorrelationRoute>>>)
+where
+    R: tokio::io::AsyncRead + Unpin,
+{
+    loop {
+        let frame = match codec::read_raw_frame(&mut reader).await {
+            Ok(frame) => frame,
+            Err(error) => {
+                tracing::debug!("agent client: reader EOF or error: {error}");
+                break;
+            }
+        };
+        dispatch_frame(InboundFrame::Raw(frame), &pending).await;
+    }
+
+    pending.lock().await.clear();
+}
+
 #[cfg(feature = "stream")]
-async fn dispatch_frame(frame: RawFrame, pending: &Arc<Mutex<HashMap<u32, CorrelationRoute>>>) {
-    let id = frame.id;
-    let is_terminal = (frame.flags & FLAG_TERMINAL) != 0;
+async fn dispatch_frame(frame: InboundFrame, pending: &Arc<Mutex<HashMap<u32, CorrelationRoute>>>) {
+    let id = frame.id();
+    let flags = frame.flags();
+    let is_terminal = (flags & FLAG_TERMINAL) != 0;
 
     let tx = {
         let mut map = pending.lock().await;
@@ -892,7 +1218,7 @@ async fn dispatch_frame(frame: RawFrame, pending: &Arc<Mutex<HashMap<u32, Correl
             tracing::trace!("agent client: no pending handler for id={id}");
             return;
         };
-        if route.state == CorrelationState::Cancelling && frame.flags == FLAG_BULK {
+        if route.state == CorrelationState::Cancelling && flags == FLAG_BULK {
             return;
         }
         let tx = route.tx.clone();
@@ -908,8 +1234,18 @@ async fn dispatch_frame(frame: RawFrame, pending: &Arc<Mutex<HashMap<u32, Correl
 }
 
 /// Translate a stream of raw frames into typed messages.
-async fn decode_stream_task(mut raw_rx: mpsc::Receiver<RawFrame>, tx: mpsc::Sender<Message>) {
+async fn decode_stream_task(mut raw_rx: mpsc::Receiver<InboundFrame>, tx: mpsc::Sender<Message>) {
     while let Some(frame) = raw_rx.recv().await {
+        #[cfg(all(feature = "uds", unix))]
+        let frame = match frame {
+            InboundFrame::Raw(frame) => frame,
+            InboundFrame::Bulk(_) => {
+                tracing::warn!("agent client: raw bulk record reached a control-only stream");
+                break;
+            }
+        };
+        #[cfg(not(all(feature = "uds", unix)))]
+        let InboundFrame::Raw(frame) = frame;
         if frame.flags & FLAG_BULK != 0 {
             tracing::warn!("agent client: raw bulk record reached a control-only stream");
             break;
@@ -930,14 +1266,17 @@ async fn decode_stream_task(mut raw_rx: mpsc::Receiver<RawFrame>, tx: mpsc::Send
 
 /// Translates raw relay frames into generation-aware control or bulk items.
 async fn decode_frame_stream_task(
-    mut raw_rx: mpsc::Receiver<RawFrame>,
+    mut raw_rx: mpsc::Receiver<InboundFrame>,
     tx: mpsc::Sender<AgentFrame>,
 ) {
     while let Some(frame) = raw_rx.recv().await {
-        let decoded = if frame.flags & FLAG_BULK != 0 {
-            codec::raw_frame_to_bulk(frame, MAX_BULK_RECORD_PAYLOAD).map(AgentFrame::Bulk)
-        } else {
-            codec::raw_frame_to_message(frame).map(AgentFrame::Control)
+        let decoded = match frame {
+            #[cfg(all(feature = "uds", unix))]
+            InboundFrame::Bulk(record) => Ok(AgentFrame::Bulk(record)),
+            InboundFrame::Raw(frame) if frame.flags & FLAG_BULK != 0 => {
+                codec::raw_frame_to_bulk(frame, MAX_BULK_RECORD_PAYLOAD).map(AgentFrame::Bulk)
+            }
+            InboundFrame::Raw(frame) => codec::raw_frame_to_message(frame).map(AgentFrame::Control),
         };
 
         match decoded {
@@ -950,6 +1289,20 @@ async fn decode_frame_stream_task(
                 tracing::warn!("agent client: failed to decode frame in bulk stream: {error}");
                 break;
             }
+        }
+    }
+}
+
+async fn materialize_raw_stream_task(
+    mut inbound_rx: mpsc::Receiver<InboundFrame>,
+    tx: mpsc::Sender<RawFrame>,
+) {
+    while let Some(frame) = inbound_rx.recv().await {
+        let Ok(frame) = frame.into_raw_frame() else {
+            break;
+        };
+        if tx.send(frame).await.is_err() {
+            break;
         }
     }
 }
@@ -984,6 +1337,10 @@ impl Drop for AgentClient {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(all(feature = "uds", unix))]
+    use crate::local_shm::{LocalShmServer, send_local_shm_upgrade};
+    #[cfg(all(feature = "uds", unix))]
+    use bytes::Bytes;
     #[cfg(all(feature = "uds", unix))]
     use microsandbox_protocol::core::Ready;
     #[cfg(all(feature = "uds", unix))]
@@ -1041,6 +1398,67 @@ mod tests {
         assert_eq!(raw_msg.t, MessageType::Ready);
     }
 
+    #[cfg(all(feature = "uds", unix))]
+    #[tokio::test]
+    async fn connect_selects_shared_arena_and_sends_bulk_by_reference() {
+        let temp = tempfile::tempdir().unwrap();
+        let sock_path = temp.path().join("agent.sock");
+        let listener = UnixListener::bind(&sock_path).unwrap();
+        let ready = Ready {
+            local_transport: Some(
+                microsandbox_protocol::transport::LocalTransportReady::shared_arena_v1(),
+            ),
+            ..Default::default()
+        };
+        let ready_msg = Message::with_payload(MessageType::Ready, 0, &ready).unwrap();
+        let expected = Bytes::from_static(b"shared payload, socket descriptor");
+        let expected_server = expected.clone();
+
+        let server = tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            socket.write_all(&1u32.to_be_bytes()).await.unwrap();
+            socket.write_all(&1024u32.to_be_bytes()).await.unwrap();
+            codec::write_message(&mut socket, &ready_msg).await.unwrap();
+
+            let upgrade = codec::read_raw_frame(&mut socket).await.unwrap();
+            assert_eq!(upgrade.id, 0);
+            assert_eq!(upgrade.flags, 0);
+            assert_eq!(
+                decode_local_body(&upgrade.body).unwrap(),
+                LocalShmFrame::UpgradeRequest
+            );
+            let arenas = LocalShmServer::create().unwrap();
+            send_local_shm_upgrade(&socket, Some(arenas.client_fds()))
+                .await
+                .unwrap();
+
+            let descriptor = codec::read_raw_frame(&mut socket).await.unwrap();
+            let LocalShmFrame::BulkRef(descriptor) = decode_local_body(&descriptor.body).unwrap()
+            else {
+                panic!("client sent bulk bytes in-band after selecting the shared arena");
+            };
+            let (release_tx, _release_rx) = mpsc::unbounded_channel();
+            let record = arenas.inbound.receive(descriptor, release_tx).unwrap();
+            assert_eq!(record.payload, expected_server);
+        });
+
+        let client =
+            AgentClient::connect_with_deadline(&sock_path, Instant::now() + Duration::from_secs(1))
+                .await
+                .unwrap();
+        client
+            .send_bulk(BulkRecord {
+                id: 1,
+                kind: microsandbox_protocol::bulk::BulkKind::Filesystem,
+                flow: microsandbox_protocol::bulk::BulkFlow::HostToGuest,
+                offset: 0,
+                payload: expected,
+            })
+            .await
+            .unwrap();
+        server.await.unwrap();
+    }
+
     #[cfg(all(feature = "named-pipe", windows))]
     #[tokio::test]
     async fn connect_decodes_ready_payload_from_named_pipe() {
@@ -1060,6 +1478,7 @@ mod tests {
             init_time_ns: 22,
             ready_time_ns: 33,
             agent_version: "named-pipe-test".to_string(),
+            ..Default::default()
         };
         let ready_msg = Message::with_payload(MessageType::Ready, 0, &ready).unwrap();
 
@@ -1477,11 +1896,18 @@ mod tests {
                 .await
                 .unwrap();
 
-            let inbound = codec::read_raw_frame(&mut server_io).await.unwrap();
-            let inbound = codec::raw_frame_to_bulk(inbound, DEFAULT_BULK_RECORD_PAYLOAD).unwrap();
-            assert_eq!(inbound.id, opening_id);
-            assert_eq!(inbound.flow, BulkFlow::HostToGuest);
-            assert_eq!(inbound.payload.as_ref(), b"host-to-guest");
+            let first = codec::read_raw_frame(&mut server_io).await.unwrap();
+            let first = codec::raw_frame_to_bulk(first, DEFAULT_BULK_RECORD_PAYLOAD).unwrap();
+            let second = codec::read_raw_frame(&mut server_io).await.unwrap();
+            let second = codec::raw_frame_to_bulk(second, DEFAULT_BULK_RECORD_PAYLOAD).unwrap();
+            assert_eq!(first.id, opening_id);
+            assert_eq!(first.flow, BulkFlow::HostToGuest);
+            assert_eq!(first.offset, 0);
+            assert_eq!(first.payload.as_ref(), b"host-to-");
+            assert_eq!(second.id, opening_id);
+            assert_eq!(second.flow, BulkFlow::HostToGuest);
+            assert_eq!(second.offset, 8);
+            assert_eq!(second.payload.as_ref(), b"guest");
 
             codec::write_bulk_record(
                 &mut server_io,
@@ -1542,7 +1968,17 @@ mod tests {
                 kind: BulkKind::Tcp,
                 flow: BulkFlow::HostToGuest,
                 offset: 0,
-                payload: b"host-to-guest".as_slice().into(),
+                payload: b"host-to-".as_slice().into(),
+            })
+            .await
+            .unwrap();
+        client
+            .send_bulk(BulkRecord {
+                id,
+                kind: BulkKind::Tcp,
+                flow: BulkFlow::HostToGuest,
+                offset: 8,
+                payload: b"guest".as_slice().into(),
             })
             .await
             .unwrap();

--- a/packages/agent-client/rust/lib/client.rs
+++ b/packages/agent-client/rust/lib/client.rs
@@ -49,6 +49,8 @@ use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::net::UnixStream;
 #[cfg(all(feature = "named-pipe", windows))]
 use tokio::net::windows::named_pipe::ClientOptions;
+#[cfg(all(feature = "stream", feature = "uds", unix))]
+use tokio::sync::watch;
 use tokio::sync::{Mutex, mpsc, oneshot};
 use tokio::task::JoinHandle;
 #[cfg(feature = "stream")]
@@ -814,6 +816,8 @@ where
     #[cfg(all(feature = "uds", unix))]
     let (local_release_tx, local_release_rx) = mpsc::unbounded_channel();
     #[cfg(all(feature = "uds", unix))]
+    let (connection_shutdown_tx, connection_shutdown_rx) = watch::channel(false);
+    #[cfg(all(feature = "uds", unix))]
     let (local_inbound, local_outbound) = match local {
         Some(local) => (Some(local.inbound), Some(local.outbound)),
         None => (None, None),
@@ -825,11 +829,20 @@ where
         local_inbound,
         local_outbound.clone(),
         local_release_tx,
+        connection_shutdown_tx.clone(),
+        connection_shutdown_rx.clone(),
     ));
     #[cfg(not(all(feature = "uds", unix)))]
     let reader_handle = tokio::spawn(reader_loop(reader, Arc::clone(&pending)));
     #[cfg(all(feature = "uds", unix))]
-    let writer_handle = tokio::spawn(stream_writer_loop(writer, writer_rx, local_release_rx));
+    let writer_handle = tokio::spawn(stream_writer_loop(
+        writer,
+        writer_rx,
+        local_release_rx,
+        local_outbound.clone(),
+        connection_shutdown_tx,
+        connection_shutdown_rx,
+    ));
     #[cfg(not(all(feature = "uds", unix)))]
     let writer_handle = tokio::spawn(stream_writer_loop(writer, writer_rx));
 
@@ -1043,14 +1056,24 @@ async fn stream_writer_loop<W>(
     mut writer: W,
     mut rx: mpsc::Receiver<WriterCommand>,
     mut local_release_rx: mpsc::UnboundedReceiver<LocalBulkRelease>,
+    local_outbound: Option<SharedArenaProducer>,
+    connection_shutdown_tx: watch::Sender<bool>,
+    mut connection_shutdown_rx: watch::Receiver<bool>,
 ) where
     W: tokio::io::AsyncWrite + Unpin,
 {
     loop {
         tokio::select! {
             biased;
+            changed = connection_shutdown_rx.changed() => {
+                if changed.is_err() || *connection_shutdown_rx.borrow() {
+                    break;
+                }
+            }
             release = local_release_rx.recv() => {
-                let Some(release) = release else { continue; };
+                // The reader owns every release sender. Its exit therefore closes this channel;
+                // continuing here would create a permanently-ready branch and busy-spin.
+                let Some(release) = release else { break; };
                 let result = async {
                     let wire = encode_local_bulk_release(release)
                         .map_err(|error| AgentClientError::LocalTransport(error.to_string()))?;
@@ -1075,6 +1098,11 @@ async fn stream_writer_loop<W>(
             }
         }
     }
+
+    if let Some(producer) = local_outbound.as_ref() {
+        producer.close();
+    }
+    let _ = connection_shutdown_tx.send(true);
 }
 
 #[cfg(all(feature = "stream", not(all(feature = "uds", unix))))]
@@ -1125,11 +1153,21 @@ async fn reader_loop<R>(
     local_inbound: Option<SharedArenaConsumer>,
     local_outbound: Option<SharedArenaProducer>,
     local_release_tx: mpsc::UnboundedSender<LocalBulkRelease>,
+    connection_shutdown_tx: watch::Sender<bool>,
+    mut connection_shutdown_rx: watch::Receiver<bool>,
 ) where
     R: tokio::io::AsyncRead + Unpin,
 {
     loop {
-        let frame = match codec::read_raw_frame(&mut reader).await {
+        let frame = match tokio::select! {
+            changed = connection_shutdown_rx.changed() => {
+                if changed.is_err() || *connection_shutdown_rx.borrow() {
+                    break;
+                }
+                continue;
+            }
+            frame = codec::read_raw_frame(&mut reader) => frame,
+        } {
             Ok(frame) => frame,
             Err(e) => {
                 tracing::debug!("agent client: reader EOF or error: {e}");
@@ -1181,6 +1219,11 @@ async fn reader_loop<R>(
 
         dispatch_frame(InboundFrame::Raw(frame), &pending).await;
     }
+
+    if let Some(producer) = local_outbound.as_ref() {
+        producer.close();
+    }
+    let _ = connection_shutdown_tx.send(true);
 
     // Reader exited — drop all senders so outstanding receivers wake up.
     let mut map = pending.lock().await;

--- a/packages/agent-client/rust/lib/error.rs
+++ b/packages/agent-client/rust/lib/error.rs
@@ -42,6 +42,10 @@ pub enum AgentClientError {
     #[error("protocol: {0}")]
     Protocol(#[from] microsandbox_protocol::ProtocolError),
 
+    /// The optional Unix-local shared-memory transport failed before or during use.
+    #[error("local transport: {0}")]
+    LocalTransport(String),
+
     /// CBOR encoding or decoding failed.
     #[error("cbor: {0}")]
     Cbor(String),

--- a/packages/agent-client/rust/lib/lib.rs
+++ b/packages/agent-client/rust/lib/lib.rs
@@ -13,6 +13,9 @@
 
 pub mod client;
 pub mod error;
+/// Unix-local shared-memory bulk transport primitives.
+#[cfg(all(feature = "uds", unix))]
+pub mod local_shm;
 pub mod message;
 pub mod stream;
 pub mod transport;

--- a/packages/agent-client/rust/lib/local_shm.rs
+++ b/packages/agent-client/rust/lib/local_shm.rs
@@ -1,0 +1,1007 @@
+//! Unix-local shared-memory bulk transport carried by the existing agent socket.
+//!
+//! This module deliberately keeps operation semantics out of shared memory. The mappings contain
+//! payload bytes only; fixed descriptors and releases remain ordered on `agent.sock`.
+
+#[cfg(target_os = "linux")]
+use std::ffi::CString;
+use std::fs::File;
+use std::io::{IoSlice, IoSliceMut};
+use std::os::fd::{AsRawFd, FromRawFd, OwnedFd, RawFd};
+use std::sync::atomic::{Ordering, fence};
+use std::sync::{Arc, Mutex};
+
+use bytes::Bytes;
+use memmap2::{Mmap, MmapMut, MmapOptions};
+use microsandbox_protocol::bulk::{BulkFlow, BulkKind, BulkRecord, MAX_BULK_RECORD_PAYLOAD};
+use microsandbox_protocol::codec::{self, RawFrame};
+use nix::errno::Errno;
+use nix::sys::socket::{ControlMessage, ControlMessageOwned, MsgFlags, recvmsg, sendmsg};
+use tokio::net::UnixStream;
+use tokio::sync::{Notify, mpsc};
+
+//--------------------------------------------------------------------------------------------------
+// Constants
+//--------------------------------------------------------------------------------------------------
+
+/// First shared-arena descriptor format.
+pub const LOCAL_SHM_FORMAT_V1: u8 = 1;
+
+/// Total bytes mapped for each transfer direction.
+pub const LOCAL_SHM_ARENA_BYTES: usize = 64 * 1024 * 1024;
+
+/// Bytes in one small record slot.
+pub const LOCAL_SHM_SMALL_SLOT_BYTES: usize = 256 * 1024;
+
+/// Number of small record slots.
+pub const LOCAL_SHM_SMALL_SLOTS: u16 = 64;
+
+/// Bytes in one large filesystem record slot.
+pub const LOCAL_SHM_LARGE_SLOT_BYTES: usize = 3 * 1024 * 1024;
+
+/// Number of large filesystem record slots.
+pub const LOCAL_SHM_LARGE_SLOTS: u16 = 16;
+
+/// Total number of independently leased slots.
+pub const LOCAL_SHM_SLOT_COUNT: u16 = LOCAL_SHM_SMALL_SLOTS + LOCAL_SHM_LARGE_SLOTS;
+
+const LOCAL_MAGIC: [u8; 4] = *b"MSBS";
+const LOCAL_KIND_UPGRADE_REQUEST: u8 = 1;
+const LOCAL_KIND_BULK_REF: u8 = 2;
+const LOCAL_KIND_BULK_RELEASE: u8 = 3;
+const LOCAL_UPGRADE_ACK: [u8; 4] = *b"MSBA";
+const LOCAL_UPGRADE_ACK_BYTES: usize = 8;
+const LOCAL_UPGRADE_ACCEPTED: u8 = 0;
+const LOCAL_UPGRADE_REJECTED: u8 = 1;
+const LOCAL_BULK_REF_BYTES: usize = 32;
+const LOCAL_BULK_RELEASE_BYTES: usize = 12;
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// Errors raised while negotiating or using the local shared arena.
+#[derive(Debug, thiserror::Error)]
+pub enum LocalShmError {
+    /// A system call or memory mapping failed.
+    #[error("local shared arena I/O: {0}")]
+    Io(#[from] std::io::Error),
+
+    /// A socket ancillary-data operation failed.
+    #[error("local shared arena socket: {0}")]
+    Socket(#[from] Errno),
+
+    /// A local descriptor violated the fixed format or ownership rules.
+    #[error("local shared arena protocol: {0}")]
+    Protocol(String),
+
+    /// The selected shared arena has no fitting free slot right now.
+    #[error("local shared arena has no free {0} slot")]
+    Full(&'static str),
+}
+
+/// Result alias for local shared-arena operations.
+pub type LocalShmResult<T> = Result<T, LocalShmError>;
+
+/// One validated local transport message carried at correlation ID zero.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LocalShmFrame {
+    /// Ask the relay to establish format 1 and transfer both arena descriptors.
+    UpgradeRequest,
+
+    /// Refer to one immutable payload retained in a leased slot.
+    BulkRef(LocalBulkRef),
+
+    /// Return one exact slot generation to its producer.
+    BulkRelease(LocalBulkRelease),
+}
+
+/// Metadata referring to one generation-7 bulk payload in a shared slot.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct LocalBulkRef {
+    /// Arena slot containing the payload.
+    pub slot: u16,
+    /// Nonzero producer generation for this lease.
+    pub generation: u32,
+    /// Agent-protocol correlation ID.
+    pub id: u32,
+    /// Filesystem or TCP bulk kind.
+    pub kind: BulkKind,
+    /// Legal protocol flow direction.
+    pub flow: BulkFlow,
+    /// Logical byte offset inside the operation.
+    pub offset: u64,
+    /// Exact payload bytes stored in the slot.
+    pub payload_len: u32,
+}
+
+/// Exact slot lease returned to a producer after the final consumer drops it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct LocalBulkRelease {
+    /// Arena slot being returned.
+    pub slot: u16,
+    /// Exact generation being returned.
+    pub generation: u32,
+}
+
+/// Relay-side mappings and producer state for one SDK connection.
+pub struct LocalShmServer {
+    /// SDK-to-runtime payload consumer.
+    pub inbound: SharedArenaConsumer,
+    /// Runtime-to-SDK payload producer.
+    pub outbound: SharedArenaProducer,
+    inbound_file: File,
+    outbound_file: File,
+}
+
+/// SDK-side mappings and producer state for one local relay connection.
+pub struct LocalShmClient {
+    /// SDK-to-runtime payload producer.
+    pub outbound: SharedArenaProducer,
+    /// Runtime-to-SDK payload consumer.
+    pub inbound: SharedArenaConsumer,
+}
+
+/// Producer for one directional shared arena.
+#[derive(Clone)]
+pub struct SharedArenaProducer {
+    inner: Arc<ProducerInner>,
+}
+
+struct ProducerInner {
+    mapping: Mutex<MmapMut>,
+    slots: Mutex<ProducerSlots>,
+    available: Notify,
+}
+
+struct ProducerSlots {
+    generations: Vec<u32>,
+    leased: Vec<Option<u32>>,
+}
+
+/// Consumer for one directional shared arena.
+#[derive(Clone)]
+pub struct SharedArenaConsumer {
+    inner: Arc<ConsumerInner>,
+}
+
+struct ConsumerInner {
+    mapping: Arc<Mmap>,
+    leased: Mutex<Vec<Option<u32>>>,
+}
+
+/// A prepared local descriptor whose slot is reclaimed unless physical socket admission commits it.
+pub struct PreparedLocalBulk {
+    producer: SharedArenaProducer,
+    descriptor: LocalBulkRef,
+    committed: bool,
+}
+
+struct SharedPayload {
+    consumer: SharedArenaConsumer,
+    offset: usize,
+    len: usize,
+    release: LocalBulkRelease,
+    release_tx: mpsc::UnboundedSender<LocalBulkRelease>,
+}
+
+/// Result of the fixed ancillary descriptor exchange.
+pub enum LocalShmUpgrade {
+    /// The relay accepted the upgrade and transferred the SDK-to-runtime then runtime-to-SDK FDs.
+    Accepted([OwnedFd; 2]),
+
+    /// The relay could not create safe arenas; the caller may continue in-band.
+    Rejected,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Methods
+//--------------------------------------------------------------------------------------------------
+
+impl LocalShmServer {
+    /// Create and map both directional arenas for one SDK connection.
+    pub fn create() -> LocalShmResult<Self> {
+        let inbound_file = create_arena_file("msb-agent-h2g")?;
+        let outbound_file = create_arena_file("msb-agent-g2h")?;
+        let inbound = SharedArenaConsumer::map(&inbound_file)?;
+        let outbound = SharedArenaProducer::map(&outbound_file)?;
+        Ok(Self {
+            inbound,
+            outbound,
+            inbound_file,
+            outbound_file,
+        })
+    }
+
+    /// File descriptors transferred to the SDK in the fixed direction order.
+    pub fn client_fds(&self) -> [RawFd; 2] {
+        [
+            self.inbound_file.as_raw_fd(),
+            self.outbound_file.as_raw_fd(),
+        ]
+    }
+}
+
+impl LocalShmClient {
+    /// Map the fixed SDK-to-runtime then runtime-to-SDK descriptor pair.
+    pub fn from_fds(fds: [OwnedFd; 2]) -> LocalShmResult<Self> {
+        let [outbound_fd, inbound_fd] = fds;
+        let outbound_file = File::from(outbound_fd);
+        let inbound_file = File::from(inbound_fd);
+        validate_arena_file(&outbound_file)?;
+        validate_arena_file(&inbound_file)?;
+        Ok(Self {
+            outbound: SharedArenaProducer::map(&outbound_file)?,
+            inbound: SharedArenaConsumer::map(&inbound_file)?,
+        })
+    }
+}
+
+impl SharedArenaProducer {
+    fn map(file: &File) -> LocalShmResult<Self> {
+        validate_arena_file(file)?;
+        // SAFETY: The file has the exact fixed length, remains referenced by this mapping, and
+        // slot leasing guarantees that only one producer task writes each disjoint range at once.
+        let mapping = unsafe {
+            MmapOptions::new()
+                .len(LOCAL_SHM_ARENA_BYTES)
+                .map_mut(file)?
+        };
+        Ok(Self {
+            inner: Arc::new(ProducerInner {
+                mapping: Mutex::new(mapping),
+                slots: Mutex::new(ProducerSlots {
+                    generations: vec![0; LOCAL_SHM_SLOT_COUNT as usize],
+                    leased: vec![None; LOCAL_SHM_SLOT_COUNT as usize],
+                }),
+                available: Notify::new(),
+            }),
+        })
+    }
+
+    /// Copy one bulk payload into a fitting slot, waiting for bounded arena capacity when needed.
+    pub async fn prepare(&self, record: &BulkRecord) -> LocalShmResult<PreparedLocalBulk> {
+        loop {
+            let notified = self.inner.available.notified();
+            match self.try_prepare(record) {
+                Ok(prepared) => return Ok(prepared),
+                Err(LocalShmError::Full(_)) => notified.await,
+                Err(error) => return Err(error),
+            }
+        }
+    }
+
+    /// Copy one payload if a fitting slot is immediately available.
+    pub fn try_prepare(&self, record: &BulkRecord) -> LocalShmResult<PreparedLocalBulk> {
+        let payload_len = record.payload.len();
+        if payload_len == 0 || payload_len > MAX_BULK_RECORD_PAYLOAD as usize {
+            return Err(LocalShmError::Protocol(format!(
+                "payload length {payload_len} is outside 1..={MAX_BULK_RECORD_PAYLOAD}"
+            )));
+        }
+        record
+            .offset
+            .checked_add(payload_len as u64)
+            .ok_or_else(|| LocalShmError::Protocol("record end offset overflows u64".into()))?;
+
+        let (slot, generation) = self.lease_slot(payload_len)?;
+        let (offset, capacity) = slot_range(slot)?;
+        debug_assert!(payload_len <= capacity);
+        {
+            let mut mapping = self.inner.mapping.lock().unwrap();
+            mapping[offset..offset + payload_len].copy_from_slice(&record.payload);
+        }
+        fence(Ordering::Release);
+
+        Ok(PreparedLocalBulk {
+            producer: self.clone(),
+            descriptor: LocalBulkRef {
+                slot,
+                generation,
+                id: record.id,
+                kind: record.kind,
+                flow: record.flow,
+                offset: record.offset,
+                payload_len: payload_len as u32,
+            },
+            committed: false,
+        })
+    }
+
+    /// Return an exact remotely released slot generation.
+    pub fn release(&self, release: LocalBulkRelease) -> LocalShmResult<()> {
+        let index = validate_slot(release.slot)?;
+        let mut slots = self.inner.slots.lock().unwrap();
+        match slots.leased[index] {
+            Some(generation) if generation == release.generation => {
+                slots.leased[index] = None;
+                drop(slots);
+                self.inner.available.notify_one();
+                Ok(())
+            }
+            Some(generation) => Err(LocalShmError::Protocol(format!(
+                "stale release for slot {} generation {}, current generation is {generation}",
+                release.slot, release.generation
+            ))),
+            None => Err(LocalShmError::Protocol(format!(
+                "duplicate release for free slot {} generation {}",
+                release.slot, release.generation
+            ))),
+        }
+    }
+
+    fn lease_slot(&self, payload_len: usize) -> LocalShmResult<(u16, u32)> {
+        let mut slots = self.inner.slots.lock().unwrap();
+        let preferred = if payload_len <= LOCAL_SHM_SMALL_SLOT_BYTES {
+            0..LOCAL_SHM_SMALL_SLOTS
+        } else {
+            LOCAL_SHM_SMALL_SLOTS..LOCAL_SHM_SLOT_COUNT
+        };
+        let fallback = (payload_len <= LOCAL_SHM_SMALL_SLOT_BYTES)
+            .then_some(LOCAL_SHM_SMALL_SLOTS..LOCAL_SHM_SLOT_COUNT);
+        let slot = preferred
+            .chain(fallback.into_iter().flatten())
+            .find(|slot| slots.leased[*slot as usize].is_none())
+            .ok_or(LocalShmError::Full(
+                if payload_len <= LOCAL_SHM_SMALL_SLOT_BYTES {
+                    "small or large"
+                } else {
+                    "large"
+                },
+            ))?;
+        let index = slot as usize;
+        let mut generation = slots.generations[index].wrapping_add(1);
+        if generation == 0 {
+            generation = 1;
+        }
+        slots.generations[index] = generation;
+        slots.leased[index] = Some(generation);
+        Ok((slot, generation))
+    }
+
+    fn release_uncommitted(&self, release: LocalBulkRelease) {
+        let Ok(index) = validate_slot(release.slot) else {
+            return;
+        };
+        let mut slots = self.inner.slots.lock().unwrap();
+        if slots.leased[index] == Some(release.generation) {
+            slots.leased[index] = None;
+            drop(slots);
+            self.inner.available.notify_one();
+        }
+    }
+}
+
+impl SharedArenaConsumer {
+    fn map(file: &File) -> LocalShmResult<Self> {
+        validate_arena_file(file)?;
+        // SAFETY: The file has the exact fixed length and the mapping owns a kernel reference to
+        // the anonymous object. This side never receives a mutable Rust slice for the mapping.
+        let mapping = unsafe { MmapOptions::new().len(LOCAL_SHM_ARENA_BYTES).map(file)? };
+        Ok(Self {
+            inner: Arc::new(ConsumerInner {
+                mapping: Arc::new(mapping),
+                leased: Mutex::new(vec![None; LOCAL_SHM_SLOT_COUNT as usize]),
+            }),
+        })
+    }
+
+    /// Validate and expose one descriptor payload without copying it from the mapping.
+    pub fn receive(
+        &self,
+        descriptor: LocalBulkRef,
+        release_tx: mpsc::UnboundedSender<LocalBulkRelease>,
+    ) -> LocalShmResult<BulkRecord> {
+        if descriptor.generation == 0 {
+            return Err(LocalShmError::Protocol(
+                "slot generation cannot be zero".into(),
+            ));
+        }
+        if descriptor.id == 0 {
+            return Err(LocalShmError::Protocol(
+                "bulk descriptor cannot use correlation ID zero".into(),
+            ));
+        }
+        let payload_len = descriptor.payload_len as usize;
+        let (offset, capacity) = slot_range(descriptor.slot)?;
+        if payload_len == 0 || payload_len > capacity {
+            return Err(LocalShmError::Protocol(format!(
+                "payload length {payload_len} exceeds slot {} capacity {capacity}",
+                descriptor.slot
+            )));
+        }
+        descriptor
+            .offset
+            .checked_add(payload_len as u64)
+            .ok_or_else(|| LocalShmError::Protocol("record end offset overflows u64".into()))?;
+
+        let index = descriptor.slot as usize;
+        {
+            let mut leased = self.inner.leased.lock().unwrap();
+            if let Some(generation) = leased[index] {
+                return Err(LocalShmError::Protocol(format!(
+                    "slot {} generation {generation} is still retained",
+                    descriptor.slot
+                )));
+            }
+            leased[index] = Some(descriptor.generation);
+        }
+        fence(Ordering::Acquire);
+
+        let payload = Bytes::from_owner(SharedPayload {
+            consumer: self.clone(),
+            offset,
+            len: payload_len,
+            release: LocalBulkRelease {
+                slot: descriptor.slot,
+                generation: descriptor.generation,
+            },
+            release_tx,
+        });
+        Ok(BulkRecord {
+            id: descriptor.id,
+            kind: descriptor.kind,
+            flow: descriptor.flow,
+            offset: descriptor.offset,
+            payload,
+        })
+    }
+}
+
+impl PreparedLocalBulk {
+    /// Descriptor sent over `agent.sock` after the payload has been published.
+    pub fn descriptor(&self) -> LocalBulkRef {
+        self.descriptor
+    }
+
+    /// Mark the descriptor physically admitted. Only a matching remote release may now reuse it.
+    pub fn commit(&mut self) {
+        self.committed = true;
+    }
+}
+
+impl Drop for PreparedLocalBulk {
+    fn drop(&mut self) {
+        if !self.committed {
+            self.producer.release_uncommitted(LocalBulkRelease {
+                slot: self.descriptor.slot,
+                generation: self.descriptor.generation,
+            });
+        }
+    }
+}
+
+impl AsRef<[u8]> for SharedPayload {
+    fn as_ref(&self) -> &[u8] {
+        &self.consumer.inner.mapping[self.offset..self.offset + self.len]
+    }
+}
+
+impl Drop for SharedPayload {
+    fn drop(&mut self) {
+        let index = self.release.slot as usize;
+        let mut leased = self.consumer.inner.leased.lock().unwrap();
+        if leased[index] == Some(self.release.generation) {
+            leased[index] = None;
+            drop(leased);
+            let _ = self.release_tx.send(self.release);
+        }
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Functions: Local framing
+//--------------------------------------------------------------------------------------------------
+
+/// Build the reserved post-Ready shared-arena upgrade request.
+pub fn local_upgrade_request_frame() -> RawFrame {
+    RawFrame {
+        id: 0,
+        flags: 0,
+        body: vec![
+            LOCAL_MAGIC[0],
+            LOCAL_MAGIC[1],
+            LOCAL_MAGIC[2],
+            LOCAL_MAGIC[3],
+            LOCAL_SHM_FORMAT_V1,
+            LOCAL_KIND_UPGRADE_REQUEST,
+        ],
+    }
+}
+
+/// Encode one shared payload descriptor as a reserved local frame.
+pub fn encode_local_bulk_ref(descriptor: LocalBulkRef) -> LocalShmResult<Bytes> {
+    let mut body = Vec::with_capacity(LOCAL_BULK_REF_BYTES);
+    body.extend_from_slice(&LOCAL_MAGIC);
+    body.push(LOCAL_SHM_FORMAT_V1);
+    body.push(LOCAL_KIND_BULK_REF);
+    body.extend_from_slice(&descriptor.slot.to_be_bytes());
+    body.extend_from_slice(&descriptor.generation.to_be_bytes());
+    body.extend_from_slice(&descriptor.id.to_be_bytes());
+    body.push(descriptor.kind as u8);
+    body.push(descriptor.flow as u8);
+    body.extend_from_slice(&[0, 0]);
+    body.extend_from_slice(&descriptor.offset.to_be_bytes());
+    body.extend_from_slice(&descriptor.payload_len.to_be_bytes());
+    debug_assert_eq!(body.len(), LOCAL_BULK_REF_BYTES);
+    encode_local_body(body)
+}
+
+/// Encode one exact slot release as a reserved local frame.
+pub fn encode_local_bulk_release(release: LocalBulkRelease) -> LocalShmResult<Bytes> {
+    let mut body = Vec::with_capacity(LOCAL_BULK_RELEASE_BYTES);
+    body.extend_from_slice(&LOCAL_MAGIC);
+    body.push(LOCAL_SHM_FORMAT_V1);
+    body.push(LOCAL_KIND_BULK_RELEASE);
+    body.extend_from_slice(&release.slot.to_be_bytes());
+    body.extend_from_slice(&release.generation.to_be_bytes());
+    debug_assert_eq!(body.len(), LOCAL_BULK_RELEASE_BYTES);
+    encode_local_body(body)
+}
+
+/// Decode one reserved local body after the outer ID and flags were validated.
+pub fn decode_local_body(body: &[u8]) -> LocalShmResult<LocalShmFrame> {
+    if body.len() < 6 || body[..4] != LOCAL_MAGIC {
+        return Err(LocalShmError::Protocol(
+            "missing MSBS local-frame magic".into(),
+        ));
+    }
+    if body[4] != LOCAL_SHM_FORMAT_V1 {
+        return Err(LocalShmError::Protocol(format!(
+            "unsupported local-frame format {}",
+            body[4]
+        )));
+    }
+    match body[5] {
+        LOCAL_KIND_UPGRADE_REQUEST if body.len() == 6 => Ok(LocalShmFrame::UpgradeRequest),
+        LOCAL_KIND_BULK_REF if body.len() == LOCAL_BULK_REF_BYTES => {
+            if body[18] != 0 || body[19] != 0 {
+                return Err(LocalShmError::Protocol(
+                    "bulk descriptor reserved bytes must be zero".into(),
+                ));
+            }
+            let kind = BulkKind::from_wire(body[16]).ok_or_else(|| {
+                LocalShmError::Protocol(format!("unknown bulk kind {}", body[16]))
+            })?;
+            let flow = BulkFlow::from_wire(body[17]).ok_or_else(|| {
+                LocalShmError::Protocol(format!("unknown bulk flow {}", body[17]))
+            })?;
+            Ok(LocalShmFrame::BulkRef(LocalBulkRef {
+                slot: u16::from_be_bytes(body[6..8].try_into().unwrap()),
+                generation: u32::from_be_bytes(body[8..12].try_into().unwrap()),
+                id: u32::from_be_bytes(body[12..16].try_into().unwrap()),
+                kind,
+                flow,
+                offset: u64::from_be_bytes(body[20..28].try_into().unwrap()),
+                payload_len: u32::from_be_bytes(body[28..32].try_into().unwrap()),
+            }))
+        }
+        LOCAL_KIND_BULK_RELEASE if body.len() == LOCAL_BULK_RELEASE_BYTES => {
+            Ok(LocalShmFrame::BulkRelease(LocalBulkRelease {
+                slot: u16::from_be_bytes(body[6..8].try_into().unwrap()),
+                generation: u32::from_be_bytes(body[8..12].try_into().unwrap()),
+            }))
+        }
+        kind => Err(LocalShmError::Protocol(format!(
+            "invalid local-frame kind {kind} or body length {}",
+            body.len()
+        ))),
+    }
+}
+
+fn encode_local_body(body: Vec<u8>) -> LocalShmResult<Bytes> {
+    let mut wire = Vec::with_capacity(9 + body.len());
+    codec::encode_raw_to_buf(
+        &RawFrame {
+            id: 0,
+            flags: 0,
+            body,
+        },
+        &mut wire,
+    )
+    .map_err(|error| LocalShmError::Protocol(error.to_string()))?;
+    Ok(Bytes::from(wire))
+}
+
+//--------------------------------------------------------------------------------------------------
+// Functions: Descriptor passing
+//--------------------------------------------------------------------------------------------------
+
+/// Send an accepted or rejected fixed upgrade acknowledgement, attaching two FDs on success.
+pub async fn send_local_shm_upgrade(
+    stream: &UnixStream,
+    fds: Option<[RawFd; 2]>,
+) -> LocalShmResult<()> {
+    send_local_shm_upgrade_fd(stream.as_raw_fd(), fds).await
+}
+
+/// Send the fixed upgrade acknowledgement through an already serialized socket writer.
+///
+/// Runtime relays retain a duplicated raw descriptor beside their Tokio write half so ancillary
+/// data and ordinary frames still have one writer actor and cannot interleave.
+pub async fn send_local_shm_upgrade_fd(
+    socket_fd: RawFd,
+    fds: Option<[RawFd; 2]>,
+) -> LocalShmResult<()> {
+    let mut ack = [0u8; LOCAL_UPGRADE_ACK_BYTES];
+    ack[..4].copy_from_slice(&LOCAL_UPGRADE_ACK);
+    ack[4] = LOCAL_SHM_FORMAT_V1;
+    ack[5] = if fds.is_some() {
+        LOCAL_UPGRADE_ACCEPTED
+    } else {
+        LOCAL_UPGRADE_REJECTED
+    };
+    ack[6] = if fds.is_some() { 2 } else { 0 };
+
+    let mut offset = 0usize;
+    let mut attach = fds;
+    while offset < ack.len() {
+        let iov = [IoSlice::new(&ack[offset..])];
+        let result = if let Some(fds) = attach.as_ref() {
+            sendmsg::<()>(
+                socket_fd,
+                &iov,
+                &[ControlMessage::ScmRights(fds)],
+                local_send_flags(),
+                None,
+            )
+        } else {
+            sendmsg::<()>(socket_fd, &iov, &[], local_send_flags(), None)
+        };
+        match result {
+            Ok(0) => return Err(std::io::Error::from(std::io::ErrorKind::WriteZero).into()),
+            Ok(sent) => {
+                offset += sent;
+                attach = None;
+            }
+            Err(Errno::EAGAIN) => {
+                tokio::task::yield_now().await;
+            }
+            Err(error) => return Err(LocalShmError::Socket(error)),
+        }
+    }
+    Ok(())
+}
+
+/// Receive the fixed upgrade acknowledgement and its exact descriptor pair.
+pub async fn receive_local_shm_upgrade(stream: &UnixStream) -> LocalShmResult<LocalShmUpgrade> {
+    let mut ack = [0u8; LOCAL_UPGRADE_ACK_BYTES];
+    let mut received = 0usize;
+    let mut owned_fds = Vec::<OwnedFd>::new();
+    let mut first = true;
+
+    while received < ack.len() {
+        stream.readable().await?;
+        let mut raw_fds = Vec::<RawFd>::new();
+        let result = stream.try_io(tokio::io::Interest::READABLE, || {
+            if first {
+                let mut cmsgspace = nix::cmsg_space!([RawFd; 2]);
+                let mut iov = [IoSliceMut::new(&mut ack[received..])];
+                let message = recvmsg::<()>(
+                    stream.as_raw_fd(),
+                    &mut iov,
+                    Some(&mut cmsgspace),
+                    MsgFlags::MSG_DONTWAIT,
+                )?;
+                for cmsg in message.cmsgs()? {
+                    if let ControlMessageOwned::ScmRights(fds) = cmsg {
+                        raw_fds.extend(fds);
+                    }
+                }
+                Ok(message.bytes)
+            } else {
+                stream.try_read(&mut ack[received..])
+            }
+        });
+        match result {
+            Ok(0) => {
+                return Err(LocalShmError::Protocol(
+                    "relay closed during local shared-arena upgrade".into(),
+                ));
+            }
+            Ok(bytes) => {
+                if first {
+                    first = false;
+                    for fd in raw_fds {
+                        set_close_on_exec(fd)?;
+                        // SAFETY: SCM_RIGHTS returned a new descriptor owned by this process.
+                        owned_fds.push(unsafe { OwnedFd::from_raw_fd(fd) });
+                    }
+                }
+                received += bytes;
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => continue,
+            Err(error) => return Err(error.into()),
+        }
+    }
+
+    if ack[..4] != LOCAL_UPGRADE_ACK || ack[4] != LOCAL_SHM_FORMAT_V1 || ack[7] != 0 {
+        return Err(LocalShmError::Protocol(
+            "malformed local shared-arena acknowledgement".into(),
+        ));
+    }
+    match (ack[5], ack[6], owned_fds.len()) {
+        (LOCAL_UPGRADE_ACCEPTED, 2, 2) => {
+            let mut fds = owned_fds.into_iter();
+            Ok(LocalShmUpgrade::Accepted([
+                fds.next().unwrap(),
+                fds.next().unwrap(),
+            ]))
+        }
+        (LOCAL_UPGRADE_REJECTED, 0, 0) => Ok(LocalShmUpgrade::Rejected),
+        _ => Err(LocalShmError::Protocol(format!(
+            "upgrade status={}, advertised_fds={}, received_fds={}",
+            ack[5],
+            ack[6],
+            owned_fds.len()
+        ))),
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Functions: Arena files and layout
+//--------------------------------------------------------------------------------------------------
+
+#[cfg(target_os = "linux")]
+fn create_arena_file(name: &str) -> LocalShmResult<File> {
+    let name = CString::new(name)
+        .map_err(|_| LocalShmError::Protocol("arena name contains NUL".into()))?;
+    // SAFETY: `name` is a valid NUL-terminated C string and flags are the documented memfd set.
+    let fd = unsafe {
+        libc::syscall(
+            libc::SYS_memfd_create,
+            name.as_ptr(),
+            libc::MFD_CLOEXEC | libc::MFD_ALLOW_SEALING,
+        )
+    } as libc::c_int;
+    if fd < 0 {
+        return Err(std::io::Error::last_os_error().into());
+    }
+    // SAFETY: The successful syscall returned a newly owned descriptor.
+    let file = unsafe { File::from_raw_fd(fd) };
+    file.set_len(LOCAL_SHM_ARENA_BYTES as u64)?;
+    let seals = libc::F_SEAL_GROW | libc::F_SEAL_SHRINK | libc::F_SEAL_SEAL;
+    // SAFETY: `file` is a memfd created with MFD_ALLOW_SEALING.
+    if unsafe { libc::fcntl(file.as_raw_fd(), libc::F_ADD_SEALS, seals) } < 0 {
+        return Err(std::io::Error::last_os_error().into());
+    }
+    Ok(file)
+}
+
+#[cfg(not(target_os = "linux"))]
+fn create_arena_file(_name: &str) -> LocalShmResult<File> {
+    let file = tempfile::tempfile()?;
+    file.set_len(LOCAL_SHM_ARENA_BYTES as u64)?;
+    Ok(file)
+}
+
+fn validate_arena_file(file: &File) -> LocalShmResult<()> {
+    let len = file.metadata()?.len();
+    if len != LOCAL_SHM_ARENA_BYTES as u64 {
+        return Err(LocalShmError::Protocol(format!(
+            "arena length is {len}, expected {LOCAL_SHM_ARENA_BYTES}"
+        )));
+    }
+    Ok(())
+}
+
+fn validate_slot(slot: u16) -> LocalShmResult<usize> {
+    if slot >= LOCAL_SHM_SLOT_COUNT {
+        return Err(LocalShmError::Protocol(format!(
+            "slot {slot} is outside 0..{LOCAL_SHM_SLOT_COUNT}"
+        )));
+    }
+    Ok(slot as usize)
+}
+
+fn slot_range(slot: u16) -> LocalShmResult<(usize, usize)> {
+    validate_slot(slot)?;
+    if slot < LOCAL_SHM_SMALL_SLOTS {
+        return Ok((
+            slot as usize * LOCAL_SHM_SMALL_SLOT_BYTES,
+            LOCAL_SHM_SMALL_SLOT_BYTES,
+        ));
+    }
+    let large = (slot - LOCAL_SHM_SMALL_SLOTS) as usize;
+    let offset = LOCAL_SHM_SMALL_SLOTS as usize * LOCAL_SHM_SMALL_SLOT_BYTES
+        + large * LOCAL_SHM_LARGE_SLOT_BYTES;
+    Ok((offset, LOCAL_SHM_LARGE_SLOT_BYTES))
+}
+
+fn set_close_on_exec(fd: RawFd) -> LocalShmResult<()> {
+    // SAFETY: `fd` is live and owned by the caller; F_GETFD/F_SETFD do not alter ownership.
+    let flags = unsafe { libc::fcntl(fd, libc::F_GETFD) };
+    if flags < 0 || unsafe { libc::fcntl(fd, libc::F_SETFD, flags | libc::FD_CLOEXEC) } < 0 {
+        return Err(std::io::Error::last_os_error().into());
+    }
+    Ok(())
+}
+
+fn local_send_flags() -> MsgFlags {
+    let flags = MsgFlags::MSG_DONTWAIT;
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    let flags = flags | MsgFlags::MSG_NOSIGNAL;
+    flags
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests
+//--------------------------------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn local_descriptor_round_trips() {
+        let descriptor = LocalBulkRef {
+            slot: 65,
+            generation: 7,
+            id: 42,
+            kind: BulkKind::Filesystem,
+            flow: BulkFlow::HostToGuest,
+            offset: 99,
+            payload_len: 1_000_000,
+        };
+        let wire = encode_local_bulk_ref(descriptor).unwrap();
+        let body = &wire[9..];
+        assert_eq!(
+            decode_local_body(body).unwrap(),
+            LocalShmFrame::BulkRef(descriptor)
+        );
+    }
+
+    #[tokio::test]
+    async fn shared_payload_is_zero_copy_and_releases_exact_generation() {
+        let server = LocalShmServer::create().unwrap();
+        let outbound_fd = server.inbound_file.try_clone().unwrap().into();
+        let inbound_fd = server.outbound_file.try_clone().unwrap().into();
+        let client = LocalShmClient::from_fds([outbound_fd, inbound_fd]).unwrap();
+        let record = BulkRecord {
+            id: 9,
+            kind: BulkKind::Filesystem,
+            flow: BulkFlow::HostToGuest,
+            offset: 3,
+            payload: Bytes::from(vec![0xA5; LOCAL_SHM_SMALL_SLOT_BYTES + 1]),
+        };
+        let mut prepared = client.outbound.prepare(&record).await.unwrap();
+        let descriptor = prepared.descriptor();
+        prepared.commit();
+        let (release_tx, mut release_rx) = mpsc::unbounded_channel();
+        let received = server.inbound.receive(descriptor, release_tx).unwrap();
+        assert_eq!(received.payload, record.payload);
+        drop(received);
+        let release = release_rx.try_recv().unwrap();
+        client.outbound.release(release).unwrap();
+    }
+
+    #[test]
+    fn duplicate_release_is_rejected() {
+        let server = LocalShmServer::create().unwrap();
+        let record = BulkRecord {
+            id: 1,
+            kind: BulkKind::Tcp,
+            flow: BulkFlow::GuestToHost,
+            offset: 0,
+            payload: Bytes::from_static(b"payload"),
+        };
+        let mut prepared = server.outbound.try_prepare(&record).unwrap();
+        let release = LocalBulkRelease {
+            slot: prepared.descriptor().slot,
+            generation: prepared.descriptor().generation,
+        };
+        prepared.commit();
+        server.outbound.release(release).unwrap();
+        assert!(server.outbound.release(release).is_err());
+    }
+
+    #[test]
+    fn slot_classes_exhaust_and_uncommitted_drop_reclaims_capacity() {
+        let server = LocalShmServer::create().unwrap();
+        let record = BulkRecord {
+            id: 1,
+            kind: BulkKind::Tcp,
+            flow: BulkFlow::GuestToHost,
+            offset: 0,
+            payload: Bytes::from_static(b"x"),
+        };
+        let mut leased = Vec::new();
+        for _ in 0..LOCAL_SHM_SLOT_COUNT {
+            leased.push(server.outbound.try_prepare(&record).unwrap());
+        }
+        assert!(matches!(
+            server.outbound.try_prepare(&record),
+            Err(LocalShmError::Full(_))
+        ));
+
+        drop(leased.pop());
+        assert!(server.outbound.try_prepare(&record).is_ok());
+    }
+
+    #[test]
+    fn large_boundary_and_oversize_are_validated_before_leasing() {
+        let server = LocalShmServer::create().unwrap();
+        let mut record = BulkRecord {
+            id: 7,
+            kind: BulkKind::Filesystem,
+            flow: BulkFlow::HostToGuest,
+            offset: 0,
+            payload: Bytes::from(vec![0x5a; LOCAL_SHM_SMALL_SLOT_BYTES + 1]),
+        };
+        let prepared = server.outbound.try_prepare(&record).unwrap();
+        assert!(prepared.descriptor().slot >= LOCAL_SHM_SMALL_SLOTS);
+        drop(prepared);
+
+        record.payload = Bytes::from(vec![0u8; MAX_BULK_RECORD_PAYLOAD as usize + 1]);
+        assert!(matches!(
+            server.outbound.try_prepare(&record),
+            Err(LocalShmError::Protocol(_))
+        ));
+    }
+
+    #[test]
+    fn generation_wrap_skips_zero_and_rejects_stale_release() {
+        let server = LocalShmServer::create().unwrap();
+        server.outbound.inner.slots.lock().unwrap().generations[0] = u32::MAX;
+        let record = BulkRecord {
+            id: 3,
+            kind: BulkKind::Tcp,
+            flow: BulkFlow::GuestToHost,
+            offset: 0,
+            payload: Bytes::from_static(b"payload"),
+        };
+        let mut prepared = server.outbound.try_prepare(&record).unwrap();
+        let descriptor = prepared.descriptor();
+        assert_eq!(descriptor.generation, 1);
+        prepared.commit();
+        assert!(
+            server
+                .outbound
+                .release(LocalBulkRelease {
+                    slot: descriptor.slot,
+                    generation: u32::MAX,
+                })
+                .is_err()
+        );
+        server
+            .outbound
+            .release(LocalBulkRelease {
+                slot: descriptor.slot,
+                generation: descriptor.generation,
+            })
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn upgrade_transfers_exact_descriptor_pair_on_existing_socket() {
+        let server = LocalShmServer::create().unwrap();
+        let (sender, receiver) = UnixStream::pair().unwrap();
+        let sent = send_local_shm_upgrade(&sender, Some(server.client_fds()));
+        let received = receive_local_shm_upgrade(&receiver);
+        let (sent, received) = tokio::join!(sent, received);
+        sent.unwrap();
+        let LocalShmUpgrade::Accepted(fds) = received.unwrap() else {
+            panic!("descriptor-bearing upgrade was rejected");
+        };
+        let client = LocalShmClient::from_fds(fds).unwrap();
+
+        let record = BulkRecord {
+            id: 11,
+            kind: BulkKind::Filesystem,
+            flow: BulkFlow::HostToGuest,
+            offset: 0,
+            payload: Bytes::from_static(b"through-the-transferred-fd"),
+        };
+        let mut prepared = client.outbound.try_prepare(&record).unwrap();
+        let descriptor = prepared.descriptor();
+        prepared.commit();
+        let (release_tx, mut release_rx) = mpsc::unbounded_channel();
+        let received = server.inbound.receive(descriptor, release_tx).unwrap();
+        assert_eq!(received.payload, record.payload);
+        drop(received);
+        client
+            .outbound
+            .release(release_rx.recv().await.unwrap())
+            .unwrap();
+    }
+}

--- a/packages/agent-client/rust/lib/local_shm.rs
+++ b/packages/agent-client/rust/lib/local_shm.rs
@@ -8,7 +8,7 @@ use std::ffi::CString;
 use std::fs::File;
 use std::io::{IoSlice, IoSliceMut};
 use std::os::fd::{AsRawFd, FromRawFd, OwnedFd, RawFd};
-use std::sync::atomic::{Ordering, fence};
+use std::sync::atomic::{AtomicBool, Ordering, fence};
 use std::sync::{Arc, Mutex};
 
 use bytes::Bytes;
@@ -29,6 +29,12 @@ pub const LOCAL_SHM_FORMAT_V1: u8 = 1;
 
 /// Total bytes mapped for each transfer direction.
 pub const LOCAL_SHM_ARENA_BYTES: usize = 64 * 1024 * 1024;
+
+/// Maximum payload bytes retained by active leases in one direction.
+///
+/// The mapping is deliberately larger so TCP-sized and filesystem-sized slots can coexist, but
+/// active transport ownership must remain within the stack-wide directional bulk budget.
+pub const LOCAL_SHM_ACTIVE_BYTES: usize = 32 * 1024 * 1024;
 
 /// Bytes in one small record slot.
 pub const LOCAL_SHM_SMALL_SLOT_BYTES: usize = 256 * 1024;
@@ -78,6 +84,10 @@ pub enum LocalShmError {
     /// The selected shared arena has no fitting free slot right now.
     #[error("local shared arena has no free {0} slot")]
     Full(&'static str),
+
+    /// The connection owning this arena has closed and cannot return further releases.
+    #[error("local shared arena connection is closed")]
+    Closed,
 }
 
 /// Result alias for local shared-arena operations.
@@ -96,7 +106,7 @@ pub enum LocalShmFrame {
     BulkRelease(LocalBulkRelease),
 }
 
-/// Metadata referring to one generation-7 bulk payload in a shared slot.
+/// Metadata referring to one generation-8 bulk payload in a shared slot.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct LocalBulkRef {
     /// Arena slot containing the payload.
@@ -152,11 +162,19 @@ struct ProducerInner {
     mapping: Mutex<MmapMut>,
     slots: Mutex<ProducerSlots>,
     available: Notify,
+    closed: AtomicBool,
 }
 
 struct ProducerSlots {
     generations: Vec<u32>,
-    leased: Vec<Option<u32>>,
+    leased: Vec<Option<ProducerLease>>,
+    active_bytes: usize,
+}
+
+#[derive(Clone, Copy)]
+struct ProducerLease {
+    generation: u32,
+    payload_len: usize,
 }
 
 /// Consumer for one directional shared arena.
@@ -253,8 +271,10 @@ impl SharedArenaProducer {
                 slots: Mutex::new(ProducerSlots {
                     generations: vec![0; LOCAL_SHM_SLOT_COUNT as usize],
                     leased: vec![None; LOCAL_SHM_SLOT_COUNT as usize],
+                    active_bytes: 0,
                 }),
                 available: Notify::new(),
+                closed: AtomicBool::new(false),
             }),
         })
     }
@@ -293,6 +313,13 @@ impl SharedArenaProducer {
         }
         fence(Ordering::Release);
 
+        // Teardown can race the payload copy after the slot lock is released. Do not publish a
+        // descriptor into a dead connection; close() has already revoked this lease generation.
+        if self.inner.closed.load(Ordering::Acquire) {
+            self.release_uncommitted(LocalBulkRelease { slot, generation });
+            return Err(LocalShmError::Closed);
+        }
+
         Ok(PreparedLocalBulk {
             producer: self.clone(),
             descriptor: LocalBulkRef {
@@ -310,18 +337,24 @@ impl SharedArenaProducer {
 
     /// Return an exact remotely released slot generation.
     pub fn release(&self, release: LocalBulkRelease) -> LocalShmResult<()> {
+        if self.inner.closed.load(Ordering::Acquire) {
+            // Connection teardown revokes every lease at once. A late release is no longer
+            // authoritative and must not resurrect or mutate the closed epoch.
+            return Ok(());
+        }
         let index = validate_slot(release.slot)?;
         let mut slots = self.inner.slots.lock().unwrap();
         match slots.leased[index] {
-            Some(generation) if generation == release.generation => {
+            Some(lease) if lease.generation == release.generation => {
                 slots.leased[index] = None;
+                slots.active_bytes = slots.active_bytes.saturating_sub(lease.payload_len);
                 drop(slots);
                 self.inner.available.notify_one();
                 Ok(())
             }
-            Some(generation) => Err(LocalShmError::Protocol(format!(
-                "stale release for slot {} generation {}, current generation is {generation}",
-                release.slot, release.generation
+            Some(lease) => Err(LocalShmError::Protocol(format!(
+                "stale release for slot {} generation {}, current generation is {}",
+                release.slot, release.generation, lease.generation
             ))),
             None => Err(LocalShmError::Protocol(format!(
                 "duplicate release for free slot {} generation {}",
@@ -330,8 +363,30 @@ impl SharedArenaProducer {
         }
     }
 
+    /// Revoke this connection epoch and wake every producer waiting for a remote release.
+    pub fn close(&self) {
+        if self.inner.closed.swap(true, Ordering::AcqRel) {
+            return;
+        }
+        let mut slots = self.inner.slots.lock().unwrap();
+        slots.leased.fill(None);
+        slots.active_bytes = 0;
+        drop(slots);
+        self.inner.available.notify_waiters();
+    }
+
     fn lease_slot(&self, payload_len: usize) -> LocalShmResult<(u16, u32)> {
         let mut slots = self.inner.slots.lock().unwrap();
+        if self.inner.closed.load(Ordering::Acquire) {
+            return Err(LocalShmError::Closed);
+        }
+        let active_bytes = slots
+            .active_bytes
+            .checked_add(payload_len)
+            .ok_or(LocalShmError::Full("directional byte-budget"))?;
+        if active_bytes > LOCAL_SHM_ACTIVE_BYTES {
+            return Err(LocalShmError::Full("directional byte-budget"));
+        }
         let preferred = if payload_len <= LOCAL_SHM_SMALL_SLOT_BYTES {
             0..LOCAL_SHM_SMALL_SLOTS
         } else {
@@ -355,7 +410,11 @@ impl SharedArenaProducer {
             generation = 1;
         }
         slots.generations[index] = generation;
-        slots.leased[index] = Some(generation);
+        slots.leased[index] = Some(ProducerLease {
+            generation,
+            payload_len,
+        });
+        slots.active_bytes = active_bytes;
         Ok((slot, generation))
     }
 
@@ -364,8 +423,10 @@ impl SharedArenaProducer {
             return;
         };
         let mut slots = self.inner.slots.lock().unwrap();
-        if slots.leased[index] == Some(release.generation) {
+        if slots.leased[index].is_some_and(|lease| lease.generation == release.generation) {
+            let lease = slots.leased[index].expect("matching local shared lease exists");
             slots.leased[index] = None;
+            slots.active_bytes = slots.active_bytes.saturating_sub(lease.payload_len);
             drop(slots);
             self.inner.available.notify_one();
         }
@@ -970,6 +1031,62 @@ mod tests {
                 generation: descriptor.generation,
             })
             .unwrap();
+    }
+
+    #[test]
+    fn active_payload_budget_is_stricter_than_mapping_capacity() {
+        let server = LocalShmServer::create().unwrap();
+        let record = BulkRecord {
+            id: 1,
+            kind: BulkKind::Filesystem,
+            flow: BulkFlow::GuestToHost,
+            offset: 0,
+            payload: Bytes::from(vec![0x5a; LOCAL_SHM_LARGE_SLOT_BYTES]),
+        };
+        let mut leased = Vec::new();
+        for _ in 0..(LOCAL_SHM_ACTIVE_BYTES / LOCAL_SHM_LARGE_SLOT_BYTES) {
+            let mut prepared = server.outbound.try_prepare(&record).unwrap();
+            prepared.commit();
+            leased.push(prepared.descriptor());
+        }
+
+        assert!(matches!(
+            server.outbound.try_prepare(&record),
+            Err(LocalShmError::Full("directional byte-budget"))
+        ));
+        assert_eq!(
+            server.outbound.inner.slots.lock().unwrap().active_bytes,
+            leased.len() * LOCAL_SHM_LARGE_SLOT_BYTES
+        );
+    }
+
+    #[tokio::test]
+    async fn connection_close_wakes_producer_with_every_slot_leased() {
+        let server = LocalShmServer::create().unwrap();
+        let record = BulkRecord {
+            id: 1,
+            kind: BulkKind::Tcp,
+            flow: BulkFlow::GuestToHost,
+            offset: 0,
+            payload: Bytes::from_static(b"x"),
+        };
+        for _ in 0..LOCAL_SHM_SLOT_COUNT {
+            let mut prepared = server.outbound.try_prepare(&record).unwrap();
+            prepared.commit();
+        }
+
+        let waiting = {
+            let producer = server.outbound.clone();
+            let record = record.clone();
+            tokio::spawn(async move { producer.prepare(&record).await })
+        };
+        tokio::task::yield_now().await;
+        server.outbound.close();
+
+        assert!(matches!(waiting.await.unwrap(), Err(LocalShmError::Closed)));
+        let slots = server.outbound.inner.slots.lock().unwrap();
+        assert_eq!(slots.active_bytes, 0);
+        assert!(slots.leased.iter().all(Option::is_none));
     }
 
     #[tokio::test]

--- a/sdk/rust/lib/sandbox/fs.rs
+++ b/sdk/rust/lib/sandbox/fs.rs
@@ -29,6 +29,16 @@ use crate::{
 };
 
 //--------------------------------------------------------------------------------------------------
+// Constants
+//--------------------------------------------------------------------------------------------------
+
+/// Largest known filesystem write that stays on the legacy inline exchange.
+///
+/// Raw bulk wins once payload work can amortize its offer, acceptance, credit, finish, and terminal
+/// lifecycle. Below this cutoff the already-supported inline exchange has lower fixed latency.
+const FS_INLINE_WRITE_MAX: u64 = 16 * 1024;
+
+//--------------------------------------------------------------------------------------------------
 // Types
 //--------------------------------------------------------------------------------------------------
 
@@ -305,7 +315,7 @@ impl<'a> SandboxFsOps<'a> {
         len: Option<u64>,
     ) -> MicrosandboxResult<FsWriteSink> {
         let client = self.agent_client(Operation::SandboxFsWriteHandleStream)?;
-        agent::write_handle_stream(client, handle, offset, len, None).await
+        agent::write_handle_stream(client, handle, offset, len, None, false).await
     }
 
     //----------------------------------------------------------------------------------------------
@@ -1082,6 +1092,16 @@ fn write_open_options() -> FsOpenOptions {
     }
 }
 
+/// Keep raw bulk unless an exact owned payload is small enough that its lifecycle cannot amortize.
+fn should_offer_fs_write_bulk(
+    bulk_supported: bool,
+    exact_owned_payload: bool,
+    transfer_len_hint: Option<u64>,
+) -> bool {
+    bulk_supported
+        && (!exact_owned_payload || transfer_len_hint.is_none_or(|len| len > FS_INLINE_WRITE_MAX))
+}
+
 //--------------------------------------------------------------------------------------------------
 // Module: agent (backend-agnostic ops driven over an agent connection)
 //--------------------------------------------------------------------------------------------------
@@ -1115,7 +1135,7 @@ pub(crate) mod agent {
     use super::{
         FsEntry, FsHandle, FsMetadata, FsReadStream, FsWriteSink, HostCopyDurability,
         HostCopyOptions, check_response, entry_info_to_fs_entry, entry_info_to_metadata,
-        receive_fs_bulk_acceptance,
+        receive_fs_bulk_acceptance, should_offer_fs_write_bulk,
     };
 
     /// Open a fresh agent connection for the named sandbox.
@@ -1265,8 +1285,8 @@ pub(crate) mod agent {
         offset: u64,
         data: &[u8],
     ) -> MicrosandboxResult<()> {
-        let sink =
-            write_handle_stream(client, handle, offset, Some(data.len() as u64), None).await?;
+        let sink = write_handle_stream(client, handle, offset, Some(data.len() as u64), None, true)
+            .await?;
         for chunk in data.chunks(FS_CHUNK_SIZE) {
             sink.write(chunk).await?;
         }
@@ -1279,6 +1299,7 @@ pub(crate) mod agent {
         offset: u64,
         len: Option<u64>,
         close_handle: Option<FsHandle>,
+        exact_owned_payload: bool,
     ) -> MicrosandboxResult<FsWriteSink> {
         let req = FsRequest {
             op: FsOp::Write {
@@ -1286,9 +1307,12 @@ pub(crate) mod agent {
                 offset,
                 len,
             },
-            bulk: client
-                .supports(MessageType::BulkAccepted)
-                .then(BulkOffer::filesystem_write),
+            bulk: should_offer_fs_write_bulk(
+                client.supports(MessageType::BulkAccepted),
+                exact_owned_payload,
+                len,
+            )
+            .then(BulkOffer::filesystem_write),
         };
         let (id, mut rx) = client.stream_frames(MessageType::FsRequest, &req).await?;
         let bulk = match req.bulk {
@@ -1413,8 +1437,15 @@ pub(crate) mod agent {
     ) -> MicrosandboxResult<()> {
         let client = Arc::new(connect_agent(backend, name).await?);
         let handle = open_file(&client, path, super::write_open_options()).await?;
-        let sink =
-            write_handle_stream(client, handle, 0, Some(data.len() as u64), Some(handle)).await?;
+        let sink = write_handle_stream(
+            client,
+            handle,
+            0,
+            Some(data.len() as u64),
+            Some(handle),
+            true,
+        )
+        .await?;
         for chunk in data.chunks(FS_CHUNK_SIZE) {
             sink.write(chunk).await?;
         }
@@ -1429,7 +1460,7 @@ pub(crate) mod agent {
         let client = Arc::new(connect_agent(backend, name).await?);
         let handle = open_file(&client, path, super::write_open_options()).await?;
 
-        write_handle_stream(client, handle, 0, None, Some(handle)).await
+        write_handle_stream(client, handle, 0, None, Some(handle), false).await
     }
 
     pub(crate) async fn list(
@@ -1707,7 +1738,39 @@ pub(crate) mod agent {
         guest_path: &str,
     ) -> MicrosandboxResult<()> {
         let mut file = tokio::fs::File::open(host_path).await?;
+        let small_candidate = file.metadata().await?.len() <= super::FS_INLINE_WRITE_MAX;
+        let first = if small_candidate {
+            let mut first = Vec::with_capacity((super::FS_INLINE_WRITE_MAX + 1) as usize);
+            (&mut file)
+                .take(super::FS_INLINE_WRITE_MAX + 1)
+                .read_to_end(&mut first)
+                .await?;
+            if first.len() as u64 <= super::FS_INLINE_WRITE_MAX {
+                // Metadata is only a hint. EOF inside the bounded probe proves that the complete
+                // owned payload can use inline without risking an unbounded control-lane stream.
+                return write(backend, name, guest_path, first).await;
+            }
+
+            // The candidate grew across the cutoff. Refill the ordinary first record before raw
+            // bulk opens rather than penalizing the transfer with a tiny leading record.
+            while first.len() < FS_CHUNK_SIZE {
+                let start = first.len();
+                first.resize(FS_CHUNK_SIZE, 0);
+                let n = file.read(&mut first[start..]).await?;
+                first.truncate(start + n);
+                if n == 0 {
+                    break;
+                }
+            }
+            Some(first)
+        } else {
+            None
+        };
+
         let sink = write_stream(backend, name, guest_path).await?;
+        if let Some(first) = first {
+            sink.write_owned(first).await?;
+        }
         loop {
             let mut buf = vec![0u8; FS_CHUNK_SIZE];
             let n = file.read(&mut buf).await?;
@@ -2008,6 +2071,28 @@ pub(crate) mod agent {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn only_exact_owned_small_filesystem_writes_stay_inline() {
+        assert!(!should_offer_fs_write_bulk(false, true, None));
+        assert!(!should_offer_fs_write_bulk(true, true, Some(0)));
+        assert!(!should_offer_fs_write_bulk(
+            true,
+            true,
+            Some(FS_INLINE_WRITE_MAX)
+        ));
+        assert!(should_offer_fs_write_bulk(
+            true,
+            true,
+            Some(FS_INLINE_WRITE_MAX + 1)
+        ));
+        assert!(should_offer_fs_write_bulk(true, true, None));
+        assert!(should_offer_fs_write_bulk(
+            true,
+            false,
+            Some(FS_INLINE_WRITE_MAX)
+        ));
+    }
 
     #[tokio::test]
     async fn read_stream_rejects_channel_close_without_terminal_response() {

--- a/sdk/rust/lib/sandbox/ssh.rs
+++ b/sdk/rust/lib/sandbox/ssh.rs
@@ -1438,9 +1438,11 @@ impl SshSession {
                 ));
                 let (output_tx, output_rx) = mpsc::channel(TCP_OUTPUT_QUEUE_CAPACITY);
                 let output = tokio::spawn(relay_tcp_output_to_ssh(
+                    channel_id,
                     tcp_id,
                     output_rx,
                     channel_writer,
+                    session_handle.clone(),
                     Arc::clone(&client),
                     bulk_receiver.as_ref().map(Arc::clone),
                 ));
@@ -2315,9 +2317,11 @@ async fn relay_ssh_to_tcp<R>(
 
 /// Drain guest TCP data into the independently writable Russh channel stream.
 async fn relay_tcp_output_to_ssh<W>(
+    channel: ChannelId,
     tcp_id: u32,
     mut output: mpsc::Receiver<TcpOutput>,
     mut writer: W,
+    session: russh::server::Handle,
     client: Arc<AgentClient>,
     bulk_receiver: Option<Arc<Mutex<BulkReceiveState>>>,
 ) where
@@ -2330,7 +2334,7 @@ async fn relay_tcp_output_to_ssh<W>(
                 consumed_offset,
             } => {
                 if writer.write_all(&payload).await.is_err() {
-                    return;
+                    break;
                 }
                 let Some(consumed_offset) = consumed_offset else {
                     continue;
@@ -2359,7 +2363,7 @@ async fn relay_tcp_output_to_ssh<W>(
             }
             TcpOutput::Eof => {
                 if writer.shutdown().await.is_err() {
-                    return;
+                    break;
                 }
             }
             TcpOutput::Close => break,
@@ -2367,6 +2371,9 @@ async fn relay_tcp_output_to_ssh<W>(
     }
 
     let _ = writer.shutdown().await;
+    // EOF closes only the SSH channel's write half. The terminal guest TcpClosed/TcpFailed event
+    // owns the full channel lifecycle and must emit SSH CLOSE so Russh wakes the input half too.
+    let _ = session.close(channel).await;
 }
 
 /// Pump agent frames without waiting on the SSH channel's output window. The bounded output queue
@@ -2867,6 +2874,7 @@ async fn sftp_write_handle(
         offset,
         Some(data.len() as u64),
         None,
+        true,
     )
     .await?;
     for chunk in data.chunks(FS_CHUNK_SIZE) {


### PR DESCRIPTION
## TL;DR

Keep the one public `agent.sock`, but move local SDK bulk bytes through two bounded shared-memory arenas instead of copying those bytes through Unix socket buffers.

## Description

- Negotiate `local-shm-v1` only between a Unix SDK and runtime; old peers and generic streams keep using the existing in-band path.
- Pass two sealed 64 MiB arena descriptors over the already-authenticated socket: one arena per direction.
- Keep control messages and ordered `BulkRef` descriptors on `agent.sock`; no extra public socket is added.
- Use fixed-size slots, generation checks, explicit release, read-only consumer mappings, and strict descriptor validation to prevent stale-slot reuse.
- Backpressure SDK-to-runtime exhaustion. Runtime-to-SDK exhaustion falls back per record to the normal socket so one client cannot stall the relay.
- Leave agentd and the generation-7 runtime-to-guest protocol unchanged.

The same fresh exact-head comparison is shown on every PR in this stack. “After” means all four PRs together at `7f3f44ce`, with automatic dual-port selection and `local-shm-v1` enabled; the original baseline is `05f53e7a`. Both profiles ran twice in ABBA order.

| Workload | Original baseline | Complete stack | Change |
|---|---:|---:|---:|
| FS host to guest, 256 MiB | 153.5 MiB/s | 323.4 MiB/s | +110.6% |
| TCP host to guest, 64 MiB | 198.8 MiB/s | 210.1 MiB/s | +5.7% |
| FS guest to host, 256 MiB | 254.6 MiB/s | 564.9 MiB/s | +121.9% |
| TCP guest to host, 64 MiB | 511.8 MiB/s | 649.7 MiB/s | +26.9% |
| TCP full duplex, 64 MiB each way | 244.4 MiB/s | 381.8 MiB/s | +56.2% |
| Idle ping median | 0.1383 ms | 0.1471 ms | +0.0088 ms |
| Ping under FS load, p95 | 480.3 ms | 1.929 ms | 99.60% lower |

Environment: OVH Advance-4, Linux/KVM, 1-vCPU guest, host CPU 8 affinity, guest tmpfs, public Rust SDK, verified payload hashes, and empty stderr. After artifacts were rebuilt from `7f3f44ce` against libkrun `ff087a1`.

## Test Plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo check -p microsandbox-protocol -p microsandbox-agent-client -p microsandbox-runtime -p microsandbox`
- [x] `cargo clippy -p microsandbox-protocol -p microsandbox-agent-client -p microsandbox-runtime -p microsandbox --lib -- -D warnings`
- [x] `cargo test -p microsandbox-protocol -p microsandbox-agent-client -p microsandbox-runtime -p microsandbox --lib` — 823 passed, 3 ignored
- [x] Rebuild matching host and embedded guest binaries on Linux/KVM and run the baseline-versus-complete-stack transport benchmark




<!-- greptile_comment -->

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(agent): harden optimized transport l..."](https://github.com/superradcompany/microsandbox/commit/efaad4ebd40b9d8d47fce64b3c3233ef4c2ad9f7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54182917)</sub>

<!-- /greptile_comment -->