### PR TITLE
fix(image): support resizing legacy ext4 upper disks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,7 @@ Repository layout:
 |-- AGENTS.md
 |-- Cargo.lock
 |-- Cargo.toml
+|-- COMPATIBILITY.md
 |-- DEVELOPMENT.md
 |-- Dockerfile.agentd
 |-- justfile
@@ -92,11 +93,47 @@ Repository layout:
 
 ## Design Principles
 
-- Before making or continuing a change that may introduce a regression or breaking change, stop and alert the human with the likely impact and affected workflows.
+- Before making or continuing a change that may introduce a regression, breaking change, or backward-compatibility risk identified below, stop and alert the human with the likely impact and affected workflows.
 - Keep changes narrowly scoped to the requested behavior. Avoid drive-by refactors, unrelated formatting, or dependency churn.
 - Treat sandbox isolation, host filesystem access, networking, and secret handling as security-sensitive. Validate inputs at boundaries and avoid exposing host paths, credentials, or ambient privileges.
 - For public APIs, keep the Rust SDK, CLI, Python SDK, Node SDK, Go SDK, docs, and examples consistent when they describe the same capability.
 - Prefer explicit errors with useful context over silent fallbacks.
+
+## Backward Compatibility Review
+
+Backward-compatibility detection is a required part of working on this project. Surface potential compatibility breaks before making or continuing the affected change.
+
+The goal is detection and reporting, not automatically preserving compatibility. Do not silently add compatibility layers, migrations, legacy codecs, fallback paths, or downgrade behavior. When a material risk is found, explain the affected releases, components, persisted artifacts, users or workflows, the likely failure mode, and the available options; then wait for human direction as required by the Design Principles above.
+
+Before changing an existing cross-version boundary, determine:
+
+- What older component, binary, sandbox, or persisted state may interact with the change.
+- Which side is the old producer or consumer.
+- Whether failure would be a clean refusal, loss of functionality, stranded state, silent misinterpretation, data loss, or possible corruption.
+- Whether the repository has a fixture or test using an actual older artifact or binary, rather than only same-version round trips.
+
+Always perform this review when a change affects any of these areas:
+
+- Host-to-guest framing, message names, flags, IDs, payload fields, version negotiation, bootstrap, or lifecycle handshakes.
+- Unix sockets, Windows named pipes, path hashing, relay routing, control messages, inherited file descriptors, signals, or process-launch JSON.
+- SQLite schemas, migration history, persisted configuration, downgrade behavior, journals, leases, or runtime recovery state.
+- ext4, EROFS, VMDK, OCI layers, filesystem metadata, device IDs, mount tags, block paths, or other on-disk formats.
+- Snapshots, archives, manifests, canonical serialization, digests, parent identities, filenames, or atomic publication order.
+- Cache keys, materializer ABIs, layer ordering, whiteouts, hardlinks, xattrs, or content-addressed storage.
+- The runtime, agentd, libkrun, firmware, kernel patches, virtio devices, shared-memory layouts, or package-version coupling.
+- Network address derivation, MACs, interface names, DNS aliases, published ports, TCP/UDP behavior, vsock, SSH, or SFTP behavior.
+- Heartbeats, boot errors, metrics, logs, lock files, runtime directories, or other files consumed across process or release boundaries.
+
+Check each applicable compatibility direction:
+
+1. A new host interacting with an old running sandbox and old agentd.
+2. A new release opening an existing `MSB_HOME` and its database.
+3. A new release reading old disks, snapshots, archives, caches, and filesystem metadata.
+4. An older release encountering state written by the new release, including downgrade refusal behavior.
+5. Exported artifacts moving between releases, platforms, or architectures.
+6. Independently running components from different releases communicating during an upgrade.
+
+Treat stable strings, numeric constants, paths, hashes, serialized field details, ordering guarantees, timing, and error interpretations as compatibility-sensitive even when they are not part of the public API. Consult [COMPATIBILITY.md](COMPATIBILITY.md) for the detailed map, source-of-truth files, evolution rules, and expected tests.
 
 ## Rust Layout And Style
 

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -1,0 +1,304 @@
+# Microsandbox Compatibility Map
+
+This document maps Microsandbox's non-public compatibility boundaries. It exists to help contributors and agents surface backward-compatibility risks early; it does not require every historical behavior to be preserved automatically.
+
+When a proposed change crosses one of these boundaries, identify the risk before implementation. Do not silently add a shim, migration, fallback, or legacy implementation. Explain the compatibility directions involved, the failure mode, and the available choices, then follow the change-safety rules in `AGENTS.md`.
+
+Public SDK, CLI, and HTTP API compatibility is intentionally outside this map. The focus here is the protocols, transports, durable formats, runtime ABIs, and lifecycle contracts that make existing Microsandbox installations and sandboxes continue to work.
+
+## Compatibility Directions
+
+Review every direction that applies to the change:
+
+```text
+new host ---------> old running sandbox / old agentd
+new release ------> old MSB_HOME / database / runtime state
+new reader -------> old disk / snapshot / archive / cache / metadata
+old release ------> state written by the new release
+exported artifact -> another release / platform / architecture
+new component ----> independently running old component during upgrade
+```
+
+A clean, early refusal may be compatible when continued operation would be unsafe. Silent reinterpretation, partial mutation before refusal, stranded durable state, and corruption are not acceptable fallback behavior.
+
+## System Boundaries
+
+```text
+CLI / SDK
+   |
+   | launch JSON + inherited descriptors or Windows config file
+   v
+host runtime <---------- JSON-lines control socket / named pipe
+   |
+   | local agent socket / named pipe
+   | fixed frame header + CBOR
+   v
+relay <---- ring buffers ----> libkrun virtio console "agent"
+                                  |
+                                  v
+                              guest agentd
+                                  |
+                   +--------------+---------------+
+                   |              |               |
+                bootstrap      filesystem      heartbeat
+
+MSB_HOME
+   +-- SQLite database and migration history
+   +-- sandbox disks and volume data
+   +-- snapshots and portable archives
+   +-- OCI/materialization cache
+   +-- filesystem metadata xattrs, ADS, and sidecars
+   +-- sockets, locks, logs, journals, and shared memory
+```
+
+## 1. Host-to-Guest Agent Protocol
+
+The agent protocol is the most explicit cross-version boundary. Its versioning policy is defined in [`crates/protocol/VERSIONING.md`](crates/protocol/VERSIONING.md).
+
+The immutable outer frame is:
+
+```text
+[length: u32 big-endian][id: u32 big-endian][flags: u8][CBOR envelope]
+
+CBOR envelope = { v: generation, t: wire message name, p: encoded payload }
+```
+
+Compatibility-sensitive elements include the header size, byte order, maximum frame size, ID routing, flag bits, CBOR envelope keys, message wire names, message introduction generations, payload field names and meanings, and terminal/session/shutdown semantics. The relay routes on IDs and flags without decoding CBOR, so changing the header cannot be hidden behind payload negotiation.
+
+Evolution rules:
+
+- Keep the outer frame shape stable.
+- Add message types; never remove, rename, or redefine shipped wire types.
+- Assign every new message type an introduction generation and bump the protocol generation.
+- Make new payload fields optional or defaultable.
+- Do not change a shipped field's meaning or type in place; use a version-specific type and converter for a genuine format break.
+- Negotiate the lower peer generation and capability-gate every newer operation before sending it.
+- Keep an old codec until the supported compatibility horizon deliberately moves; the current host still understands the pre-0.5 codec and handshake.
+- Make any new flag bit safe for an old relay to ignore, or use a capability-gated message instead.
+
+Sources and checks:
+
+- [`crates/protocol/lib/message.rs`](crates/protocol/lib/message.rs) defines the generation, frame constants, flags, wire names, and message introduction map.
+- [`crates/protocol/lib/codec.rs`](crates/protocol/lib/codec.rs) defines current framing and validation.
+- [`packages/agent-client/rust/lib/client.rs`](packages/agent-client/rust/lib/client.rs) performs codec detection, version negotiation, and host-side send gating.
+- [`crates/runtime/lib/relay.rs`](crates/runtime/lib/relay.rs) depends on ID ranges and flag semantics without decoding message bodies.
+- [`crates/protocol/tests/schema_snapshot.rs`](crates/protocol/tests/schema_snapshot.rs) freezes the versioned surface and checks append-only message evolution.
+- [`scripts/smoke/cli/pre05-running-sandbox-compat.sh`](scripts/smoke/cli/pre05-running-sandbox-compat.sh) exercises a current host against a real pre-0.5 running sandbox.
+
+Required review should include golden encoded payload bytes when serialization changes. Schema snapshots protect the protocol inventory, but they do not freeze every payload's encoded representation.
+
+## 2. Bootstrap, Init, and Guest Runtime Contract
+
+The first current-protocol host frame is `core.bootstrap` with message ID zero and no flags. The guest then reports resolved init state, the relay installs identity mappings, the host acknowledges init, and only then may the guest become ready.
+
+```text
+host                     guest agentd
+ |---- core.bootstrap ------>|
+ |<--- core.init.resolved ---|
+ |---- core.init.ack -------->|
+ |<--- core.ready -----------|
+```
+
+Compatibility-sensitive elements include bootstrap field defaults and tagged variants, first-message ordering, root/mount/network/security encoding, bind identity exchange, hostname and environment behavior, handoff state, and legacy boot-environment spellings.
+
+Stable guest/VMM identifiers and paths include:
+
+- Virtio-console port name `agent`.
+- Runtime virtiofs tag `msb_runtime`.
+- Guest runtime mount point `/.msb` and its script, TLS, and heartbeat paths.
+- Root block device `/dev/vda`.
+- Additional disk lookup through `/dev/disk/by-id/virtio-<id>` with the existing sysfs fallback.
+- Special host and guest shutdown delays used for normal termination and handoff.
+
+Sources: [`crates/protocol/lib/bootstrap.rs`](crates/protocol/lib/bootstrap.rs), [`crates/protocol/lib/lib.rs`](crates/protocol/lib/lib.rs), [`crates/agentd/lib/agent.rs`](crates/agentd/lib/agent.rs), [`crates/agentd/lib/init.rs`](crates/agentd/lib/init.rs), and [`crates/runtime/lib/vm.rs`](crates/runtime/lib/vm.rs).
+
+## 3. Local Agent IPC and Relay Routing
+
+Unix clients and runtimes recognize canonical hashed socket paths, legacy flat hashed paths, and an older deep sandbox path. Windows uses named pipes derived from the legacy hash. The runtime publishes compatibility symlinks where safe and must not overwrite a live endpoint.
+
+Compatibility-sensitive elements include the hash input and truncation, directory and socket names, Unix path-length fallback, Windows pipe names, compatibility symlinks, stale-endpoint cleanup ordering, lifecycle-lock paths, and lock ownership. Relay compatibility also depends on client ID-range allocation, maximum clients, terminal routing, disconnect cleanup, and shutdown flags.
+
+Sources: [`crates/runtime/lib/ipc.rs`](crates/runtime/lib/ipc.rs), [`crates/runtime/lib/relay.rs`](crates/runtime/lib/relay.rs), and [`sdk/rust/lib/runtime/spawn.rs`](sdk/rust/lib/runtime/spawn.rs).
+
+Path changes require an old-path probe or alias for the supported horizon. Never change a path hash or delete a socket until liveness and ownership have been resolved through the existing lock and endpoint checks.
+
+## 4. Live-Control Protocol
+
+The host runtime exposes a separate Unix socket or Windows named pipe for live modifications. Each connection exchanges one JSON request line and one JSON response line. Operations currently cover capability discovery, CPU and memory state or targets, and secret updates.
+
+Compatibility-sensitive elements include newline framing, the tagged `op` names, response variants, resource field meanings, capability discovery, and the distinction between an absent endpoint, an unsupported operation, and a failed operation. Older runtimes predate capability discovery, and callers intentionally use operation-specific fallback behavior.
+
+Sources: [`crates/runtime/lib/control.rs`](crates/runtime/lib/control.rs) and [`sdk/rust/lib/sandbox/modify.rs`](sdk/rust/lib/sandbox/modify.rs).
+
+Add operations and optional fields rather than redefining existing ones. Capability-gate behavior whose absence cannot be interpreted safely by older clients.
+
+## 5. Launcher-to-Runtime Process Protocol
+
+Starting a sandbox crosses a private process boundary. On Unix, launch JSON is passed through inherited descriptor 96, the parent watchdog uses descriptor 97, startup JSON uses descriptor 98, and the lifecycle lock uses descriptor 99. Windows uses a short-lived launch-config file and platform-specific startup plumbing. Detach acknowledgement bytes and graceful-shutdown signals are also part of this contract.
+
+Compatibility-sensitive elements include descriptor numbers, ownership and close-on-exec behavior, launch JSON field names and defaults, startup response shape, watchdog EOF meaning, signal meaning, detach acknowledgement, secret transport, and parent/child cleanup ordering.
+
+Sources: [`crates/runtime/lib/launch.rs`](crates/runtime/lib/launch.rs), [`crates/runtime/lib/vm.rs`](crates/runtime/lib/vm.rs), [`sdk/rust/lib/runtime/spawn.rs`](sdk/rust/lib/runtime/spawn.rs), and [`crates/cli/lib/sandbox_cmd.rs`](crates/cli/lib/sandbox_cmd.rs).
+
+This protocol has no explicit version envelope. Treat additions as optional and consider adding explicit version or capability negotiation before allowing independently versioned launchers and runtimes.
+
+## 6. Database, Configuration, and Migration History
+
+The SQLite database under `MSB_HOME` is a durable protocol between releases. Host and runtime processes must also agree on WAL, busy timeout, foreign-key, synchronous, and writer settings.
+
+Compatibility-sensitive elements include migration IDs and order, migration semantics, schema columns and constraints, persisted enum/tag spellings, JSON configuration shapes, desired versus active configuration, install and maintenance leases, allocation state, recovery journals, and the downgrade floor.
+
+Evolution rules:
+
+- Never reorder, rename, or reuse a shipped migration ID.
+- Do not edit an applied migration to produce different historical results; add a new migration.
+- Require applied migrations to form the canonical prefix and refuse a schema ahead of the current binary.
+- Transform every persisted representation of changed state, including desired and active configurations.
+- Journal multi-artifact operations durably and refuse startup or downgrade while an incomplete operation remains.
+- Make downgrade either reconstruct the older representation exactly or refuse before mutating state.
+- Resolve active runtimes and install leases before migrating shared state.
+
+Sources: [`crates/db/lib/pool.rs`](crates/db/lib/pool.rs), [`crates/migration/lib/lib.rs`](crates/migration/lib/lib.rs), [`crates/migration/lib/schema_metadata.rs`](crates/migration/lib/schema_metadata.rs), and [`sdk/rust/lib/backend/local/mod.rs`](sdk/rust/lib/backend/local/mod.rs).
+
+Tests should open copies of real older databases, migrate them, exercise the affected behavior, and test every supported reverse migration or refusal path.
+
+## 7. Home and Runtime Path Layout
+
+Directory names under `MSB_HOME` and the runtime directory are durable locators used by binaries from different releases. This includes the database, cache, sandboxes, volumes, snapshots, logs, secrets, TLS material, SSH state, sockets, locks, journals, and configuration files.
+
+Sources: [`crates/utils/lib/lib.rs`](crates/utils/lib/lib.rs) and [`crates/runtime/lib/ipc.rs`](crates/runtime/lib/ipc.rs).
+
+Renaming a directory or file requires migration or old-location probing. Preserve atomic publication and cleanup ordering, and never infer that an unrecognized old path is safe to delete.
+
+## 8. Disk and Filesystem Image Formats
+
+Disk-image bytes outlive the binary that produced them. ext4 compatibility includes superblock feature flags, group descriptors, checksums, inode size and reserved inodes, 64-bit layouts, JBD2 journal state, resize-inode behavior, clean/dirty state, and replay requirements. EROFS and VMDK constants, descriptors, block sizes, extents, device tables, adapters, and alignment rules are likewise durable formats.
+
+Sources: [`crates/image/lib/ext4`](crates/image/lib/ext4), [`crates/image/lib/erofs/format.rs`](crates/image/lib/erofs/format.rs), and [`crates/image/lib/stitch/vmdk.rs`](crates/image/lib/stitch/vmdk.rs).
+
+Parsers and mutators must validate the complete supported feature set before their first write. Unsupported state must fail cleanly without partially updating metadata. Tests for mutators must use multiple historical layouts, dirty and journaled images, boundary sizes, failure injection, filesystem checkers, and post-operation mount/read/write verification where the platform permits.
+
+## 9. Snapshots, Manifests, and Portable Archives
+
+Snapshot descriptor bytes are identity-bearing: their canonical bytes determine the snapshot ID. Compatibility-sensitive elements include field order, required `null` values, map ordering, duplicate-key handling, tag spellings, schema and integrity identifiers, payload names, parent identities, state/scope/format variants, extension requirements, and translation-graph behavior.
+
+Archive compatibility includes compression detection, `archive.json`, canonical inventory order, transport digests, accepted path grammar, legacy paths, cache-closure entries, and rejection of duplicate, missing, or escaping paths.
+
+Evolution rules:
+
+- Do not make semantically harmless serialization changes to identity-bearing bytes without treating them as an identity format change.
+- Keep legacy descriptor translation explicit; do not rely on a permissive generic reader when exact reconstruction matters.
+- Use additive extensions with sorted must-understand requirements, or introduce a new schema plus forward and reverse translation.
+- Publish payloads first and the verified descriptor last through temporary files, fsync, and atomic rename.
+- Keep downgrade refusal until durable reverse artifact migration is complete.
+
+Sources: [`crates/image/lib/snapshot/manifest.rs`](crates/image/lib/snapshot/manifest.rs), [`crates/image/lib/snapshot/migration.rs`](crates/image/lib/snapshot/migration.rs), and [`sdk/rust/lib/snapshot/archive.rs`](sdk/rust/lib/snapshot/archive.rs).
+
+## 10. OCI Cache and Materializer ABI
+
+The cache is rebuildable, but cache entries and closures can cross releases through `MSB_HOME` and snapshot archives. OCI semantics are externally defined: compressed descriptor digests, uncompressed diff IDs, ordered layers, whiteouts, opaque directories, hardlinks, extended attributes, non-UTF-8 paths, special files, and permissions must retain their meaning.
+
+Flat filesystem cache identity includes a materializer ABI. Bump that ABI whenever emitted filesystem bytes or interpretation can change so incompatible entries miss instead of being reused. Preserve content-addressed verification and never retain bytes under a mismatched digest or size.
+
+Sources: [`crates/image/MATERIALIZATION.md`](crates/image/MATERIALIZATION.md), [`crates/image/lib/cache/store.rs`](crates/image/lib/cache/store.rs), and [`crates/image/lib/flat.rs`](crates/image/lib/flat.rs).
+
+## 11. Host Filesystem Metadata
+
+Bind mounts and volumes persist virtual Linux stat information outside the guest. Linux uses the `user.msb.override_stat` xattr with a fixed packed versioned payload. Windows uses an alternate data stream or `.msb_override_stat` sidecar. The hidden synthetic `init.krun` entry is also a reserved filesystem contract used to inject agentd.
+
+Compatibility-sensitive elements include xattr, ADS, and sidecar names; payload version, width, and byte order; uid, gid, mode, and rdev interpretation; symlink representation; path encoding; hidden-metadata filtering; reserved inode/handle values; and whiteout immunity.
+
+Sources: [`crates/filesystem/lib/backends/shared/stat_override.rs`](crates/filesystem/lib/backends/shared/stat_override.rs), [`crates/filesystem/lib/backends/passthroughfs/windows`](crates/filesystem/lib/backends/passthroughfs/windows), and [`crates/filesystem/lib/backends/shared/init_binary.rs`](crates/filesystem/lib/backends/shared/init_binary.rs).
+
+New metadata layouts require a new decoder version and, when old writers must consume the state, a migration or clean refusal before mutation.
+
+## 12. Runtime, Agentd, Libkrun, Firmware, and Kernel Bundle
+
+The runtime, embedded agentd, exact `msb_krun` version, libkrun ABI, firmware, and patched kernel form one release unit. Their interfaces include virtio feature bits, device config layouts, console behavior, metrics and CPU-capacity devices, vsock behavior, TSI behavior, firmware filenames, and platform-specific VMM backends.
+
+Sources: [`Cargo.toml`](Cargo.toml), [`crates/filesystem/build.rs`](crates/filesystem/build.rs), [`crates/filesystem/lib/agentd.rs`](crates/filesystem/lib/agentd.rs), [`crates/utils/lib/lib.rs`](crates/utils/lib/lib.rs), and [`vendor/libkrunfw/patches`](vendor/libkrunfw/patches).
+
+Do not independently substitute or upgrade one component because its upstream ABI appears compatible. Verify the release bundle as a unit on every supported OS and architecture, including the embedded matching agentd, firmware/kernel, library soname, device behavior, and package-version checks.
+
+## 13. Networking, DNS, Published Ports, and Secret Substitution
+
+Observable network behavior is an effective compatibility contract. It includes default MTU, sandbox-slot address derivation, IPv4 subnet sizing, guest and gateway offsets, IPv6 prefixes, deterministic MAC addresses, interface name `eth0`, `host.microsandbox.internal`, DNS UDP and TCP behavior, DNS-over-TLS, TLS interception and trust paths, published-port binding, TCP half-close, UDP peer lifetime, destination policy, and host-side secret placeholder substitution.
+
+Sources: [`crates/network/lib/lib.rs`](crates/network/lib/lib.rs), [`crates/network/lib/network.rs`](crates/network/lib/network.rs), and the remaining modules under [`crates/network/lib`](crates/network/lib).
+
+Address or MAC changes can create collisions or silently alter policy identity. Protocol changes should be tested with real TCP, UDP, DNS, TLS, HTTP CONNECT, published-port, and secret-substitution clients, including fragmentation, half-close, cancellation, and denied-destination cases.
+
+## 14. Vsock and SSH Protocol Adapters
+
+Vsock stream and datagram routes have different message-boundary and shutdown semantics, with platform-specific Unix socket and Windows named-pipe backends. SSH maps exec channels to agent exec, SFTP to agent filesystem messages, and direct TCP forwarding to agent TCP messages. These mappings inherit agent protocol generation requirements.
+
+Compatibility-sensitive elements include vsock port and route configuration, stream half-close, datagram boundaries, backend availability, SSH host-key and known-host persistence, authentication behavior, exit status and signal mapping, SFTP file semantics, and direct-tcpip capability gating.
+
+Sources: [`crates/vsock/lib/stream.rs`](crates/vsock/lib/stream.rs), [`crates/vsock/lib/dgram.rs`](crates/vsock/lib/dgram.rs), [`crates/runtime/lib/vm.rs`](crates/runtime/lib/vm.rs), and [`sdk/rust/lib/sandbox/ssh.rs`](sdk/rust/lib/sandbox/ssh.rs).
+
+Use standards-compliant clients in tests and exercise connections against older running agentd versions when changing the adapter-to-agent mapping.
+
+## 15. Metrics Shared-Memory ABI
+
+Metrics use a binary shared-memory structure across independently executing processes. The header and slots have fixed sizes, magic, registry version, ABI, atomics, seqlock ordering, generation counters, lifecycle states, and reserved bytes.
+
+Sources: [`crates/metrics/lib/layout.rs`](crates/metrics/lib/layout.rs), [`crates/metrics/lib/registry.rs`](crates/metrics/lib/registry.rs), and [`crates/utils/lib/lib.rs`](crates/utils/lib/lib.rs).
+
+Do not reorder fields, change widths or alignment, weaken atomic ordering, or redefine slot states under the same ABI. Incompatible changes must bump the registry version or ABI so old and new processes do not map the same object. Prefer checked-in offset and binary-layout fixtures in addition to total-size assertions.
+
+## 16. Heartbeats, Boot Errors, Logs, and Runtime Diagnostics
+
+Operational artifacts are consumed across process boundaries and can influence lifecycle decisions. These include `/.msb/heartbeat.json`, `boot-error.json`, `exec.log`, runtime and kernel logs, temporary filenames, JSON field names, sequence numbers, timestamps, source labels, rotation suffixes, and atomic rename behavior.
+
+Heartbeat semantics are compatibility-sensitive: missing or stale data alone is not proof that a sandbox has died, while active sessions affect idle shutdown. Boot errors must remain available before agent readiness. Log schemas and rotation ordering must remain readable by current SDK consumers.
+
+Sources: [`crates/protocol/lib/heartbeat.rs`](crates/protocol/lib/heartbeat.rs), [`crates/runtime/lib/heartbeat.rs`](crates/runtime/lib/heartbeat.rs), [`crates/runtime/lib/boot_error.rs`](crates/runtime/lib/boot_error.rs), and [`crates/runtime/lib/exec_log.rs`](crates/runtime/lib/exec_log.rs).
+
+Add optional fields where readers are tolerant. Rename files or fields only with dual-read or migration behavior for the supported horizon.
+
+## 17. Lifecycle, Locks, Leases, and Ordering
+
+Compatibility can depend on operation order even when no serialized shape changes. Lifecycle locks, database run rows, PID ownership, endpoints, metrics slots, CPU and writeback allocations, heartbeat state, maintenance leases, signals, shutdown delays, and cleanup together determine whether a sandbox is live and who may mutate it.
+
+Compatibility-sensitive ordering includes:
+
+- Resolving lock and process ownership before replacing or deleting endpoints.
+- Preventing database and artifact migration while incompatible runtimes remain active.
+- Reserving, activating, marking stale, and freeing shared resources in the established order.
+- Allowing agentd and the guest filesystem to drain before forced VMM termination.
+- Writing and verifying payloads before atomically publishing their identity-bearing descriptor.
+- Persisting a recovery journal before the first mutation and clearing it only after durable completion.
+
+Sources: [`crates/runtime/lib/ipc.rs`](crates/runtime/lib/ipc.rs), [`sdk/rust/lib/backend/local/mod.rs`](sdk/rust/lib/backend/local/mod.rs), [`sdk/rust/lib/runtime/handle.rs`](sdk/rust/lib/runtime/handle.rs), and artifact-specific migration and publication modules.
+
+Review concurrency and crash points explicitly. A same-version happy-path test does not establish cross-version or crash compatibility.
+
+## Review Triggers in Diffs
+
+When inspecting a proposed change, treat these patterns as compatibility tripwires:
+
+- `serde` rename, tag, default, flatten, deny-unknown-fields, enum, or numeric-type changes.
+- Modified magic values, protocol versions, feature flags, message names, operation names, IDs, reserved bits, or frame limits.
+- Changed path constants, filenames, extensions, hashes, truncation lengths, mount tags, interface names, device names, xattr keys, ADS names, or environment variables.
+- Changed canonical serialization, field order, sorting, hashing domains, digest algorithms, UUID derivation, parent identity, or archive inventory.
+- Edits to an existing migration instead of a newly appended migration.
+- Changed ext4, EROFS, VMDK, OCI, journal, inode, block, descriptor, or checksum logic.
+- Changed `repr(C)` structs, shared-memory fields, atomic orderings, slot states, virtio feature bits, or device config layouts.
+- Changed startup, readiness, shutdown, timeout, signal, lock, lease, rename, fsync, or cleanup order.
+- Changed exact internal dependency pins, embedded-agent selection, firmware versions, sonames, bundle URLs, or platform artifact names.
+- Removal of a legacy parser, codec, path probe, translation, fallback, migration, or compatibility test.
+
+## Expected Evidence Before Declaring Compatibility Safe
+
+Choose evidence proportional to the boundary and failure risk:
+
+1. Unit tests for parsing, validation, capability gates, and clean refusal before mutation.
+2. Golden bytes or checked-in fixtures for wire, canonical, binary-layout, and identity-bearing formats.
+3. Copies of artifacts produced by supported older releases: databases, ext4 images, manifests, archives, cache entries, and metadata trees.
+4. Real older binaries for live host-to-agent, local IPC, launcher/runtime, and bundle interoperability.
+5. Forward migration plus supported reverse migration or downgrade-refusal tests.
+6. Crash and failure injection around journals, metadata writes, fsync, rename, publication, and cleanup.
+7. External validators such as filesystem checkers and standards-compliant SSH, SFTP, DNS, TLS, TCP, UDP, OCI, and archive readers.
+8. Platform and architecture coverage for Linux/KVM, macOS/HVF, Windows/WHP, Unix sockets, named pipes, firmware, and packaged runtime artifacts.
+
+If an applicable direction cannot be tested locally, state exactly what remains unverified and which CI, platform, historical binary, or fixture is required.

--- a/crates/image/lib/ext4/formatter.rs
+++ b/crates/image/lib/ext4/formatter.rs
@@ -15,8 +15,8 @@ use super::format::{
     EXT4_FEATURE_RO_COMPAT_LARGE_FILE, EXT4_FEATURE_RO_COMPAT_METADATA_CSUM,
     EXT4_FEATURE_RO_COMPAT_SPARSE_SUPER, EXT4_FIRST_INO, EXT4_INODE_SIZE, EXT4_INODES_PER_GROUP,
     EXT4_JOURNAL_INO, EXT4_LOG_BLOCK_SIZE, EXT4_MIN_EXTRA_ISIZE, EXT4_ROOT_INO,
-    EXT4_SB_OVERHEAD_BLOCKS_OFFSET, EXT4_SUPER_MAGIC, JBD2_MAGIC, JBD2_SUPERBLOCK_V2, S_IFBLK,
-    S_IFCHR, S_IFDIR, S_IFIFO, S_IFLNK, S_IFREG, S_IFSOCK,
+    EXT4_SB_ERROR_COUNT_OFFSET, EXT4_SB_OVERHEAD_BLOCKS_OFFSET, EXT4_SUPER_MAGIC, JBD2_MAGIC,
+    JBD2_SUPERBLOCK_V2, S_IFBLK, S_IFCHR, S_IFDIR, S_IFIFO, S_IFLNK, S_IFREG, S_IFSOCK,
 };
 use super::layout::{
     GroupDescStats, GroupGeometry, MAX_BLOCKS, RESERVED_GDT_BLOCKS, bitmap_checksum,
@@ -148,8 +148,10 @@ struct Layout {
     inode_table_blocks: u32,
     /// First data block after inode table (root dir block).
     first_data_block: u64,
-    /// Double-indirect block owned by the reserved-GDT inode.
-    resize_inode_block: u64,
+    /// Double-indirect block owned by the reserved-GDT inode. Legacy test
+    /// images intentionally omit this block to reproduce the pre-0.6.9
+    /// formatter layout.
+    resize_inode_block: Option<u64>,
     /// First block of the journal region.
     journal_start_block: u64,
     /// Total journal blocks.
@@ -318,7 +320,13 @@ impl Layout {
         root_dir_blocks: u32,
         reserved_gdt_blocks: u32,
     ) -> Result<Self, Ext4Error> {
-        Self::compute_with_root_blocks_and_uuid(opts, root_dir_blocks, reserved_gdt_blocks, None)
+        Self::compute_with_root_blocks_and_uuid(
+            opts,
+            root_dir_blocks,
+            reserved_gdt_blocks,
+            None,
+            true,
+        )
     }
 
     fn compute_with_root_blocks_and_uuid(
@@ -326,6 +334,7 @@ impl Layout {
         root_dir_blocks: u32,
         reserved_gdt_blocks: u32,
         uuid: Option<[u8; 16]>,
+        with_resize_inode: bool,
     ) -> Result<Self, Ext4Error> {
         let block_size = EXT4_BLOCK_SIZE as u64;
         if !opts.size_bytes.is_multiple_of(block_size) {
@@ -376,8 +385,9 @@ impl Layout {
         let block_bitmap_block = overhead_blocks;
         let inode_bitmap_block = block_bitmap_block + 1;
         let inode_table_block = inode_bitmap_block + 1;
-        let resize_inode_block = inode_table_block + inode_table_blocks as u64;
-        let first_data_block = resize_inode_block + 1;
+        let inode_table_end = inode_table_block + inode_table_blocks as u64;
+        let resize_inode_block = with_resize_inode.then_some(inode_table_end);
+        let first_data_block = inode_table_end + u64::from(with_resize_inode);
         let journal_start_block = first_data_block + root_dir_blocks as u64;
 
         let min_blocks = journal_start_block + opts.journal_blocks as u64 + 1; // +1 slack
@@ -391,10 +401,12 @@ impl Layout {
 
         let csum_seed = crc32c::crc32c_raw(0xFFFF_FFFF, &uuid);
 
-        let feature_compat = EXT4_FEATURE_COMPAT_HAS_JOURNAL
+        let mut feature_compat = EXT4_FEATURE_COMPAT_HAS_JOURNAL
             | EXT4_FEATURE_COMPAT_EXT_ATTR
-            | EXT4_FEATURE_COMPAT_RESIZE_INODE
             | EXT4_FEATURE_COMPAT_DIR_INDEX;
+        if with_resize_inode {
+            feature_compat |= EXT4_FEATURE_COMPAT_RESIZE_INODE;
+        }
 
         let feature_incompat = EXT4_FEATURE_INCOMPAT_FILETYPE
             | EXT4_FEATURE_INCOMPAT_EXTENTS
@@ -494,7 +506,9 @@ impl Layout {
     fn group_used_blocks(&self, group: u32) -> u32 {
         let mut used = self.group_metadata_blocks(group);
         if group == 0 {
-            used += 2 + self.journal_blocks; // resize inode block + root dir + journal
+            // Root directory + journal, plus the reserved-GDT inode's pointer block in the
+            // modern layout. Pre-0.6.9 images did not allocate that final block.
+            used += 1 + self.journal_blocks + u32::from(self.resize_inode_block.is_some());
         }
         used.min(self.blocks_in_group(group))
     }
@@ -535,6 +549,19 @@ impl Layout {
             .sum()
     }
 
+    fn recorded_overhead_blocks(&self, total_free_blocks: u64) -> (usize, u64) {
+        if self.resize_inode_block.is_none() {
+            // The released pre-0.6.9 formatter wrote total used blocks at 0x194, before that
+            // offset was corrected to ext4's actual error counter and overhead moved to 0x248.
+            (
+                EXT4_SB_ERROR_COUNT_OFFSET,
+                self.num_blocks - total_free_blocks,
+            )
+        } else {
+            (EXT4_SB_OVERHEAD_BLOCKS_OFFSET, self.total_overhead_blocks())
+        }
+    }
+
     fn validate_group_metadata(&self) -> Result<(), Ext4Error> {
         for group in 0..self.num_groups {
             let blocks_in_group = self.blocks_in_group(group);
@@ -553,7 +580,9 @@ impl Layout {
 impl BitmapPlan {
     fn new(layout: &Layout, plans: &[NodePlan]) -> Self {
         let mut block_extents = Vec::new();
-        block_extents.push((layout.resize_inode_block, 1));
+        if let Some(block) = layout.resize_inode_block {
+            block_extents.push((block, 1));
+        }
         block_extents.push((
             layout.first_data_block,
             (layout.journal_start_block - layout.first_data_block) as u32,
@@ -641,6 +670,7 @@ fn format_ext4_with_tree_and_reserved(
         reserved_gdt_blocks,
         None,
         TreeEncodingMode::Upper,
+        true,
     )
 }
 
@@ -657,6 +687,27 @@ pub(super) fn format_ext4_rootfs_with_tree_and_uuid(
         RESERVED_GDT_BLOCKS,
         Some(uuid),
         TreeEncodingMode::Rootfs,
+        true,
+    )
+}
+
+/// Reproduce the resize-metadata shape written before v0.6.9.
+///
+/// This is deliberately test-only: production formatting must always create
+/// the resize inode and its ownership graph.
+#[cfg(test)]
+pub(super) fn format_ext4_legacy_for_test(
+    path: &Path,
+    options: &Ext4FormatOptions,
+) -> Result<(), Ext4Error> {
+    format_ext4_with_tree_and_reserved_uuid(
+        path,
+        options,
+        FileTree::new(),
+        RESERVED_GDT_BLOCKS,
+        None,
+        TreeEncodingMode::Upper,
+        false,
     )
 }
 
@@ -667,6 +718,7 @@ fn format_ext4_with_tree_and_reserved_uuid(
     reserved_gdt_blocks: u32,
     uuid: Option<[u8; 16]>,
     encoding_mode: TreeEncodingMode,
+    with_resize_inode: bool,
 ) -> Result<(), Ext4Error> {
     let mut next_inode = EXT4_FIRST_INO;
     let mut plans = Vec::new();
@@ -690,6 +742,7 @@ fn format_ext4_with_tree_and_reserved_uuid(
         root_dir_blocks.max(1),
         reserved_gdt_blocks,
         uuid,
+        with_resize_inode,
     )?;
     let max_inode = next_inode.saturating_sub(1);
     let available_inodes = layout.num_groups.saturating_mul(EXT4_INODES_PER_GROUP);
@@ -747,14 +800,16 @@ fn format_ext4_with_tree_and_reserved_uuid(
     write_bitmaps(&mut file, &layout, &bitmap_plan)?;
     write_tree_data(&mut file, &layout, &all_plans)?;
     write_inode_table_with_plan(&mut file, &layout, &all_plans)?;
-    write_resize_inode(
-        &mut file,
-        &layout.geometry(),
-        layout.group_inode_table_block(0),
-        layout.resize_inode_block,
-        layout.csum_seed,
-        layout.num_groups,
-    )?;
+    if let Some(resize_inode_block) = layout.resize_inode_block {
+        write_resize_inode(
+            &mut file,
+            &layout.geometry(),
+            layout.group_inode_table_block(0),
+            resize_inode_block,
+            layout.csum_seed,
+            layout.num_groups,
+        )?;
+    }
     write_journal(&mut file, &layout)?;
 
     let sb_bytes = build_superblock_with_stats(&layout, &stats)?;
@@ -1760,11 +1815,12 @@ fn build_superblock_with_stats_for_group(
     put_le32(sb, 0x0C, stats.total_free_blocks as u32);
     put_le32(sb, 0x10, stats.total_free_inodes as u32);
     put_le32(sb, 0x158, (stats.total_free_blocks >> 32) as u32);
-    put_le32(
-        sb,
-        EXT4_SB_OVERHEAD_BLOCKS_OFFSET,
-        stats.overhead_blocks as u32,
-    );
+    let (overhead_offset, overhead_blocks) = if layout.resize_inode_block.is_none() {
+        layout.recorded_overhead_blocks(stats.total_free_blocks)
+    } else {
+        (EXT4_SB_OVERHEAD_BLOCKS_OFFSET, stats.overhead_blocks)
+    };
+    put_le32(sb, overhead_offset, overhead_blocks as u32);
     let checksum = superblock_checksum(sb);
     put_le32(sb, 0x3FC, checksum);
     Ok(block)
@@ -2468,12 +2524,11 @@ fn build_superblock(
     // s_kbytes_written (0x178, u64) -- 0
     // s_snapshot_inum, etc. -- leave zeroed
 
-    // s_overhead_clusters (0x248, u32)
-    put_le32(
-        sb,
-        EXT4_SB_OVERHEAD_BLOCKS_OFFSET,
-        layout.total_overhead_blocks() as u32,
-    );
+    // Modern images use s_overhead_clusters at 0x248. The test-only legacy formatter preserves
+    // the pre-0.6.9 field placement at 0x194 so compatibility tests exercise released bytes.
+    let (overhead_offset, overhead_blocks) =
+        layout.recorded_overhead_blocks(layout.total_free_blocks());
+    put_le32(sb, overhead_offset, overhead_blocks as u32);
 
     // s_checksum_seed (0x270, u32) -- crc32c::crc32c_raw(~0, uuid)
     // Only used if INCOMPAT_CSUM_SEED is set. For METADATA_CSUM without

--- a/crates/image/lib/ext4/resizer.rs
+++ b/crates/image/lib/ext4/resizer.rs
@@ -22,7 +22,7 @@ use super::format::{
     EXT4_FEATURE_RO_COMPAT_METADATA_CSUM, EXT4_FEATURE_RO_COMPAT_SPARSE_SUPER, EXT4_FIRST_INO,
     EXT4_INODE_SIZE, EXT4_INODES_PER_GROUP, EXT4_JOURNAL_INO, EXT4_LOG_BLOCK_SIZE, EXT4_RESIZE_INO,
     EXT4_ROOT_INO, EXT4_SB_ERROR_COUNT_OFFSET, EXT4_SB_OVERHEAD_BLOCKS_OFFSET, EXT4_SUPER_MAGIC,
-    sparse_super_group,
+    S_IFDIR, sparse_super_group,
 };
 use super::formatter::{Ext4Error, mark_sparse};
 use super::jbd2;
@@ -52,6 +52,10 @@ const LEGACY_FEATURE_COMPAT: u32 =
 
 /// Feature mask written by the current formatter.
 const MODERN_FEATURE_COMPAT: u32 = LEGACY_FEATURE_COMPAT | EXT4_FEATURE_COMPAT_RESIZE_INODE;
+
+/// Maximum extent-tree depth accepted by ext4. Normal guest activity can grow a directory beyond
+/// the inline extent root, so legacy recognition must be able to follow its left-most path.
+const EXT4_MAX_EXTENT_DEPTH: u16 = 5;
 
 //--------------------------------------------------------------------------------------------------
 // Types
@@ -709,20 +713,36 @@ fn validate_legacy_resize_metadata(file: &mut File, img: &ParsedImage) -> Result
     }
 
     let root_inode = read_inode(file, &geometry, EXT4_ROOT_INO)?;
-    validate_allocated_inode(file, img, 0, EXT4_ROOT_INO - 1, EXT4_ROOT_INO, &[])?;
-    let extent_root = &root_inode[0x28..0x64];
-    if get_le32(&root_inode, 0x20) & EXT4_EXTENTS_FL == 0
-        || get_le16(extent_root, 0) != EXT4_EH_MAGIC
-        || get_le16(extent_root, 2) != 1
-        || get_le16(extent_root, 6) != 0
-        || get_le32(extent_root, 12) != 0
+    let stored_checksum =
+        u32::from(get_le16(&root_inode, 0x7C)) | (u32::from(get_le16(&root_inode, 0x82)) << 16);
+    if inode_checksum(
+        img.csum_seed,
+        EXT4_ROOT_INO,
+        get_le32(&root_inode, 0x64),
+        &root_inode,
+    ) != stored_checksum
+    {
+        return Err(unsupported("legacy image root inode checksum mismatch"));
+    }
+    if get_le16(&root_inode, 0) & 0xF000 != S_IFDIR
+        || get_le32(&root_inode, 0x20) & EXT4_EXTENTS_FL == 0
     {
         return Err(unsupported(
-            "legacy image root inode does not use the expected single extent",
+            "legacy image root inode is not an extent-backed directory",
         ));
     }
-    let root_block =
-        u64::from(get_le32(extent_root, 20)) | (u64::from(get_le16(extent_root, 18)) << 32);
+    let xattr_block =
+        u64::from(get_le32(&root_inode, 0x68)) | (u64::from(get_le16(&root_inode, 0x76)) << 32);
+    if xattr_block != 0 {
+        validate_external_xattrs(file, img, xattr_block, EXT4_ROOT_INO)?;
+    }
+    if get_le32(&root_inode, 0xA0) == 0xEA02_0000 {
+        validate_xattr_entries(&root_inode[0xA4..], 0xA4, root_inode.len(), EXT4_ROOT_INO)?;
+    }
+
+    // Only logical block zero is a creation-time fingerprint. The guest may add and fragment
+    // later root-directory blocks, turning the inline leaf into a multi-level extent tree.
+    let root_block = first_extent_physical_block(file, img, EXT4_ROOT_INO, &root_inode)?;
     let expected_root_block =
         geometry.group_inode_table_block(0) + u64::from(img.inode_table_blocks);
     if root_block != expected_root_block {
@@ -744,6 +764,93 @@ fn validate_legacy_resize_metadata(file: &mut File, img: &ParsedImage) -> Result
     }
 
     Ok(())
+}
+
+/// Resolve logical block zero through a checksummed extent tree.
+///
+/// Legacy identification only depends on the first root-directory block. Following the left-most
+/// index path preserves that stable fingerprint while accepting extent fanout created by normal
+/// guest writes.
+fn first_extent_physical_block(
+    file: &mut File,
+    img: &ParsedImage,
+    inode_number: u32,
+    inode: &[u8],
+) -> Result<u64, Ext4Error> {
+    let generation = get_le32(inode, 0x64);
+    let mut node = inode[0x28..0x64].to_vec();
+    let mut entry_capacity = 4usize;
+    let mut parent_depth: Option<u16> = None;
+
+    loop {
+        if get_le16(&node, 0) != EXT4_EH_MAGIC {
+            return Err(unsupported(format!(
+                "inode {inode_number} has bad extent magic"
+            )));
+        }
+        let entries = usize::from(get_le16(&node, 2));
+        let max = usize::from(get_le16(&node, 4));
+        let depth = get_le16(&node, 6);
+        if entries == 0
+            || entries > max
+            || max > entry_capacity
+            || depth > EXT4_MAX_EXTENT_DEPTH
+            || parent_depth.is_some_and(|parent| depth.checked_add(1) != Some(parent))
+        {
+            return Err(unsupported(format!(
+                "inode {inode_number} has invalid extent header"
+            )));
+        }
+
+        let first = &node[12..24];
+        if get_le32(first, 0) != 0 {
+            return Err(unsupported(format!(
+                "inode {inode_number} extent tree does not start at logical block zero"
+            )));
+        }
+        if depth == 0 {
+            let raw_len = get_le16(first, 4);
+            if raw_len == 0 || raw_len > 0x8000 {
+                return Err(unsupported(format!(
+                    "inode {inode_number} has an invalid first extent"
+                )));
+            }
+            let block_count = if raw_len == 0x8000 {
+                32768
+            } else {
+                u64::from(raw_len)
+            };
+            let physical = u64::from(get_le32(first, 8)) | (u64::from(get_le16(first, 6)) << 32);
+            if physical
+                .checked_add(block_count)
+                .is_none_or(|end| end > img.num_blocks)
+            {
+                return Err(unsupported(format!(
+                    "inode {inode_number} first extent is out of bounds"
+                )));
+            }
+            return Ok(physical);
+        }
+
+        let child_block = u64::from(get_le32(first, 4)) | (u64::from(get_le16(first, 8)) << 32);
+        if child_block >= img.num_blocks {
+            return Err(unsupported(format!(
+                "inode {inode_number} extent index is out of bounds"
+            )));
+        }
+        let child = read_block_at(file, child_block)?;
+        let tail = child.len() - 4;
+        if get_le32(&child, tail)
+            != dir_block_checksum(img.csum_seed, inode_number, generation, &child[..tail])
+        {
+            return Err(unsupported(format!(
+                "inode {inode_number} extent index checksum mismatch"
+            )));
+        }
+        parent_depth = Some(depth);
+        entry_capacity = (tail - 12) / 12;
+        node = child;
+    }
 }
 
 fn read_inode(
@@ -1171,6 +1278,125 @@ mod tests {
         format_ext4_legacy_for_test(path, &opts).unwrap();
     }
 
+    /// Reproduce a root directory that has outgrown the inode's inline extent leaf.
+    ///
+    /// The kernel normally creates this shape after enough directory churn. Building the same
+    /// valid on-disk shape directly keeps the regression deterministic and exercises the exact
+    /// compatibility fingerprint: logical block zero stays at its legacy location while its
+    /// extent record moves into a checksummed depth-one leaf.
+    fn grow_legacy_root_extent_tree(path: &Path) -> u64 {
+        let mut file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(path)
+            .unwrap();
+        let img = parse_and_validate(&mut file).unwrap();
+        assert_eq!(img.resize_metadata, ResizeMetadata::Legacy);
+        let geo = img.geometry();
+
+        let mut root_inode = read_inode(&mut file, &geo, EXT4_ROOT_INO).unwrap();
+        assert_eq!(get_le16(&root_inode, 0x28), EXT4_EH_MAGIC);
+        assert_eq!(get_le16(&root_inode, 0x2A), 1);
+        assert_eq!(get_le16(&root_inode, 0x2E), 0);
+        let original_extent = root_inode[0x34..0x40].to_vec();
+
+        // Keep the synthetic extent metadata away from formatter-owned data and mark it allocated
+        // exactly as ext4 would. The released test layout keeps this location in block group zero.
+        let location =
+            jbd2::locate_journal(&mut file, geo.group_inode_table_block(0), img.csum_seed).unwrap();
+        let extent_block = location.start_block + u64::from(location.len_blocks) + 16;
+        let group = (extent_block / u64::from(EXT4_BLOCKS_PER_GROUP)) as u32;
+        assert_eq!(group, 0, "test extent metadata must remain in group zero");
+        let local_block = (extent_block % u64::from(EXT4_BLOCKS_PER_GROUP)) as u32;
+
+        let bitmap_block = geo.group_block_bitmap_block(group);
+        let mut block_bitmap = read_block_at(&mut file, bitmap_block).unwrap();
+        let byte = &mut block_bitmap[(local_block / 8) as usize];
+        let mask = 1 << (local_block % 8);
+        assert_eq!(*byte & mask, 0, "chosen extent block is already allocated");
+        *byte |= mask;
+
+        // External extent nodes reserve their final four bytes for the metadata checksum.
+        let mut extent_leaf = vec![0u8; EXT4_BLOCK_SIZE as usize];
+        let checksum_offset = extent_leaf.len() - 4;
+        put_le16(&mut extent_leaf, 0x00, EXT4_EH_MAGIC);
+        put_le16(&mut extent_leaf, 0x02, 1);
+        put_le16(&mut extent_leaf, 0x04, ((checksum_offset - 12) / 12) as u16);
+        extent_leaf[0x0C..0x18].copy_from_slice(&original_extent);
+        let generation = get_le32(&root_inode, 0x64);
+        let checksum = dir_block_checksum(
+            img.csum_seed,
+            EXT4_ROOT_INO,
+            generation,
+            &extent_leaf[..checksum_offset],
+        );
+        put_le32(&mut extent_leaf, checksum_offset, checksum);
+
+        // Replace the inline leaf with a one-entry index pointing at the new external leaf.
+        root_inode[0x28..0x64].fill(0);
+        put_le16(&mut root_inode, 0x28, EXT4_EH_MAGIC);
+        put_le16(&mut root_inode, 0x2A, 1);
+        put_le16(&mut root_inode, 0x2C, 4);
+        put_le16(&mut root_inode, 0x2E, 1);
+        put_le32(&mut root_inode, 0x38, extent_block as u32);
+        put_le16(&mut root_inode, 0x3C, (extent_block >> 32) as u16);
+        let inode_sectors = get_le32(&root_inode, 0x1C) + u32::from(EXT4_BLOCK_SIZE / 512);
+        put_le32(&mut root_inode, 0x1C, inode_sectors);
+        let root_checksum = inode_checksum(img.csum_seed, EXT4_ROOT_INO, generation, &root_inode);
+        put_le16(&mut root_inode, 0x7C, root_checksum as u16);
+        put_le16(&mut root_inode, 0x82, (root_checksum >> 16) as u16);
+
+        // Allocation metadata is redundant by design: update the bitmap, group descriptor,
+        // primary superblock, and every sparse-super backup as one coherent test fixture.
+        let mut gdt = img.gdt.clone();
+        let desc_offset = group as usize * EXT4_DESC_SIZE as usize;
+        let desc = &mut gdt[desc_offset..desc_offset + EXT4_DESC_SIZE as usize];
+        let free_blocks = get_le16(desc, 0x0C) as u32 | (u32::from(get_le16(desc, 0x2C)) << 16);
+        put_le16(desc, 0x0C, (free_blocks - 1) as u16);
+        put_le16(desc, 0x2C, ((free_blocks - 1) >> 16) as u16);
+        let bitmap_checksum =
+            bitmap_checksum(img.csum_seed, &block_bitmap, EXT4_BLOCK_SIZE as usize);
+        put_le16(desc, 0x18, bitmap_checksum as u16);
+        put_le16(desc, 0x38, (bitmap_checksum >> 16) as u16);
+        put_le16(desc, 0x1E, 0);
+        let desc_checksum = gdt_checksum(img.csum_seed, group, desc);
+        put_le16(desc, 0x1E, desc_checksum);
+
+        let mut sb = img.sb.clone();
+        let total_free = img.free_blocks - 1;
+        put_le32(&mut sb, 0x0C, total_free as u32);
+        put_le32(&mut sb, 0x158, (total_free >> 32) as u32);
+        let legacy_overhead = get_le32(&sb, EXT4_SB_ERROR_COUNT_OFFSET) + 1;
+        put_le32(&mut sb, EXT4_SB_ERROR_COUNT_OFFSET, legacy_overhead);
+        let sb_checksum = superblock_checksum(&sb);
+        put_le32(&mut sb, 0x3FC, sb_checksum);
+
+        write_block_at(&mut file, bitmap_block, &block_bitmap).unwrap();
+        write_block_at(&mut file, extent_block, &extent_leaf).unwrap();
+        let root_offset = geo.group_inode_table_block(0) * u64::from(EXT4_BLOCK_SIZE)
+            + u64::from(EXT4_ROOT_INO - 1) * u64::from(EXT4_INODE_SIZE);
+        file.seek(SeekFrom::Start(root_offset)).unwrap();
+        file.write_all(&root_inode).unwrap();
+        write_gdt_at(&mut file, 0, &gdt).unwrap();
+
+        for backup_group in 1..img.num_groups {
+            if !sparse_super_group(backup_group) {
+                continue;
+            }
+            let mut backup_sb = sb.clone();
+            put_le16(&mut backup_sb, 0x5A, backup_group as u16);
+            let backup_checksum = superblock_checksum(&backup_sb);
+            put_le32(&mut backup_sb, 0x3FC, backup_checksum);
+            let group_start = geo.group_start_block(backup_group);
+            write_backup_superblock_at(&mut file, group_start, &backup_sb).unwrap();
+            write_gdt_at(&mut file, group_start, &gdt).unwrap();
+        }
+        file.seek(SeekFrom::Start(SB_OFFSET)).unwrap();
+        file.write_all(&sb).unwrap();
+        file.sync_all().unwrap();
+        extent_block
+    }
+
     fn parse(path: &Path) -> ParsedImage {
         let mut file = File::open(path).unwrap();
         parse_and_validate(&mut file).unwrap()
@@ -1470,6 +1696,54 @@ mod tests {
             hash_stable_prefix(&path, before_img.num_blocks, span)
         );
         assert_image_invariants(&path);
+    }
+
+    #[test]
+    fn test_grow_legacy_image_with_mutated_root_extent_tree() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("legacy-mutated-root.ext4");
+        format_legacy_image(&path, 256 * MIB);
+        grow_legacy_root_extent_tree(&path);
+
+        let before = parse(&path);
+        assert_eq!(before.resize_metadata, ResizeMetadata::Legacy);
+        let mut file = File::open(&path).unwrap();
+        let root_inode = read_inode(&mut file, &before.geometry(), EXT4_ROOT_INO).unwrap();
+        assert_eq!(get_le16(&root_inode, 0x2E), 1);
+        drop(file);
+        assert_image_invariants(&path);
+
+        grow_image(&path, 512 * MIB).unwrap();
+
+        assert_eq!(parse(&path).resize_metadata, ResizeMetadata::Legacy);
+        assert_image_invariants(&path);
+    }
+
+    #[test]
+    fn test_legacy_root_extent_checksum_mismatch_is_rejected_untouched() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("legacy-bad-root-extent.ext4");
+        format_legacy_image(&path, 256 * MIB);
+        let extent_block = grow_legacy_root_extent_tree(&path);
+
+        let mut file = OpenOptions::new().write(true).open(&path).unwrap();
+        file.seek(SeekFrom::Start(
+            extent_block * u64::from(EXT4_BLOCK_SIZE) + 24,
+        ))
+        .unwrap();
+        file.write_all(&[0xA5]).unwrap();
+        drop(file);
+
+        let before = hash_file(&path);
+        let result = grow_image(&path, 512 * MIB);
+        match result {
+            Err(Ext4Error::Unsupported(message)) => assert!(
+                message.contains("extent index checksum mismatch"),
+                "message: {message}"
+            ),
+            other => panic!("expected Unsupported, got {other:?}"),
+        }
+        assert_eq!(hash_file(&path), before, "failed grow modified the image");
     }
 
     #[test]
@@ -2300,6 +2574,56 @@ mod tests {
         true
     }
 
+    /// Ask e2fsprogs to perform the same mutation as a busy guest: enough top-level files force
+    /// the root directory to allocate additional, potentially fragmented extents. This gives the
+    /// ignored interoperability test an independently produced legacy image rather than another
+    /// image assembled solely by this crate.
+    fn populate_legacy_root_with_debugfs(path: &Path) -> bool {
+        let dir = tempfile::tempdir().unwrap();
+        let empty = dir.path().join("empty");
+        let commands = dir.path().join("debugfs.commands");
+        std::fs::write(&empty, []).unwrap();
+
+        let mut script = String::new();
+        for index in 0..600 {
+            script.push_str(&format!(
+                "write {} /root-entry-{index:04}\n",
+                empty.display()
+            ));
+        }
+        std::fs::write(&commands, script).unwrap();
+
+        let output = match std::process::Command::new("debugfs")
+            .arg("-w")
+            .arg("-f")
+            .arg(&commands)
+            .arg(path)
+            .output()
+        {
+            Ok(output) => output,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                eprintln!("debugfs not found; skipping");
+                return false;
+            }
+            Err(error) => panic!("failed to run debugfs: {error}"),
+        };
+        assert!(
+            output.status.success(),
+            "debugfs failed:\nstdout: {}\nstderr: {}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+
+        let img = parse(path);
+        let mut file = File::open(path).unwrap();
+        let root_inode = read_inode(&mut file, &img.geometry(), EXT4_ROOT_INO).unwrap();
+        assert!(
+            get_le16(&root_inode, 0x2A) > 1 || get_le16(&root_inode, 0x2E) > 0,
+            "debugfs did not grow the legacy root extent tree"
+        );
+        true
+    }
+
     /// Full `e2fsck -fn` validation of a formatted and grown image. Gated behind `--ignored`
     /// because e2fsprogs is only guaranteed on Linux CI; skips cleanly when the binary is absent.
     #[test]
@@ -2374,7 +2698,11 @@ mod tests {
         let path = dir.path().join("fsck-legacy.ext4");
         format_legacy_image(&path, 256 * MIB);
 
-        if !assert_e2fsck_legacy_baseline(&path, "legacy format") {
+        if !populate_legacy_root_with_debugfs(&path) {
+            return;
+        }
+
+        if !assert_e2fsck_legacy_baseline(&path, "legacy format with a grown root extent tree") {
             return;
         }
         grow_image(&path, 512 * MIB).unwrap();

--- a/crates/image/lib/ext4/resizer.rs
+++ b/crates/image/lib/ext4/resizer.rs
@@ -1,9 +1,9 @@
 //! Offline grow-only resizer for ext4 upper images produced by this crate's formatter.
 //!
 //! The resizer parses and strictly validates the primary superblock (it refuses anything the formatter did not write), then appends whole block groups: per-group bitmaps, backup
-//! superblock + GDT copies in new sparse_super groups, descriptors appended to the primary GDT and every backup GDT, and finally the updated primary superblock. Because the
-//! formatter reserves `RESERVED_GDT_BLOCKS` after the GDT, descriptors can extend into that reserved span without moving any existing metadata: `gdt_blocks +
-//! s_reserved_gdt_blocks` stays constant across grows.
+//! superblock + GDT copies in new sparse_super groups, descriptors appended to the primary GDT and every backup GDT, and finally the updated primary superblock. Both the current
+//! resize-inode layout and the exact pre-0.6.9 microsandbox layout are supported. Because both formatters reserve `RESERVED_GDT_BLOCKS` after the GDT, descriptors can extend into
+//! that reserved span without moving any existing metadata: `gdt_blocks + s_reserved_gdt_blocks` stays constant across grows.
 //!
 //! Images whose guest was stopped without unmounting carry `EXT4_FEATURE_INCOMPAT_RECOVER` plus a pending jbd2 log; those are recovered first (see the [`jbd2`](super::jbd2)
 //! module) and then grown as clean images.
@@ -20,8 +20,8 @@ use super::format::{
     EXT4_FEATURE_RO_COMPAT_DIR_NLINK, EXT4_FEATURE_RO_COMPAT_EXTRA_ISIZE,
     EXT4_FEATURE_RO_COMPAT_HUGE_FILE, EXT4_FEATURE_RO_COMPAT_LARGE_FILE,
     EXT4_FEATURE_RO_COMPAT_METADATA_CSUM, EXT4_FEATURE_RO_COMPAT_SPARSE_SUPER, EXT4_FIRST_INO,
-    EXT4_INODE_SIZE, EXT4_INODES_PER_GROUP, EXT4_JOURNAL_INO, EXT4_LOG_BLOCK_SIZE, EXT4_ROOT_INO,
-    EXT4_SB_ERROR_COUNT_OFFSET, EXT4_SB_OVERHEAD_BLOCKS_OFFSET, EXT4_SUPER_MAGIC,
+    EXT4_INODE_SIZE, EXT4_INODES_PER_GROUP, EXT4_JOURNAL_INO, EXT4_LOG_BLOCK_SIZE, EXT4_RESIZE_INO,
+    EXT4_ROOT_INO, EXT4_SB_ERROR_COUNT_OFFSET, EXT4_SB_OVERHEAD_BLOCKS_OFFSET, EXT4_SUPER_MAGIC,
     sparse_super_group,
 };
 use super::formatter::{Ext4Error, mark_sparse};
@@ -45,6 +45,14 @@ const SB_OFFSET: u64 = 1024;
 /// On-disk superblock size.
 const SB_SIZE: usize = 1024;
 
+/// Feature mask written by microsandbox through v0.6.8. These images reserve
+/// GDT headroom but intentionally have no resize inode.
+const LEGACY_FEATURE_COMPAT: u32 =
+    EXT4_FEATURE_COMPAT_HAS_JOURNAL | EXT4_FEATURE_COMPAT_EXT_ATTR | EXT4_FEATURE_COMPAT_DIR_INDEX;
+
+/// Feature mask written by the current formatter.
+const MODERN_FEATURE_COMPAT: u32 = LEGACY_FEATURE_COMPAT | EXT4_FEATURE_COMPAT_RESIZE_INODE;
+
 //--------------------------------------------------------------------------------------------------
 // Types
 //--------------------------------------------------------------------------------------------------
@@ -63,6 +71,26 @@ pub struct GrowOutcome {
 
     /// Block group count after the grow.
     pub new_groups: u32,
+}
+
+/// Resize metadata layout identified from both feature flags and structural
+/// invariants. A dirty modern image has no parsed block until journal replay
+/// completes and the clean image is validated again.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ResizeMetadata {
+    Legacy,
+    Modern { block: Option<u64> },
+}
+
+impl ResizeMetadata {
+    fn overhead_blocks_offset(self) -> usize {
+        match self {
+            // The pre-0.6.9 formatter used 0x194 for its used-block/overhead counter. Preserve
+            // that released layout exactly instead of silently converting superblock semantics.
+            Self::Legacy => EXT4_SB_ERROR_COUNT_OFFSET,
+            Self::Modern { .. } => EXT4_SB_OVERHEAD_BLOCKS_OFFSET,
+        }
+    }
 }
 
 /// Superblock and primary GDT state parsed from an image and validated to match exactly what
@@ -86,7 +114,7 @@ struct ParsedImage {
     free_blocks: u64,
     free_inodes: u32,
     overhead_blocks: u32,
-    resize_inode_block: u64,
+    resize_metadata: ResizeMetadata,
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -111,6 +139,16 @@ impl ParsedImage {
         let capacity_groups =
             (self.gdt_blocks as u64 + self.reserved_gdt_blocks as u64) * descs_per_block;
         (capacity_groups * EXT4_BLOCKS_PER_GROUP as u64).min(MAX_BLOCKS)
+    }
+
+    fn resize_inode_block(&self) -> Result<Option<u64>, Ext4Error> {
+        match self.resize_metadata {
+            ResizeMetadata::Legacy => Ok(None),
+            ResizeMetadata::Modern { block: Some(block) } => Ok(Some(block)),
+            ResizeMetadata::Modern { block: None } => Err(unsupported(
+                "modern resize metadata was not validated after journal recovery",
+            )),
+        }
     }
 }
 
@@ -295,7 +333,11 @@ pub fn grow_image(path: &Path, new_size_bytes: u64) -> Result<GrowOutcome, Ext4E
         img.free_inodes + added_groups * EXT4_INODES_PER_GROUP,
     );
     put_le16(&mut new_sb, 0xCE, new_reserved as u16);
-    put_le32(&mut new_sb, EXT4_SB_OVERHEAD_BLOCKS_OFFSET, overhead as u32);
+    put_le32(
+        &mut new_sb,
+        img.resize_metadata.overhead_blocks_offset(),
+        overhead as u32,
+    );
     let new_sb_csum = superblock_checksum(&new_sb);
     put_le32(&mut new_sb, 0x3FC, new_sb_csum);
 
@@ -317,16 +359,19 @@ pub fn grow_image(path: &Path, new_size_bytes: u64) -> Result<GrowOutcome, Ext4E
         write_backup_superblock_at(&mut file, new_geo.group_start_block(group), &backup_sb)?;
         write_gdt_at(&mut file, new_geo.group_start_block(group), &gdt)?;
     }
-    // Consuming reserved headroom shifts the live pointer range in inode 7. Rebuild the complete
-    // structure after all descriptor copies are in place so no consumed GDT block is overwritten.
-    write_resize_inode(
-        &mut file,
-        &new_geo,
-        new_geo.group_inode_table_block(0),
-        img.resize_inode_block,
-        img.csum_seed,
-        new_groups,
-    )?;
+    // Modern images account for reserved GDT blocks through inode 7. Legacy microsandbox images
+    // predate that ownership graph and must retain their original layout; fabricating inode 7
+    // here would require allocating and publishing another data block transactionally.
+    if let Some(resize_inode_block) = img.resize_inode_block()? {
+        write_resize_inode(
+            &mut file,
+            &new_geo,
+            new_geo.group_inode_table_block(0),
+            resize_inode_block,
+            img.csum_seed,
+            new_groups,
+        )?;
+    }
     file.sync_all()?;
 
     // Phase 2: the only pre-publish writes visible at the old size (the old final group's
@@ -364,6 +409,11 @@ pub(super) fn validate_rootfs_image(path: &Path) -> Result<(), Ext4Error> {
     if img.needs_recovery {
         return Err(unsupported(
             "new rootfs unexpectedly requires journal recovery",
+        ));
+    }
+    if matches!(img.resize_metadata, ResizeMetadata::Legacy) {
+        return Err(unsupported(
+            "new rootfs unexpectedly uses the legacy resize-metadata layout",
         ));
     }
     let geometry = img.geometry();
@@ -443,10 +493,6 @@ fn parse_and_validate(file: &mut File) -> Result<ParsedImage, Ext4Error> {
     let compat = get_le32(&sb, 0x5C);
     let incompat = get_le32(&sb, 0x60);
     let ro_compat = get_le32(&sb, 0x64);
-    let expected_compat = EXT4_FEATURE_COMPAT_HAS_JOURNAL
-        | EXT4_FEATURE_COMPAT_EXT_ATTR
-        | EXT4_FEATURE_COMPAT_RESIZE_INODE
-        | EXT4_FEATURE_COMPAT_DIR_INDEX;
     let expected_incompat = EXT4_FEATURE_INCOMPAT_FILETYPE
         | EXT4_FEATURE_INCOMPAT_EXTENTS
         | EXT4_FEATURE_INCOMPAT_64BIT;
@@ -456,11 +502,21 @@ fn parse_and_validate(file: &mut File) -> Result<ParsedImage, Ext4Error> {
         | EXT4_FEATURE_RO_COMPAT_DIR_NLINK
         | EXT4_FEATURE_RO_COMPAT_EXTRA_ISIZE
         | EXT4_FEATURE_RO_COMPAT_METADATA_CSUM;
-    // Acceptance rule: exactly the formatter's masks, with one exception — INCOMPAT_RECOVER may additionally be set, because every upper that was ever mounted carries it (the
-    // guest does not unmount on stop). RECOVER images get their journal replayed by grow_image before the deep validation below ever runs on them.
+    // Acceptance rule: exactly one of microsandbox's two formatter masks, with one exception —
+    // INCOMPAT_RECOVER may additionally be set because every mounted upper carries it. Structural
+    // validation below distinguishes a real legacy image from a damaged modern image whose
+    // RESIZE_INODE bit was merely cleared.
+    let resize_metadata = match compat {
+        LEGACY_FEATURE_COMPAT => ResizeMetadata::Legacy,
+        MODERN_FEATURE_COMPAT => ResizeMetadata::Modern { block: None },
+        _ => {
+            return Err(unsupported(format!(
+                "feature flags do not match this crate's formatter (compat={compat:#x}, incompat={incompat:#x}, ro_compat={ro_compat:#x})"
+            )));
+        }
+    };
     let needs_recovery = incompat & EXT4_FEATURE_INCOMPAT_RECOVER != 0;
-    if compat != expected_compat
-        || incompat & !EXT4_FEATURE_INCOMPAT_RECOVER != expected_incompat
+    if incompat & !EXT4_FEATURE_INCOMPAT_RECOVER != expected_incompat
         || ro_compat != expected_ro_compat
     {
         return Err(unsupported(format!(
@@ -510,7 +566,8 @@ fn parse_and_validate(file: &mut File) -> Result<ParsedImage, Ext4Error> {
             "unexpected flex_bg/meta_bg layout",
         ),
         (
-            get_le32(&sb, EXT4_SB_ERROR_COUNT_OFFSET) == 0,
+            matches!(resize_metadata, ResizeMetadata::Legacy)
+                || get_le32(&sb, EXT4_SB_ERROR_COUNT_OFFSET) == 0,
             "superblock error count is nonzero",
         ),
     ];
@@ -559,8 +616,8 @@ fn parse_and_validate(file: &mut File) -> Result<ParsedImage, Ext4Error> {
         csum_seed,
         free_blocks: get_le32(&sb, 0x0C) as u64 | ((get_le32(&sb, 0x158) as u64) << 32),
         free_inodes: get_le32(&sb, 0x10),
-        overhead_blocks: get_le32(&sb, EXT4_SB_OVERHEAD_BLOCKS_OFFSET),
-        resize_inode_block: 0,
+        overhead_blocks: get_le32(&sb, resize_metadata.overhead_blocks_offset()),
+        resize_metadata,
         gdt: Vec::new(),
         needs_recovery,
         sb,
@@ -612,20 +669,96 @@ fn parse_and_validate(file: &mut File) -> Result<ParsedImage, Ext4Error> {
         }
     }
 
-    let resize_inode_block = validate_resize_inode(
-        file,
-        &geo,
-        geo.group_inode_table_block(0),
-        img.csum_seed,
-        img.num_groups,
-        img.num_blocks,
-    )?;
+    let resize_metadata = match img.resize_metadata {
+        ResizeMetadata::Legacy => {
+            validate_legacy_resize_metadata(file, &img)?;
+            ResizeMetadata::Legacy
+        }
+        ResizeMetadata::Modern { .. } => {
+            let block = validate_resize_inode(
+                file,
+                &geo,
+                geo.group_inode_table_block(0),
+                img.csum_seed,
+                img.num_groups,
+                img.num_blocks,
+            )?;
+            ResizeMetadata::Modern { block: Some(block) }
+        }
+    };
 
     Ok(ParsedImage {
         gdt,
-        resize_inode_block,
+        resize_metadata,
         ..img
     })
+}
+
+/// Validate the exact layout emitted through v0.6.8.
+///
+/// Feature flags alone are insufficient: clearing RESIZE_INODE on a modern
+/// image must not route it through the legacy grow path. Old images have a
+/// zero inode 7, place the root directory immediately after the inode table,
+/// and leave every still-reserved primary GDT block sparse-zeroed. These
+/// invariants remain true after any number of grows by the legacy resizer.
+fn validate_legacy_resize_metadata(file: &mut File, img: &ParsedImage) -> Result<(), Ext4Error> {
+    let geometry = img.geometry();
+    let resize_inode = read_inode(file, &geometry, EXT4_RESIZE_INO)?;
+    if resize_inode.iter().any(|byte| *byte != 0) {
+        return Err(unsupported("legacy image has a non-empty resize inode"));
+    }
+
+    let root_inode = read_inode(file, &geometry, EXT4_ROOT_INO)?;
+    validate_allocated_inode(file, img, 0, EXT4_ROOT_INO - 1, EXT4_ROOT_INO, &[])?;
+    let extent_root = &root_inode[0x28..0x64];
+    if get_le32(&root_inode, 0x20) & EXT4_EXTENTS_FL == 0
+        || get_le16(extent_root, 0) != EXT4_EH_MAGIC
+        || get_le16(extent_root, 2) != 1
+        || get_le16(extent_root, 6) != 0
+        || get_le32(extent_root, 12) != 0
+    {
+        return Err(unsupported(
+            "legacy image root inode does not use the expected single extent",
+        ));
+    }
+    let root_block =
+        u64::from(get_le32(extent_root, 20)) | (u64::from(get_le16(extent_root, 18)) << 32);
+    let expected_root_block =
+        geometry.group_inode_table_block(0) + u64::from(img.inode_table_blocks);
+    if root_block != expected_root_block {
+        return Err(unsupported(
+            "legacy image root directory is not immediately after the inode table",
+        ));
+    }
+
+    // A modern resize inode stores backup pointers in these blocks. Requiring zeros prevents a
+    // modern image with a cleared feature bit from passing as legacy. GDT blocks consumed by a
+    // previous legacy grow are excluded because `gdt_blocks` has already advanced past them.
+    for offset in 0..img.reserved_gdt_blocks {
+        let block = 1 + u64::from(img.gdt_blocks + offset);
+        if read_block_at(file, block)?.iter().any(|byte| *byte != 0) {
+            return Err(unsupported(format!(
+                "legacy image reserved GDT block {block} is not zeroed"
+            )));
+        }
+    }
+
+    Ok(())
+}
+
+fn read_inode(
+    file: &mut File,
+    geometry: &GroupGeometry,
+    inode_number: u32,
+) -> Result<Vec<u8>, Ext4Error> {
+    let group = (inode_number - 1) / EXT4_INODES_PER_GROUP;
+    let local_inode = (inode_number - 1) % EXT4_INODES_PER_GROUP;
+    let offset = geometry.group_inode_table_block(group) * u64::from(EXT4_BLOCK_SIZE)
+        + u64::from(local_inode) * u64::from(EXT4_INODE_SIZE);
+    let mut inode = vec![0u8; EXT4_INODE_SIZE as usize];
+    file.seek(SeekFrom::Start(offset))?;
+    file.read_exact(&mut inode)?;
+    Ok(inode)
 }
 
 /// Replay the pending jbd2 log, then clear `EXT4_FEATURE_INCOMPAT_RECOVER` from the primary and every backup superblock.
@@ -1013,6 +1146,7 @@ mod tests {
     use super::super::format::JBD2_MAGIC;
     use super::super::formatter::{
         Ext4FormatOptions, format_ext4, format_ext4_for_test_with_reserved_gdt,
+        format_ext4_legacy_for_test,
     };
     use super::super::jbd2::{JournalLocation, TestTransaction, write_test_log};
     use super::super::layout::{RESERVED_GDT_BLOCKS, count_used_bits, get_be32, put_be32};
@@ -1027,6 +1161,14 @@ mod tests {
             journal_blocks: 4096,
         };
         format_ext4(path, &opts).unwrap();
+    }
+
+    fn format_legacy_image(path: &Path, size_bytes: u64) {
+        let opts = Ext4FormatOptions {
+            size_bytes,
+            journal_blocks: 4096,
+        };
+        format_ext4_legacy_for_test(path, &opts).unwrap();
     }
 
     fn parse(path: &Path) -> ParsedImage {
@@ -1143,7 +1285,9 @@ mod tests {
             }
             // A grow legitimately refreshes inode 7 and its double-indirect block so that the
             // reserved-GDT ownership graph includes newly created sparse-super backups.
-            if block == resize_inode_table_block || block == img.resize_inode_block {
+            if let Some(resize_inode_block) = img.resize_inode_block().unwrap()
+                && (block == resize_inode_table_block || block == resize_inode_block)
+            {
                 continue;
             }
             file.seek(SeekFrom::Start(block * EXT4_BLOCK_SIZE as u64))
@@ -1168,8 +1312,12 @@ mod tests {
         (location, uuid)
     }
 
-    /// Simulate the state every mounted-but-never-unmounted upper is left in: RECOVER set in the primary superblock (the kernel never sets it in backups).
-    fn set_recover_flag(path: &Path) {
+    fn parse_dirty_superblock(path: &Path) -> Vec<u8> {
+        let mut file = File::open(path).unwrap();
+        read_superblock_at(&mut file, SB_OFFSET, "test primary").unwrap()
+    }
+
+    fn rewrite_primary_superblock(path: &Path, update: impl FnOnce(&mut [u8])) {
         let mut file = OpenOptions::new()
             .read(true)
             .write(true)
@@ -1178,12 +1326,19 @@ mod tests {
         let mut sb = vec![0u8; SB_SIZE];
         file.seek(SeekFrom::Start(SB_OFFSET)).unwrap();
         file.read_exact(&mut sb).unwrap();
-        let incompat = get_le32(&sb, 0x60) | EXT4_FEATURE_INCOMPAT_RECOVER;
-        put_le32(&mut sb, 0x60, incompat);
+        update(&mut sb);
         let checksum = superblock_checksum(&sb);
         put_le32(&mut sb, 0x3FC, checksum);
         file.seek(SeekFrom::Start(SB_OFFSET)).unwrap();
         file.write_all(&sb).unwrap();
+    }
+
+    /// Simulate the state every mounted-but-never-unmounted upper is left in: RECOVER set in the primary superblock (the kernel never sets it in backups).
+    fn set_recover_flag(path: &Path) {
+        rewrite_primary_superblock(path, |sb| {
+            let incompat = get_le32(sb, 0x60) | EXT4_FEATURE_INCOMPAT_RECOVER;
+            put_le32(sb, 0x60, incompat);
+        });
     }
 
     fn write_dirty_journal(path: &Path, start_seq: u32, transactions: &[TestTransaction]) {
@@ -1277,6 +1432,264 @@ mod tests {
     }
 
     #[test]
+    fn test_legacy_image_matches_pre_0_6_9_layout() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("legacy.ext4");
+        format_legacy_image(&path, 256 * MIB);
+
+        let img = parse(&path);
+        assert_eq!(img.resize_metadata, ResizeMetadata::Legacy);
+        assert_eq!(get_le32(&img.sb, 0x5C), LEGACY_FEATURE_COMPAT);
+        assert_eq!(get_le32(&img.sb, 0x60), 0xC2);
+        assert_eq!(get_le32(&img.sb, 0x64), 0x46B);
+        assert_ne!(get_le32(&img.sb, EXT4_SB_ERROR_COUNT_OFFSET), 0);
+        assert_eq!(get_le32(&img.sb, EXT4_SB_OVERHEAD_BLOCKS_OFFSET), 0);
+        assert_eq!(img.resize_inode_block().unwrap(), None);
+        assert_image_invariants(&path);
+    }
+
+    #[test]
+    fn test_grow_legacy_image_preserves_layout_and_existing_data() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("legacy-grow.ext4");
+        format_legacy_image(&path, 256 * MIB);
+
+        let before_img = parse(&path);
+        let span = before_img.gdt_blocks + before_img.reserved_gdt_blocks;
+        let before = hash_stable_prefix(&path, before_img.num_blocks, span);
+
+        let outcome = grow_image(&path, 512 * MIB).unwrap();
+        assert_eq!(outcome.old_groups, 2);
+        assert_eq!(outcome.new_groups, 4);
+
+        let after_img = parse(&path);
+        assert_eq!(after_img.resize_metadata, ResizeMetadata::Legacy);
+        assert_eq!(get_le32(&after_img.sb, 0x5C), LEGACY_FEATURE_COMPAT);
+        assert_eq!(
+            before,
+            hash_stable_prefix(&path, before_img.num_blocks, span)
+        );
+        assert_image_invariants(&path);
+    }
+
+    #[test]
+    fn test_grow_legacy_image_twice() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("legacy-twice.ext4");
+        format_legacy_image(&path, 256 * MIB);
+
+        grow_image(&path, 512 * MIB).unwrap();
+        assert_image_invariants(&path);
+        let outcome = grow_image(&path, 1024 * MIB).unwrap();
+
+        assert_eq!(outcome.old_groups, 4);
+        assert_eq!(outcome.new_groups, 8);
+        assert_eq!(parse(&path).resize_metadata, ResizeMetadata::Legacy);
+        assert_image_invariants(&path);
+    }
+
+    #[test]
+    fn test_grow_legacy_image_consumes_reserved_gdt_headroom() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("legacy-consume.ext4");
+        format_legacy_image(&path, 256 * MIB);
+
+        let outcome = grow_image(&path, 68 * 128 * MIB).unwrap();
+        assert_eq!(outcome.new_groups, 68);
+
+        let img = parse(&path);
+        assert_eq!(img.resize_metadata, ResizeMetadata::Legacy);
+        assert_eq!(img.gdt_blocks, 2);
+        assert_eq!(img.reserved_gdt_blocks, RESERVED_GDT_BLOCKS - 1);
+        assert_image_invariants(&path);
+    }
+
+    #[test]
+    fn test_grow_legacy_image_to_reported_30_gib_target() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("legacy-30g.ext4");
+        format_legacy_image(&path, 4 * 1024 * MIB);
+
+        let outcome = grow_image(&path, 30 * 1024 * MIB).unwrap();
+
+        assert_eq!(outcome.old_groups, 32);
+        assert_eq!(outcome.new_groups, 240);
+        assert_eq!(std::fs::metadata(&path).unwrap().len(), 30 * 1024 * MIB);
+        let img = parse(&path);
+        assert_eq!(img.resize_metadata, ResizeMetadata::Legacy);
+        assert_eq!(img.gdt_blocks, 4);
+        assert_eq!(img.reserved_gdt_blocks, RESERVED_GDT_BLOCKS - 3);
+        assert_image_invariants(&path);
+    }
+
+    #[test]
+    fn test_grow_replays_legacy_pending_journal() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("legacy-replay.ext4");
+        format_legacy_image(&path, 256 * MIB);
+
+        let (location, _) = journal_location(&path);
+        let target = location.start_block + location.len_blocks as u64 + 16;
+        let data = pattern_block(0xA5);
+        write_dirty_journal(
+            &path,
+            2,
+            &[TestTransaction {
+                writes: vec![(target, data.clone())],
+                revokes: vec![],
+                corrupt_commit: false,
+            }],
+        );
+        assert_eq!(get_le32(&parse_dirty_superblock(&path), 0x60), 0xC6);
+
+        grow_image(&path, 512 * MIB).unwrap();
+
+        let mut file = File::open(&path).unwrap();
+        assert_eq!(read_block_at(&mut file, target).unwrap(), data);
+        drop(file);
+        assert_recover_cleared_everywhere(&path);
+        assert_eq!(parse(&path).resize_metadata, ResizeMetadata::Legacy);
+        assert_image_invariants(&path);
+    }
+
+    #[test]
+    fn test_legacy_replay_rejects_unknown_journal_features_untouched() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("legacy-bad-journal.ext4");
+        format_legacy_image(&path, 256 * MIB);
+
+        let (location, _) = journal_location(&path);
+        let mut file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(&path)
+            .unwrap();
+        let mut jsb = vec![0u8; 1024];
+        file.seek(SeekFrom::Start(
+            location.start_block * u64::from(EXT4_BLOCK_SIZE),
+        ))
+        .unwrap();
+        file.read_exact(&mut jsb).unwrap();
+        let incompat = get_be32(&jsb, 0x28);
+        put_be32(&mut jsb, 0x28, incompat | 0x04);
+        jsb[0xFC..0x100].fill(0);
+        let checksum = crc32c::crc32c_raw(0xFFFF_FFFF, &jsb);
+        put_be32(&mut jsb, 0xFC, checksum);
+        file.seek(SeekFrom::Start(
+            location.start_block * u64::from(EXT4_BLOCK_SIZE),
+        ))
+        .unwrap();
+        file.write_all(&jsb).unwrap();
+        drop(file);
+        set_recover_flag(&path);
+        let before = hash_file(&path);
+
+        let result = grow_image(&path, 512 * MIB);
+        match result {
+            Err(Ext4Error::Unsupported(message)) => {
+                assert!(message.contains("journal feature"), "message: {message}")
+            }
+            other => panic!("expected Unsupported, got {other:?}"),
+        }
+        assert_eq!(
+            hash_file(&path),
+            before,
+            "failed recovery modified the image"
+        );
+        assert_eq!(std::fs::metadata(&path).unwrap().len(), 256 * MIB);
+    }
+
+    #[test]
+    fn test_cleared_modern_resize_feature_is_not_misclassified_as_legacy() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("modern-with-cleared-feature.ext4");
+        format_image(&path, 256 * MIB);
+
+        rewrite_primary_superblock(&path, |sb| {
+            put_le32(sb, 0x5C, LEGACY_FEATURE_COMPAT);
+        });
+        let before = hash_file(&path);
+
+        let result = grow_image(&path, 512 * MIB);
+        match result {
+            Err(Ext4Error::Unsupported(message)) => {
+                assert!(
+                    message.contains("non-empty resize inode"),
+                    "message: {message}"
+                )
+            }
+            other => panic!("expected Unsupported, got {other:?}"),
+        }
+        assert_eq!(hash_file(&path), before, "rejected image was modified");
+        assert_eq!(std::fs::metadata(&path).unwrap().len(), 256 * MIB);
+    }
+
+    #[test]
+    fn test_cleared_modern_feature_and_inode_still_fails_legacy_structure() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("modern-with-cleared-inode.ext4");
+        format_image(&path, 256 * MIB);
+        let img = parse(&path);
+        let inode_offset = img.geometry().group_inode_table_block(0) * u64::from(EXT4_BLOCK_SIZE)
+            + u64::from(EXT4_RESIZE_INO - 1) * u64::from(EXT4_INODE_SIZE);
+
+        let mut file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(&path)
+            .unwrap();
+        file.seek(SeekFrom::Start(inode_offset)).unwrap();
+        file.write_all(&vec![0u8; EXT4_INODE_SIZE as usize])
+            .unwrap();
+        drop(file);
+        rewrite_primary_superblock(&path, |sb| {
+            put_le32(sb, 0x5C, LEGACY_FEATURE_COMPAT);
+        });
+        let before = hash_file(&path);
+
+        let result = grow_image(&path, 512 * MIB);
+        match result {
+            Err(Ext4Error::Unsupported(message)) => assert!(
+                message.contains("root directory is not immediately after the inode table"),
+                "message: {message}"
+            ),
+            other => panic!("expected Unsupported, got {other:?}"),
+        }
+        assert_eq!(hash_file(&path), before, "rejected image was modified");
+        assert_eq!(std::fs::metadata(&path).unwrap().len(), 256 * MIB);
+    }
+
+    #[test]
+    fn test_legacy_grow_rejects_nonzero_reserved_gdt_block_untouched() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("legacy-corrupt-reserved.ext4");
+        format_legacy_image(&path, 256 * MIB);
+        let img = parse(&path);
+        let reserved_block = 1 + u64::from(img.gdt_blocks);
+
+        let mut file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(&path)
+            .unwrap();
+        file.seek(SeekFrom::Start(reserved_block * u64::from(EXT4_BLOCK_SIZE)))
+            .unwrap();
+        file.write_all(&[1]).unwrap();
+        drop(file);
+        let before = hash_file(&path);
+
+        let result = grow_image(&path, 512 * MIB);
+        match result {
+            Err(Ext4Error::Unsupported(message)) => {
+                assert!(message.contains("reserved GDT block"), "message: {message}")
+            }
+            other => panic!("expected Unsupported, got {other:?}"),
+        }
+        assert_eq!(hash_file(&path), before, "rejected image was modified");
+        assert_eq!(std::fs::metadata(&path).unwrap().len(), 256 * MIB);
+    }
+
+    #[test]
     fn test_grow_doubles_aligned_image() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("grow.ext4");
@@ -1351,7 +1764,8 @@ mod tests {
             .open(&path)
             .unwrap();
         file.seek(SeekFrom::Start(
-            img.resize_inode_block * u64::from(EXT4_BLOCK_SIZE) + u64::from(img.gdt_blocks) * 4,
+            img.resize_inode_block().unwrap().unwrap() * u64::from(EXT4_BLOCK_SIZE)
+                + u64::from(img.gdt_blocks) * 4,
         ))
         .unwrap();
         file.write_all(&0u32.to_le_bytes()).unwrap();
@@ -1842,6 +2256,50 @@ mod tests {
         true
     }
 
+    /// Validate a released legacy layout without pretending its known formatter defect is new.
+    /// e2fsprogs has always diagnosed the reserved-GDT field because these images predate the
+    /// resize inode; growth is acceptable only when that remains the sole diagnostic.
+    fn assert_e2fsck_legacy_baseline(path: &Path, label: &str) -> bool {
+        let output = match std::process::Command::new("e2fsck")
+            .arg("-fn")
+            .arg(path)
+            .output()
+        {
+            Ok(output) => output,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                eprintln!("e2fsck not found; skipping");
+                return false;
+            }
+            Err(error) => panic!("failed to run e2fsck: {error}"),
+        };
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let diagnostics = format!("{stdout}\n{stderr}");
+        let expected = "Filesystem does not have resize_inode enabled, but s_reserved_gdt_blocks";
+        let unexpected = [
+            "WARNING:",
+            "UNEXPECTED INCONSISTENCY",
+            "Filesystem still has errors",
+            "Block bitmap differences",
+            "Inode bitmap differences",
+            "Free blocks count wrong",
+            "Free inodes count wrong",
+            "multiply-claimed",
+            "checksum does not match",
+        ];
+        assert!(
+            output.status.success()
+                && diagnostics.contains(expected)
+                && diagnostics.contains("should be zero.  Fix? no")
+                && unexpected
+                    .iter()
+                    .all(|diagnostic| !diagnostics.contains(diagnostic)),
+            "e2fsck found a non-baseline inconsistency after {label}:\nstdout: {stdout}\nstderr: {stderr}"
+        );
+        true
+    }
+
     /// Full `e2fsck -fn` validation of a formatted and grown image. Gated behind `--ignored`
     /// because e2fsprogs is only guaranteed on Linux CI; skips cleanly when the binary is absent.
     #[test]
@@ -1904,5 +2362,24 @@ mod tests {
 
         grow_image(&path, 512 * MIB).unwrap();
         assert_e2fsck_clean(&path, "replay + grow");
+    }
+
+    /// Compare a legacy image before and after repeated growth using e2fsprogs. The one accepted
+    /// warning is present in released v0.6.8 images before this resizer touches them; no additional
+    /// inconsistency may appear after either grow.
+    #[test]
+    #[ignore]
+    fn test_e2fsck_legacy_baseline_survives_repeated_growth() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("fsck-legacy.ext4");
+        format_legacy_image(&path, 256 * MIB);
+
+        if !assert_e2fsck_legacy_baseline(&path, "legacy format") {
+            return;
+        }
+        grow_image(&path, 512 * MIB).unwrap();
+        assert_e2fsck_legacy_baseline(&path, "legacy grow to 512 MiB");
+        grow_image(&path, 1024 * MIB).unwrap();
+        assert_e2fsck_legacy_baseline(&path, "legacy grow to 1 GiB");
     }
 }


### PR DESCRIPTION
## TL;DR
Allow `msb modify --root-disk` to grow upper ext4 images created before v0.6.9 while refusing damaged or ambiguous layouts before resize writes begin.

## Description
- Recognize the exact legacy ext4 feature mask and preserve its historical superblock counter placement during growth.
- Validate the empty resize inode, root extent placement, and untouched reserved GDT headroom before classifying an image as legacy.
- Keep the modern resize-inode path strict so clearing one feature bit cannot route a damaged modern image through compatibility handling.
- Replay and revalidate pending legacy journals before changing filesystem geometry.
- Add legacy formatter fixtures and regression coverage for repeated growth, reserved GDT consumption, the reported 4 GiB to 30 GiB resize, journal recovery, rejected corruption, and stable existing data.

## Test Plan
- [x] `cargo fmt --all -- --check` exits 0
- [x] `cargo test --offline -p microsandbox-image` passes 217 tests with 4 host-tool tests ignored
- [x] `cargo clippy --offline -p microsandbox-image --all-targets -- -D warnings` exits 0
- [x] `cargo test --offline -p microsandbox sandbox::upper::tests` passes 2 tests
- [x] `cargo test --offline -p microsandbox sandbox::modify::tests` passes 49 tests and `cargo test -p microsandbox-cli commands::modify::tests` passes 9 tests
- [x] A released v0.6.8 upper filled to ENOSPC grows from 256 MiB to 512 MiB to 1 GiB, preserves its existing file, boots successfully, keeps the same `e2fsck` baseline, and mounts with the Linux kernel
