### PR TITLE
fix(release): lower Linux glibc baseline to 2.28

### DIFF
--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -270,7 +270,10 @@ jobs:
           consumer_dir="${RUNNER_TEMP}/microsandbox-consumer"
           mkdir -p "$pack_dir" "$consumer_dir"
           main_tarball=$(npm pack --silent --pack-destination "$pack_dir")
-          platform_tarball=$(npm pack --silent --pack-destination "$pack_dir" npm/${{ inputs.npm_dir }})
+          platform_tarball=$(
+            cd npm/${{ inputs.npm_dir }}
+            npm pack --silent --pack-destination "$pack_dir"
+          )
           cd "$consumer_dir"
           npm init --yes >/dev/null
           npm install --ignore-scripts --omit=optional \

--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -1,0 +1,386 @@
+name: Release Linux
+
+on:
+  workflow_call:
+    inputs:
+      target:
+        description: Release target label.
+        required: true
+        type: string
+      runner:
+        description: Architecture-native GitHub Actions runner label.
+        required: true
+        type: string
+      manylinux_image:
+        description: Digest-pinned manylinux 2.28 build image.
+        required: true
+        type: string
+      arch:
+        description: Release architecture label.
+        required: true
+        type: string
+      agentd_artifact:
+        description: Matching musl agentd artifact.
+        required: true
+        type: string
+      firmware_artifact:
+        description: Matching generated kernel.c artifact.
+        required: true
+        type: string
+      libkrunfw_file:
+        description: Canonical runtime library filename.
+        required: true
+        type: string
+      libkrunfw_asset:
+        description: Public release asset name for libkrunfw.
+        required: true
+        type: string
+      napi_target:
+        description: napi-rs target triple.
+        required: true
+        type: string
+      node_file:
+        description: Platform Node native binding filename.
+        required: true
+        type: string
+      npm_dir:
+        description: Platform npm package directory.
+        required: true
+        type: string
+      go_ffi_file:
+        description: Cargo output filename for the Go FFI library.
+        required: true
+        type: string
+      go_bundle_name:
+        description: Embedded Go SDK bundle filename.
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_NET_RETRY: "10"
+  CARGO_HTTP_TIMEOUT: "120"
+  CARGO_HTTP_MULTIPLEXING: "false"
+  CARGO_INCREMENTAL: "0"
+  LIBKRUNFW_VERSION: "5.6.1"
+  LIBKRUNFW_ABI: "5"
+  LINUX_GLIBC_BASELINE: "2.28"
+
+# Every shipped Linux ELF is compiled or linked inside the architecture-native
+# manylinux container. Building the kernel remains outside this workflow; only
+# the generated kernel.c bundle is linked here so libkrunfw shares the baseline.
+jobs:
+  runtime:
+    name: Runtime (${{ inputs.target }})
+    runs-on: ${{ inputs.runner }}
+    container:
+      image: ${{ inputs.manylinux_image }}
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+
+      - uses: Swatinem/rust-cache@258712b0b7b1ddf8bddc9fc3b0faca682b2736c3 # v2
+        with:
+          cache-bin: false
+          cache-targets: true
+          shared-key: release-runtime-${{ inputs.target }}
+
+      - name: Install build dependencies
+        run: dnf install -y libcap-ng-devel
+
+      - name: Download agentd
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ${{ inputs.agentd_artifact }}
+          path: build/
+
+      - name: Download firmware bundle
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ${{ inputs.firmware_artifact }}
+          path: firmware/
+
+      - name: Link libkrunfw against the baseline
+        run: |
+          mkdir -p build
+          cc -fPIC -DABI_VERSION=${{ env.LIBKRUNFW_ABI }} -shared \
+            -Wl,-soname,libkrunfw.so.${{ env.LIBKRUNFW_ABI }} \
+            -o build/${{ inputs.libkrunfw_file }} firmware/kernel.c
+          strip build/${{ inputs.libkrunfw_file }}
+          cd build
+          ln -sf ${{ inputs.libkrunfw_file }} libkrunfw.so.${{ env.LIBKRUNFW_ABI }}
+          ln -sf libkrunfw.so.${{ env.LIBKRUNFW_ABI }} libkrunfw.so
+
+      - name: Build msb
+        run: |
+          cargo build --release --no-default-features --features net,ssh -p microsandbox-cli
+          cp target/release/msb build/msb
+
+      - name: Verify runtime and glibc baseline
+        run: |
+          build/msb --version
+          python3 scripts/ci/validate_linux_glibc.py \
+            --max-version ${{ env.LINUX_GLIBC_BASELINE }} \
+            build/agentd build/msb build/${{ inputs.libkrunfw_file }}
+
+      - name: Upload runtime artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: runtime-${{ inputs.target }}
+          # upload-artifact dereferences symlinks. Listing only the canonical
+          # library prevents SONAME aliases from becoming duplicate real files.
+          path: |
+            build/agentd
+            build/msb
+            build/${{ inputs.libkrunfw_file }}
+          compression-level: 0
+
+  metrics:
+    name: Metrics (${{ inputs.target }})
+    runs-on: ${{ inputs.runner }}
+    container:
+      image: ${{ inputs.manylinux_image }}
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+
+      - uses: Swatinem/rust-cache@258712b0b7b1ddf8bddc9fc3b0faca682b2736c3 # v2
+        with:
+          cache-bin: false
+          cache-targets: true
+          shared-key: release-metrics-${{ inputs.target }}
+
+      - name: Build msb-metrics
+        run: cargo build --release -p microsandbox-metrics-collector
+
+      - name: Verify glibc baseline
+        run: |
+          python3 scripts/ci/validate_linux_glibc.py \
+            --max-version ${{ env.LINUX_GLIBC_BASELINE }} \
+            target/release/msb-metrics
+
+      - name: Upload metrics artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: metrics-${{ inputs.target }}
+          path: target/release/msb-metrics
+          compression-level: 0
+
+  go-ffi:
+    name: Go FFI (${{ inputs.target }})
+    needs: runtime
+    runs-on: ${{ inputs.runner }}
+    container:
+      image: ${{ inputs.manylinux_image }}
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+
+      - uses: Swatinem/rust-cache@258712b0b7b1ddf8bddc9fc3b0faca682b2736c3 # v2
+        with:
+          cache-bin: false
+          cache-targets: true
+          shared-key: release-go-${{ inputs.target }}
+
+      - name: Install build dependencies
+        run: dnf install -y libcap-ng-devel
+
+      - name: Download runtime artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: runtime-${{ inputs.target }}
+          path: build/
+
+      - name: Build and validate Go FFI
+        run: |
+          cargo build --release -p microsandbox-go
+          python3 scripts/ci/validate_linux_glibc.py \
+            --max-version ${{ env.LINUX_GLIBC_BASELINE }} \
+            target/release/${{ inputs.go_ffi_file }}
+
+      - name: Upload Go FFI artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: go-ffi-${{ inputs.target }}
+          path: target/release/${{ inputs.go_ffi_file }}
+          compression-level: 0
+
+  node:
+    name: Node SDK (${{ inputs.target }})
+    needs: runtime
+    runs-on: ${{ inputs.runner }}
+    container:
+      image: ${{ inputs.manylinux_image }}
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+
+      - uses: Swatinem/rust-cache@258712b0b7b1ddf8bddc9fc3b0faca682b2736c3 # v2
+        with:
+          cache-bin: false
+          cache-targets: true
+          shared-key: release-node-${{ inputs.target }}
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: sdk/node-ts/package-lock.json
+
+      - name: Install build dependencies
+        run: dnf install -y libcap-ng-devel
+
+      - name: Download runtime artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: runtime-${{ inputs.target }}
+          path: build/
+
+      - name: Build Node native binding
+        working-directory: sdk/node-ts
+        run: |
+          node scripts/prune-platform-optional-deps.mjs
+          npm install --package-lock=false
+          npm run build:native -- --target ${{ inputs.napi_target }}
+          node -e 'require("./native/index.cjs")'
+
+      - name: Prepare and validate Node packages
+        working-directory: sdk/node-ts
+        run: |
+          npm run build:ts
+          node scripts/prepare-platform-package.mjs ${{ inputs.npm_dir }}
+          python3 ../../scripts/ci/validate_linux_glibc.py \
+            --max-version ${{ env.LINUX_GLIBC_BASELINE }} \
+            native/${{ inputs.node_file }} npm/${{ inputs.npm_dir }}
+
+          # Install exactly the tarballs that will be published, without relying
+          # on a source-tree override or an already-published optional package.
+          pack_dir="${RUNNER_TEMP}/microsandbox-packs"
+          consumer_dir="${RUNNER_TEMP}/microsandbox-consumer"
+          mkdir -p "$pack_dir" "$consumer_dir"
+          main_tarball=$(npm pack --silent --pack-destination "$pack_dir")
+          platform_tarball=$(npm pack --silent --pack-destination "$pack_dir" npm/${{ inputs.npm_dir }})
+          cd "$consumer_dir"
+          npm init --yes >/dev/null
+          npm install --ignore-scripts --omit=optional \
+            "$pack_dir/$main_tarball" "$pack_dir/$platform_tarball"
+          node --input-type=module -e 'await import("microsandbox")'
+
+      - name: Upload Node SDK artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: node-sdk-${{ inputs.npm_dir }}
+          path: |
+            sdk/node-ts/native/${{ inputs.node_file }}
+            sdk/node-ts/native/index.cjs
+            sdk/node-ts/native/index.d.ts
+            sdk/node-ts/npm/${{ inputs.npm_dir }}/${{ inputs.node_file }}
+            sdk/node-ts/npm/${{ inputs.npm_dir }}/bin/msb
+            sdk/node-ts/npm/${{ inputs.npm_dir }}/lib/*
+          compression-level: 0
+
+  python:
+    name: Python SDK (${{ inputs.target }})
+    needs: runtime
+    runs-on: ${{ inputs.runner }}
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+
+      - uses: Swatinem/rust-cache@258712b0b7b1ddf8bddc9fc3b0faca682b2736c3 # v2
+        with:
+          cache-bin: false
+          cache-targets: true
+          shared-key: release-python-${{ inputs.target }}
+
+      - name: Install build dependencies
+        run: sudo apt-get update && sudo apt-get install -y libcap-ng-dev
+
+      - name: Download runtime artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: runtime-${{ inputs.target }}
+          path: build/
+
+      - name: Stage runtime bundle
+        run: |
+          mkdir -p sdk/python/microsandbox/_bundled/bin sdk/python/microsandbox/_bundled/lib
+          cp build/msb sdk/python/microsandbox/_bundled/bin/
+          cp build/${{ inputs.libkrunfw_file }} sdk/python/microsandbox/_bundled/lib/
+
+      - name: Build Python wheel
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1
+        with:
+          working-directory: sdk/python
+          command: build
+          args: --release --out dist
+          manylinux: 2_28
+          before-script-linux: dnf install -y libcap-ng-devel
+
+      - name: Verify wheel glibc baseline
+        run: |
+          python3 scripts/ci/validate_linux_glibc.py \
+            --max-version ${{ env.LINUX_GLIBC_BASELINE }} \
+            sdk/python/dist
+
+      - name: Upload Python SDK wheel
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: python-sdk-${{ inputs.target }}
+          path: sdk/python/dist/*.whl
+          compression-level: 0
+
+  assemble-platform:
+    name: Assemble (${{ inputs.target }})
+    needs: [runtime, metrics, go-ffi]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download runtime artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: runtime-${{ inputs.target }}
+          path: bundle/runtime/
+
+      - name: Download metrics artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: metrics-${{ inputs.target }}
+          path: bundle/metrics/
+
+      - name: Download Go FFI artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: go-ffi-${{ inputs.target }}
+          path: bundle/go/
+
+      - name: Stage platform artifacts
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts
+          cp bundle/runtime/msb artifacts/msb-${{ inputs.target }}
+          cp bundle/metrics/msb-metrics artifacts/msb-metrics-${{ inputs.target }}
+          cp bundle/runtime/${{ inputs.libkrunfw_file }} artifacts/${{ inputs.libkrunfw_asset }}
+          cp bundle/runtime/agentd artifacts/agentd-${{ inputs.arch }}
+          tar -czf artifacts/microsandbox-${{ inputs.target }}.tar.gz \
+            -C bundle/runtime msb ${{ inputs.libkrunfw_file }}
+          cp bundle/go/${{ inputs.go_ffi_file }} artifacts/${{ inputs.go_bundle_name }}
+
+      - name: Upload platform artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: release-${{ inputs.target }}
+          path: artifacts/
+          compression-level: 0

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -1,4 +1,4 @@
-name: Release Unix
+name: Release macOS
 
 on:
   workflow_call:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
     paths:
       - .github/workflows/release.yml
       - .github/workflows/release-linux.yml
-      - .github/workflows/release-unix.yml
+      - .github/workflows/release-macos.yml
       - .github/workflows/release-windows.yml
       - .github/actions/cache-libkrunfw-kernel/action.yml
       - scripts/ci/publish-crates.py
@@ -248,7 +248,7 @@ jobs:
   darwin-aarch64:
     name: macOS aarch64
     needs: [firmware-aarch64, agentd-aarch64]
-    uses: ./.github/workflows/release-unix.yml
+    uses: ./.github/workflows/release-macos.yml
     with:
       target: darwin-aarch64
       runner: macos-14

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,11 +6,14 @@ on:
   pull_request:
     paths:
       - .github/workflows/release.yml
+      - .github/workflows/release-linux.yml
       - .github/workflows/release-unix.yml
       - .github/workflows/release-windows.yml
       - .github/actions/cache-libkrunfw-kernel/action.yml
       - scripts/ci/publish-crates.py
       - scripts/ci/validate-release-artifacts.py
+      - scripts/ci/validate_linux_glibc.py
+      - scripts/ci/test_validate_linux_glibc.py
       - scripts/ci/wait-for-npm-packages.mjs
   # Manual runs exercise the full release build and validation graph. Every
   # irreversible job below is independently guarded to tag pushes only.
@@ -54,8 +57,8 @@ jobs:
           path: vendor/libkrunfw/tarballs/*.tar.gz
           compression-level: 0
 
-  # Build each firmware bundle once. Linux consumes the shared library directly;
-  # macOS and Windows consume the matching generated kernel.c.
+  # Build each firmware bundle once. Platform workflows consume the generated
+  # kernel.c; Linux relinks it inside its baseline container.
   firmware-aarch64:
     name: Firmware (aarch64)
     needs: kernel-sources
@@ -207,11 +210,11 @@ jobs:
   linux-x86_64:
     name: Linux x86_64
     needs: [firmware-x86_64, agentd-x86_64]
-    uses: ./.github/workflows/release-unix.yml
+    uses: ./.github/workflows/release-linux.yml
     with:
       target: linux-x86_64
       runner: ubuntu-latest
-      os: linux
+      manylinux_image: quay.io/pypa/manylinux_2_28_x86_64@sha256:0c87ccb5996dab6c3b7612ee4fda7b80c4ab3c44a86c2541e4a872afdf4f131b
       arch: x86_64
       agentd_artifact: agentd-x86_64-linux-musl
       firmware_artifact: firmware-x86_64
@@ -226,11 +229,11 @@ jobs:
   linux-aarch64:
     name: Linux aarch64
     needs: [firmware-aarch64, agentd-aarch64]
-    uses: ./.github/workflows/release-unix.yml
+    uses: ./.github/workflows/release-linux.yml
     with:
       target: linux-aarch64
       runner: ubuntu-24.04-arm
-      os: linux
+      manylinux_image: quay.io/pypa/manylinux_2_28_aarch64@sha256:561427136aabf3787bffb294b3515748241e0962d1527ae28bea1e076bfb9d99
       arch: aarch64
       agentd_artifact: agentd-aarch64-linux-musl
       firmware_artifact: firmware-aarch64
@@ -949,6 +952,13 @@ jobs:
             --node-dir node-artifacts \
             --python-dir python-artifacts \
             --manifest release-validation/manifest.json
+
+      - name: Validate Linux glibc baseline
+        run: |
+          python3 -m unittest scripts.ci.test_validate_linux_glibc
+          python3 scripts/ci/validate_linux_glibc.py \
+            --max-version 2.28 \
+            release-artifacts node-artifacts python-artifacts
 
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 

--- a/scripts/ci/test_validate_linux_glibc.py
+++ b/scripts/ci/test_validate_linux_glibc.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""Tests for the Linux glibc release-artifact validator."""
+
+from __future__ import annotations
+
+import unittest
+
+from scripts.ci.validate_linux_glibc import (
+    parse_glibc_versions,
+    parse_version,
+    version_key,
+)
+
+
+class ValidateLinuxGlibcTests(unittest.TestCase):
+    def test_parse_glibc_versions_collects_required_and_weak_versions(self) -> None:
+        output = """
+          0x0010: Name: GLIBC_2.17  Flags: none  Version: 6
+          0x0030: Name: GLIBC_2.28  Flags: none  Version: 4
+          0x0050: Name: GLIBC_2.39  Flags: WEAK  Version: 3
+          0x0070: Name: GLIBCXX_3.4.29  Flags: none  Version: 2
+        """
+
+        self.assertEqual(
+            parse_glibc_versions(output),
+            {(2, 17), (2, 28), (2, 39)},
+        )
+
+    def test_version_key_treats_trailing_zeroes_as_equal(self) -> None:
+        self.assertEqual(
+            version_key(parse_version("2.28")), version_key(parse_version("2.28.0"))
+        )
+
+    def test_version_key_orders_newer_glibc_versions(self) -> None:
+        self.assertGreater(
+            version_key(parse_version("2.38")), version_key(parse_version("2.28"))
+        )
+
+    def test_parse_version_rejects_non_numeric_values(self) -> None:
+        with self.assertRaises(ValueError):
+            parse_version("GLIBC_2.28")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/ci/validate_linux_glibc.py
+++ b/scripts/ci/validate_linux_glibc.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""Reject Linux release artifacts that exceed the supported glibc baseline."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import shutil
+import subprocess
+import tarfile
+import tempfile
+import zipfile
+from collections.abc import Iterator
+from pathlib import Path
+from typing import BinaryIO
+
+ELF_MAGIC = b"\x7fELF"
+GLIBC_VERSION = re.compile(r"\bGLIBC_(\d+(?:\.\d+)+)\b")
+ARCHIVE_SUFFIXES = (".tar.gz", ".tgz", ".tar", ".whl", ".zip")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Validate the maximum required glibc symbol version in ELF artifacts."
+    )
+    parser.add_argument(
+        "paths",
+        type=Path,
+        nargs="+",
+        help="Files or directories to inspect recursively.",
+    )
+    parser.add_argument(
+        "--max-version",
+        default="2.28",
+        help="Highest allowed GLIBC symbol version (default: 2.28).",
+    )
+    return parser.parse_args()
+
+
+def parse_version(value: str) -> tuple[int, ...]:
+    """Convert a dotted numeric version to a tuple suitable for comparison."""
+    if not re.fullmatch(r"\d+(?:\.\d+)+", value):
+        raise ValueError(f"invalid numeric version: {value}")
+    return tuple(int(part) for part in value.split("."))
+
+
+def version_key(version: tuple[int, ...], width: int = 4) -> tuple[int, ...]:
+    """Pad versions so 2.28 and 2.28.0 compare as the same baseline."""
+    return (*version, *(0 for _ in range(max(0, width - len(version)))))
+
+
+def parse_glibc_versions(readelf_output: str) -> set[tuple[int, ...]]:
+    """Extract every versioned glibc dependency reported by readelf."""
+    return {parse_version(match) for match in GLIBC_VERSION.findall(readelf_output)}
+
+
+def is_elf(path: Path) -> bool:
+    try:
+        with path.open("rb") as source:
+            return source.read(len(ELF_MAGIC)) == ELF_MAGIC
+    except OSError:
+        return False
+
+
+def iter_files(paths: list[Path]) -> Iterator[Path]:
+    for path in paths:
+        if path.is_dir():
+            yield from (
+                candidate
+                for candidate in sorted(path.rglob("*"))
+                if candidate.is_file()
+            )
+        elif path.is_file():
+            yield path
+        else:
+            raise FileNotFoundError(f"artifact path does not exist: {path}")
+
+
+def copy_if_elf(source: BinaryIO, destination: Path) -> bool:
+    """Copy an archive member only when its first bytes identify an ELF file."""
+    prefix = source.read(len(ELF_MAGIC))
+    if prefix != ELF_MAGIC:
+        return False
+    with destination.open("wb") as output:
+        output.write(prefix)
+        shutil.copyfileobj(source, output)
+    return True
+
+
+def iter_archive_elfs(archive: Path, temporary: Path) -> Iterator[tuple[str, Path]]:
+    """Materialize ELF archive members under generated, traversal-safe names."""
+    if archive.name.endswith((".whl", ".zip")):
+        with zipfile.ZipFile(archive) as package:
+            for index, member in enumerate(package.infolist()):
+                if member.is_dir():
+                    continue
+                destination = temporary / f"zip-{index}"
+                with package.open(member) as source:
+                    if copy_if_elf(source, destination):
+                        yield f"{archive}!{member.filename}", destination
+        return
+
+    with tarfile.open(archive, mode="r:*") as package:
+        for index, member in enumerate(package):
+            if not member.isfile():
+                continue
+            source = package.extractfile(member)
+            if source is None:
+                continue
+            destination = temporary / f"tar-{index}"
+            with source:
+                if copy_if_elf(source, destination):
+                    yield f"{archive}!{member.name}", destination
+
+
+def read_glibc_versions(path: Path, readelf: str) -> set[tuple[int, ...]]:
+    result = subprocess.run(
+        [readelf, "--version-info", "--wide", str(path)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return parse_glibc_versions(result.stdout)
+
+
+def main() -> None:
+    args = parse_args()
+    try:
+        maximum = parse_version(args.max_version)
+    except ValueError as error:
+        raise SystemExit(str(error)) from error
+
+    readelf = shutil.which("readelf")
+    if readelf is None:
+        raise SystemExit("readelf is required to validate Linux glibc compatibility")
+
+    inspected = 0
+    failures: list[str] = []
+    with tempfile.TemporaryDirectory(
+        prefix="microsandbox-glibc-"
+    ) as temporary_directory:
+        temporary = Path(temporary_directory)
+        for artifact in iter_files(args.paths):
+            candidates: Iterator[tuple[str, Path]]
+            if artifact.name.endswith(ARCHIVE_SUFFIXES):
+                candidates = iter_archive_elfs(artifact, temporary)
+            elif is_elf(artifact):
+                candidates = iter(((str(artifact), artifact),))
+            else:
+                continue
+
+            for label, candidate in candidates:
+                inspected += 1
+                versions = read_glibc_versions(candidate, readelf)
+                incompatible = sorted(
+                    (
+                        version
+                        for version in versions
+                        if version_key(version) > version_key(maximum)
+                    ),
+                    key=version_key,
+                )
+                if incompatible:
+                    rendered = ", ".join(
+                        f"GLIBC_{'.'.join(map(str, version))}"
+                        for version in incompatible
+                    )
+                    failures.append(f"{label}: requires {rendered}")
+
+    if inspected == 0:
+        raise SystemExit("no ELF artifacts found in the supplied paths")
+    if failures:
+        raise SystemExit(
+            f"Linux artifacts exceed the GLIBC_{args.max_version} baseline:\n- "
+            + "\n- ".join(failures)
+        )
+    print(f"validated {inspected} ELF artifacts against GLIBC_{args.max_version}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## TL;DR
Build every published Linux host artifact against glibc 2.28 and prevent future releases from silently raising that baseline.

Closes #931.

## Description
- Split Linux artifact production into an architecture-native reusable workflow backed by digest-pinned manylinux 2.28 x86_64 and aarch64 images.
- Build `msb`, `msb-metrics`, the Node N-API binding, and the Go FFI library inside the baseline container.
- Relink Microsandbox's existing generated `kernel.c` firmware bundle inside the same container so the packaged `libkrunfw` shared library has the same host ABI baseline. This does not change the `libkrun` or `libkrunfw` source repositories.
- Keep the Python extension on maturin's existing manylinux 2.28 path while bundling the newly baseline-built runtime artifacts.
- Add early ABI checks to each Linux build and a final gate that scans raw release files, npm payloads, tarballs, and wheels for any required `GLIBC_*` version newer than 2.28, including weak requirements.
- Pack the main and platform npm packages, install both into a clean consumer project without source overrides, and import `microsandbox` before uploading the Node artifacts.
- Leave all publication jobs tag-only; this PR does not bump a version or publish a release.

## Test Plan
- [x] `python3 -m unittest scripts.ci.test_validate_linux_glibc`
- [x] Ruff lint and formatting checks pass for the validator and its tests
- [x] `git diff --check`
- [x] `actionlint` passes for the new reusable Linux workflow
- [x] `actionlint` passes for the parent release workflow after ignoring its pre-existing custom `windows-11-arm` runner-label warning
- [x] On the OVH x86_64 KVM host, build the unmodified 0.6.10 runtime, metrics collector, Node binding, and Go FFI library in manylinux 2.28; all seven raw/packed ELF instances pass the new ABI validator
- [x] Install the locally packed main and Linux x64 npm packages into a clean Node 24 consumer on Debian 12/glibc 2.36 and import `microsandbox`
- [x] Use that clean package to create an Alpine microVM and exercise command execution, streaming, TTY, filesystem, metrics, logs, and lifecycle operations (15/15 smoke checks passed)
- [x] Confirm the validator rejects the published 0.6.10 Linux x64 addon and reports requirements through `GLIBC_2.39`
- [x] Full x86_64 and aarch64 release build graph, including the final assembled release/npm/wheel glibc scan
