### PR TITLE
fix(runtime): format bind mount paths correctly

### DIFF
--- a/crates/runtime/lib/vm.rs
+++ b/crates/runtime/lib/vm.rs
@@ -1605,8 +1605,9 @@ fn build_vm(
             // Name the folder on a permission error, usually an OS access restriction.
             if e.kind() == std::io::ErrorKind::PermissionDenied {
                 RuntimeError::Custom(format!(
-                    "mount {tag}: permission denied reading host folder {host_path} ({e}). \
-                     On macOS, grant access in System Settings > Privacy & Security."
+                    "mount {tag}: permission denied reading host folder {} ({e}). \
+                     On macOS, grant access in System Settings > Privacy & Security.",
+                    host_path.display()
                 ))
             } else {
                 RuntimeError::Custom(format!("mount {tag}: {e}"))


### PR DESCRIPTION
## TL;DR
Restore the runtime build by formatting the retained bind-mount `PathBuf` through `Path::display` in permission errors.

## Description
- Format the bind-mount host path without requiring `PathBuf` to implement `Display`.
- Preserve the existing permission error text and macOS guidance.

## Test Plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo check -p microsandbox-runtime`
- [x] `cargo test -p microsandbox-runtime vm::tests` (37 passed)

<!-- greptile_comment -->

<sub>Reviews (1): Last reviewed commit: ["fix(runtime): format bind mount paths co..."](https://github.com/superradcompany/microsandbox/commit/93936d99c9f6edeaf3c28fa48a8e33bf5139b5be) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54207420)</sub>

<!-- /greptile_comment -->