### PR TITLE
docs: clarify Windows support requirements

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -9,7 +9,7 @@ For contribution guidelines (forking, commit signing, pull requests), see [CONTR
 - **Operating System**:
   - macOS with Apple Silicon (M1/M2/M3/M4)
   - Linux with KVM enabled
-  - Windows 11, or Windows Server with nested virtualization, with Windows Hypervisor Platform enabled
+  - Windows 10+ (x64 or ARM64) with Windows Hypervisor Platform enabled; Windows Server also needs nested virtualization
 - **Tools**: [`just`](https://github.com/casey/just), `git`, and `pre-commit`
   - Linux: `sudo apt install just git` and `pip install pre-commit` (or `sudo apt install pre-commit`)
   - macOS: `brew install just git pre-commit`

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@
 >
 > - <img height="14" src="https://api.iconify.design/simple-icons:apple.svg?color=%23A770EF" alt="macOS"> **macOS**: Apple Silicon.
 > - <img height="14" src="https://api.iconify.design/simple-icons:linux.svg?color=%23A770EF" alt="Linux"> **Linux**: KVM enabled.
-> - <img height="14" src="https://api.iconify.design/simple-icons:windows.svg?color=%23A770EF" alt="Windows"> **Windows**: WHP enabled.
+> - <img height="14" src="https://api.iconify.design/simple-icons:windows.svg?color=%23A770EF" alt="Windows"> **Windows**: Windows 10+ (x64 or ARM64) with WHP enabled.
 >
 > **Warning**: Microsandbox is still **beta software**. Expect breaking changes, missing features, and rough edges.
 

--- a/sdk/go/README.md
+++ b/sdk/go/README.md
@@ -27,7 +27,7 @@ For the full API reference and longer guides, use Go docs and the microsandbox d
 
 - Go 1.22+
 - CGO enabled and a C compiler/toolchain available
-- Linux with KVM, macOS with Apple Silicon, or Windows 10/11 with Windows Hypervisor Platform enabled
+- Linux with KVM, macOS with Apple Silicon, or Windows 10+ with WHP enabled
 
 ## Supported Platforms
 

--- a/sdk/node-ts/README.md
+++ b/sdk/node-ts/README.md
@@ -25,7 +25,7 @@ For the full API reference and longer guides, use the docs site:
 ## Requirements
 
 - Node.js 22+
-- Linux with KVM, macOS with Apple Silicon, or Windows with Windows Hypervisor Platform
+- Linux with KVM, macOS with Apple Silicon, or Windows 10+ with WHP enabled
 - Windows support is currently preview; see the [Windows troubleshooting guide](https://docs.microsandbox.dev/troubleshooting/windows) for WHP and runtime setup notes.
 
 The package root is ESM-only for normal imports:

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -24,7 +24,7 @@ For the full API reference and longer guides, use the docs site:
 ## Requirements
 
 - Python 3.10+
-- Linux with KVM, macOS with Apple Silicon, or Windows with Windows Hypervisor Platform
+- Linux with KVM, macOS with Apple Silicon, or Windows 10+ with WHP enabled
 - Windows support is currently preview; see the [Windows troubleshooting guide](https://docs.microsandbox.dev/troubleshooting/windows) for WHP and runtime setup notes.
 
 ## Supported Platforms

--- a/sdk/ruby/README.md
+++ b/sdk/ruby/README.md
@@ -85,8 +85,7 @@ require "microsandbox"
 Microsandbox.install unless Microsandbox.installed?
 ```
 
-Local sandboxes require Apple Silicon virtualization on macOS, KVM on Linux,
-or WHP on Windows. Ruby CI currently covers Linux x86_64.
+Local sandboxes require Apple Silicon virtualization on macOS or KVM on Linux. On Windows, use Windows 10 or later on x64 or ARM64 and enable WHP. Ruby CI currently covers Linux x86_64.
 
 ## Quick start
 

--- a/sdk/rust/README.md
+++ b/sdk/rust/README.md
@@ -25,7 +25,7 @@ For full API documentation, use the docs site and generated Rust docs:
 ## Requirements
 
 - Rust toolchain with Rust 2024 edition support
-- Linux with KVM, macOS with Apple Silicon, or Windows with Windows Hypervisor Platform
+- Linux with KVM, macOS with Apple Silicon, or Windows 10+ (x64 or ARM64) with WHP enabled
 - Windows support is currently preview; see the [Windows troubleshooting guide](https://docs.microsandbox.dev/troubleshooting/windows) for WHP and runtime setup notes.
 
 ## Installation


### PR DESCRIPTION
## TL;DR
Document Windows 10 and later as the supported Windows baseline instead of implying that Windows 11 is required.

## Description
- State that local Windows sandboxes require Windows 10+ with WHP enabled.
- Include x64 and ARM64 where the surrounding guide does not already provide an architecture table.
- Keep Windows support marked as preview and retain the nested virtualization requirement for Windows Server development hosts.

## Test Plan
- [x] `git diff --check origin/main...HEAD` exits 0
- [x] A scoped search finds no remaining Windows 11, Windows 10/11, or versionless WHP requirement wording in the updated root and SDK guides
- [x] `git diff --name-only origin/main...HEAD` contains only `README.md`, `DEVELOPMENT.md`, and SDK README files
