### PR TITLE
docs: align SDK and CLI examples with current APIs

### DIFF
--- a/docs/changelog/2026-05-15.mdx
+++ b/docs/changelog/2026-05-15.mdx
@@ -70,7 +70,7 @@ See [Networking DNS](/networking/dns).
 - **Ingress policy gate on published ports.** Inbound TCP connections on published ports are now evaluated against the network policy before the listener accepts them; denied peers receive a TCP RST instead of a graceful close. See the [networking overview](/networking/overview).
 - **`MSB_HOME` env override.** Point a sandbox at an isolated state directory without touching `$HOME`, useful for CI jobs that share a runner. The build script honors the same variable, so build-time and runtime paths agree.
 - **Secret injection for Basic auth.** Placeholders inside `Authorization: Basic <base64>` headers are now decoded, substituted, and re-encoded. The proxy also detects bypass attempts via URL percent-encoding, JSON unicode escapes, and placeholders split across TCP writes. The Python SDK gained the same `SecretInjection` options (`headers`, `basic_auth`, `query_params`, `body`) as the Node SDK.
-- **`createWithProgress` in the Node TS SDK.** Stream image pull events (layer downloads, extraction) while creating a sandbox; the returned `PullSession` resolves to the live sandbox. See the [TypeScript SDK reference](/sdk/typescript/sandbox).
+- **`createWithPullProgress` in the Node TS SDK.** Stream image pull events (layer downloads, extraction) while creating a sandbox; the returned `PullProgressCreate` resolves to the live sandbox. See the [TypeScript SDK reference](/sdk/typescript/sandbox).
 - **`--replace-grace` flag.** Configure how long `replace()` waits for the previous sandbox to shut down before escalating, exposed in the CLI and all SDKs.
 
 ## Bug fixes

--- a/docs/changelog/2026-05-29.mdx
+++ b/docs/changelog/2026-05-29.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Week of May 29, 2026"
 sidebarTitle: "Week of the 29th"
-description: "Native SSH and SFTP, configurable OCI upper size, msb copy and rootfs patch flags, hardened mount options, env-backed secret shorthand, and a fix for multi-second published-port stalls."
+description: "Native SSH and SFTP, configurable OCI root disk size, msb copy and rootfs patch flags, hardened mount options, env-backed secret shorthand, and a fix for multi-second published-port stalls."
 icon: "bolt"
 ---
 
@@ -24,14 +24,16 @@ sftp -P 2222 root@127.0.0.1
 
 See the [SSH overview](/sandboxes/ssh).
 
-**Configurable OCI upper size**
+**Configurable OCI root disk size**
 
-The writable upper layer for OCI sandboxes is now configurable, so workloads that generate large amounts of state during a session no longer have to fit inside the previous fixed default. `msb run --oci-upper-size 8G ...` sets it from the CLI, and `sandbox_defaults.oci.upper_size_mib` sets the deployment-wide default. The Rust, TypeScript, Python, and Go SDKs gained matching surfaces. Fresh OCI roots default to 4096 MiB; snapshot upper layers are copied as-is.
+The writable root disk for OCI sandboxes is now configurable, so workloads that generate large amounts of state during a session no longer have to fit inside the previous fixed default. `msb run --root-disk 8G ...` sets it from the CLI, and `sandbox_defaults.oci.root_disk` sets the deployment-wide default. The Rust, TypeScript, Python, and Go SDKs expose matching root-disk settings. Fresh managed OCI roots default to 4096 MiB; snapshot upper layers are copied as-is.
 
 ```python
+from microsandbox import Image, RootDisk, Sandbox
+
 sandbox = await Sandbox.create(
     "worker",
-    image=Image.oci("python:3.12", upper_size_mib=8192),
+    image=Image.oci("python:3.12", root_disk=RootDisk.managed(8192)),
 )
 ```
 

--- a/docs/changelog/2026-06-19.mdx
+++ b/docs/changelog/2026-06-19.mdx
@@ -16,12 +16,13 @@ icon: "bolt"
 The Rust, TypeScript, Python, and Go SDKs can now target a local microsandbox install or a hosted cloud backend from the same program. A profile-aware config under `~/.microsandbox/config.json` plus `MSB_BACKEND`, `MSB_API_URL`, `MSB_API_KEY`, and `MSB_PROFILE` environment variables select the backend, and per-sandbox overrides let you mix local and cloud sandboxes in one process. Cloud sandboxes support the create, start, get, list, stop, remove, collected exec, and live log streaming operations; streaming exec, attach, metrics, guest filesystem, volumes, snapshots, and bounded log snapshots remain local-only for now.
 
 ```python
-from microsandbox import set_default_backend, PythonSandbox
+from microsandbox import Sandbox, set_default_backend
 
 set_default_backend("cloud", profile="prod")
 
-async with PythonSandbox.create(name="hello") as sb:
-    print(await sb.run("print('hi from the cloud')"))
+async with await Sandbox.create("hello", image="python") as sb:
+    output = await sb.exec("python", ["-c", "print('hi from the cloud')"])
+    print(output.stdout_text)
 ```
 
 See the [Python SDK reference](/sdk/python/sandbox).

--- a/docs/changelog/2026-06-26.mdx
+++ b/docs/changelog/2026-06-26.mdx
@@ -37,13 +37,14 @@ See the [volumes guide](/sandboxes/volumes).
 `RootfsSource::Bind` is now a first-class SDK option in Rust, Go, TypeScript, and Python, so a sandbox can boot directly off a host directory with no OCI pull and no overlay. The Python SDK already exposed `ImageSource.bind`; this brings the other languages to parity with `ImageBuilder.bind(host)` in Rust and TypeScript, and `WithBindRootfs(path)` in Go.
 
 ```python
-from microsandbox import PythonSandbox, Image
+from microsandbox import Image, Sandbox
 
-async with PythonSandbox.create(
-    name="dev",
+async with await Sandbox.create(
+    "dev",
     image=Image.bind("/srv/rootfs/python-base"),
 ) as sb:
-    await sb.run("print('hello from bind rootfs')")
+    output = await sb.exec("python", ["-c", "print('hello from bind rootfs')"])
+    print(output.stdout_text)
 ```
 
 See the [Python images reference](/sdk/python/images).

--- a/docs/changelog/2026-07-24.mdx
+++ b/docs/changelog/2026-07-24.mdx
@@ -15,26 +15,25 @@ icon: "bolt"
 
 Network policy is now built from named profiles instead of ad-hoc presets. Pass one or more of `public`, `private`, and `host` to `--net` on the CLI, or to `NetworkPolicy.from_profiles()` / `fromProfiles()` / `FromProfiles()` in the SDKs. `--net` is repeatable and accepts a comma-separated list, plus the terminal values `all` and `none`. Explicit `--net-rule` entries keep first-match precedence and now understand `allow@dns` / `deny@dns` targets, so DNS answers are policy-aware instead of implicitly allowed.
 
-The IPv4 and IPv6 unspecified addresses are excluded from `public`, closing a DNS-rebinding gap. This is a breaking change for pre-1.0 callers: the legacy `public_only` and `non_local` presets are removed. Migrate to `from_profiles("public")` or the CLI equivalent.
+The IPv4 and IPv6 unspecified addresses are excluded from `public`, closing a DNS-rebinding gap. This is a breaking change for pre-1.0 callers: the legacy `public_only` and `non_local` presets are removed. Migrate to the `public` profile or the CLI equivalent.
 
 ```bash
-msb run --net public,private --net-rule 'allow@dns:api.example.com' python
+msb run --net public,private --net-rule 'allow@dns' python
 ```
 
 ```python
-from microsandbox import NetworkPolicy, Rule
+from microsandbox import NetworkPolicy, NetworkProfile
 
-policy = NetworkPolicy.from_profiles("public", "private").with_rules(
-    Rule.allow_dns("api.example.com"),
-    Rule.deny_dns("telemetry.example.com"),
-)
+policy = NetworkPolicy.from_profiles([
+    NetworkProfile.PUBLIC,
+    NetworkProfile.PRIVATE,
+])
 ```
 
 ```typescript
-const policy = NetworkPolicy.fromProfiles("public").withRules(
-  Rule.allowDns("api.example.com"),
-  Rule.denyDns("telemetry.example.com"),
-);
+import { NetworkPolicy } from "microsandbox";
+
+const policy = NetworkPolicy.fromProfiles(["public", "private"]);
 ```
 
 See the [networking overview](/networking/overview).

--- a/docs/changelog/2026-08-07.mdx
+++ b/docs/changelog/2026-08-07.mdx
@@ -13,9 +13,9 @@ microsandbox now ships a first-class Ruby 3.1\+ gem backed by a native Magnus ex
 ```ruby
 require "microsandbox"
 
-Microsandbox::Sandbox.with(name: "worker", image: "alpine:3.19") do |sb|
+Microsandbox::Sandbox.with("worker", image: "alpine:3.19") do |sb|
   result = sb.shell("echo hello from ruby")
-  puts result.stdout_text
+  puts result.stdout
 end
 ```
 

--- a/docs/cli/overview.mdx
+++ b/docs/cli/overview.mdx
@@ -77,7 +77,7 @@ msb images            # List cached images
 msb rmi python        # Remove a cached image
 
 # Volumes
-msb volume create data --size 10G
+msb volume create data
 msb volumes              # Also: msb vols
 msb volume rm data
 

--- a/docs/configuration.mdx
+++ b/docs/configuration.mdx
@@ -154,7 +154,7 @@ On Windows, the default `home` is `%USERPROFILE%\.microsandbox`. JSON strings ca
 | Field | Default | Description |
 |-------|---------|-------------|
 | `msb` | `{home}/bin/msb` | `msb` binary. Resolved via: `MSB_PATH` env, SDK-provided runtime path, this field, debug workspace build paths, default install path, then `PATH` |
-| `libkrunfw` | `{home}/lib/libkrunfw` | Path to a custom VM kernel (`.so` on Linux, `.dylib` on macOS, `.dll` on Windows). Resolved via: `MSB_LIBKRUNFW_PATH` env, SDK-provided runtime path, this field, paths next to the resolved `msb` binary, then default install path |
+| `libkrunfw` | `{home}/lib/libkrunfw` | Path to the libkrunfw shared library (`.so` on Linux, `.dylib` on macOS, `.dll` on Windows). Resolved via: `MSB_LIBKRUNFW_PATH` env, SDK-provided runtime path, this field, paths next to the resolved `msb` binary, then default install path |
 | `cache` | `{home}/cache` | Image layer cache |
 | `sandboxes` | `{home}/sandboxes` | Per-sandbox state |
 | `volumes` | `{home}/volumes` | Named volumes |

--- a/docs/getting-started/introduction.mdx
+++ b/docs/getting-started/introduction.mdx
@@ -34,7 +34,7 @@ msb run debian
 - **Fast startup.** Sandboxes are lightweight enough to create from application code.
 - **Docker-like inputs.** Use familiar OCI images from Docker Hub, GHCR, ECR, GCR, or another registry.
 - **Programmable controls.** Configure resources, volumes, secrets, networking, and lifecycle from the CLI or SDK.
-- **Multi-language SDKs.** Rust, TypeScript, Python, and Go expose the same core model.
+- **Multi-language SDKs.** Rust, TypeScript, Python, Go, and Ruby expose the same core model.
 
 ## Example use cases
 

--- a/docs/getting-started/quickstart.mdx
+++ b/docs/getting-started/quickstart.mdx
@@ -60,6 +60,10 @@ Having trouble with a local installation? Choose your platform for setup checks 
     go get github.com/superradcompany/microsandbox/sdk/go
     ```
 
+    ```bash Ruby
+    gem install microsandbox
+    ```
+
     </CodeGroup>
 
     Check local virtualization support with:
@@ -140,6 +144,17 @@ Having trouble with a local installation? Choose your platform for setup checks 
         return err
     }
     fmt.Println(output.Stdout()) // Hello from a microVM!
+    ```
+
+    ```ruby Ruby
+    require "microsandbox"
+
+    Microsandbox.install unless Microsandbox.installed?
+
+    Microsandbox::Sandbox.with("hello", image: "python", memory: 512) do |sandbox|
+      output = sandbox.exec("python", ["-c", "print('Hello from a microVM!')"])
+      puts output.stdout
+    end
     ```
 
     ```bash CLI

--- a/docs/networking/dns.mdx
+++ b/docs/networking/dns.mdx
@@ -124,7 +124,8 @@ await using sb = await Sandbox.builder("safe-agent")
 ```
 
 ```python Python
-from microsandbox import DnsConfig, Network, Sandbox
+from microsandbox import Network, Sandbox
+from microsandbox.types import DnsConfig
 
 sb = await Sandbox.create(
     "safe-agent",

--- a/docs/operations/backends.mdx
+++ b/docs/operations/backends.mdx
@@ -62,10 +62,13 @@ set_default_backend("cloud", api_key=os.environ["MSB_API_KEY"])
 set_default_backend("local")
 ```
 
-```go Go
-// Select cloud explicitly and provide its credential before the first call.
-os.Setenv("MSB_BACKEND", "cloud")
-os.Setenv("MSB_API_KEY", apiKey)
+```ruby Ruby
+require "microsandbox"
+
+Microsandbox.use_cloud_backend!(ENV.fetch("MSB_API_KEY"))
+
+# Or force the local runtime.
+Microsandbox.use_local_backend!
 ```
 </CodeGroup>
 
@@ -117,7 +120,7 @@ msb context
 msb context --format json
 ```
 
-The SDKs expose the same secret-safe information:
+Use the SDK accessors to inspect the active backend without exposing its API key. Detailed backend info includes the kind, cloud API URL, selection source, and profile when applicable:
 
 <CodeGroup>
 ```rust Rust
@@ -147,6 +150,13 @@ if err != nil {
 }
 fmt.Println(info.Kind)
 fmt.Println(sandbox.BackendKind())
+```
+
+```ruby Ruby
+require "microsandbox"
+
+puts Microsandbox.default_backend_kind
+puts sandbox.backend
 ```
 </CodeGroup>
 

--- a/docs/sandboxes/volumes.mdx
+++ b/docs/sandboxes/volumes.mdx
@@ -37,7 +37,7 @@ await volume.fs().write("state.json", b'{"ready": true}')
 
 ```go Go
 volume, err := m.GetDefaultVolume(ctx)
-err = volume.FS().WriteString("state.json", `{"ready":true}`)
+err = volume.FS().WriteString(ctx, "state.json", `{"ready":true}`)
 ```
 </CodeGroup>
 

--- a/docs/sdk/errors.mdx
+++ b/docs/sdk/errors.mdx
@@ -1,10 +1,10 @@
 ---
 title: Error handling
-description: Typed errors and resource cleanup patterns
+description: Error matching and resource cleanup patterns
 icon: "triangle-exclamation"
 ---
 
-All SDKs surface typed errors so you can match on specific failure modes instead of parsing strings. Rust has an `Error` enum, TypeScript exposes a dedicated subclass per variant (use `instanceof`), Python provides dedicated exception classes, and Go provides an `*Error` value with an `ErrorKind` discriminator matched via `m.IsKind(err, kind)` or `errors.As`.
+SDKs surface failures through language-idiomatic error values. Match documented typed variants where they are available, and otherwise report or propagate the returned error without parsing its message.
 
 ## Matching errors
 
@@ -29,7 +29,7 @@ match sb.exec("python", ["script.py"]).await {
     Ok(output) => {
         eprintln!("Exit {}: {}", output.status().code, output.stderr()?);
     }
-    Err(Error::ExecTimeout) => eprintln!("Timed out"),
+    Err(Error::ExecTimeout(_)) => eprintln!("Timed out"),
     Err(Error::Runtime(msg)) => eprintln!("Runtime: {msg}"),
     Err(e) => return Err(e),
 }
@@ -134,14 +134,13 @@ case err != nil:
 `exec()` distinguishes between:
 
 - **A program that ran and exited non-zero**: the call returns an `ExecOutput` with a non-zero `code`. This is *not* an error in the SDK sense; it's a normal result.
-- **A program that never started**: the binary doesn't exist, isn't executable, the working directory is unreachable, etc. This surfaces as a typed error variant: `ExecFailed` (Rust), `ExecFailedError` (TypeScript), `ExecFailedError` (Python).
+- **A program that never started**: the binary doesn't exist, isn't executable, the working directory is unreachable, etc. The call returns or raises an SDK error.
 
-The typed error carries a classified `kind` plus the underlying `errno`, so callers can branch on the cause and react. Common kinds: `NotFound` (binary missing on PATH), `PermissionDenied`, `NotExecutable`, `BadCwd`, `BadArgs`, `ResourceLimit`, `UserSetupFailed`, `OutOfMemory`, `PtySetupFailed`, `Other`.
+Rust exposes a structured `ExecFailed` payload, and Go exposes the same detail on streaming execution events. Common failure kinds include `NotFound` (binary missing on `PATH`), `PermissionDenied`, `NotExecutable`, `BadCwd`, `BadArgs`, `ResourceLimit`, `UserSetupFailed`, `OutOfMemory`, `PtySetupFailed`, and `Other`.
 
 <CodeGroup>
 ```rust Rust
-use microsandbox::Error;
-use microsandbox_protocol::exec::ExecFailureKind;
+use microsandbox::{protocol::exec::ExecFailureKind, Error};
 
 match sb.exec("nonexistent", []).await {
     Ok(output) => { /* program ran, check output.status() */ }
@@ -164,44 +163,33 @@ match sb.exec("nonexistent", []).await {
 ```
 
 ```typescript TypeScript
-import { ExecFailedError, Sandbox } from "microsandbox";
-
 try {
     const output = await sb.exec("nonexistent");
     // program ran, check output.success / output.code
 } catch (e) {
-    if (e instanceof ExecFailedError) {
-        switch (e.kind) {
-            case "not_found":
-                console.error("Binary not on PATH:", e.message);
-                break;
-            case "permission_denied":
-                console.error("Not executable (chmod +x?):", e.message);
-                break;
-            default:
-                console.error(`Spawn failed (${e.kind}):`, e.message);
-        }
-        // e.errno, e.errnoName, e.stage are also available
-    } else {
-        throw e;
-    }
+    console.error("Program could not be started:", e);
 }
 ```
 
 ```python Python
-from microsandbox import ExecFailedError
+from microsandbox import MicrosandboxError
 
 try:
     output = await sb.exec("nonexistent")
     # program ran, check output.success / output.exit_code
-except ExecFailedError as e:
-    if e.kind == "not_found":
-        print(f"Binary not on PATH: {e.message}")
-    elif e.kind == "permission_denied":
-        print(f"Not executable (chmod +x?): {e.message}")
-    else:
-        print(f"Spawn failed ({e.kind}): {e.message}")
-    # e.errno, e.errno_name, e.stage are also available
+except MicrosandboxError as e:
+    print(f"Program could not be started: {e}")
+```
+
+```ruby Ruby
+require "microsandbox"
+
+begin
+  output = sandbox.exec("nonexistent")
+  # program ran, check output.success / output.exit_code
+rescue Microsandbox::Error => e
+  warn "Program could not be started: #{e.message}"
+end
 ```
 
 ```go Go
@@ -238,7 +226,7 @@ for {
 ```
 </CodeGroup>
 
-The CLI maps these kinds to POSIX-style exit codes: `127` for `NotFound`, `126` for `PermissionDenied` and `NotExecutable`, `1` otherwise. SDK callers reading the error directly don't need to think about exit codes; branch on `kind` instead.
+The CLI maps these kinds to POSIX-style exit codes: `127` for `NotFound`, `126` for `PermissionDenied` and `NotExecutable`, and `1` otherwise.
 
 ## Name conflicts
 
@@ -246,7 +234,7 @@ Creating a sandbox with a name that's already in use (and without `replace`) sur
 
 <CodeGroup>
 ```rust Rust
-use microsandbox::Error;
+use microsandbox::{Error, Sandbox};
 
 match Sandbox::builder("worker").image("alpine").create().await {
     Ok(sb) => { /* ... */ }
@@ -258,7 +246,7 @@ match Sandbox::builder("worker").image("alpine").create().await {
 ```
 
 ```typescript TypeScript
-import { SandboxAlreadyExistsError } from "microsandbox";
+import { Sandbox, SandboxAlreadyExistsError } from "microsandbox";
 
 try {
     const sb = await Sandbox.builder("worker").image("alpine").create();
@@ -272,20 +260,12 @@ try {
 ```
 
 ```python Python
-from microsandbox import SandboxAlreadyExistsError
+from microsandbox import Sandbox, SandboxAlreadyExistsError
 
 try:
     sb = await Sandbox.create("worker", image="alpine")
 except SandboxAlreadyExistsError:
     print("sandbox already exists; resume or pass replace=True")
-```
-
-```go Go
-sb, err := m.CreateSandbox(ctx, "worker",
-    m.WithImage("alpine"))
-if m.IsKind(err, m.ErrSandboxAlreadyExists) {
-    log.Println("sandbox already exists; resume or pass WithReplace()")
-}
 ```
 
 </CodeGroup>
@@ -294,65 +274,59 @@ Pass `replace()` / `replace=True` / `--replace` / `WithReplace()` to stop the ex
 
 ## Sandbox start failures
 
-When a sandbox process exits before the agent relay is ready (mount errors, missing rootfs, network setup failures), the SDK surfaces a typed `BootStart` / `BootStartError`. The payload carries the failure stage and errno so callers can recover or report cleanly.
+When a sandbox process exits before the agent relay is ready, creation returns or raises an SDK error. Rust exposes a structured `BootStart` payload with the failure stage and underlying message.
 
 <CodeGroup>
 ```rust Rust
-use microsandbox::Error;
-use microsandbox_runtime::boot_error::BootErrorStage;
+use microsandbox::{Error, Sandbox};
 
 match Sandbox::builder("svc").image("alpine").create().await {
     Ok(sb) => { /* ... */ }
     Err(Error::BootStart { name, err }) => {
         eprintln!("Sandbox {name:?} failed at stage {:?}: {}", err.stage, err.message);
-        if matches!(err.stage, BootErrorStage::Mount) {
-            eprintln!("Hint: a host volume path may not exist.");
-        }
     }
     Err(e) => return Err(e),
 }
 ```
 
 ```typescript TypeScript
-import { BootStartError } from "microsandbox";
+import { Sandbox } from "microsandbox";
 
 try {
     const sb = await Sandbox.builder("svc").image("alpine").create();
 } catch (e) {
-    if (e instanceof BootStartError) {
-        console.error(`Sandbox "${e.name}" failed at stage ${e.stage}: ${e.message}`);
-        if (e.stage === "mount") {
-            console.error("Hint: a host volume path may not exist.");
-        }
-    } else {
-        throw e;
-    }
+    console.error("Sandbox failed to start:", e);
 }
 ```
 
 ```python Python
-from microsandbox import BootStartError
+from microsandbox import MicrosandboxError, Sandbox
 
 try:
     sb = await Sandbox.create("svc", image="alpine")
-except BootStartError as e:
-    print(f"Sandbox {e.name!r} failed at stage {e.stage}: {e.message}")
-    if e.stage == "mount":
-        print("Hint: a host volume path may not exist.")
+except MicrosandboxError as e:
+    print(f"Sandbox failed to start: {e}")
 ```
 
 ```go Go
-// The Go SDK surfaces boot failures as *m.Error.
-// Inspect Kind and Message for the failure details.
 _, err := m.CreateSandbox(ctx, "svc", m.WithImage("alpine"))
-var me *m.Error
-if errors.As(err, &me) {
-    log.Printf("sandbox boot failed (kind=%s): %s", me.Kind, me.Message)
+if err != nil {
+    log.Printf("sandbox failed to start: %v", err)
 }
+```
+
+```ruby Ruby
+require "microsandbox"
+
+begin
+  sandbox = Microsandbox::Sandbox.create("svc", image: "alpine")
+rescue Microsandbox::Error => e
+  warn "Sandbox failed to start: #{e.message}"
+end
 ```
 </CodeGroup>
 
-The CLI prepends the same payload as a styled `error:` block before any captured log output, so you see "what went wrong + a hint" inline. SDK callers get the structured payload to make their own decisions.
+The CLI prints the startup failure before any captured log output so the immediate cause stays visible.
 
 ## Resource cleanup
 
@@ -407,12 +381,19 @@ if err != nil {
 defer func() {
     stopCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
     defer cancel()
-    _, _ = sb.Stop(stopCtx)
+    _ = sb.Stop(stopCtx)
     _ = sb.Close()
 }()
 
 out, _ := sb.Exec(ctx, "python", []string{"-c", "print('hello')"})
 fmt.Println(out.Stdout())
+```
+
+```ruby Ruby
+Microsandbox::Sandbox.with("temp", image: "python", replace: true) do |sandbox|
+  output = sandbox.exec("python", ["-c", "print('hello')"])
+  puts output.stdout
+end
 ```
 
 </CodeGroup>

--- a/docs/sdk/go/sandbox.mdx
+++ b/docs/sdk/go/sandbox.mdx
@@ -1033,13 +1033,41 @@ Set the root filesystem source: an OCI image name, local directory path, or disk
   </div>
 </div>
 
+#### <span className="msb-recv"></span><span className="msb-hn">WithRootDisk()</span>
+
+```go
+func WithRootDisk(disk RootDiskConfig) SandboxOption
+```
+
+Configure root storage for an OCI image. Construct the value with the [`RootDisk`](#rootdisk) factory.
+
+<Accordion title="Example">
+
+```go
+sb, err := m.CreateSandbox(ctx, "worker",
+    m.WithImage("python:3.12"),
+    m.WithRootDisk(m.RootDisk.Managed(8192)),
+)
+```
+
+</Accordion>
+
+<p className="msb-label">Parameters</p>
+
+<div className="msb-params">
+  <div className="msb-param">
+    <div className="msb-param-key"><code>disk</code><span className="msb-type">RootDiskConfig</span></div>
+    <div className="msb-param-desc">Managed, tmpfs, user-supplied disk-image, or flat OCI root storage.</div>
+  </div>
+</div>
+
 #### <span className="msb-recv"></span><span className="msb-hn">WithOCIUpperSize()</span>
 
 ```go
 func WithOCIUpperSize(mebibytes uint32) SandboxOption
 ```
 
-Set the writable overlay upper size for an OCI image, in MiB. Valid only with an OCI image rootfs, not disk images or snapshots.
+Deprecated alias for `WithRootDisk(RootDisk.Managed(mebibytes))`.
 
 <p className="msb-label">Parameters</p>
 
@@ -2663,7 +2691,8 @@ The full configuration of a sandbox. Most callers build a sandbox via `CreateSan
 | Name | `string` | Sandbox name, up to 128 UTF-8 bytes |
 | Image | `string` | OCI image, local path, or disk image |
 | ImageFstype | `string` | Optional inner filesystem type for disk-image roots |
-| OCIUpperSizeMiB | `uint32` | Writable overlay upper size for OCI image roots |
+| RootDisk | [`*RootDiskConfig`](#rootdiskconfig) | Root storage for an OCI image |
+| OCIUpperSizeMiB | `uint32` | Deprecated managed-root-disk size alias; ignored when `RootDisk` is set |
 | Snapshot | `string` | Snapshot artifact path or bare name; mutually exclusive with `Image` |
 | MemoryMiB | `uint32` | Guest memory in MiB |
 | CPUs | `uint8` | Virtual CPUs |
@@ -2697,6 +2726,75 @@ The full configuration of a sandbox. Most callers build a sandbox via `CreateSan
 | Secrets | [`[]SecretEntry`](/sdk/go/secrets#secretentry) | Secret injection entries |
 | Patches | [`[]PatchConfig`](#patchconfig) | Rootfs modifications applied before boot |
 | Volumes | `map[string]MountConfig` | Volume mounts keyed by guest path |
+
+### RootDisk
+
+Factory namespace for [`RootDiskConfig`](#rootdiskconfig) values. Pass the result to [`WithRootDisk`](#withrootdisk).
+
+```go
+m.RootDisk.Managed(8192)
+m.RootDisk.Tmpfs(m.RootDiskTmpfsOptions{SizeMiB: 512})
+m.RootDisk.Disk("./scratch.qcow2", m.RootDiskImageOptions{Format: "qcow2", Fstype: "ext4"})
+m.RootDisk.Flat(m.RootDiskFlatOptions{SizeMiB: 8192, Clone: m.FlatCloneAuto})
+```
+
+### RootDiskConfig
+
+Root storage configuration returned by the [`RootDisk`](#rootdisk) factory. Use [`Kind()`](#rootdiskconfig-kind) to inspect its backing.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `SizeMiB` | `uint32` | Managed, tmpfs, or flat root-disk size; zero selects the runtime default where supported |
+| `Path` | `string` | Host path for a user-supplied disk image |
+| `Format` | `string` | Disk-image format: `raw` or `qcow2`; inferred from the path when empty |
+| `Fstype` | `string` | Inner filesystem type; defaults to `ext4` |
+| `Clone` | [`FlatClone`](#flatclone) | Private flat-root provisioning strategy |
+
+#### <span className="msb-recv">rootDiskConfig.</span><span className="msb-hn">Kind()</span>
+
+```go
+func (r RootDiskConfig) Kind() RootDiskKind
+```
+
+Return the configured root-disk backing.
+
+### RootDiskKind
+
+| Constant | Description |
+|----------|-------------|
+| `RootDiskKindManaged` | Microsandbox-owned sparse ext4 writable layer |
+| `RootDiskKindTmpfs` | Ephemeral RAM-backed writable layer |
+| `RootDiskKindDiskImage` | User-supplied writable disk image |
+| `RootDiskKindFlat` | Complete OCI root filesystem mounted without guest OverlayFS |
+
+### RootDiskTmpfsOptions
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `SizeMiB` | `uint32` | Tmpfs size; zero uses half of sandbox memory |
+
+### RootDiskImageOptions
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `Format` | `string` | Optional `raw` or `qcow2` format; inferred from the path when empty |
+| `Fstype` | `string` | Optional inner filesystem type; defaults to `ext4` |
+
+### RootDiskFlatOptions
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `SizeMiB` | `uint32` | Final guest capacity; zero uses the runtime default |
+| `Fstype` | `string` | Generated filesystem type; currently `ext4` |
+| `Clone` | [`FlatClone`](#flatclone) | Private disk provisioning strategy |
+
+### FlatClone
+
+| Constant | Value | Description |
+|----------|-------|-------------|
+| `FlatCloneAuto` | `"auto"` | Try a native reflink, then fall back to a sparse copy |
+| `FlatCloneCopy` | `"copy"` | Always create a sparse copy |
+| `FlatCloneReflink` | `"reflink"` | Require a native reflink and fail when unavailable |
 
 ### SandboxOption
 

--- a/docs/sdk/overview.mdx
+++ b/docs/sdk/overview.mdx
@@ -25,6 +25,10 @@ pip install microsandbox
 ```bash Go
 go get github.com/superradcompany/microsandbox/sdk/go
 ```
+
+```bash Ruby
+gem install microsandbox
+```
 </CodeGroup>
 
 For explicit runtime installation, verification, custom install locations, and environment overrides, see [Runtime setup](/sdk/setup).
@@ -116,6 +120,17 @@ func main() {
 }
 ```
 
+```ruby Ruby
+require "microsandbox"
+
+Microsandbox.install unless Microsandbox.installed?
+
+Microsandbox::Sandbox.with("hello", image: "python") do |sandbox|
+  output = sandbox.exec("python", ["-c", "print('Hello, World!')"])
+  puts "Output: #{output.stdout}"
+end
+```
+
 </CodeGroup>
 
 ## Reference
@@ -126,5 +141,6 @@ Choose the SDK for your language:
 - [TypeScript SDK](/sdk/typescript/sandbox)
 - [Python SDK](/sdk/python/sandbox)
 - [Go SDK](/sdk/go/sandbox)
+- [Ruby SDK](https://github.com/superradcompany/microsandbox/tree/main/sdk/ruby)
 
 For low-level protocol integrations, see the Agent Client references for [Rust](/sdk/rust/agent-client), [TypeScript](/sdk/typescript/agent-client), [Python](/sdk/python/agent-client), and [Go](/sdk/go/agent-client). See also [error handling](/sdk/errors).

--- a/docs/sdk/python/execution.mdx
+++ b/docs/sdk/python/execution.mdx
@@ -41,7 +41,7 @@ print(out.exit_code)  # 0
 
 </Accordion>
 
-Run a command inside the sandbox and wait for it to complete, buffering all stdout and stderr into memory. The keyword-only options apply to this call alone and don't change the sandbox's defaults. For long-running processes or large output, use [`exec_stream()`](#sandbox-exec_stream) instead. Raises [`ExecTimeoutError`](/sdk/python/sandbox) if `timeout` elapses and [`ExecFailedError`](/sdk/python/sandbox) if the process can't be spawned.
+Run a command inside the sandbox and wait for it to complete, buffering all stdout and stderr into memory. The keyword-only options apply to this call alone and don't change the sandbox's defaults. For long-running processes or large output, use [`exec_stream()`](#sandbox-exec_stream) instead. Raises [`ExecTimeoutError`](/sdk/errors) if `timeout` elapses and `MicrosandboxError` if the process can't be spawned.
 
 <p className="msb-label">Parameters</p>
 

--- a/docs/sdk/python/images.mdx
+++ b/docs/sdk/python/images.mdx
@@ -557,7 +557,8 @@ Explicit rootfs image source. Build one with [`Image.oci()`](#image-oci), [`Imag
 | `_type` | [`ImageSourceKind`](#imagesourcekind) | Source kind |
 | `_path` | `str \| None` | Host path for `bind` / `disk` sources |
 | `_reference` | `str \| None` | OCI reference for `oci` sources |
-| `_upper_size_mib` | `int \| None` | Writable overlay upper size in MiB (OCI only) |
+| `_root_disk` | [`RootDiskConfig`](#rootdiskconfig)` \| int \| None` | Writable root disk configuration or managed-disk size in MiB (OCI only) |
+| `_upper_size_mib` | `int \| None` | Deprecated managed-disk size alias |
 | `_fstype` | `str \| None` | Filesystem type for `disk` sources |
 | `_format` | [`DiskImageFormat`](#diskimageformat)` \| None` | Disk image format (inferred from extension) |
 

--- a/docs/sdk/rust/sandbox.mdx
+++ b/docs/sdk/rust/sandbox.mdx
@@ -1103,14 +1103,14 @@ fn image_with(self, f: impl FnOnce(ImageBuilder) -> ImageBuilder) -> Self
 use microsandbox::size::SizeExt;
 
 let sb = Sandbox::builder("worker")
-    .image_with(|i| i.oci("python:3.12").upper_size(8.gib()))
+    .image_with(|i| i.oci("python:3.12").root_disk(8.gib()))
     .create()
     .await?;
 ```
 
 </Accordion>
 
-Configure an explicit rootfs source. Use this for OCI-only settings such as the writable overlay upper size, or for disk images when the filesystem type can't be auto-detected.
+Configure an explicit rootfs source. Use this for OCI-only settings such as the writable root disk, or for disk images when the filesystem type can't be auto-detected.
 
 <p className="msb-label">Parameters</p>
 

--- a/docs/sdk/setup.mdx
+++ b/docs/sdk/setup.mdx
@@ -45,14 +45,21 @@ if !m.IsInstalled() {
     }
 }
 ```
+
+```ruby Ruby
+require "microsandbox"
+
+Microsandbox.install unless Microsandbox.installed?
+```
 </CodeGroup>
 
 | SDK | Install | Check | Behavior |
 |-----|---------|-------|----------|
 | Rust | `setup::install() -> MicrosandboxResult<()>` | `setup::is_installed() -> bool` | Downloads the SDK's pinned runtime and verifies it. |
 | TypeScript | `install(): Promise<void>` | `isInstalled(): boolean` | Downloads the package's pinned runtime and verifies it. |
-| Python | `install() -> None` (async) | `is_installed() -> bool` | Installs and verifies the runtime; release wheels normally bundle matching files. |
+| Python | `install() -> Awaitable[None]` | `is_installed() -> bool` | Installs and verifies the runtime; release wheels normally bundle matching files. |
 | Go | `EnsureInstalled(ctx, ...SetupOption) error` | `IsInstalled() bool` | Installs `msb` and `libkrunfw`; the Go FFI library is embedded separately. |
+| Ruby | `install -> nil` | `installed? -> bool` | Installs and verifies the runtime used by the native extension. |
 
 ## Customize installation
 
@@ -108,7 +115,7 @@ In Go, `WithSkipDownload()` returns a `SetupOption`, whose exported type is `fun
 
 ## Override runtime paths
 
-The Rust, TypeScript, and Python SDKs can override the process-wide `libkrunfw` path directly. Call the setter before creating a local sandbox.
+The Rust, TypeScript, Python, and Ruby SDKs can override the process-wide `libkrunfw` path directly. Call the setter before creating a local sandbox.
 
 <CodeGroup>
 ```rust Rust
@@ -127,6 +134,12 @@ setRuntimeLibkrunfwPath("/opt/microsandbox/lib/libkrunfw.dylib");
 from microsandbox import set_libkrunfw_path
 
 set_libkrunfw_path("/opt/microsandbox/lib/libkrunfw.dylib")
+```
+
+```ruby Ruby
+require "microsandbox"
+
+Microsandbox.set_runtime_libkrunfw_path("/opt/microsandbox/lib/libkrunfw.dylib")
 ```
 </CodeGroup>
 

--- a/docs/sdk/typescript/sandbox.mdx
+++ b/docs/sdk/typescript/sandbox.mdx
@@ -1159,13 +1159,13 @@ imageWith(configure: (b: ImageBuilder) => ImageBuilder): this
 
 ```typescript
 const sandbox = await Sandbox.builder("worker")
-  .imageWith((i) => i.oci("python:3.12").upperSize(8192))
+  .imageWith((i) => i.oci("python:3.12").rootDisk(8192))
   .create();
 ```
 
 </Accordion>
 
-Configure an explicit rootfs source. Use this for OCI-only settings such as the writable overlay upper size, or for disk images when the filesystem type can't be auto-detected.
+Configure an explicit rootfs source. Use this for OCI-only settings such as the writable root disk, or for disk images when the filesystem type can't be auto-detected.
 
 <p className="msb-label">Parameters</p>
 


### PR DESCRIPTION
## TL;DR
Update the docs to use the current SDK, CLI, and config APIs, and remove examples for typed surfaces that some SDKs do not expose. Add representative Ruby coverage and document the current Go root disk API.

## Description
- Replace hallucinated TypeScript and Python exec and boot error types with supported error handling, and remove the unsupported Go typed name-conflict example.
- Refresh root disk, networking, DNS, volume, setup, cleanup, and CLI examples against the current implementations.
- Update historical changelog snippets that still used removed SDK classes, methods, option names, or invalid argument shapes.
- Document the current Go root disk factory, configuration types, options, kinds, and clone strategies.
- Add Ruby to the current installation, quickstart, backend, setup, error-handling, and lifecycle examples.

## Test Plan
- [x] `git diff --check origin/mintlify..HEAD` exits 0
- [x] `GOCACHE=/tmp/msb-docs-go-cache go test ./...` passes in `sdk/go`
- [x] Edited Python snippets compile with top-level `await` enabled
- [x] Edited Ruby snippets pass `ruby -c`
- [x] Edited internal links resolve and JSON and code fences validate