### PR TITLE
fix(release): preserve bundled msb executable mode

### DIFF
--- a/.github/workflows/check-platform.yml
+++ b/.github/workflows/check-platform.yml
@@ -236,8 +236,9 @@ jobs:
       - name: Stage runtime bundle
         run: |
           mkdir -p sdk/python/microsandbox/_bundled/bin sdk/python/microsandbox/_bundled/lib
-          cp build/msb sdk/python/microsandbox/_bundled/bin/
-          cp build/${{ inputs.libkrunfw_file }} sdk/python/microsandbox/_bundled/lib/
+          # Match the release wheel after artifact download strips executable bits.
+          install -m 755 build/msb sdk/python/microsandbox/_bundled/bin/msb
+          install -m 644 build/${{ inputs.libkrunfw_file }} sdk/python/microsandbox/_bundled/lib/
           cd sdk/python/microsandbox/_bundled/lib
           if [ "${{ inputs.os }}" = "darwin" ]; then
             ln -sf ${{ inputs.libkrunfw_file }} libkrunfw.dylib

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -868,8 +868,9 @@ jobs:
       - name: Stage runtime bundle
         run: |
           mkdir -p sdk/python/microsandbox/_bundled/bin sdk/python/microsandbox/_bundled/lib
-          cp build/msb sdk/python/microsandbox/_bundled/bin/
-          cp build/libkrunfw.so.${{ env.LIBKRUNFW_VERSION }} sdk/python/microsandbox/_bundled/lib/
+          # Match the release wheel after artifact download strips executable bits.
+          install -m 755 build/msb sdk/python/microsandbox/_bundled/bin/msb
+          install -m 644 build/libkrunfw.so.${{ env.LIBKRUNFW_VERSION }} sdk/python/microsandbox/_bundled/lib/
           cd sdk/python/microsandbox/_bundled/lib
           ln -sf libkrunfw.so.${{ env.LIBKRUNFW_VERSION }} libkrunfw.so.${{ env.LIBKRUNFW_ABI }}
           ln -sf libkrunfw.so.${{ env.LIBKRUNFW_ABI }} libkrunfw.so

--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -321,8 +321,10 @@ jobs:
       - name: Stage runtime bundle
         run: |
           mkdir -p sdk/python/microsandbox/_bundled/bin sdk/python/microsandbox/_bundled/lib
-          cp build/msb sdk/python/microsandbox/_bundled/bin/
-          cp build/${{ inputs.libkrunfw_file }} sdk/python/microsandbox/_bundled/lib/
+          # GitHub artifact archives normalize every file to 0644. Restore the
+          # runtime mode explicitly before maturin records it in the wheel.
+          install -m 755 build/msb sdk/python/microsandbox/_bundled/bin/msb
+          install -m 644 build/${{ inputs.libkrunfw_file }} sdk/python/microsandbox/_bundled/lib/
 
       - name: Build Python wheel
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1
@@ -373,6 +375,9 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p artifacts
+          # Preserve an executable msb entry in the release tarball after the
+          # runtime artifact round trip normalized it to 0644.
+          chmod 755 bundle/runtime/msb
           cp bundle/runtime/msb artifacts/msb-${{ inputs.target }}
           cp bundle/metrics/msb-metrics artifacts/msb-metrics-${{ inputs.target }}
           cp bundle/runtime/${{ inputs.libkrunfw_file }} artifacts/${{ inputs.libkrunfw_asset }}

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -291,8 +291,10 @@ jobs:
       - name: Stage runtime bundle
         run: |
           mkdir -p sdk/python/microsandbox/_bundled/bin sdk/python/microsandbox/_bundled/lib
-          cp build/msb sdk/python/microsandbox/_bundled/bin/
-          cp build/${{ inputs.libkrunfw_file }} sdk/python/microsandbox/_bundled/lib/
+          # GitHub artifact archives normalize every file to 0644. Restore the
+          # runtime mode explicitly before maturin records it in the wheel.
+          install -m 755 build/msb sdk/python/microsandbox/_bundled/bin/msb
+          install -m 644 build/${{ inputs.libkrunfw_file }} sdk/python/microsandbox/_bundled/lib/
 
       - name: Build Python wheel
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1
@@ -337,6 +339,9 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p artifacts
+          # Preserve an executable msb entry in the release tarball after the
+          # runtime artifact round trip normalized it to 0644.
+          chmod 755 bundle/runtime/msb
           cp bundle/runtime/msb artifacts/msb-${{ inputs.target }}
           cp bundle/metrics/msb-metrics artifacts/msb-metrics-${{ inputs.target }}
           cp bundle/runtime/${{ inputs.libkrunfw_file }} artifacts/${{ inputs.libkrunfw_asset }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ on:
       - .github/actions/cache-libkrunfw-kernel/action.yml
       - scripts/ci/publish-crates.py
       - scripts/ci/validate-release-artifacts.py
+      - scripts/ci/test_validate_release_artifacts.py
       - scripts/ci/validate_linux_glibc.py
       - scripts/ci/test_validate_linux_glibc.py
       - scripts/ci/wait-for-npm-packages.mjs
@@ -947,6 +948,7 @@ jobs:
 
       - name: Validate artifact manifest
         run: |
+          python3 -m unittest scripts.ci.test_validate_release_artifacts
           python3 scripts/ci/validate-release-artifacts.py \
             --release-dir release-artifacts \
             --node-dir node-artifacts \

--- a/scripts/ci/test_validate_release_artifacts.py
+++ b/scripts/ci/test_validate_release_artifacts.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Tests for executable-mode validation in release archives."""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import tarfile
+import tempfile
+import unittest
+import zipfile
+from pathlib import Path
+
+
+# The release validator keeps its CLI-oriented hyphenated filename, so load it
+# directly instead of importing it as a normal Python module.
+VALIDATOR_PATH = Path(__file__).with_name("validate-release-artifacts.py")
+VALIDATOR_SPEC = importlib.util.spec_from_file_location(
+    "validate_release_artifacts", VALIDATOR_PATH
+)
+assert VALIDATOR_SPEC is not None and VALIDATOR_SPEC.loader is not None
+VALIDATOR = importlib.util.module_from_spec(VALIDATOR_SPEC)
+VALIDATOR_SPEC.loader.exec_module(VALIDATOR)
+
+WHEEL_MSB_PATH = VALIDATOR.WHEEL_MSB_PATH
+validate_bundle_executable = VALIDATOR.validate_bundle_executable
+validate_wheel_executable = VALIDATOR.validate_wheel_executable
+
+
+class ValidateReleaseArtifactModesTests(unittest.TestCase):
+    def test_wheel_accepts_executable_msb(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            wheel = Path(directory) / "microsandbox.whl"
+            self.write_wheel(wheel, 0o755)
+            errors: list[str] = []
+
+            validate_wheel_executable(wheel, errors)
+
+            self.assertEqual(errors, [])
+
+    def test_wheel_rejects_non_executable_msb(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            wheel = Path(directory) / "microsandbox.whl"
+            self.write_wheel(wheel, 0o644)
+            errors: list[str] = []
+
+            validate_wheel_executable(wheel, errors)
+
+            self.assertEqual(
+                errors,
+                [
+                    "non-executable microsandbox/_bundled/bin/msb in "
+                    "microsandbox.whl: mode 0o644"
+                ],
+            )
+
+    def test_bundle_accepts_executable_msb(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            bundle = Path(directory) / "microsandbox-linux-x86_64.tar.gz"
+            self.write_bundle(bundle, 0o755)
+            errors: list[str] = []
+
+            validate_bundle_executable(bundle, errors)
+
+            self.assertEqual(errors, [])
+
+    def test_bundle_rejects_non_executable_msb(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            bundle = Path(directory) / "microsandbox-linux-x86_64.tar.gz"
+            self.write_bundle(bundle, 0o644)
+            errors: list[str] = []
+
+            validate_bundle_executable(bundle, errors)
+
+            self.assertEqual(
+                errors,
+                [
+                    "non-executable msb in microsandbox-linux-x86_64.tar.gz: "
+                    "mode 0o644"
+                ],
+            )
+
+    @staticmethod
+    def write_wheel(path: Path, mode: int) -> None:
+        member = zipfile.ZipInfo(WHEEL_MSB_PATH)
+        member.external_attr = mode << 16
+        with zipfile.ZipFile(path, "w") as archive:
+            archive.writestr(member, b"msb")
+
+    @staticmethod
+    def write_bundle(path: Path, mode: int) -> None:
+        payload = b"msb"
+        member = tarfile.TarInfo("msb")
+        member.mode = mode
+        member.size = len(payload)
+        with tarfile.open(path, "w:gz") as archive:
+            archive.addfile(member, io.BytesIO(payload))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/ci/validate-release-artifacts.py
+++ b/scripts/ci/validate-release-artifacts.py
@@ -7,6 +7,8 @@ import argparse
 import hashlib
 import json
 import re
+import tarfile
+import zipfile
 from pathlib import Path
 
 
@@ -41,6 +43,14 @@ RELEASE_FILES = {
     "msb-metrics-windows-aarch64.exe",
     "msb-metrics-windows-x86_64.exe",
 }
+
+UNIX_RELEASE_BUNDLES = {
+    "microsandbox-darwin-aarch64.tar.gz",
+    "microsandbox-linux-aarch64.tar.gz",
+    "microsandbox-linux-x86_64.tar.gz",
+}
+
+WHEEL_MSB_PATH = "microsandbox/_bundled/bin/msb"
 
 NODE_PACKAGES = {
     "darwin-arm64": ("microsandbox.darwin-arm64.node", "msb", "libkrunfw.5.dylib"),
@@ -83,6 +93,39 @@ def require_nonempty(path: Path, errors: list[str]) -> None:
         errors.append(f"empty file: {path}")
 
 
+def require_executable(mode: int, description: str, errors: list[str]) -> None:
+    if mode & 0o111 != 0o111:
+        errors.append(f"non-executable {description}: mode {mode & 0o777:#05o}")
+
+
+def validate_bundle_executable(path: Path, errors: list[str]) -> None:
+    if not path.is_file() or path.stat().st_size == 0:
+        return
+
+    try:
+        with tarfile.open(path, "r:gz") as archive:
+            member = archive.getmember("msb")
+            require_executable(member.mode, f"msb in {path.name}", errors)
+    except (KeyError, OSError, tarfile.TarError) as error:
+        errors.append(f"invalid Unix release bundle {path}: {error}")
+
+
+def validate_wheel_executable(path: Path, errors: list[str]) -> None:
+    if not path.is_file() or path.stat().st_size == 0:
+        return
+
+    try:
+        with zipfile.ZipFile(path) as archive:
+            member = archive.getinfo(WHEEL_MSB_PATH)
+            require_executable(
+                member.external_attr >> 16,
+                f"{WHEEL_MSB_PATH} in {path.name}",
+                errors,
+            )
+    except (KeyError, OSError, zipfile.BadZipFile) as error:
+        errors.append(f"invalid Unix Python wheel {path}: {error}")
+
+
 def validate_release_files(root: Path, errors: list[str]) -> list[Path]:
     actual = {path.name for path in root.iterdir() if path.is_file()} if root.is_dir() else set()
     for name in sorted(RELEASE_FILES - actual):
@@ -93,6 +136,8 @@ def validate_release_files(root: Path, errors: list[str]) -> list[Path]:
     files = [root / name for name in sorted(RELEASE_FILES)]
     for path in files:
         require_nonempty(path, errors)
+        if path.name in UNIX_RELEASE_BUNDLES:
+            validate_bundle_executable(path, errors)
     return files
 
 
@@ -124,6 +169,8 @@ def validate_wheels(root: Path, errors: list[str]) -> list[Path]:
         if len(matches) != 1:
             names = ", ".join(wheel.name for wheel in matches) or "none"
             errors.append(f"expected one {platform} wheel, found: {names}")
+        elif not platform.startswith("windows-"):
+            validate_wheel_executable(matches[0], errors)
     for wheel in wheels:
         require_nonempty(wheel, errors)
     return wheels

--- a/sdk/python/tests/test_runtime_binary.py
+++ b/sdk/python/tests/test_runtime_binary.py
@@ -26,3 +26,5 @@ def test_native_resolver_returns_bundled_path():
     expected = os.environ.get("MSB_PATH") or str(bundled)
     assert resolved_msb_path() == expected
     assert os.path.exists(expected)
+    if os.name != "nt":
+        assert os.access(expected, os.X_OK), f"bundled msb is not executable: {expected}"


### PR DESCRIPTION
## TL;DR
Restore the executable bit on `msb` after GitHub artifact transfers so Unix Python wheels and release tarballs work after publication.

## Description
- Stage the bundled Unix `msb` with mode `0755` in release and check workflows before building Python wheels.
- Restore mode `0755` before creating Linux and macOS release tarballs.
- Reject release wheels and Unix bundles whose embedded `msb` is not executable.
- Assert that an installed Unix Python wheel resolves an executable bundled runtime.
- Close #1408.

## Test Plan
- [x] A simulated `0644` artifact download is staged, executed, packed into a wheel and tarball, and validated with mode `0755` in both archives.
- [x] `python3 -m unittest scripts.ci.test_validate_release_artifacts scripts.ci.test_validate_linux_glibc` passes 10 tests.
- [x] Python byte-compilation and Ruff checks pass for the changed Python files.
- [x] Ruby YAML parsing succeeds for all five changed workflow files.
- [x] `git diff --check` succeeds.
- [ ] The release workflow builds and validates all platform artifacts. (runs in CI)
