### PR TITLE
fix(cli): stop temporary exec sandboxes on errors

### DIFF
--- a/crates/cli/lib/commands/exec.rs
+++ b/crates/cli/lib/commands/exec.rs
@@ -77,24 +77,75 @@ pub async fn run(args: ExecArgs) -> anyhow::Result<()> {
     // driver. A terminal stdin would be read in cooked mode (local echo, line
     // buffering, Ctrl-C delivered to msb) — the opposite of the byte-faithful
     // stream this mode promises. Interactive users want the PTY path (`--tty`).
-    if args.stream && std::io::stdin().is_terminal() {
+    let stdin_is_terminal = std::io::stdin().is_terminal();
+    if args.stream && stdin_is_terminal {
         anyhow::bail!(
             "`--stream` requires piped (non-terminal) stdin; use `--tty` for an interactive terminal session"
         );
     }
 
-    let sandbox = super::resolve_and_start(&args.name, args.quiet).await?;
-
-    // Build exec options.
     let env_pairs: Vec<(String, String)> = args
         .env
         .iter()
         .map(|s| ui::parse_env(s).map_err(anyhow::Error::msg))
         .collect::<anyhow::Result<Vec<_>>>()?;
 
-    let workdir = args.workdir;
-    let stdin_is_terminal = std::io::stdin().is_terminal();
     let interactive = super::common::use_interactive_tty(stdin_is_terminal, args.no_tty);
+
+    let rlimits = args
+        .rlimit
+        .iter()
+        .map(|s| super::common::parse_rlimit(s))
+        .collect::<anyhow::Result<Vec<_>>>()?;
+
+    let timeout = args
+        .timeout
+        .as_deref()
+        .map(super::common::parse_duration_secs)
+        .transpose()?
+        .map(Duration::from_secs);
+
+    let sandbox = super::resolve_and_start(&args.name, args.quiet).await?;
+
+    let result = run_started(
+        &sandbox,
+        args,
+        env_pairs,
+        timeout,
+        rlimits,
+        stdin_is_terminal,
+        interactive,
+    )
+    .await;
+
+    // `maybe_stop` is a no-op for a sandbox that was already running, but it
+    // synchronously restores a sandbox that `exec` temporarily started.
+    super::maybe_stop(&sandbox).await;
+
+    let exit_code = result?;
+    if exit_code != 0 {
+        std::process::exit(exit_code);
+    }
+
+    Ok(())
+}
+
+//--------------------------------------------------------------------------------------------------
+// Functions: Helpers
+//--------------------------------------------------------------------------------------------------
+
+/// Run validated inputs while the caller retains responsibility for cleanup.
+#[allow(clippy::too_many_arguments)]
+async fn run_started(
+    sandbox: &Sandbox,
+    args: ExecArgs,
+    env_pairs: Vec<(String, String)>,
+    timeout: Option<Duration>,
+    rlimits: Vec<(RlimitResource, u64, u64)>,
+    stdin_is_terminal: bool,
+    interactive: bool,
+) -> anyhow::Result<i32> {
+    let workdir = args.workdir;
 
     // Read piped stdin upfront so it can be forwarded into the sandbox.
     // Skipped in `--stream` mode, where stdin is forwarded incrementally.
@@ -116,28 +167,12 @@ pub async fn run(args: ExecArgs) -> anyhow::Result<()> {
     let (cmd, cmd_args) =
         match super::common::resolve_exec_command(sandbox.config(), args.command, interactive)? {
             (Some(cmd), cmd_args) => (cmd, cmd_args),
-            (None, _) => {
-                super::maybe_stop(&sandbox).await;
-                std::process::exit(0);
-            }
+            (None, _) => return Ok(0),
         };
-
-    // Parse rlimits.
-    let rlimits: Vec<_> = args
-        .rlimit
-        .iter()
-        .map(|s| super::common::parse_rlimit(s))
-        .collect::<anyhow::Result<Vec<_>>>()?;
-
-    // Parse timeout.
-    let timeout = match &args.timeout {
-        Some(t) => Some(Duration::from_secs(super::common::parse_duration_secs(t)?)),
-        None => None,
-    };
 
     if args.stream {
         return run_stream(
-            &sandbox, cmd, cmd_args, &env_pairs, &workdir, &args.user, timeout, &rlimits,
+            sandbox, cmd, cmd_args, &env_pairs, &workdir, &args.user, timeout, &rlimits,
         )
         .await;
     }
@@ -162,12 +197,7 @@ pub async fn run(args: ExecArgs) -> anyhow::Result<()> {
                 a
             })
             .await?;
-
-        super::maybe_stop(&sandbox).await;
-
-        if exit_code != 0 {
-            std::process::exit(exit_code);
-        }
+        Ok(exit_code)
     } else {
         // Non-interactive: exec and capture output.
         let output: ExecOutput = sandbox
@@ -190,20 +220,9 @@ pub async fn run(args: ExecArgs) -> anyhow::Result<()> {
 
         std::io::stdout().write_all(output.stdout_bytes())?;
         std::io::stderr().write_all(output.stderr_bytes())?;
-
-        super::maybe_stop(&sandbox).await;
-
-        if !output.status().success {
-            std::process::exit(output.status().code);
-        }
+        Ok(output.status().code)
     }
-
-    Ok(())
 }
-
-//--------------------------------------------------------------------------------------------------
-// Functions: Helpers
-//--------------------------------------------------------------------------------------------------
 
 /// Apply the options shared by every `exec` mode (env, cwd, user, timeout,
 /// rlimits) onto an [`ExecOptionsBuilder`]. Mode-specific bits (stdin handling,
@@ -243,8 +262,6 @@ fn should_read_buffered_stdin(stdin_is_terminal: bool, interactive: bool, stream
 ///
 /// Forwards host stdin into the guest incrementally and flushes guest
 /// stdout/stderr per chunk, so a host driver can run the guest turn by turn.
-/// Always stops the sandbox (when we own its lifecycle) before returning, so a
-/// broken host pipe or a timeout can't leak it.
 #[allow(clippy::too_many_arguments)]
 async fn run_stream(
     sandbox: &Sandbox,
@@ -255,8 +272,8 @@ async fn run_stream(
     user: &Option<String>,
     timeout: Option<Duration>,
     rlimits: &[(RlimitResource, u64, u64)],
-) -> anyhow::Result<()> {
-    let mut handle = match sandbox
+) -> anyhow::Result<i32> {
+    let mut handle = sandbox
         .exec_stream_with(cmd, |e| {
             apply_common_exec_opts(
                 e.args(cmd_args).stdin_pipe(),
@@ -267,14 +284,7 @@ async fn run_stream(
                 rlimits,
             )
         })
-        .await
-    {
-        Ok(handle) => handle,
-        Err(e) => {
-            super::maybe_stop(sandbox).await;
-            return Err(e.into());
-        }
-    };
+        .await?;
 
     // Forward host stdin → guest incrementally in the background so it runs
     // concurrently with draining output. EOF or any read/write error closes the
@@ -297,17 +307,7 @@ async fn run_stream(
         });
     }
 
-    let result = drive_stream(&mut handle, timeout).await;
-
-    // Stop before propagating so neither a host-pipe error nor a timeout can
-    // leave the sandbox running.
-    super::maybe_stop(sandbox).await;
-
-    match result {
-        Ok(0) => Ok(()),
-        Ok(code) => std::process::exit(code),
-        Err(e) => Err(e),
-    }
+    drive_stream(&mut handle, timeout).await
 }
 
 /// Pump events from a streaming exec session to the host's stdout/stderr until

--- a/crates/cli/tests/exec_lifecycle.rs
+++ b/crates/cli/tests/exec_lifecycle.rs
@@ -1,0 +1,163 @@
+//! Lifecycle regression tests for `msb exec` against stopped and running sandboxes.
+
+use std::process::{Output, Stdio};
+use std::time::Duration;
+
+use microsandbox::{Sandbox, sandbox::SandboxStatus};
+use test_utils::msb_test;
+use tokio::process::Command;
+use tokio::time::timeout;
+
+//--------------------------------------------------------------------------------------------------
+// Constants
+//--------------------------------------------------------------------------------------------------
+
+const IMAGE: &str = "mirror.gcr.io/library/alpine";
+
+//--------------------------------------------------------------------------------------------------
+// Functions: Helpers
+//--------------------------------------------------------------------------------------------------
+
+/// Run the freshly built CLI with closed stdin and a hard timeout.
+async fn msb(args: &[&str]) -> Output {
+    timeout(
+        Duration::from_secs(90),
+        Command::new(env!("CARGO_BIN_EXE_msb"))
+            .args(args)
+            .stdin(Stdio::null())
+            .output(),
+    )
+    .await
+    .unwrap_or_else(|_| panic!("msb {args:?} timed out after 90s"))
+    .unwrap_or_else(|error| panic!("msb {args:?} failed to spawn: {error}"))
+}
+
+/// Remove any sandbox left by an earlier interrupted test run.
+async fn cleanup(name: &str) {
+    if let Ok(handle) = Sandbox::get(name).await {
+        let _ = handle.kill().await;
+        let _ = handle.remove().await;
+    }
+}
+
+/// Create a named sandbox, stop it cleanly, and release its process handle.
+async fn create_stopped(name: &str) {
+    let sandbox = Sandbox::builder(name)
+        .image(IMAGE)
+        .cpus(1)
+        .memory(512)
+        .replace()
+        .create()
+        .await
+        .expect("create sandbox");
+    sandbox.stop().await.expect("stop sandbox");
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests
+//--------------------------------------------------------------------------------------------------
+
+/// Invalid CLI-only options must fail before `exec` temporarily starts a stopped sandbox.
+#[msb_test]
+async fn invalid_options_do_not_start_stopped_sandbox() {
+    let name = "cli-exec-invalid-options-lifecycle";
+    cleanup(name).await;
+    create_stopped(name).await;
+
+    let output = msb(&[
+        "exec",
+        "--quiet",
+        "--rlimit",
+        "definitely-invalid",
+        name,
+        "--",
+        "true",
+    ])
+    .await;
+    let status = Sandbox::get(name)
+        .await
+        .expect("get sandbox after invalid exec options")
+        .status_snapshot();
+    cleanup(name).await;
+
+    assert!(!output.status.success(), "invalid rlimit must fail");
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("rlimit must be in format"),
+        "unexpected stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        status,
+        SandboxStatus::Stopped,
+        "invalid options must not start a stopped sandbox"
+    );
+}
+
+/// Errors after startup must stop an owned sandbox, without stopping one that was already running.
+#[msb_test]
+async fn exec_errors_restore_the_previous_lifecycle() {
+    let name = "cli-exec-error-lifecycle";
+    cleanup(name).await;
+
+    let sandbox = Sandbox::builder(name)
+        .image(IMAGE)
+        .cpus(1)
+        .memory(512)
+        .replace()
+        .create()
+        .await
+        .expect("create running sandbox");
+
+    let running_output = msb(&[
+        "exec",
+        "--quiet",
+        "--user",
+        "definitely-missing-user",
+        name,
+        "--",
+        "true",
+    ])
+    .await;
+    let running_status = Sandbox::get(name)
+        .await
+        .expect("get running sandbox after failed exec")
+        .status_snapshot();
+
+    sandbox.stop().await.expect("stop sandbox between cases");
+    drop(sandbox);
+
+    let stopped_output = msb(&[
+        "exec",
+        "--quiet",
+        "--user",
+        "definitely-missing-user",
+        name,
+        "--",
+        "true",
+    ])
+    .await;
+    let stopped_status = Sandbox::get(name)
+        .await
+        .expect("get stopped sandbox after failed exec")
+        .status_snapshot();
+    cleanup(name).await;
+
+    assert!(
+        !running_output.status.success(),
+        "invalid guest user must fail"
+    );
+    assert!(
+        !stopped_output.status.success(),
+        "invalid guest user must fail"
+    );
+    assert_eq!(
+        running_status,
+        SandboxStatus::Running,
+        "exec must not stop a sandbox that was already running"
+    );
+    assert_eq!(
+        stopped_status,
+        SandboxStatus::Stopped,
+        "exec must stop a sandbox that it temporarily started"
+    );
+}

--- a/docs/cli/sandbox-commands.mdx
+++ b/docs/cli/sandbox-commands.mdx
@@ -317,7 +317,9 @@ A live resize may not apply instantly; `--format json` reports a per-resource `r
 
 ## msb exec
 
-Execute a command inside a running sandbox.
+Execute a command inside a sandbox.
+
+`msb exec` leaves an already-running sandbox running. If the sandbox is stopped or crashed, the CLI starts it temporarily and waits for it to stop again before returning, including when the command cannot start or another execution error occurs. Invalid `--env`, `--rlimit`, and `--timeout` values fail before the sandbox starts.
 
 ```bash
 msb exec devbox -- python -c "print('hello')"


### PR DESCRIPTION
## TL;DR
Validate exec options before starting a stopped sandbox and wait for CLI-owned sandboxes to stop before returning from execution errors. Sandboxes that were already running stay running.

## Description
- Parse environment variables, resource limits, and timeouts before resolving or starting the target sandbox, so malformed options have no lifecycle side effects.
- Route buffered, PTY, and streaming execution through one cleanup boundary, so errors and guest exit codes cannot bypass sandbox shutdown.
- Preserve the existing behavior for already-running sandboxes by keeping lifecycle cleanup conditional on ownership.
- Document when exec starts and stops a sandbox and which invalid options fail before startup.
- Add real-VM regression coverage for invalid options, post-start execution failures, stopped sandboxes, and already-running sandboxes.

## Test Plan
- [x] `rustfmt --edition 2024 --check crates/cli/lib/commands/exec.rs crates/cli/tests/exec_lifecycle.rs` passes
- [x] `cargo test -p microsandbox-cli --lib` passes 307 unit tests
- [x] `cargo clippy -p microsandbox-cli --lib --test exec_lifecycle -- -D warnings` exits 0
- [x] `cargo test -p microsandbox-cli --test exec_lifecycle -- --ignored --test-threads=1 --nocapture` passes both real-VM lifecycle tests