### PR TITLE
fix(docs): repair animation and installation guidance

### DIFF
--- a/docs/cli/overview.mdx
+++ b/docs/cli/overview.mdx
@@ -28,7 +28,7 @@ irm https://install.microsandbox.dev/windows | iex
 On Linux and macOS, the install script writes the runtime to `~/.microsandbox/` and creates command links in `~/.local/bin/`. It does not edit shell startup files. If `~/.local/bin` is not on your `PATH`, the installer prints the command to add it. On macOS, Homebrew provides the same CLI through the official tap. On Windows, use PowerShell. Windows support is currently in preview.
 
 <Note>
-  Local sandboxes require glibc-based Linux with KVM, an Apple Silicon Mac, or an x64 or ARM64 machine running Windows 10 or later with Windows Hypervisor Platform enabled. See [Linux troubleshooting](/troubleshooting/linux), [macOS troubleshooting](/troubleshooting/macos), or [Windows troubleshooting](/troubleshooting/windows) for setup help.
+  Local sandboxes require Linux with glibc 2.28 or newer and KVM, an Apple Silicon Mac, or an x64 or ARM64 machine running Windows 10 or later with Windows Hypervisor Platform enabled. See [Linux troubleshooting](/troubleshooting/linux), [macOS troubleshooting](/troubleshooting/macos), or [Windows troubleshooting](/troubleshooting/windows) for setup help.
 </Note>
 
 Check your local setup with:

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -359,6 +359,7 @@
             "group": "Data & Observability",
             "icon": "database",
             "pages": [
+              "examples/data/juicefs-s3",
               "examples/data/postgresql",
               "examples/data/migration-rehearsal",
               "examples/data/redis",
@@ -488,6 +489,10 @@
     {
       "source": "/recipes/:slug*",
       "destination": "/examples/:slug*"
+    },
+    {
+      "source": "/examples/data/juicefs-r2",
+      "destination": "/examples/data/juicefs-s3"
     },
     {
       "source": "/cloud/compatibility",

--- a/docs/examples/agents/gemini-cli.mdx
+++ b/docs/examples/agents/gemini-cli.mdx
@@ -1,25 +1,24 @@
 ---
 title: Gemini CLI
-description: Run Google's Gemini CLI against a copied project in a microVM
+description: Run Google's Gemini CLI against a project on your host
 icon: "/images/recipes/agents/gemini-cli.svg"
 ---
 
-This example runs the official scoped Gemini CLI package inside a disposable Node.js microVM. The project is copied into the guest, while Gemini authentication and settings live in a named volume.
+This example runs the official scoped Gemini CLI package inside a disposable Node.js microVM. The project is mounted from your host, while Gemini authentication and settings live on the sandbox's root disk.
 
 ## Run Gemini CLI
 
 <Steps>
 <Step title="Start Gemini CLI">
 
-<Tooltip tip="On microsandbox cloud, create the named volume first and omit replace-on-create from this command."><span className="msb-badge-limited">Limited on cloud <Icon icon="circle-info" size={11} /></span></Tooltip>
+<Tooltip tip="Writable host-directory mounts are local-only. On microsandbox cloud, use the isolated-copy alternative and omit replace-on-create."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
 
 <CodeGroup>
 ```sh macOS & Linux
 msb run -t --name gemini-demo --replace \
   --cpus 2 --memory 2G --root-disk 4G \
-  --copy-dir ./my-project:/workspace \
+  --mount-dir ./my-project:/workspace:rw \
   --workdir /workspace \
-  --mount-named gemini-data:/root/.gemini \
   node:24-bookworm-slim -- sh -lc '
     apt-get update &&
     apt-get install -y --no-install-recommends ca-certificates git &&
@@ -31,9 +30,8 @@ msb run -t --name gemini-demo --replace \
 ```powershell Windows
 msb run -t --name gemini-demo --replace `
   --cpus 2 --memory 2G --root-disk 4G `
-  --copy-dir ./my-project:/workspace `
+  --mount-dir ./my-project:/workspace:rw `
   --workdir /workspace `
-  --mount-named gemini-data:/root/.gemini `
   node:24-bookworm-slim -- sh -lc '
     apt-get update &&
     apt-get install -y --no-install-recommends ca-certificates git &&
@@ -43,7 +41,11 @@ msb run -t --name gemini-demo --replace `
 ```
 </CodeGroup>
 
-Gemini CLI first asks whether you trust the workspace. Review the copied files, then continue to authentication. The sandbox cannot directly modify the original host directory.
+Gemini CLI first asks whether you trust the workspace. Review the mounted project, then continue to authentication.
+
+<Tip>
+  For an isolated workspace—or when using microsandbox cloud—replace `--mount-dir ./my-project:/workspace:rw` with `--copy-dir ./my-project:/workspace`.
+</Tip>
 
 <Warning>
   Install the scoped package exactly as shown: `@google/gemini-cli`. Do not substitute similarly named unscoped packages.
@@ -73,9 +75,15 @@ The pinned example prints `0.52.0`.
 
 </Step>
 
-<Step title="Export changes">
+<Step title="Review or export changes">
 
-Create a patch inside the sandbox:
+With the default writable mount, changes are already in the host checkout. Review them inside the sandbox:
+
+```sh
+msb exec gemini-demo -- sh -lc 'cd /workspace && git status --short && git diff --stat && git diff'
+```
+
+If you chose the isolated `--copy-dir` alternative, create a patch inside the sandbox:
 
 ```sh
 msb exec gemini-demo -- sh -lc 'cd /workspace && git add -N . && git diff --binary > /tmp/gemini.patch'
@@ -103,11 +111,7 @@ Remove the sandbox:
 msb rm -f gemini-demo
 ```
 
-Remove persisted Gemini data only when you no longer need it:
-
-```sh
-msb volume rm gemini-data
-```
+Removing the sandbox also removes its Gemini authentication and settings. Changes made through the default workspace mount remain in the host checkout.
 
 </Step>
 </Steps>

--- a/docs/examples/agents/goose.mdx
+++ b/docs/examples/agents/goose.mdx
@@ -1,6 +1,6 @@
 ---
 title: Goose
-description: Run the native Goose coding agent in an isolated project copy
+description: Run the native Goose coding agent against a project on your host
 icon: "/images/recipes/agents/goose.svg"
 ---
 
@@ -11,16 +11,14 @@ Goose publishes native Linux binaries for both `aarch64` and `x86_64`. Its insta
 <Steps>
 <Step title="Start Goose">
 
-<Tooltip tip="On microsandbox cloud, create the named volume first and omit replace-on-create from this command."><span className="msb-badge-limited">Limited on cloud <Icon icon="circle-info" size={11} /></span></Tooltip>
+<Tooltip tip="Writable host-directory mounts are local-only. On microsandbox cloud, use the isolated-copy alternative and omit replace-on-create."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
 
 <CodeGroup>
 ```sh macOS & Linux
 msb run -t --name goose-demo --replace \
   --cpus 2 --memory 2G --root-disk 3G \
-  --copy-dir ./my-project:/workspace \
+  --mount-dir ./my-project:/workspace:rw \
   --workdir /workspace \
-  --mount-named goose-data:/data/goose \
-  -e GOOSE_PATH_ROOT=/data/goose \
   debian:bookworm-slim -- sh -lc '
     apt-get update &&
     apt-get install -y --no-install-recommends ca-certificates curl bzip2 git &&
@@ -33,10 +31,8 @@ msb run -t --name goose-demo --replace \
 ```powershell Windows
 msb run -t --name goose-demo --replace `
   --cpus 2 --memory 2G --root-disk 3G `
-  --copy-dir ./my-project:/workspace `
+  --mount-dir ./my-project:/workspace:rw `
   --workdir /workspace `
-  --mount-named goose-data:/data/goose `
-  -e GOOSE_PATH_ROOT=/data/goose `
   debian:bookworm-slim -- sh -lc '
     apt-get update &&
     apt-get install -y --no-install-recommends ca-certificates curl bzip2 git &&
@@ -47,10 +43,10 @@ msb run -t --name goose-demo --replace `
 ```
 </CodeGroup>
 
-On first launch Goose asks whether to share anonymous usage data, then walks through provider configuration. `GOOSE_BIN_DIR` installs the executable on the sandbox's normal `PATH`, including later `msb exec` sessions. `GOOSE_PATH_ROOT` keeps its configuration, data, and session state in the `goose-data` volume.
+On first launch Goose asks whether to share anonymous usage data, then walks through provider configuration. `GOOSE_BIN_DIR` installs the executable on the sandbox's normal `PATH`, including later `msb exec` sessions. Goose keeps its configuration, data, and session state on the sandbox's 3 GiB root disk.
 
 <Tip>
-  To test Goose without copying a project, replace `--copy-dir ./my-project:/workspace` with `--mkdir /workspace`.
+  For an isolated workspace—or when using microsandbox cloud—replace `--mount-dir ./my-project:/workspace:rw` with `--copy-dir ./my-project:/workspace`. To test Goose without a project, use `--mkdir /workspace` instead.
 </Tip>
 
 </Step>
@@ -77,9 +73,15 @@ The pinned installer reports `1.44.0`.
 
 </Step>
 
-<Step title="Export changes">
+<Step title="Review or export changes">
 
-Use the same review boundary as other coding-agent examples:
+With the default writable mount, changes are already in the host checkout. Review them inside the sandbox:
+
+```sh
+msb exec goose-demo -- sh -lc 'cd /workspace && git status --short && git diff --stat && git diff'
+```
+
+If you chose the isolated `--copy-dir` alternative, create a patch inside the sandbox:
 
 ```sh
 msb exec goose-demo -- sh -lc 'cd /workspace && git add -N . && git diff --binary > /tmp/goose.patch'
@@ -107,11 +109,7 @@ Remove the sandbox:
 msb rm -f goose-demo
 ```
 
-Remove persisted Goose data only when you no longer need it:
-
-```sh
-msb volume rm goose-data
-```
+Removing the sandbox also removes its Goose configuration and session data. Changes made through the default workspace mount remain in the host checkout.
 
 </Step>
 </Steps>

--- a/docs/examples/agents/opencode.mdx
+++ b/docs/examples/agents/opencode.mdx
@@ -1,17 +1,17 @@
 ---
 title: OpenCode
-description: Run the OpenCode terminal agent against an isolated copy of a project
+description: Run the OpenCode terminal agent against a project on your host
 icon: "/images/recipes/agents/opencode.svg"
 ---
 
-This example installs OpenCode in a microVM and opens its terminal UI in an isolated workspace. Project files are copied into the sandbox rather than bind-mounted, so commands and edits cannot directly change the host checkout.
+This example installs OpenCode in a microVM and opens its terminal UI in a project mounted from your host. OpenCode edits the source checkout directly while its tools and dependencies stay inside the sandbox.
 
 ## Run OpenCode
 
 <Steps>
 <Step title="Start OpenCode">
 
-<Tooltip tip="On microsandbox cloud, create the named volumes first and omit replace-on-create from this command."><span className="msb-badge-limited">Limited on cloud <Icon icon="circle-info" size={11} /></span></Tooltip>
+<Tooltip tip="Writable host-directory mounts are local-only. On microsandbox cloud, use the isolated-copy alternative and omit replace-on-create."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
 
 Replace `./my-project` with the project directory you want OpenCode to work on:
 
@@ -19,10 +19,8 @@ Replace `./my-project` with the project directory you want OpenCode to work on:
 ```sh macOS & Linux
 msb run -t --name opencode-demo --replace \
   --cpus 2 --memory 2G --root-disk 4G \
-  --copy-dir ./my-project:/workspace \
+  --mount-dir ./my-project:/workspace:rw \
   --workdir /workspace \
-  --mount-named opencode-config:/root/.config/opencode \
-  --mount-named opencode-data:/root/.local/share/opencode \
   node:24-bookworm-slim -- sh -lc '
     apt-get update &&
     apt-get install -y --no-install-recommends ca-certificates git &&
@@ -34,10 +32,8 @@ msb run -t --name opencode-demo --replace \
 ```powershell Windows
 msb run -t --name opencode-demo --replace `
   --cpus 2 --memory 2G --root-disk 4G `
-  --copy-dir ./my-project:/workspace `
+  --mount-dir ./my-project:/workspace:rw `
   --workdir /workspace `
-  --mount-named opencode-config:/root/.config/opencode `
-  --mount-named opencode-data:/root/.local/share/opencode `
   node:24-bookworm-slim -- sh -lc '
     apt-get update &&
     apt-get install -y --no-install-recommends ca-certificates git &&
@@ -47,10 +43,10 @@ msb run -t --name opencode-demo --replace `
 ```
 </CodeGroup>
 
-The first run downloads the package and may take a couple of minutes. OpenCode should render its prompt and offer `/connect` for provider setup. The two named volumes retain its normal XDG configuration and data directories if you recreate the sandbox.
+The first run downloads the package and may take a couple of minutes. OpenCode should render its prompt and offer `/connect` for provider setup. Its XDG configuration, provider connections, and session data live on the sandbox's 4 GiB root disk and remain available when the sandbox stops and starts.
 
 <Tip>
-  To try the TUI without a project, replace `--copy-dir ./my-project:/workspace` with `--mkdir /workspace`.
+  For an isolated workspace—or when using microsandbox cloud—replace `--mount-dir ./my-project:/workspace:rw` with `--copy-dir ./my-project:/workspace`. To try the TUI without a project, use `--mkdir /workspace` instead.
 </Tip>
 
 </Step>
@@ -77,15 +73,15 @@ The pinned example prints `1.18.4`.
 
 </Step>
 
-<Step title="Export changes">
+<Step title="Review or export changes">
 
-Review the diff inside the sandbox before copying anything back:
+With the default writable mount, changes are already in the host checkout. Review the diff from either side of the mount:
 
 ```sh
 msb exec opencode-demo -- sh -lc 'cd /workspace && git status --short && git diff --stat && git diff'
 ```
 
-For a Git repository, export a patch instead of replacing your host checkout:
+If you chose the isolated `--copy-dir` alternative, export a patch from the sandbox:
 
 ```sh
 msb exec opencode-demo -- sh -lc 'cd /workspace && git add -N . && git diff --binary > /tmp/opencode.patch'
@@ -113,13 +109,7 @@ Remove the sandbox:
 msb rm -f opencode-demo
 ```
 
-Remove persisted configuration and data only when you no longer need them:
-
-```sh
-msb volume rm opencode-config opencode-data
-```
-
-Keep the volumes if you want to retain provider connections, sessions, and OpenCode configuration. Never copy an agent's entire home directory back to the host.
+Removing the sandbox also removes its provider connections, sessions, and OpenCode configuration. Changes made through the default workspace mount remain in the host checkout. Never copy an agent's entire home directory back to the host.
 
 </Step>
 </Steps>

--- a/docs/examples/agents/pi.mdx
+++ b/docs/examples/agents/pi.mdx
@@ -1,24 +1,24 @@
 ---
 title: Pi coding agent
 sidebarTitle: Pi
-description: Run the Pi terminal coding agent in an isolated project copy
+description: Run the Pi terminal coding agent against a project on your host
 icon: "/images/recipes/agents/pi.svg"
 ---
 
-Pi is a terminal coding agent distributed as a Node.js package. This example pins the tested package version and gives it a copied workspace inside the microVM.
+Pi is a terminal coding agent distributed as a Node.js package. This example pins the tested package version and gives it writable access to a project mounted from your host.
 
 ## Run Pi
 
 <Steps>
 <Step title="Start Pi">
 
-<Tooltip tip="This agent works on microsandbox cloud after omitting replace-on-create from the command."><span className="msb-badge-limited">Limited on cloud <Icon icon="circle-info" size={11} /></span></Tooltip>
+<Tooltip tip="Writable host-directory mounts are local-only. On microsandbox cloud, use the isolated-copy alternative and omit replace-on-create."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
 
 <CodeGroup>
 ```sh macOS & Linux
 msb run -t --name pi-demo --replace \
   --cpus 2 --memory 2G --root-disk 4G \
-  --copy-dir ./my-project:/workspace \
+  --mount-dir ./my-project:/workspace:rw \
   --workdir /workspace \
   node:24-bookworm-slim -- sh -lc '
     apt-get update &&
@@ -31,7 +31,7 @@ msb run -t --name pi-demo --replace \
 ```powershell Windows
 msb run -t --name pi-demo --replace `
   --cpus 2 --memory 2G --root-disk 4G `
-  --copy-dir ./my-project:/workspace `
+  --mount-dir ./my-project:/workspace:rw `
   --workdir /workspace `
   node:24-bookworm-slim -- sh -lc '
     apt-get update &&
@@ -43,6 +43,10 @@ msb run -t --name pi-demo --replace `
 </CodeGroup>
 
 The tested install downloads 188 packages and takes about a minute on a warm Node image cache. Configure a provider from the TUI when prompted.
+
+<Tip>
+  For an isolated workspace—or when using microsandbox cloud—replace `--mount-dir ./my-project:/workspace:rw` with `--copy-dir ./my-project:/workspace`.
+</Tip>
 
 </Step>
 
@@ -68,9 +72,15 @@ The pinned example prints `0.73.1`.
 
 </Step>
 
-<Step title="Export changes">
+<Step title="Review or export changes">
 
-Create a patch inside the sandbox:
+With the default writable mount, changes are already in the host checkout. Review them inside the sandbox:
+
+```sh
+msb exec pi-demo -- sh -lc 'cd /workspace && git status --short && git diff --stat && git diff'
+```
+
+If you chose the isolated `--copy-dir` alternative, create a patch inside the sandbox:
 
 ```sh
 msb exec pi-demo -- sh -lc 'cd /workspace && git add -N . && git diff --binary > /tmp/pi.patch'
@@ -95,6 +105,8 @@ git apply --check ./pi.patch
 ```sh
 msb rm -f pi-demo
 ```
+
+Changes made through the default workspace mount remain in the host checkout.
 
 </Step>
 </Steps>

--- a/docs/examples/ci-cd/compose-tests.mdx
+++ b/docs/examples/ci-cd/compose-tests.mdx
@@ -5,34 +5,38 @@ description: Run a Compose stack without exposing the host Docker socket
 icon: "boxes-stacked"
 ---
 
-Run Docker Compose inside a microVM when a test needs several containers. The inner daemon gets its own disk and never receives the host's `/var/run/docker.sock`.
+Run Docker Compose inside a microVM when a test needs several containers. The inner daemon uses the sandbox's flat root disk and never receives the host's `/var/run/docker.sock`.
 
-This example assumes the current directory contains `compose.yaml` and a test service named `test`.
+This example assumes `./my-project` contains `compose.yaml` and a test service named `test`.
 
 ## Run the integration tests
 
 <Steps>
 <Step title="Start Docker">
 
-<Tooltip tip="On microsandbox cloud, create a directory-backed Docker volume first and omit disk-kind, size, and replace-on-create options from this command."><span className="msb-badge-limited">Limited on cloud <Icon icon="circle-info" size={11} /></span></Tooltip>
+<Tooltip tip="Flat root disks are not yet available on microsandbox cloud."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
 
 <CodeGroup>
 ```sh macOS & Linux
 msb run -d --name compose-ci --replace \
-  --memory 2G --root-disk 4G --max-duration 10m \
-  --mount-named compose-ci-cache:/var/lib/docker:kind=disk,size=6G \
-  --copy-dir .:/workspace --workdir /workspace \
+  --memory 2G --root-disk flat:10G --max-duration 10m \
   docker:27.5.1-dind
 ```
 
 ```powershell Windows
 msb run -d --name compose-ci --replace `
-  --memory 2G --root-disk 4G --max-duration 10m `
-  --mount-named compose-ci-cache:/var/lib/docker:kind=disk,size=6G `
-  --copy-dir .:/workspace --workdir /workspace `
+  --memory 2G --root-disk flat:10G --max-duration 10m `
   docker:27.5.1-dind
 ```
 </CodeGroup>
+
+The flat root gives Docker a direct ext4 filesystem for its own overlay storage, avoiding an overlay-on-overlay stack. Its 10 GiB capacity covers the image, project, build cache, and containers.
+
+Copy the project into the running sandbox. This happens after creation because flat roots do not currently accept create-time rootfs patches such as `--copy-dir`:
+
+```sh
+msb cp ./my-project/. compose-ci:/workspace
+```
 
 The official `dind` image starts `dockerd`. Wait for it before sending Compose commands:
 
@@ -79,7 +83,7 @@ msb exec --timeout 5m --workdir /workspace compose-ci -- `
 Replace `test` with the service whose exit code should decide the CI result. `msb exec` returns that code to the host.
 
 <Note>
-  `--copy-dir` makes a guest copy. Run the command from a clean project directory, or replace it with narrower `--copy-file` and `--copy-dir` flags when the checkout contains credentials or unrelated files.
+  `msb cp` makes a guest copy. Use a clean project directory, and do not copy credentials or unrelated files into the sandbox.
 </Note>
 
 </Step>
@@ -98,13 +102,7 @@ Remove the sandbox:
 msb rm -f compose-ci
 ```
 
-Delete the cache only when you no longer need it:
-
-```sh
-msb volume remove compose-ci-cache
-```
-
-Keep the named volume if you want a repository-specific image cache between trusted runs. Do not share a writable cache across repositories or trust boundaries.
+Removing the sandbox also removes Docker's image and build cache. Keep the sandbox between trusted runs if you want to reuse that cache; do not carry a writable cache across repositories or trust boundaries.
 
 </Step>
 </Steps>

--- a/docs/examples/data/juicefs-s3.mdx
+++ b/docs/examples/data/juicefs-s3.mdx
@@ -1,0 +1,309 @@
+---
+title: Mount S3 with JuiceFS
+sidebarTitle: S3 with JuiceFS
+description: Mount an S3-backed JuiceFS filesystem and verify persistent file operations inside a sandbox
+icon: "cloud"
+---
+
+<Tooltip tip="This workflow needs the default guest security profile because FUSE mounts require mount administration. A backend that enforces the restricted profile cannot run it."><span className="msb-badge-limited">Limited on cloud <Icon icon="circle-info" size={11} /></span></Tooltip>
+
+This example mounts an Amazon S3 or S3-compatible bucket as a POSIX filesystem inside a microsandbox, exercises common file operations, and verifies a cold read after remounting with an empty cache.
+
+JuiceFS stores file data as objects in S3 and keeps filesystem metadata in a separate database. This single-sandbox example keeps SQLite metadata on the sandbox's root disk. Use a shared metadata engine such as Redis or PostgreSQL when multiple clients need to mount the same filesystem or when the metadata must outlive the sandbox.
+
+## Create the S3-backed filesystem
+
+<Steps>
+<Step title="Prepare S3 credentials">
+
+Create credentials with read, write, list, and delete access scoped to the bucket you want JuiceFS to use. Set the full bucket URL, access key ID, and secret access key in your host shell, then write only those values to a temporary file. The bucket URL can point to Amazon S3 or an S3-compatible provider such as Cloudflare R2 or MinIO.
+
+<CodeGroup>
+```sh macOS & Linux
+export S3_BUCKET_URL="https://your-bucket.s3.us-east-1.amazonaws.com"
+export S3_ACCESS_KEY_ID="your-access-key-id"
+export S3_SECRET_ACCESS_KEY="your-secret-access-key"
+
+umask 077
+printf 'S3_BUCKET_URL=%s\nACCESS_KEY=%s\nSECRET_KEY=%s\n' \
+  "$S3_BUCKET_URL" \
+  "$S3_ACCESS_KEY_ID" \
+  "$S3_SECRET_ACCESS_KEY" > juicefs-s3.env
+```
+
+```powershell Windows
+$env:S3_BUCKET_URL = 'https://your-bucket.s3.us-east-1.amazonaws.com'
+$env:S3_ACCESS_KEY_ID = 'your-access-key-id'
+$env:S3_SECRET_ACCESS_KEY = 'your-secret-access-key'
+
+$lines = @(
+  "S3_BUCKET_URL=$env:S3_BUCKET_URL"
+  "ACCESS_KEY=$env:S3_ACCESS_KEY_ID"
+  "SECRET_KEY=$env:S3_SECRET_ACCESS_KEY"
+)
+$encoding = New-Object System.Text.UTF8Encoding $false
+[System.IO.File]::WriteAllLines((Join-Path (Get-Location) 'juicefs-s3.env'), $lines, $encoding)
+```
+</CodeGroup>
+
+Do not commit `juicefs-s3.env`. The sandbox receives the filtered file instead of your complete host environment.
+
+</Step>
+
+<Step title="Create the helper scripts">
+
+Save the guest-side workflows as shell files on your host. Keeping them separate makes each later `msb exec` command a single, readable action.
+
+<div className="msb-accordion-group">
+  <AccordionGroup>
+    <Accordion title="mount-juicefs.sh">
+      ```sh mount-juicefs.sh
+      #!/bin/sh
+      set -eu
+
+      . /root/juicefs-s3.env
+      export ACCESS_KEY SECRET_KEY
+
+      volume_file=/var/lib/juicefs/volume-name
+      metadata_file=/var/lib/juicefs/metadata.db
+      metadata_url=sqlite3:///var/lib/juicefs/metadata.db
+
+      mkdir -p /var/lib/juicefs /mnt/juicefs
+
+      if [ -f "$volume_file" ]; then
+        volume="$(cat "$volume_file")"
+      else
+        volume="microsandbox-$(date +%Y%m%d%H%M%S)"
+        printf "%s\n" "$volume" > "$volume_file"
+      fi
+
+      if [ ! -f "$metadata_file" ]; then
+        juicefs format \
+          --storage s3 \
+          --bucket "$S3_BUCKET_URL" \
+          --trash-days 0 \
+          "$metadata_url" \
+          "$volume"
+      fi
+
+      if ! mountpoint -q /mnt/juicefs; then
+        juicefs mount \
+          --background \
+          --backup-meta 0 \
+          --cache-dir /var/cache/juicefs \
+          --log /tmp/juicefs.log \
+          "$metadata_url" \
+          /mnt/juicefs
+      fi
+
+      mountpoint /mnt/juicefs
+      printf "Object prefix: %s/\n" "$volume"
+      ```
+    </Accordion>
+    <Accordion title="test-juicefs.sh">
+      ```sh test-juicefs.sh
+      #!/bin/sh
+      set -eu
+
+      root=/mnt/juicefs/example
+      expected=$(printf "alpha\nbeta")
+      mkdir -p "$root/batch"
+
+      printf "alpha\n" > "$root/message.txt"
+      test "$(cat "$root/message.txt")" = "alpha"
+
+      printf "beta\n" >> "$root/message.txt"
+      test "$(cat "$root/message.txt")" = "$expected"
+
+      mv "$root/message.txt" "$root/renamed.txt"
+      ln "$root/renamed.txt" "$root/hardlink.txt"
+      ln -s renamed.txt "$root/symlink.txt"
+
+      dd if=/dev/urandom of="$root/payload.bin" bs=1M count=8 status=none
+      sha256sum "$root/payload.bin" > /var/lib/juicefs/payload.sha256
+
+      for number in 1 2 3 4; do
+        dd if=/dev/zero of="$root/batch/$number.bin" bs=1M count=1 status=none &
+      done
+      wait
+
+      test "$(find "$root/batch" -type f | wc -l)" -eq 4
+      test "$(cat "$root/hardlink.txt")" = "$expected"
+      test "$(cat "$root/symlink.txt")" = "$expected"
+      sync
+
+      printf "write=ok\nread=ok\nappend=ok\nrename=ok\nlinks=ok\nconcurrent_writes=ok\n"
+      ```
+    </Accordion>
+    <Accordion title="remount-juicefs.sh">
+      ```sh remount-juicefs.sh
+      #!/bin/sh
+      set -eu
+
+      metadata_url=sqlite3:///var/lib/juicefs/metadata.db
+
+      juicefs umount /mnt/juicefs
+      rm -rf /var/cache/juicefs
+      juicefs mount \
+        --background \
+        --backup-meta 0 \
+        --cache-dir /var/cache/juicefs-remount \
+        --log /tmp/juicefs-remount.log \
+        "$metadata_url" \
+        /mnt/juicefs
+
+      sha256sum --check /var/lib/juicefs/payload.sha256
+      ```
+    </Accordion>
+    <Accordion title="cleanup-juicefs.sh">
+      ```sh cleanup-juicefs.sh
+      #!/bin/sh
+      set -eu
+
+      rm -rf /mnt/juicefs/example
+      sync
+      juicefs umount /mnt/juicefs
+      printf "Delete the object prefix: %s/\n" "$(cat /var/lib/juicefs/volume-name)"
+      ```
+    </Accordion>
+  </AccordionGroup>
+</div>
+
+</Step>
+
+<Step title="Create the sandbox">
+
+Boot Ubuntu with a 6 GiB root disk for the JuiceFS client, metadata database, and local cache. Copy the filtered credentials and register each helper under a short command name:
+
+<CodeGroup>
+```sh macOS & Linux
+msb create ubuntu:24.04 \
+  --name juicefs-s3-demo \
+  --replace \
+  --cpus 2 \
+  --memory 2G \
+  --root-disk 6G \
+  --copy-file ./juicefs-s3.env:/root/juicefs-s3.env \
+  --script-path mount-juicefs:./mount-juicefs.sh \
+  --script-path test-juicefs:./test-juicefs.sh \
+  --script-path remount-juicefs:./remount-juicefs.sh \
+  --script-path cleanup-juicefs:./cleanup-juicefs.sh
+```
+
+```powershell Windows
+msb create ubuntu:24.04 `
+  --name juicefs-s3-demo `
+  --replace `
+  --cpus 2 `
+  --memory 2G `
+  --root-disk 6G `
+  --copy-file ./juicefs-s3.env:/root/juicefs-s3.env `
+  --script-path mount-juicefs:./mount-juicefs.sh `
+  --script-path test-juicefs:./test-juicefs.sh `
+  --script-path remount-juicefs:./remount-juicefs.sh `
+  --script-path cleanup-juicefs:./cleanup-juicefs.sh
+```
+</CodeGroup>
+
+The root disk keeps the metadata database when the sandbox stops and starts. Removing or replacing the sandbox removes that metadata, while the file data remains in S3.
+
+</Step>
+
+<Step title="Install and mount JuiceFS">
+
+Install FUSE and the official JuiceFS client:
+
+```sh
+msb exec juicefs-s3-demo -- sh -lc '
+  apt-get update -qq &&
+  apt-get install -y -qq ca-certificates curl fuse3 &&
+  curl -fsSL https://d.juicefs.com/install | sh -
+'
+```
+
+Format a new JuiceFS volume the first time this sandbox is used, then mount it at `/mnt/juicefs`:
+
+```sh
+msb exec juicefs-s3-demo -- mount-juicefs
+```
+
+`--backup-meta 0` keeps this single-sandbox example's metadata lifecycle explicit. It is also required when the S3-compatible provider is Cloudflare R2 because JuiceFS metadata backup relies on object-listing behavior that R2 does not provide.
+
+</Step>
+
+<Step title="Test file operations">
+
+Create, read, append, rename, link, and concurrently write files through the mount. The script also saves the checksum of an 8 MiB payload for the remount test:
+
+```sh
+msb exec juicefs-s3-demo -- test-juicefs
+```
+
+All six checks should print `ok`.
+
+</Step>
+
+<Step title="Verify a cold remount">
+
+Unmount JuiceFS, clear its local cache, mount it again, and verify the payload against the saved checksum:
+
+```sh
+msb exec juicefs-s3-demo -- remount-juicefs
+```
+
+The checksum should report `/mnt/juicefs/example/payload.bin: OK`. Because the first cache was removed before remounting, this read verifies data persisted to S3 rather than only to the guest cache.
+
+</Step>
+
+<Step title="Clean up or keep the filesystem">
+
+To retain the filesystem, stop and keep the sandbox together with the object prefix printed during mounting. The SQLite metadata on its root disk is required to interpret the objects in S3.
+
+To remove the example, delete its files through JuiceFS and unmount it first:
+
+```sh
+msb exec juicefs-s3-demo -- cleanup-juicefs
+```
+
+Delete that exact prefix from the bucket with your provider's console or S3 client, then remove the sandbox:
+
+```sh
+msb rm -f juicefs-s3-demo
+```
+
+Finally, remove the temporary credential file and clear its variables from the host shell:
+
+<CodeGroup>
+```sh macOS & Linux
+rm -f juicefs-s3.env \
+  mount-juicefs.sh test-juicefs.sh \
+  remount-juicefs.sh cleanup-juicefs.sh
+unset S3_BUCKET_URL S3_ACCESS_KEY_ID S3_SECRET_ACCESS_KEY
+```
+
+```powershell Windows
+Remove-Item juicefs-s3.env, mount-juicefs.sh, `
+  test-juicefs.sh, remount-juicefs.sh, cleanup-juicefs.sh
+Remove-Item Env:S3_BUCKET_URL, Env:S3_ACCESS_KEY_ID, Env:S3_SECRET_ACCESS_KEY
+```
+</CodeGroup>
+
+<Warning>
+  On Cloudflare R2, do not substitute `juicefs destroy` for the prefix deletion. JuiceFS documents `destroy`, `gc`, `fsck`, and `sync` as incompatible with R2's object-listing behavior. Check your provider's compatibility before using object-listing-dependent maintenance commands.
+</Warning>
+
+</Step>
+</Steps>
+
+## Production considerations
+
+- Replace SQLite with Redis, PostgreSQL, or another shared metadata engine before mounting the filesystem from multiple sandboxes.
+- Scope the S3 credentials to the target bucket and grant only the object operations JuiceFS needs.
+- Persist the metadata engine independently from the sandbox. S3 objects are not enough to reconstruct the complete filesystem namespace without metadata.
+- Configure metadata backups for your provider. Keep `--backup-meta 0` on R2 mounts and operate an explicit metadata backup process outside the R2 bucket.
+
+## References
+
+- [JuiceFS: object storage](https://juicefs.com/docs/community/reference/how_to_set_up_object_storage/)
+- [JuiceFS: Cloudflare R2 compatibility](https://juicefs.com/docs/community/reference/how_to_set_up_object_storage/#cloudflare-r2)
+- [JuiceFS: metadata engines](https://juicefs.com/docs/community/databases_for_metadata/)

--- a/docs/examples/data/postgresql.mdx
+++ b/docs/examples/data/postgresql.mdx
@@ -4,9 +4,9 @@ description: Run a persistent PostgreSQL service with a localhost-only forwarded
 icon: "database"
 ---
 
-<Tooltip tip="This example depends on a disk-kind named volume and a published client-host port, which are not available on microsandbox cloud."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
+<Tooltip tip="This example publishes a client-host port, which is not available on microsandbox cloud."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
 
-This example runs PostgreSQL 17 in a microVM, stores the database on a disk-backed named volume, and publishes the service only to host loopback.
+This example runs PostgreSQL 17 in a microVM, stores the database on a sized root disk, and publishes the service only to host loopback.
 
 <Note>
   The current `postgres:17-alpine` image contains tab characters in `DOCKER_PG_LLVM_DEPS`. Passing `-e DOCKER_PG_LLVM_DEPS=` is a temporary compatibility workaround for microsandbox's guest environment validation.
@@ -38,23 +38,21 @@ Start the database:
 <CodeGroup>
 ```sh macOS & Linux
 msb run -d --name postgres-demo --replace \
-  --cpus 1 --memory 1G --root-disk 2G \
+  --cpus 1 --memory 1G --root-disk 6G \
   -p 127.0.0.1:55432:5432 \
   -e POSTGRES_PASSWORD="$POSTGRES_PASSWORD" \
   -e POSTGRES_DB=examples \
   -e DOCKER_PG_LLVM_DEPS= \
-  --mount-named postgres-data:/var/lib/postgresql/data:kind=disk,size=5G \
   postgres:17-alpine
 ```
 
 ```powershell Windows
 msb run -d --name postgres-demo --replace `
-  --cpus 1 --memory 1G --root-disk 2G `
+  --cpus 1 --memory 1G --root-disk 6G `
   -p 127.0.0.1:55432:5432 `
   -e "POSTGRES_PASSWORD=$env:POSTGRES_PASSWORD" `
   -e POSTGRES_DB=examples `
   -e DOCKER_PG_LLVM_DEPS= `
-  --mount-named postgres-data:/var/lib/postgresql/data:kind=disk,size=5G `
   postgres:17-alpine
 ```
 </CodeGroup>
@@ -99,18 +97,12 @@ Applications on the host can connect to `127.0.0.1:55432` with the same database
 
 </Step>
 
-<Step title="Clean up or keep the data">
+<Step title="Clean up">
 
-Remove the VM while keeping its database:
+Remove the sandbox and its database:
 
 ```sh
 msb rm -f postgres-demo
-```
-
-Remove the database volume only when you no longer need its contents:
-
-```sh
-msb volume rm postgres-data
 ```
 
 Clear the password from the host shell:

--- a/docs/examples/data/redis.mdx
+++ b/docs/examples/data/redis.mdx
@@ -6,7 +6,7 @@ icon: "database"
 
 <Tooltip tip="This example publishes Redis to a port on the computer running the CLI, which is not available on microsandbox cloud."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
 
-This example starts Redis 7 with password authentication, a persistent named volume, and a localhost-only forwarded port.
+This example starts Redis 7 with password authentication, a sized root disk, and a localhost-only forwarded port.
 
 ## Run Redis
 
@@ -34,9 +34,8 @@ Start Redis:
 <CodeGroup>
 ```sh macOS & Linux
 msb run -d --name redis-demo --replace \
-  --cpus 1 --memory 512M --root-disk 1G \
+  --cpus 1 --memory 512M --root-disk 2G \
   -p 127.0.0.1:56379:6379 \
-  --mount-named redis-data:/data \
   redis:7-alpine -- redis-server \
     --bind 0.0.0.0 \
     --protected-mode yes \
@@ -46,9 +45,8 @@ msb run -d --name redis-demo --replace \
 
 ```powershell Windows
 msb run -d --name redis-demo --replace `
-  --cpus 1 --memory 512M --root-disk 1G `
+  --cpus 1 --memory 512M --root-disk 2G `
   -p 127.0.0.1:56379:6379 `
-  --mount-named redis-data:/data `
   redis:7-alpine -- redis-server `
     --bind 0.0.0.0 `
     --protected-mode yes `
@@ -111,18 +109,12 @@ The three commands should return `OK`, `ready`, and `PONG`. Host applications co
 
 </Step>
 
-<Step title="Clean up or keep the data">
+<Step title="Clean up">
 
-Remove the sandbox while retaining the append-only database:
+Remove the sandbox and its append-only database:
 
 ```sh
 msb rm -f redis-demo
-```
-
-Delete all persisted Redis data:
-
-```sh
-msb volume rm redis-data
 ```
 
 Clear the password from the host shell:

--- a/docs/examples/development/jupyterlab.mdx
+++ b/docs/examples/development/jupyterlab.mdx
@@ -6,7 +6,7 @@ icon: "flask"
 
 <Tooltip tip="This example publishes JupyterLab to a port on the computer running the CLI, which is not available on microsandbox cloud."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
 
-This example installs JupyterLab into a Python microVM, stores notebooks in a named volume, and exposes the server only on host loopback.
+This example installs JupyterLab into a Python microVM, stores notebooks on a sized root disk, and exposes the server only on host loopback.
 
 ## Run JupyterLab
 
@@ -29,43 +29,46 @@ $env:JUPYTER_TOKEN = -join ($bytes | ForEach-Object { $_.ToString('x2') })
 ```
 </CodeGroup>
 
+Create a startup script for the guest:
+
+```sh start-jupyter.sh
+#!/bin/sh
+set -eu
+
+pip install --no-cache-dir jupyterlab==4.6.2
+exec jupyter lab \
+  --ip=0.0.0.0 \
+  --port=8888 \
+  --no-browser \
+  --allow-root \
+  --IdentityProvider.token="$JUPYTER_TOKEN"
+```
+
 Start the server:
 
 <CodeGroup>
 ```sh macOS & Linux
 msb run -d --name jupyter-demo --replace \
-  --cpus 2 --memory 2G --root-disk 4G \
+  --cpus 2 --memory 2G --root-disk 6G \
   -p 127.0.0.1:8888:8888 \
   -e JUPYTER_TOKEN="$JUPYTER_TOKEN" \
-  --mount-named jupyter-notebooks:/workspace \
+  --mkdir /workspace \
   --workdir /workspace \
-  python:3.13-slim -- sh -lc '
-    pip install --no-cache-dir jupyterlab==4.6.2 &&
-    exec jupyter lab \
-      --ip=0.0.0.0 \
-      --port=8888 \
-      --no-browser \
-      --allow-root \
-      --IdentityProvider.token="$JUPYTER_TOKEN"
-  '
+  --script-path start-jupyter:./start-jupyter.sh \
+  --entrypoint start-jupyter \
+  python:3.13-slim
 ```
 
 ```powershell Windows
 msb run -d --name jupyter-demo --replace `
-  --cpus 2 --memory 2G --root-disk 4G `
+  --cpus 2 --memory 2G --root-disk 6G `
   -p 127.0.0.1:8888:8888 `
   -e "JUPYTER_TOKEN=$env:JUPYTER_TOKEN" `
-  --mount-named jupyter-notebooks:/workspace `
+  --mkdir /workspace `
   --workdir /workspace `
-  python:3.13-slim -- sh -lc '
-    pip install --no-cache-dir jupyterlab==4.6.2 &&
-    exec jupyter lab \
-      --ip=0.0.0.0 \
-      --port=8888 \
-      --no-browser \
-      --allow-root \
-      --IdentityProvider.token="$JUPYTER_TOKEN"
-  '
+  --script-path start-jupyter:./start-jupyter.sh `
+  --entrypoint start-jupyter `
+  python:3.13-slim
 ```
 </CodeGroup>
 
@@ -93,7 +96,7 @@ Then inspect the recent server output:
 msb logs --tail 20 jupyter-demo
 ```
 
-The logs show Jupyter Server listening on guest port 8888. Notebooks saved under `/workspace` remain in `jupyter-notebooks` after the sandbox is removed.
+The logs show Jupyter Server listening on guest port 8888. Notebooks saved under `/workspace` remain on the root disk when the sandbox stops and starts.
 
 <Warning>
   The token is visible to the guest and to processes that can inspect the host command environment. Use the [secrets workflow](/sandboxes/secrets) for production credentials, retain the loopback bind, and place a TLS-terminating authenticated proxy in front of any remote deployment.
@@ -109,25 +112,21 @@ Remove the sandbox:
 msb rm -f jupyter-demo
 ```
 
-Remove persisted notebooks only when you no longer need them:
-
-```sh
-msb volume rm jupyter-notebooks
-```
-
 Clear the token from the host shell:
 
 <CodeGroup>
 ```sh macOS & Linux
+rm -f start-jupyter.sh
 unset JUPYTER_TOKEN
 ```
 
 ```powershell Windows
+Remove-Item start-jupyter.sh
 Remove-Item Env:JUPYTER_TOKEN
 ```
 </CodeGroup>
 
-Keep `jupyter-notebooks` if you want to retain the notebooks.
+Copy any notebooks you want to keep to the host before removing the sandbox.
 
 </Step>
 </Steps>

--- a/docs/examples/docker/docker-in-sandbox.mdx
+++ b/docs/examples/docker/docker-in-sandbox.mdx
@@ -6,7 +6,7 @@ icon: "docker"
 
 This example starts a complete Docker environment inside a microsandbox VM. It is useful for sandboxed builds, agent workflows that need their own Docker daemon, or experiments you do not want leaking onto the dev machine. The host's Docker setup, if any, is left untouched.
 
-The command below boots the `docker:dind` image, starts Docker inside the sandbox, waits for it to be ready, and then opens an interactive shell. From there, Docker commands run against the daemon inside the sandbox, not your host.
+The command below boots the `docker:dind` image on a flat root disk, starts Docker inside the sandbox, waits for it to be ready, and then opens an interactive shell. From there, Docker commands run against the daemon inside the sandbox, not your host.
 
 ## Run Docker in a sandbox
 
@@ -14,53 +14,7 @@ The command below boots the `docker:dind` image, starts Docker inside the sandbo
 
 <Step title="Start Docker">
 
-<Tooltip tip="On microsandbox cloud, create the named volume separately without disk-kind or size options, then omit replace-on-create from this command."><span className="msb-badge-limited">Limited on cloud <Icon icon="circle-info" size={11} /></span></Tooltip>
-
-<CodeGroup>
-```sh macOS & Linux
-msb run --name docker-demo --replace \
-  --memory 2G \
-  --mount-named docker-data:/var/lib/docker:kind=disk,size=10G \
-  --script start='dockerd >/tmp/dockerd.log 2>&1 &
-  timeout 60 sh -c "until docker info>/dev/null 2>&1;do sleep 1;done" || {
-    cat /tmp/dockerd.log
-    false
-  }
-  exec sh' \
-  --entrypoint start \
-  docker:dind
-```
-
-```powershell Windows
-msb run --name docker-demo --replace `
-  --memory 2G `
-  --mount-named docker-data:/var/lib/docker:kind=disk,size=10G `
-  --script start='dockerd >/tmp/dockerd.log 2>&1 &
-  timeout 60 sh -c "until docker info>/dev/null 2>&1;do sleep 1;done" || {
-    cat /tmp/dockerd.log
-    false
-  }
-  exec sh' `
-  --entrypoint start `
-  docker:dind
-```
-</CodeGroup>
-
-This command does three things:
-
-- Starts the `docker:dind` image in a sandbox named `docker-demo`.
-- Mounts a disk-backed named volume called `docker-data` at `/var/lib/docker`, where Docker stores images, containers, and build cache.
-- Runs the inline `start` script as the entrypoint. The script starts Docker, waits until it is ready, and then opens a shell.
-
-`--mount-named docker-data:/var/lib/docker:kind=disk,size=10G` is idempotent. If `docker-data` does not exist, the CLI creates it before starting the sandbox. If it already exists with compatible disk settings, the same command reuses it, so pulled images and created containers can survive `msb rm docker-demo`.
-
-</Step>
-
-<Step title="Optional: use a flat root disk">
-
-<Tooltip tip="Flat root disks are not available on microsandbox cloud."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
-
-For a simpler local setup, use a flat root disk instead of a separate named volume. A flat root mounts ext4 directly, so Docker's overlay storage is not nested on the default sandbox OverlayFS.
+<Tooltip tip="Flat root disks are not yet available on microsandbox cloud."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
 
 <CodeGroup>
 ```sh macOS & Linux
@@ -92,7 +46,13 @@ msb run --name docker-demo --replace `
 ```
 </CodeGroup>
 
-This stores Docker's images, containers, and build cache on the sandbox's root disk. The data persists when the sandbox stops and starts, but unlike a named volume, it does not survive removing or replacing the sandbox. The `10G` capacity covers the entire root filesystem, including Docker's data.
+This command does three things:
+
+- Starts the `docker:dind` image in a sandbox named `docker-demo`.
+- Gives the sandbox a 10 GiB flat root disk for the image, Docker data, and build cache.
+- Runs the inline `start` script as the entrypoint. The script starts Docker, waits until it is ready, and then opens a shell.
+
+The flat root mounts ext4 directly, so Docker's overlay storage is not nested on the default sandbox OverlayFS. Docker's images, containers, and build cache persist when the sandbox stops and starts, but are removed with the sandbox.
 
 </Step>
 
@@ -128,15 +88,7 @@ Back on the host, remove the sandbox:
 msb rm -f docker-demo
 ```
 
-Remove the Docker data only when you no longer need it:
-
-```sh
-msb volume rm docker-data
-```
-
-Remove `docker-data` only when you no longer need the images, containers, and build cache stored by the nested daemon.
-
-If you used the flat-root alternative, skip `msb volume rm docker-data`; removing the sandbox also removes its Docker data.
+Removing the sandbox also removes the nested daemon's images, containers, and build cache.
 
 </Step>
 
@@ -144,7 +96,7 @@ If you used the flat-root alternative, skip `msb volume rm docker-data`; removin
 
 ## Details
 
-The disk-backed named mount gives Docker its own ext4 filesystem at `/var/lib/docker`. That matters because the sandbox root filesystem is already overlay-backed, and Docker's default storage driver also uses overlay layers. Keeping Docker's data root on a dedicated disk-backed volume avoids putting Docker's overlay storage directly on top of the sandbox root overlay.
+The flat root gives Docker a direct ext4 filesystem. That matters because Docker's default storage driver uses overlay layers; a normal managed root would place those layers on top of the sandbox's own OverlayFS.
 
 ## Notes
 

--- a/docs/examples/overview.mdx
+++ b/docs/examples/overview.mdx
@@ -43,4 +43,4 @@ These examples start with the smallest useful microsandbox workflow. Short comma
 - **Automation**: Scheduled dependency audits and parallel batch dispatch.
 - **Tool isolation**: Vet native Terraform providers in constrained workers.
 - **Web Automation**: Playwright browser jobs and bounded Scrapy crawls.
-- **Systems and data**: Docker, systemd, VNC, PostgreSQL, Redis, migrations, metrics backends, and file processing.
+- **Systems and data**: Docker, systemd, VNC, S3 with JuiceFS, PostgreSQL, Redis, migrations, metrics backends, and file processing.

--- a/docs/examples/sandboxing/warm-workers.mdx
+++ b/docs/examples/sandboxing/warm-workers.mdx
@@ -31,35 +31,38 @@ test -z "$(git remote)"
 opencode --version
 ```
 
+Create the preparation script that installs the baseline toolchain:
+
+```sh prepare-worker.sh
+#!/bin/sh
+set -eu
+
+apt-get update
+apt-get install -y --no-install-recommends ca-certificates git
+rm -rf /var/lib/apt/lists/*
+npm install -g opencode-ai@1.18.4
+mkdir -p /workspace/project
+chown -R node:node /workspace
+opencode --version
+```
+
 <CodeGroup>
 ```sh macOS & Linux
 msb run --name agent-base --replace \
   --cpus 2 --memory 2G --root-disk 4G \
+  --script-path prepare-worker:./prepare-worker.sh \
   --script-path verify-worker:./verify-worker.sh \
-  node:24-bookworm-slim -- sh -lc '
-    apt-get update &&
-    apt-get install -y --no-install-recommends ca-certificates git &&
-    rm -rf /var/lib/apt/lists/* &&
-    npm install -g opencode-ai@1.18.4 &&
-    mkdir -p /workspace/project &&
-    chown -R node:node /workspace &&
-    opencode --version
-  '
+  --entrypoint prepare-worker \
+  node:24-bookworm-slim
 ```
 
 ```powershell Windows
 msb run --name agent-base --replace `
   --cpus 2 --memory 2G --root-disk 4G `
+  --script-path prepare-worker:./prepare-worker.sh `
   --script-path verify-worker:./verify-worker.sh `
-  node:24-bookworm-slim -- sh -lc '
-    apt-get update &&
-    apt-get install -y --no-install-recommends ca-certificates git &&
-    rm -rf /var/lib/apt/lists/* &&
-    npm install -g opencode-ai@1.18.4 &&
-    mkdir -p /workspace/project &&
-    chown -R node:node /workspace &&
-    opencode --version
-  '
+  --entrypoint prepare-worker `
+  node:24-bookworm-slim
 ```
 </CodeGroup>
 
@@ -214,12 +217,12 @@ Remove the prepared sandbox and workers:
 <CodeGroup>
 ```sh macOS & Linux
 msb rm -f agent-base coding-worker-1 coding-worker-2
-rm -f verify-worker.sh
+rm -f prepare-worker.sh verify-worker.sh
 ```
 
 ```powershell Windows
 msb rm -f agent-base coding-worker-1 coding-worker-2
-Remove-Item verify-worker.sh
+Remove-Item prepare-worker.sh, verify-worker.sh
 ```
 </CodeGroup>
 

--- a/docs/getting-started/quickstart.mdx
+++ b/docs/getting-started/quickstart.mdx
@@ -4,26 +4,7 @@ description: Get a sandbox running in under 5 minutes
 icon: "bolt"
 ---
 
-## Choose where to run
-
-<div className="msb-platform-strip" role="list" aria-label="Supported platforms">
-  <a className="msb-platform-item msb-platform-link" role="listitem" href="/troubleshooting/linux">
-    <span className="msb-platform-icon"><Icon icon="linux" size={18} /></span>
-    <span className="msb-platform-copy"><strong>Linux</strong><span>glibc + KVM</span></span>
-  </a>
-  <a className="msb-platform-item msb-platform-link" role="listitem" href="/troubleshooting/macos">
-    <span className="msb-platform-icon"><Icon icon="apple" size={18} /></span>
-    <span className="msb-platform-copy"><strong>macOS</strong><span>Apple Silicon</span></span>
-  </a>
-  <a className="msb-platform-item msb-platform-link" role="listitem" href="/troubleshooting/windows">
-    <span className="msb-platform-icon"><Icon icon="windows" size={18} /></span>
-    <span className="msb-platform-copy"><strong>Windows</strong><span>10+ · WHP</span></span>
-  </a>
-  <a className="msb-platform-item msb-platform-link" role="listitem" href="/cloud/overview">
-    <span className="msb-platform-icon"><Icon icon="cloud" size={18} /></span>
-    <span className="msb-platform-copy"><strong>Cloud</strong><span>No hypervisor setup</span></span>
-  </a>
-</div>
+## Run your first sandbox
 
 <CodeGroup>
 ```bash npx
@@ -40,6 +21,23 @@ irm https://install.microsandbox.dev/windows | iex
 msb run debian
 ```
 </CodeGroup>
+
+Having trouble with a local installation? Choose your platform for setup checks and fixes.
+
+<div className="msb-platform-strip msb-platform-strip-three" role="list" aria-label="Installation troubleshooting">
+  <a className="msb-platform-item msb-platform-link" role="listitem" href="/troubleshooting/linux">
+    <span className="msb-platform-icon"><Icon icon="linux" size={18} /></span>
+    <span className="msb-platform-copy"><strong>Linux</strong><span>glibc + KVM</span></span>
+  </a>
+  <a className="msb-platform-item msb-platform-link" role="listitem" href="/troubleshooting/macos">
+    <span className="msb-platform-icon"><Icon icon="apple" size={18} /></span>
+    <span className="msb-platform-copy"><strong>macOS</strong><span>Apple Silicon</span></span>
+  </a>
+  <a className="msb-platform-item msb-platform-link" role="listitem" href="/troubleshooting/windows">
+    <span className="msb-platform-icon"><Icon icon="windows" size={18} /></span>
+    <span className="msb-platform-copy"><strong>Windows</strong><span>10+ · WHP</span></span>
+  </a>
+</div>
 
 <Steps>
   <Step title="Install microsandbox">

--- a/docs/getting-started/quickstart.mdx
+++ b/docs/getting-started/quickstart.mdx
@@ -27,7 +27,7 @@ Having trouble with a local installation? Choose your platform for setup checks 
 <div className="msb-platform-strip msb-platform-strip-three" role="list" aria-label="Installation troubleshooting">
   <a className="msb-platform-item msb-platform-link" role="listitem" href="/troubleshooting/linux">
     <span className="msb-platform-icon"><Icon icon="linux" size={18} /></span>
-    <span className="msb-platform-copy"><strong>Linux</strong><span>glibc + KVM</span></span>
+    <span className="msb-platform-copy"><strong>Linux</strong><span>glibc 2.28+ and KVM</span></span>
   </a>
   <a className="msb-platform-item msb-platform-link" role="listitem" href="/troubleshooting/macos">
     <span className="msb-platform-icon"><Icon icon="apple" size={18} /></span>

--- a/docs/images/live-modify.svg
+++ b/docs/images/live-modify.svg
@@ -18,12 +18,48 @@
     text { font-family: ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; }
     .text { fill: var(--text); }
     .muted { fill: var(--muted); }
+    .sandbox-box {
+      transform-box: view-box;
+      transform-origin: 180px 200px;
+      animation: resize-sandbox 8s cubic-bezier(0.4, 0, 0.2, 1) infinite;
+    }
+    .sandbox-copy {
+      animation: move-copy 8s cubic-bezier(0.4, 0, 0.2, 1) infinite;
+    }
     .grow-outline { animation: show-grow-outline 8s ease-in-out infinite; }
     .shrink-outline { animation: show-shrink-outline 8s ease-in-out infinite; }
-    .grow-arrow { animation: show-grow-arrow 8s ease-in-out infinite; }
-    .shrink-arrow { animation: show-shrink-arrow 8s ease-in-out infinite; }
+    .grow-arrow {
+      transform-box: view-box;
+      transform-origin: 0 0;
+      animation: move-grow-arrow 8s cubic-bezier(0.4, 0, 0.2, 1) infinite, show-grow-arrow 8s ease-in-out infinite;
+    }
+    .shrink-arrow {
+      transform-box: view-box;
+      transform-origin: 0 0;
+      animation: move-shrink-arrow 8s cubic-bezier(0.4, 0, 0.2, 1) infinite, show-shrink-arrow 8s ease-in-out infinite;
+    }
     .small-allocation { animation: show-small 8s ease-in-out infinite; }
     .large-allocation { animation: show-large 8s ease-in-out infinite; }
+
+    @keyframes resize-sandbox {
+      0%, 14%, 86%, 100% { transform: scale(1); }
+      39%, 61% { transform: scale(1.454545); }
+    }
+
+    @keyframes move-copy {
+      0%, 14%, 86%, 100% { transform: translate(-50px, 25px); }
+      39%, 61% { transform: translate(0, 0); }
+    }
+
+    @keyframes move-grow-arrow {
+      0%, 14% { transform: translate(400px, 90px) rotate(-26.565deg) scaleX(1); }
+      36%, 100% { transform: translate(489px, 45.5px) rotate(-26.565deg) scaleX(0.01); }
+    }
+
+    @keyframes move-shrink-arrow {
+      0%, 61% { transform: translate(489px, 45.5px) rotate(153.435deg) scaleX(1); }
+      83%, 100% { transform: translate(400px, 90px) rotate(153.435deg) scaleX(0.01); }
+    }
 
     @keyframes show-grow-outline {
       0%, 8%, 42%, 100% { opacity: 0; }
@@ -64,39 +100,34 @@
     }
 
     @media (prefers-reduced-motion: reduce) {
-      .motion { display: none; }
-      .grow-outline, .shrink-outline, .grow-arrow, .shrink-arrow { animation: none; opacity: 0; }
-      .small-allocation { animation: none; opacity: 1; }
-      .large-allocation { animation: none; opacity: 0; }
+      .sandbox-box, .sandbox-copy, .grow-outline, .shrink-outline, .grow-arrow, .shrink-arrow, .small-allocation, .large-allocation { animation: none; }
+      .sandbox-box { transform: scale(1); }
+      .sandbox-copy { transform: translate(-50px, 25px); }
+      .grow-outline, .shrink-outline, .grow-arrow, .shrink-arrow { opacity: 0; }
+      .small-allocation { opacity: 1; }
+      .large-allocation { opacity: 0; }
     }
   </style>
 
   <!-- The target outline appears only before and during the upward resize. -->
   <rect class="grow-outline" x="180" y="40" width="320" height="160" rx="12" fill="none" stroke="var(--muted)" stroke-width="1.2" stroke-dasharray="3 7" opacity="0" />
 
-  <!-- The tail follows the active corner exactly; only the head is inset from the target boundary. -->
-  <line class="grow-arrow" x1="400" y1="90" x2="489" y2="45.5" stroke="var(--accent)" stroke-width="1.5" stroke-linecap="round" marker-end="url(#arrowhead)" opacity="0">
-    <animate class="motion" attributeName="x1" values="400;400;400;500;500;500;500;500" keyTimes="0;0.08;0.14;0.39;0.55;0.61;0.86;1" dur="8s" repeatCount="indefinite" calcMode="spline" keySplines="0.4 0 0.2 1;0.4 0 0.2 1;0.4 0 0.2 1;0.4 0 0.2 1;0.4 0 0.2 1;0.4 0 0.2 1;0.4 0 0.2 1" />
-    <animate class="motion" attributeName="y1" values="90;90;90;40;40;40;40;40" keyTimes="0;0.08;0.14;0.39;0.55;0.61;0.86;1" dur="8s" repeatCount="indefinite" calcMode="spline" keySplines="0.4 0 0.2 1;0.4 0 0.2 1;0.4 0 0.2 1;0.4 0 0.2 1;0.4 0 0.2 1;0.4 0 0.2 1;0.4 0 0.2 1" />
-  </line>
+  <!-- A local horizontal arrow is rotated into place, then shrinks toward its fixed head. -->
+  <g class="grow-arrow" opacity="0">
+    <line x1="0" y1="0" x2="99.5" y2="0" stroke="var(--accent)" stroke-width="1.5" stroke-linecap="round" marker-end="url(#arrowhead)" />
+  </g>
 
   <!-- The smaller destination and reverse arrow appear only before and during the downward resize. -->
   <rect class="shrink-outline" x="180" y="90" width="220" height="110" rx="12" fill="none" stroke="var(--muted)" stroke-width="1.2" stroke-dasharray="3 7" opacity="0" />
-  <!-- On shrink, the relationship reverses: inset tail, exact destination corner. -->
-  <line class="shrink-arrow" x1="489" y1="45.5" x2="400" y2="90" stroke="var(--accent)" stroke-width="1.5" stroke-linecap="round" marker-end="url(#arrowhead)" opacity="0">
-    <animate class="motion" attributeName="x1" values="489;489;489;489;489;489;389;389" keyTimes="0;0.08;0.14;0.39;0.55;0.61;0.86;1" dur="8s" repeatCount="indefinite" calcMode="spline" keySplines="0.4 0 0.2 1;0.4 0 0.2 1;0.4 0 0.2 1;0.4 0 0.2 1;0.4 0 0.2 1;0.4 0 0.2 1;0.4 0 0.2 1" />
-    <animate class="motion" attributeName="y1" values="45.5;45.5;45.5;45.5;45.5;45.5;95.5;95.5" keyTimes="0;0.08;0.14;0.39;0.55;0.61;0.86;1" dur="8s" repeatCount="indefinite" calcMode="spline" keySplines="0.4 0 0.2 1;0.4 0 0.2 1;0.4 0 0.2 1;0.4 0 0.2 1;0.4 0 0.2 1;0.4 0 0.2 1;0.4 0 0.2 1" />
-  </line>
+  <!-- On shrink, the head stays on the small destination while the inset tail approaches it. -->
+  <g class="shrink-arrow" opacity="0">
+    <line x1="0" y1="0" x2="99.5" y2="0" stroke="var(--accent)" stroke-width="1.5" stroke-linecap="round" marker-end="url(#arrowhead)" />
+  </g>
 
   <!-- The left edge and bottom edge stay fixed, making the top-right corner travel diagonally. -->
-  <rect x="180" y="90" width="220" height="110" rx="12" fill="var(--accent)" fill-opacity="0.05" stroke="var(--accent)" stroke-width="1.5" stroke-dasharray="6 5">
-    <animate class="motion" attributeName="y" values="90;90;90;40;40;40;90;90" keyTimes="0;0.08;0.14;0.39;0.55;0.61;0.86;1" dur="8s" repeatCount="indefinite" calcMode="spline" keySplines="0.4 0 0.2 1;0.4 0 0.2 1;0.4 0 0.2 1;0.4 0 0.2 1;0.4 0 0.2 1;0.4 0 0.2 1;0.4 0 0.2 1" />
-    <animate class="motion" attributeName="width" values="220;220;220;320;320;320;220;220" keyTimes="0;0.08;0.14;0.39;0.55;0.61;0.86;1" dur="8s" repeatCount="indefinite" calcMode="spline" keySplines="0.4 0 0.2 1;0.4 0 0.2 1;0.4 0 0.2 1;0.4 0 0.2 1;0.4 0 0.2 1;0.4 0 0.2 1;0.4 0 0.2 1" />
-    <animate class="motion" attributeName="height" values="110;110;110;160;160;160;110;110" keyTimes="0;0.08;0.14;0.39;0.55;0.61;0.86;1" dur="8s" repeatCount="indefinite" calcMode="spline" keySplines="0.4 0 0.2 1;0.4 0 0.2 1;0.4 0 0.2 1;0.4 0 0.2 1;0.4 0 0.2 1;0.4 0 0.2 1;0.4 0 0.2 1" />
-  </rect>
+  <rect class="sandbox-box" x="180" y="90" width="220" height="110" rx="12" fill="var(--accent)" fill-opacity="0.05" stroke="var(--accent)" stroke-width="1.5" stroke-dasharray="6 5" vector-effect="non-scaling-stroke" />
 
-  <g>
-    <animateTransform class="motion" attributeName="transform" type="translate" values="-50 25;-50 25;-50 25;0 0;0 0;0 0;-50 25;-50 25" keyTimes="0;0.08;0.14;0.39;0.55;0.61;0.86;1" dur="8s" repeatCount="indefinite" calcMode="spline" keySplines="0.4 0 0.2 1;0.4 0 0.2 1;0.4 0 0.2 1;0.4 0 0.2 1;0.4 0 0.2 1;0.4 0 0.2 1;0.4 0 0.2 1" />
+  <g class="sandbox-copy">
     <text x="340" y="105" class="muted" text-anchor="middle" font-size="13" font-weight="600">sandbox</text>
 
     <g class="small-allocation">

--- a/docs/style.css
+++ b/docs/style.css
@@ -97,8 +97,8 @@ nav[aria-label="Pages"] a > div:has(> img[src*="/pi.svg"]) { --msb-agent-icon: u
 }
 
 /* Compact platform preflight: one grouped strip keeps host requirements
- * visible without giving four short facts the visual weight of full cards or
- * a page-width comparison table. */
+ * visible without giving short facts the visual weight of full cards or a
+ * page-width comparison table. */
 .msb-platform-strip {
   display: grid;
   grid-template-columns: repeat(4, minmax(0, 1fr));
@@ -108,6 +108,10 @@ nav[aria-label="Pages"] a > div:has(> img[src*="/pi.svg"]) { --msb-agent-icon: u
   border: 1px solid rgba(109, 75, 196, 0.16);
   border-radius: 0.75rem;
   background: rgba(109, 75, 196, 0.16);
+}
+
+.msb-platform-strip-three {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
 }
 
 .msb-platform-item {

--- a/docs/troubleshooting/linux.mdx
+++ b/docs/troubleshooting/linux.mdx
@@ -6,6 +6,14 @@ icon: "linux"
 
 microsandbox local sandboxes use hardware virtualization. On Linux, confirm that the host has a glibc-based Linux userland and that KVM is available through `/dev/kvm`.
 
+## Install or reinstall
+
+Run the installer, then open a new terminal if it updates your `PATH`:
+
+```bash
+curl -fsSL https://install.microsandbox.dev | sh
+```
+
 ## Quick checks
 
 Start with the doctor command for the local setup checks:

--- a/docs/troubleshooting/linux.mdx
+++ b/docs/troubleshooting/linux.mdx
@@ -4,7 +4,7 @@ description: Diagnose KVM, permissions, and host runtime setup on Linux
 icon: "linux"
 ---
 
-microsandbox local sandboxes use hardware virtualization. On Linux, confirm that the host has a glibc-based Linux userland and that KVM is available through `/dev/kvm`.
+microsandbox local sandboxes use hardware virtualization. On Linux, confirm that the host has glibc 2.28 or newer and that KVM is available through `/dev/kvm`.
 
 ## Install or reinstall
 
@@ -13,6 +13,22 @@ Run the installer, then open a new terminal if it updates your `PATH`:
 ```bash
 curl -fsSL https://install.microsandbox.dev | sh
 ```
+
+## glibc version
+
+Microsandbox Linux releases require glibc 2.28 or newer on x64 and ARM64 hosts. Check the version provided by your distribution:
+
+```bash
+getconf GNU_LIBC_VERSION
+```
+
+If `getconf` is unavailable, inspect the first line reported by `ldd`:
+
+```bash
+ldd --version | head -n 1
+```
+
+Use a newer glibc-based distribution if the version is below 2.28. Do not replace the system C library manually. Musl-only environments, such as a bare Alpine host, cannot run the local runtime; use a supported host or [microsandbox cloud](/cloud/overview) instead.
 
 ## Quick checks
 
@@ -134,7 +150,3 @@ Do not run either command while `/dev/kvm` has users. A distribution may build K
 </Accordion>
 
 Microsandbox never changes this host-wide policy automatically. See [Optimization](/sandboxes/optimization#host-interrupt-acceleration) for when interrupt acceleration matters.
-
-## Linux userland
-
-Use a normal glibc-based Linux host for the local runtime. Minimal or musl-only environments, such as a bare Alpine host image, are not the tested path for running local microsandbox sandboxes.

--- a/docs/troubleshooting/macos.mdx
+++ b/docs/troubleshooting/macos.mdx
@@ -6,6 +6,14 @@ icon: "apple"
 
 microsandbox local sandboxes on macOS require Apple Silicon. Intel Macs are not supported for the local runtime.
 
+## Install or reinstall
+
+Run the installer, then open a new terminal if it updates your `PATH`:
+
+```bash
+curl -fsSL https://install.microsandbox.dev | sh
+```
+
 ## Quick checks
 
 Start with the doctor command for the local setup checks:

--- a/docs/troubleshooting/windows.mdx
+++ b/docs/troubleshooting/windows.mdx
@@ -6,6 +6,14 @@ icon: "windows"
 
 Windows support is currently in preview. To run sandboxes locally, use Windows 10 or later on an x64 or ARM64 machine and enable Windows Hypervisor Platform (WHP).
 
+## Install or reinstall
+
+Run the installer in PowerShell, then open a new terminal:
+
+```powershell
+irm https://install.microsandbox.dev/windows | iex
+```
+
 ## Quick checks
 
 Start with the doctor command:


### PR DESCRIPTION
## TL;DR
Make the Live Modify resize animation survive Mintlify production processing and make the Quickstart platform cards clearly route installation problems to the right troubleshooting guide.

## Description
- Move the sandbox resize, text movement, and directional arrow motion to CSS keyframes that Mintlify preserves.
- Keep the sandbox anchored at its bottom-left corner while it scales between the approved small and large dimensions.
- Move the operating system strip below the first-run code group and introduce it explicitly as installation troubleshooting.
- Add the matching install or reinstall command near the top of the Linux, macOS, and Windows troubleshooting guides.
- Preserve the temporary target outlines, early arrow fade, allocation labels, and reduced-motion fallback.
- Remove all SVG SMIL `animate` and `animateTransform` elements from the asset.

## Test Plan
- [x] `xmllint --noout docs/images/live-modify.svg` exits 0
- [x] A scoped search confirms the SVG contains no `animate` or `animateTransform` elements
- [x] `npx mintlify broken-links` reports no broken links
- [x] The local Mintlify preview renders both resize states with identical left and bottom coordinates
- [x] The grow and shrink arrows render in the correct direction without crossing the large target boundary
- [x] Quickstart renders a complete three-column troubleshooting strip after the first-run code group
- [x] Each operating system troubleshooting page leads with its matching installer command
- [ ] Confirm the merged MintCDN asset completes both resize directions (requires production deployment)
