### PR TITLE
fix(release): align installer glibc floor

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -958,6 +958,7 @@ jobs:
           python3 -m unittest scripts.ci.test_validate_linux_glibc
           python3 scripts/ci/validate_linux_glibc.py \
             --max-version 2.28 \
+            --installer scripts/install.sh \
             release-artifacts node-artifacts python-artifacts
 
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable

--- a/scripts/ci/test_validate_linux_glibc.py
+++ b/scripts/ci/test_validate_linux_glibc.py
@@ -8,6 +8,7 @@ import unittest
 from scripts.ci.validate_linux_glibc import (
     parse_glibc_versions,
     parse_version,
+    validate_installer_baseline,
     version_key,
 )
 
@@ -39,6 +40,21 @@ class ValidateLinuxGlibcTests(unittest.TestCase):
     def test_parse_version_rejects_non_numeric_values(self) -> None:
         with self.assertRaises(ValueError):
             parse_version("GLIBC_2.28")
+
+    def test_installer_baseline_matches_release_artifacts(self) -> None:
+        installer = 'LINUX_GLIBC_MIN_VERSION="2.28"\n'
+
+        self.assertEqual(validate_installer_baseline(installer, (2, 28)), (2, 28))
+
+    def test_installer_baseline_rejects_drift(self) -> None:
+        installer = 'LINUX_GLIBC_MIN_VERSION="2.39"\n'
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "installer requires glibc 2.39, but release artifacts are audited "
+            "against glibc 2.28",
+        ):
+            validate_installer_baseline(installer, (2, 28))
 
 
 if __name__ == "__main__":

--- a/scripts/ci/validate_linux_glibc.py
+++ b/scripts/ci/validate_linux_glibc.py
@@ -16,6 +16,9 @@ from typing import BinaryIO
 
 ELF_MAGIC = b"\x7fELF"
 GLIBC_VERSION = re.compile(r"\bGLIBC_(\d+(?:\.\d+)+)\b")
+INSTALLER_GLIBC_MIN_VERSION = re.compile(
+    r'^LINUX_GLIBC_MIN_VERSION="(?P<version>\d+(?:\.\d+)+)"$', re.MULTILINE
+)
 ARCHIVE_SUFFIXES = (".tar.gz", ".tgz", ".tar", ".whl", ".zip")
 
 
@@ -33,6 +36,11 @@ def parse_args() -> argparse.Namespace:
         "--max-version",
         default="2.28",
         help="Highest allowed GLIBC symbol version (default: 2.28).",
+    )
+    parser.add_argument(
+        "--installer",
+        type=Path,
+        help="Installer script whose declared minimum must match --max-version.",
     )
     return parser.parse_args()
 
@@ -52,6 +60,25 @@ def version_key(version: tuple[int, ...], width: int = 4) -> tuple[int, ...]:
 def parse_glibc_versions(readelf_output: str) -> set[tuple[int, ...]]:
     """Extract every versioned glibc dependency reported by readelf."""
     return {parse_version(match) for match in GLIBC_VERSION.findall(readelf_output)}
+
+
+def validate_installer_baseline(
+    installer: str, maximum: tuple[int, ...]
+) -> tuple[int, ...]:
+    """Return the installer floor when it matches the audited artifact baseline."""
+    match = INSTALLER_GLIBC_MIN_VERSION.search(installer)
+    if match is None:
+        raise ValueError("installer does not declare LINUX_GLIBC_MIN_VERSION")
+
+    minimum = parse_version(match.group("version"))
+    if version_key(minimum) != version_key(maximum):
+        rendered_minimum = ".".join(map(str, minimum))
+        rendered_maximum = ".".join(map(str, maximum))
+        raise ValueError(
+            f"installer requires glibc {rendered_minimum}, but release artifacts "
+            f"are audited against glibc {rendered_maximum}"
+        )
+    return minimum
 
 
 def is_elf(path: Path) -> bool:
@@ -129,6 +156,13 @@ def main() -> None:
         maximum = parse_version(args.max_version)
     except ValueError as error:
         raise SystemExit(str(error)) from error
+
+    if args.installer is not None:
+        try:
+            installer = args.installer.read_text()
+            validate_installer_baseline(installer, maximum)
+        except (OSError, ValueError) as error:
+            raise SystemExit(str(error)) from error
 
     readelf = shutil.which("readelf")
     if readelf is None:

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -13,9 +13,9 @@ BIN_DIR="$INSTALL_DIR/bin"
 LIB_DIR="$INSTALL_DIR/lib"
 LOCAL_BIN_DIR="$HOME/.local/bin"
 
-# Current Linux release bundles are built on GitHub Actions ubuntu-latest,
-# which currently maps to Ubuntu 24.04 (glibc 2.39).
-LINUX_GLIBC_MIN_VERSION="2.39"
+# Published Linux release bundles are built and audited against the
+# manylinux_2_28 baseline.
+LINUX_GLIBC_MIN_VERSION="2.28"
 
 # Progress bar
 BAR_WIDTH=40


### PR DESCRIPTION
## TL;DR
Lower the Linux installer requirement to glibc 2.28 and make release validation fail if the installer and artifact baselines drift apart again.

## Description
- Change the installer minimum from glibc 2.39 to 2.28 to match the manylinux_2_28 release artifact baseline.
- Add an `--installer` check to the Linux glibc validator and cover matching and mismatched floors in its unit tests.
- Run the installer consistency check as part of final release artifact validation.
- Merge this together with or after the first 2.28-baseline release because the currently published v0.6.10 Linux artifacts still require glibc 2.39.

## Test Plan
- [x] `python3 -m unittest scripts.ci.test_validate_linux_glibc` passes all 6 tests
- [x] `sh -n scripts/install.sh` exits 0
- [x] `PYTHONPYCACHEPREFIX=/tmp/microsandbox-installer-glibc-pycache python3 -m py_compile scripts/ci/validate_linux_glibc.py scripts/ci/test_validate_linux_glibc.py` exits 0
- [x] `git diff --check origin/main..HEAD` exits 0
- [ ] Run the full Linux release artifact scan with `readelf` and assembled release packages (runs in CI)
