### PR TITLE
fix(cli): remove backend notices and add mod alias

### DIFF
--- a/crates/cli/bin/main.rs
+++ b/crates/cli/bin/main.rs
@@ -99,6 +99,7 @@ enum Commands {
     Create(create::CreateArgs),
 
     /// Modify sandbox configuration.
+    #[command(visible_alias = "mod")]
     Modify(modify::ModifyArgs),
 
     /// Start a stopped sandbox.
@@ -650,12 +651,7 @@ fn run_async_command_anyhow(
             // the SDK's ambient convenience fallback, the CLI must not run a
             // sandbox operation locally after an invalid explicit cloud selection.
             let backend = microsandbox::resolve_default_backend()?;
-            let backend_info = backend.info();
             microsandbox::set_default_backend(backend);
-
-            if shows_backend_notice(&command) {
-                microsandbox_cli::ui::notice("Backend", &context::notice_text(&backend_info));
-            }
         }
 
         match command {
@@ -739,30 +735,6 @@ fn is_backend_independent_maintenance_command(command: &Commands) -> bool {
     }
 }
 
-/// Return whether a command benefits from an explicit execution-context notice.
-fn shows_backend_notice(command: &Commands) -> bool {
-    matches!(
-        command,
-        Commands::Create(_) | Commands::Remove(_) | Commands::Exec(_)
-    ) || cfg!(feature = "ssh") && matches_ssh_command(command)
-}
-
-#[cfg(feature = "ssh")]
-fn matches_ssh_command(command: &Commands) -> bool {
-    match command {
-        Commands::Ssh(args) => !matches!(
-            args.subcommand.as_ref(),
-            Some(microsandbox_cli::commands::ssh::SshCommand::Authorize(_))
-        ),
-        _ => false,
-    }
-}
-
-#[cfg(not(feature = "ssh"))]
-fn matches_ssh_command(_command: &Commands) -> bool {
-    false
-}
-
 #[cfg(test)]
 mod command_tests {
     use super::*;
@@ -796,18 +768,12 @@ mod command_tests {
     }
 
     #[test]
-    fn backend_notices_cover_requested_commands_only() {
-        let create = Cli::try_parse_from(["msb", "create", "alpine:3.19"]).unwrap();
-        let remove = Cli::try_parse_from(["msb", "remove", "demo"]).unwrap();
-        let exec = Cli::try_parse_from(["msb", "exec", "demo", "--", "true"]).unwrap();
-        let context = Cli::try_parse_from(["msb", "context"]).unwrap();
-        let context_alias = Cli::try_parse_from(["msb", "ctx"]).unwrap();
+    fn command_aliases_route_to_their_canonical_commands() {
+        let context = Cli::try_parse_from(["msb", "ctx"]).unwrap();
+        let modify = Cli::try_parse_from(["msb", "mod", "demo", "--cpus", "2"]).unwrap();
 
-        assert!(shows_backend_notice(&create.command));
-        assert!(shows_backend_notice(&remove.command));
-        assert!(shows_backend_notice(&exec.command));
-        assert!(!shows_backend_notice(&context.command));
-        assert!(matches!(context_alias.command, Commands::Context(_)));
+        assert!(matches!(context.command, Commands::Context(_)));
+        assert!(matches!(modify.command, Commands::Modify(_)));
     }
 
     #[test]
@@ -829,23 +795,6 @@ mod command_tests {
             let cli = Cli::try_parse_from(["msb", command]).unwrap();
             assert!(matches!(cli.command, Commands::Registries(_)));
         }
-    }
-
-    #[cfg(feature = "ssh")]
-    #[test]
-    fn ssh_connect_has_notice_but_authorize_does_not() {
-        let connect = Cli::try_parse_from(["msb", "ssh", "demo"]).unwrap();
-        let authorize = Cli::try_parse_from([
-            "msb",
-            "ssh",
-            "authorize",
-            "--key",
-            "ssh-ed25519 AAAAexample",
-        ])
-        .unwrap();
-
-        assert!(shows_backend_notice(&connect.command));
-        assert!(!shows_backend_notice(&authorize.command));
     }
 }
 

--- a/crates/cli/lib/commands/context.rs
+++ b/crates/cli/lib/commands/context.rs
@@ -33,7 +33,7 @@ pub fn run(args: ContextArgs) -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Format the concise stderr notice used before mutating and interactive commands.
+/// Format backend information for concise diagnostic notices.
 pub fn notice_text(info: &BackendInfo) -> String {
     match info.api_url.as_deref() {
         Some(api_url) => format!("{} · {api_url}", info.kind.as_str()),

--- a/crates/cli/lib/commands/context.rs
+++ b/crates/cli/lib/commands/context.rs
@@ -33,14 +33,6 @@ pub fn run(args: ContextArgs) -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Format backend information for concise diagnostic notices.
-pub fn notice_text(info: &BackendInfo) -> String {
-    match info.api_url.as_deref() {
-        Some(api_url) => format!("{} · {api_url}", info.kind.as_str()),
-        None => info.kind.as_str().to_string(),
-    }
-}
-
 fn render_human(info: &BackendInfo) -> ui::Table {
     let mut table = ui::Table::new(&["FIELD", "VALUE"]);
     table.add_row(vec!["Backend".into(), info.kind.as_str().into()]);
@@ -91,13 +83,5 @@ mod tests {
             r#"{"kind":"cloud","api_url":"https://api.microsandbox.dev","source":"MSB_API_KEY"}"#
         );
         assert!(!rendered.contains("msb_ak_"));
-    }
-
-    #[test]
-    fn notice_is_concise() {
-        assert_eq!(
-            notice_text(&cloud_info()),
-            "cloud · https://api.microsandbox.dev"
-        );
     }
 }

--- a/crates/image/lib/ext4/formatter.rs
+++ b/crates/image/lib/ext4/formatter.rs
@@ -1553,7 +1553,7 @@ fn write_extent_bytes(
 }
 
 fn update_dir_block_checksums(csum_seed: u32, inode: u32, data: &mut [u8]) {
-    for chunk in data.chunks_exact_mut(EXT4_BLOCK_SIZE as usize) {
+    for chunk in data.as_chunks_mut::<{ EXT4_BLOCK_SIZE as usize }>().0 {
         let tail = EXT4_BLOCK_SIZE as usize - 12;
         let checksum = dir_block_checksum(csum_seed, inode, 0, &chunk[..tail]);
         put_le32(chunk, tail + 8, checksum);
@@ -2161,8 +2161,8 @@ fn xattr_entry_hash(name: &[u8], padded_value: &[u8]) -> u32 {
     for byte in name {
         hash = hash.rotate_left(5) ^ u32::from(*byte);
     }
-    for word in padded_value.chunks_exact(4) {
-        hash = hash.rotate_left(16) ^ u32::from_le_bytes(word.try_into().unwrap());
+    for word in padded_value.as_chunks::<4>().0 {
+        hash = hash.rotate_left(16) ^ u32::from_le_bytes(*word);
     }
     hash
 }

--- a/docs/changelog/2026-08-07.mdx
+++ b/docs/changelog/2026-08-07.mdx
@@ -69,7 +69,7 @@ See [volumes](/sandboxes/volumes).
 **Other features**
 
 - **Root disk resizing in every SDK.** The TypeScript, Python, and Go SDKs now expose `rootDiskSize` / `root_disk_size` / `RootDiskSizeMiB` on `modify()`, mapped to the canonical `root_disk_size_mib` patch field. Restart and next-start semantics and backing-specific limits are documented in the [tuning guide](/sandboxes/tuning).
-- **Active backend context.** New `default_backend_info()` / `defaultBackendInfo()` accessors, and per-sandbox `backendKind` / `backend_kind` fields, let applications inspect the resolved default backend, its cloud API URL, the selector that chose it, and its profile. The API key is never included. A new `msb context` command prints the same information, and `create`, `remove`, `exec`, and `ssh` show a short backend notice. Invalid cloud CLI configuration now fails closed instead of silently dispatching locally. See [backends](/getting-started/backends).
+- **Active backend context.** New `default_backend_info()` / `defaultBackendInfo()` accessors, and per-sandbox `backendKind` / `backend_kind` fields, let applications inspect the resolved default backend, its cloud API URL, the selector that chose it, and its profile. The API key is never included. A new `msb context` command prints the same information. Invalid cloud CLI configuration now fails closed instead of silently dispatching locally. See [backends](/getting-started/backends).
 - **Go SDK: attach as non-default guest users.** The Go SDK gains `AttachWith`, with `WithAttachUser`, `WithAttachCwd`, `WithAttachEnv`, and `WithAttachDetachKeys`, matching the Python and TypeScript surface. The existing `Attach` API is unchanged. See the [Go SDK reference](/sdk/go/execution).
 
 ## Breaking changes

--- a/docs/cli/sandbox-commands.mdx
+++ b/docs/cli/sandbox-commands.mdx
@@ -279,6 +279,8 @@ msb touch --label app=engine
 
 <Tooltip tip="Not yet available on microsandbox cloud; recreate the sandbox with the new configuration."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
 
+`msb mod` is a shorter alias for `msb modify`.
+
 Change a running sandbox's configuration. Every change is planned and applied all-or-nothing. CPU and memory resize live within the `max_cpus` / `max_memory` ceilings; other changes that can't apply live need `--restart` or `--next-start`.
 
 ```bash


### PR DESCRIPTION
## TL;DR
Stop printing the active backend before sandbox commands and add `msb mod` as a shorter form of `msb modify`.

## Description
- Keep command output focused on the invoked program by removing automatic backend notices from create, remove, exec, and SSH commands.
- Preserve explicit backend inspection through `msb context` and `msb ctx`.
- Add `mod` as a visible alias for the existing `modify` command.
- Update the CLI reference and backend-context changelog to match the current behavior.

```bash
msb mod worker --cpus 4
```

## Test Plan
- [x] Rust formatting check passes for the changed CLI files
- [x] `cargo test -p microsandbox-cli --bin msb` passes
- [x] `cargo test -p microsandbox-cli --lib context` passes
- [x] The built CLI lists `mod` as an alias and emits no backend notice before an exec error