### PR TITLE
feat(cli): add JSON output to exec

### DIFF
--- a/crates/cli/lib/commands/exec.rs
+++ b/crates/cli/lib/commands/exec.rs
@@ -3,6 +3,7 @@
 use std::io::{IsTerminal, Write};
 use std::time::Duration;
 
+use base64::Engine as _;
 use clap::Args;
 use microsandbox::sandbox::exec::{ExecEvent, ExecHandle};
 use microsandbox::sandbox::{ExecOptionsBuilder, ExecOutput, RlimitResource, Sandbox};
@@ -61,6 +62,15 @@ pub struct ExecArgs {
     #[arg(long, conflicts_with = "tty")]
     pub stream: bool,
 
+    /// Output the captured result as JSON.
+    #[arg(
+        long,
+        value_name = "FORMAT",
+        value_parser = ["json"],
+        conflicts_with_all = ["stream", "tty"]
+    )]
+    pub format: Option<String>,
+
     /// Command to run inside the sandbox (after --).
     /// When omitted in interactive mode, attaches to the default shell.
     #[arg(last = true)]
@@ -94,7 +104,11 @@ pub async fn run(args: ExecArgs) -> anyhow::Result<()> {
 
     let workdir = args.workdir;
     let stdin_is_terminal = std::io::stdin().is_terminal();
-    let interactive = super::common::use_interactive_tty(stdin_is_terminal, args.no_tty);
+    let interactive = use_interactive_exec(
+        stdin_is_terminal,
+        args.no_tty,
+        args.format.as_deref() == Some("json"),
+    );
 
     // Read piped stdin upfront so it can be forwarded into the sandbox.
     // Skipped in `--stream` mode, where stdin is forwarded incrementally.
@@ -188,8 +202,19 @@ pub async fn run(args: ExecArgs) -> anyhow::Result<()> {
             })
             .await?;
 
-        std::io::stdout().write_all(output.stdout_bytes())?;
-        std::io::stderr().write_all(output.stderr_bytes())?;
+        if args.format.as_deref() == Some("json") {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&exec_result_json(
+                    output.status().code,
+                    output.stdout_bytes(),
+                    output.stderr_bytes(),
+                ))?
+            );
+        } else {
+            std::io::stdout().write_all(output.stdout_bytes())?;
+            std::io::stderr().write_all(output.stderr_bytes())?;
+        }
 
         super::maybe_stop(&sandbox).await;
 
@@ -237,6 +262,37 @@ fn apply_common_exec_opts(
 /// Return whether buffered exec should consume host stdin before starting.
 fn should_read_buffered_stdin(stdin_is_terminal: bool, interactive: bool, stream: bool) -> bool {
     !stdin_is_terminal && !interactive && !stream
+}
+
+/// Decide whether execution should use the interactive PTY path.
+fn use_interactive_exec(stdin_is_terminal: bool, no_tty: bool, json: bool) -> bool {
+    !json && super::common::use_interactive_tty(stdin_is_terminal, no_tty)
+}
+
+/// Build the machine-readable result for one captured execution.
+fn exec_result_json(exit_code: i32, stdout: &[u8], stderr: &[u8]) -> serde_json::Value {
+    let (stdout, stdout_encoding) = encode_output(stdout);
+    let (stderr, stderr_encoding) = encode_output(stderr);
+
+    serde_json::json!({
+        "exit_code": exit_code,
+        "success": exit_code == 0,
+        "stdout": stdout,
+        "stdout_encoding": stdout_encoding,
+        "stderr": stderr,
+        "stderr_encoding": stderr_encoding,
+    })
+}
+
+/// Preserve UTF-8 output as text and encode arbitrary bytes losslessly.
+fn encode_output(bytes: &[u8]) -> (String, &'static str) {
+    match std::str::from_utf8(bytes) {
+        Ok(text) => (text.to_string(), "utf8"),
+        Err(_) => (
+            base64::engine::general_purpose::STANDARD.encode(bytes),
+            "base64",
+        ),
+    }
 }
 
 /// Drive a non-PTY bidirectional streaming exec session (`--stream`).
@@ -401,6 +457,58 @@ mod tests {
     }
 
     #[test]
+    fn parses_json_format() {
+        let args = parse_exec_args(&["worker", "--format", "json", "--", "true"]);
+
+        assert_eq!(args.format.as_deref(), Some("json"));
+        assert_eq!(args.command, vec!["true"]);
+    }
+
+    #[test]
+    fn json_format_conflicts_with_streaming_modes() {
+        for mode in ["--stream", "--tty"] {
+            let err =
+                TestCli::try_parse_from(["msb", "worker", "--format", "json", mode]).unwrap_err();
+
+            assert_eq!(err.kind(), ErrorKind::ArgumentConflict);
+        }
+    }
+
+    #[test]
+    fn renders_utf8_exec_result_as_json() {
+        let result = exec_result_json(0, b"hello\n", b"");
+
+        assert_eq!(
+            result,
+            serde_json::json!({
+                "exit_code": 0,
+                "success": true,
+                "stdout": "hello\n",
+                "stdout_encoding": "utf8",
+                "stderr": "",
+                "stderr_encoding": "utf8",
+            })
+        );
+    }
+
+    #[test]
+    fn renders_binary_exec_result_as_base64() {
+        let result = exec_result_json(7, &[0xff, 0x00], &[0x80]);
+
+        assert_eq!(
+            result,
+            serde_json::json!({
+                "exit_code": 7,
+                "success": false,
+                "stdout": "/wA=",
+                "stdout_encoding": "base64",
+                "stderr": "gA==",
+                "stderr_encoding": "base64",
+            })
+        );
+    }
+
+    #[test]
     fn no_tty_parses_before_command_delimiter() {
         let args = parse_exec_args(&["box", "--no-tty", "--", "python3", "-c", "print('ok')"]);
 
@@ -426,5 +534,10 @@ mod tests {
     #[test]
     fn no_tty_with_terminal_stdin_does_not_buffer_stdin() {
         assert!(!should_read_buffered_stdin(true, false, false));
+    }
+
+    #[test]
+    fn json_format_disables_interactive_exec() {
+        assert!(!use_interactive_exec(true, false, true));
     }
 }

--- a/crates/cli/lib/commands/exec.rs
+++ b/crates/cli/lib/commands/exec.rs
@@ -132,6 +132,7 @@ pub async fn run(args: ExecArgs) -> anyhow::Result<()> {
             (Some(cmd), cmd_args) => (cmd, cmd_args),
             (None, _) => {
                 super::maybe_stop(&sandbox).await;
+                reject_missing_json_command(args.format.as_deref() == Some("json"))?;
                 std::process::exit(0);
             }
         };
@@ -203,14 +204,13 @@ pub async fn run(args: ExecArgs) -> anyhow::Result<()> {
             .await?;
 
         if args.format.as_deref() == Some("json") {
-            println!(
-                "{}",
-                serde_json::to_string_pretty(&exec_result_json(
-                    output.status().code,
-                    output.stdout_bytes(),
-                    output.stderr_bytes(),
-                ))?
-            );
+            let json = serde_json::to_string_pretty(&exec_result_json(
+                output.status().code,
+                output.stdout_bytes(),
+                output.stderr_bytes(),
+            ))?;
+            let mut stdout = std::io::stdout().lock();
+            write_json_result(&mut stdout, &json)?;
         } else {
             std::io::stdout().write_all(output.stdout_bytes())?;
             std::io::stderr().write_all(output.stderr_bytes())?;
@@ -267,6 +267,20 @@ fn should_read_buffered_stdin(stdin_is_terminal: bool, interactive: bool, stream
 /// Decide whether execution should use the interactive PTY path.
 fn use_interactive_exec(stdin_is_terminal: bool, no_tty: bool, json: bool) -> bool {
     !json && super::common::use_interactive_tty(stdin_is_terminal, no_tty)
+}
+
+fn reject_missing_json_command(json: bool) -> anyhow::Result<()> {
+    if json {
+        anyhow::bail!(
+            "cannot produce an exec result: no command was provided and the image has no default command"
+        );
+    }
+    Ok(())
+}
+
+fn write_json_result(mut writer: impl Write, json: &str) -> std::io::Result<()> {
+    writeln!(writer, "{json}")?;
+    writer.flush()
 }
 
 /// Build the machine-readable result for one captured execution.
@@ -539,5 +553,22 @@ mod tests {
     #[test]
     fn json_format_disables_interactive_exec() {
         assert!(!use_interactive_exec(true, false, true));
+    }
+
+    #[test]
+    fn json_format_rejects_missing_command() {
+        let error = reject_missing_json_command(true).unwrap_err();
+
+        assert!(error.to_string().contains("no command was provided"));
+        assert!(reject_missing_json_command(false).is_ok());
+    }
+
+    #[test]
+    fn writes_complete_json_result() {
+        let mut output = Vec::new();
+
+        write_json_result(&mut output, r#"{"success":false}"#).unwrap();
+
+        assert_eq!(output, b"{\"success\":false}\n");
     }
 }

--- a/docs/cli/sandbox-commands.mdx
+++ b/docs/cli/sandbox-commands.mdx
@@ -343,7 +343,8 @@ JSON output includes `exit_code`, `success`, `stdout`, and `stderr`. Each output
 field has a matching `*_encoding` field: valid UTF-8 is returned as text, while
 arbitrary bytes use lossless Base64. The `msb exec` process still exits with the
 guest command's exit code, so orchestration scripts can inspect the JSON result
-and use the normal process status.
+and use the normal process status. JSON mode returns an error when neither an
+explicit command nor an image default command is available.
 
 ## msb copy
 

--- a/docs/cli/sandbox-commands.mdx
+++ b/docs/cli/sandbox-commands.mdx
@@ -320,6 +320,7 @@ Execute a command inside a running sandbox.
 ```bash
 msb exec devbox -- python -c "print('hello')"
 msb exec devbox -- ls -la /app
+msb exec devbox --format json -- sh -c 'echo result; exit 2'
 ```
 
 | Flag | Description |
@@ -331,11 +332,18 @@ msb exec devbox -- ls -la /app
 | `-u`, `--user` | Run the command as the specified guest user |
 | `--timeout` | Kill the command after this duration (e.g. `30s`, `5m`, `1h`) |
 | `--rlimit` | Set a POSIX resource limit (e.g. `nofile=1024`, `nproc=64`) |
+| `--format json` | Capture stdout and stderr in one machine-readable result |
 | `-q`, `--quiet` | Suppress progress output |
 
 <Tip>
   The CLI auto-detects whether stdin is a terminal. When interactive, `msb exec` uses `attach` mode (TTY, line editing). When piped, it captures output. Use `--no-tty` to force captured, non-interactive execution even from a terminal.
 </Tip>
+
+JSON output includes `exit_code`, `success`, `stdout`, and `stderr`. Each output
+field has a matching `*_encoding` field: valid UTF-8 is returned as text, while
+arbitrary bytes use lossless Base64. The `msb exec` process still exits with the
+guest command's exit code, so orchestration scripts can inspect the JSON result
+and use the normal process status.
 
 ## msb copy
 


### PR DESCRIPTION
## TL;DR

Add structured JSON output to `msb exec` so agents and host-side orchestrators can consume exit status and captured output without parsing terminal text.

## Description

- Add `msb exec NAME --format json -- COMMAND` for non-interactive execution.
- Return `exit_code`, `success`, `stdout`, and `stderr` in one JSON object.
- Preserve UTF-8 as text and encode arbitrary output bytes as Base64 with explicit encoding fields.
- Keep the guest exit code as the `msb` process exit code.
- Reject JSON output with `--tty` or `--stream`, and document the machine-readable contract.

## Test Plan

- `cargo fmt --all -- --check`
- `cargo test -p microsandbox-cli --lib` in `rust:1.97-bookworm` with `libcap-ng-dev` (314 passed)
- `cargo clippy -p microsandbox-cli --lib -- -D warnings` in the same Linux container

Real microVM execution was not run because the available host is Intel macOS, while this project's local libkrun runtime does not support that host configuration.
