### PR TITLE
feat(cli): add JSON output to ping

### DIFF
--- a/crates/cli/lib/commands/ping.rs
+++ b/crates/cli/lib/commands/ping.rs
@@ -1,5 +1,6 @@
 //! `msb ping` command — check agent reachability for running sandboxes.
 
+use std::io::Write;
 use std::time::Duration;
 
 use clap::Args;
@@ -105,7 +106,9 @@ pub async fn run(args: PingArgs) -> anyhow::Result<()> {
     }
 
     if json {
-        println!("{}", serde_json::to_string_pretty(&reports)?);
+        let json = serde_json::to_string_pretty(&reports)?;
+        let mut stdout = std::io::stdout().lock();
+        write_json_report(&mut stdout, &json)?;
     }
 
     if failed {
@@ -113,6 +116,11 @@ pub async fn run(args: PingArgs) -> anyhow::Result<()> {
     }
 
     Ok(())
+}
+
+fn write_json_report(mut writer: impl Write, json: &str) -> std::io::Result<()> {
+    writeln!(writer, "{json}")?;
+    writer.flush()
 }
 
 async fn ping_one(name: &str, touch: bool, quiet: bool) -> anyhow::Result<PingReport> {
@@ -250,6 +258,15 @@ mod tests {
                 },
             ])
         );
+    }
+
+    #[test]
+    fn writes_complete_json_report() {
+        let mut output = Vec::new();
+
+        write_json_report(&mut output, r#"[{"reachable":false}]"#).unwrap();
+
+        assert_eq!(output, b"[{\"reachable\":false}]\n");
     }
 
     #[test]

--- a/crates/cli/lib/commands/ping.rs
+++ b/crates/cli/lib/commands/ping.rs
@@ -4,6 +4,7 @@ use std::time::Duration;
 
 use clap::Args;
 use microsandbox::sandbox::Sandbox;
+use serde::Serialize;
 
 use crate::ui;
 
@@ -32,6 +33,42 @@ pub struct PingArgs {
     /// Suppress progress output.
     #[arg(short, long)]
     pub quiet: bool,
+
+    /// Output format (json).
+    #[arg(long, value_name = "FORMAT", value_parser = ["json"])]
+    pub format: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct PingReport {
+    name: String,
+    reachable: bool,
+    latency_us: Option<u64>,
+    error: Option<String>,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Methods
+//--------------------------------------------------------------------------------------------------
+
+impl PingReport {
+    fn reachable(name: impl Into<String>, latency: Duration) -> Self {
+        Self {
+            name: name.into(),
+            reachable: true,
+            latency_us: Some(latency.as_micros().min(u64::MAX as u128) as u64),
+            error: None,
+        }
+    }
+
+    fn unreachable(name: impl Into<String>, error: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            reachable: false,
+            latency_us: None,
+            error: Some(error.into()),
+        }
+    }
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -40,19 +77,35 @@ pub struct PingArgs {
 
 /// Execute the `msb ping` command.
 pub async fn run(args: PingArgs) -> anyhow::Result<()> {
-    let names = common::resolve_bulk_targets(&args.names, &args.label, args.quiet).await?;
+    let json = args.format.as_deref() == Some("json");
+    let quiet = args.quiet || json;
+    let names = common::resolve_bulk_targets(&args.names, &args.label, quiet).await?;
     let mut failed = false;
+    let mut reports = Vec::with_capacity(names.len());
 
     for name in &names {
-        match ping_one(name, args.touch, args.quiet).await {
-            Ok(()) => {}
+        match ping_one(name, args.touch, quiet).await {
+            Ok(report) => {
+                if let Some(error) = &report.error {
+                    if !quiet {
+                        ui::error(error);
+                    }
+                    failed = true;
+                }
+                reports.push(report);
+            }
             Err(e) => {
-                if !args.quiet {
+                if !quiet {
                     ui::error(&format!("{e}"));
                 }
+                reports.push(PingReport::unreachable(name, e.to_string()));
                 failed = true;
             }
         }
+    }
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&reports)?);
     }
 
     if failed {
@@ -62,7 +115,7 @@ pub async fn run(args: PingArgs) -> anyhow::Result<()> {
     Ok(())
 }
 
-async fn ping_one(name: &str, touch: bool, quiet: bool) -> anyhow::Result<()> {
+async fn ping_one(name: &str, touch: bool, quiet: bool) -> anyhow::Result<PingReport> {
     let handle = Sandbox::get(name).await?;
     let spinner = if quiet {
         ui::Spinner::quiet()
@@ -72,6 +125,7 @@ async fn ping_one(name: &str, touch: bool, quiet: bool) -> anyhow::Result<()> {
 
     match handle.ping().await {
         Ok(result) => {
+            let report = PingReport::reachable(&result.name, result.latency);
             spinner.finish_clear();
             if !quiet {
                 ui::success(
@@ -79,18 +133,19 @@ async fn ping_one(name: &str, touch: bool, quiet: bool) -> anyhow::Result<()> {
                     &format!("{} ({})", result.name, format_latency(result.latency)),
                 );
             }
+            if touch && let Err(error) = touch_after_ping(name, quiet).await {
+                return Ok(PingReport {
+                    error: Some(format!("touch failed: {error}")),
+                    ..report
+                });
+            }
+            Ok(report)
         }
         Err(e) => {
             spinner.finish_clear();
-            return Err(e.into());
+            Err(e.into())
         }
     }
-
-    if touch {
-        touch_after_ping(name, quiet).await?;
-    }
-
-    Ok(())
 }
 
 async fn touch_after_ping(name: &str, quiet: bool) -> anyhow::Result<()> {
@@ -161,6 +216,40 @@ mod tests {
         assert_eq!(args.label, vec!["app=api"]);
         assert!(args.touch);
         assert!(args.quiet);
+    }
+
+    #[test]
+    fn parses_json_format() {
+        let args = parse_ping_args(&["api", "worker", "--format", "json"]);
+
+        assert_eq!(args.names, vec!["api", "worker"]);
+        assert_eq!(args.format.as_deref(), Some("json"));
+    }
+
+    #[test]
+    fn renders_mixed_ping_results_as_json() {
+        let reports = vec![
+            PingReport::reachable("api", Duration::from_micros(750)),
+            PingReport::unreachable("worker", "connection refused"),
+        ];
+
+        assert_eq!(
+            serde_json::to_value(&reports).unwrap(),
+            serde_json::json!([
+                {
+                    "name": "api",
+                    "reachable": true,
+                    "latency_us": 750,
+                    "error": null,
+                },
+                {
+                    "name": "worker",
+                    "reachable": false,
+                    "latency_us": null,
+                    "error": "connection refused",
+                },
+            ])
+        );
     }
 
     #[test]

--- a/docs/cli/sandbox-commands.mdx
+++ b/docs/cli/sandbox-commands.mdx
@@ -248,6 +248,7 @@ msb ping devbox
 msb ping api worker
 msb ping --label app=engine
 msb ping api --touch
+msb ping api worker --format json
 ```
 
 Use `--touch` when a successful health check should also refresh the idle timer. Without `--touch`, ping is a pure reachability check.
@@ -256,7 +257,14 @@ Use `--touch` when a successful health check should also refresh the idle timer.
 |------|-------------|
 | `--label` | Ping every sandbox carrying this label (`KEY=VALUE`). Repeatable; AND-matched. Unioned with any named sandboxes |
 | `--touch` | Refresh the sandbox idle timer after a successful ping |
+| `--format json` | Emit one reachability report per selected sandbox |
 | `-q`, `--quiet` | Suppress progress output |
+
+JSON output includes each sandbox name, a `reachable` flag, round-trip
+`latency_us`, and an error message when the probe or requested touch fails. If
+ping succeeds but touch fails, `reachable` remains `true` and the measured
+latency is preserved. All selected sandboxes are checked even when one is
+unreachable; the command exits nonzero if any probe or requested touch fails.
 
 ## msb touch
 


### PR DESCRIPTION
## TL;DR

Add structured multi-sandbox health reports to `msb ping` for agent supervisors, gateways, and infrastructure probes.

## Description

- Add `msb ping --format json` with name, reachability, latency, and error fields per selected sandbox.
- Continue probing remaining targets after lookup, ping, or requested touch failures.
- Preserve successful reachability and latency when a follow-up `--touch` fails.
- Exit nonzero after emitting the complete report when any selected target fails.
- Document the partial-success shape for ping-plus-touch workflows.

## Test Plan

- `cargo fmt --all -- --check`
- `cargo test -p microsandbox-cli --lib` in `rust:1.97-bookworm` with `libcap-ng-dev` (310 passed)
- `cargo clippy -p microsandbox-cli --lib -- -D warnings` in the same Linux container

Real microVM execution was not run because the available host is Intel macOS, while this project's local libkrun runtime does not support that host configuration.
