### PR TITLE
docs(sdk): make TypeScript the default documentation language

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -77,6 +77,17 @@ jobs:
               - 'sdk/rust/**'
 
   # ---------------------------------------------------------------------------
+  # Keep TypeScript as the default SDK in generic documentation surfaces.
+  # ---------------------------------------------------------------------------
+  docs-language-order:
+    name: Docs language order
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Check TypeScript-first documentation
+        run: python3 scripts/check-docs-language-order.py
+
+  # ---------------------------------------------------------------------------
   # Build kernel.c on Linux for macOS libkrunfw linking
   # ---------------------------------------------------------------------------
   build-kernel:
@@ -1865,6 +1876,7 @@ jobs:
     if: always()
     needs:
       - changes
+      - docs-language-order
       - test-linux-x86_64
       - check
     runs-on: ubuntu-latest
@@ -1884,6 +1896,7 @@ jobs:
     if: always()
     needs:
       - changes
+      - docs-language-order
       - build-kernel
       - build-kernel-x86_64
       - build-agentd-aarch64

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
+    branches: [main, mintlify]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/docs/cloud/overview.mdx
+++ b/docs/cloud/overview.mdx
@@ -26,6 +26,18 @@ msb context
 Everything from the [quickstart](/getting-started/quickstart) works unchanged. With cloud selected and the API key exported, this creates a sandbox on cloud instead of your machine:
 
 <CodeGroup>
+```typescript TypeScript
+import { Sandbox } from "microsandbox";
+
+await using sb = await Sandbox.builder("hello")
+    .image("python")
+    .memory(512)
+    .create();
+
+const output = await sb.exec("python", ["-c", "print('Hello from the cloud!')"]);
+console.log(output.stdout());
+```
+
 ```rust Rust
 use microsandbox::Sandbox;
 
@@ -39,18 +51,6 @@ let output = sb.exec("python", ["-c", "print('Hello from the cloud!')"]).await?;
 println!("{}", output.stdout()?);
 
 sb.stop().await?;
-```
-
-```typescript TypeScript
-import { Sandbox } from "microsandbox";
-
-await using sb = await Sandbox.builder("hello")
-    .image("python")
-    .memory(512)
-    .create();
-
-const output = await sb.exec("python", ["-c", "print('Hello from the cloud!')"]);
-console.log(output.stdout());
 ```
 
 ```python Python

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -108,23 +108,6 @@
             "icon": "code",
             "pages": [
               {
-                "group": "Rust",
-                "icon": "rust",
-                "expanded": false,
-                "pages": [
-                  "sdk/rust/sandbox",
-                  "sdk/rust/execution",
-                  "sdk/rust/ssh",
-                  "sdk/rust/filesystem",
-                  "sdk/rust/volumes",
-                  "sdk/rust/networking",
-                  "sdk/rust/secrets",
-                  "sdk/rust/snapshots",
-                  "sdk/rust/images",
-                  "sdk/rust/agent-client"
-                ]
-              },
-              {
                 "group": "TypeScript",
                 "icon": "js",
                 "expanded": false,
@@ -139,6 +122,23 @@
                   "sdk/typescript/snapshots",
                   "sdk/typescript/images",
                   "sdk/typescript/agent-client"
+                ]
+              },
+              {
+                "group": "Rust",
+                "icon": "rust",
+                "expanded": false,
+                "pages": [
+                  "sdk/rust/sandbox",
+                  "sdk/rust/execution",
+                  "sdk/rust/ssh",
+                  "sdk/rust/filesystem",
+                  "sdk/rust/volumes",
+                  "sdk/rust/networking",
+                  "sdk/rust/secrets",
+                  "sdk/rust/snapshots",
+                  "sdk/rust/images",
+                  "sdk/rust/agent-client"
                 ]
               },
               {

--- a/docs/examples/docker/local-images.mdx
+++ b/docs/examples/docker/local-images.mdx
@@ -123,14 +123,6 @@ msb pull localhost:5050/my-image:latest --insecure
 <Step title="Use it in microsandbox">
 
 <CodeGroup>
-```rust Rust
-let sb = Sandbox::builder("worker")
-    .image("localhost:5050/my-image:latest")
-    .registry(|r| r.insecure())
-    .create()
-    .await?;
-```
-
 ```typescript TypeScript
 import { Sandbox } from "microsandbox";
 
@@ -138,6 +130,14 @@ await using sb = await Sandbox.builder("worker")
     .image("localhost:5050/my-image:latest")
     .registry((r) => r.insecure())
     .create();
+```
+
+```rust Rust
+let sb = Sandbox::builder("worker")
+    .image("localhost:5050/my-image:latest")
+    .registry(|r| r.insecure())
+    .create()
+    .await?;
 ```
 </CodeGroup>
 

--- a/docs/getting-started/introduction.mdx
+++ b/docs/getting-started/introduction.mdx
@@ -34,7 +34,7 @@ msb run debian
 - **Fast startup.** Sandboxes are lightweight enough to create from application code.
 - **Docker-like inputs.** Use familiar OCI images from Docker Hub, GHCR, ECR, GCR, or another registry.
 - **Programmable controls.** Configure resources, volumes, secrets, networking, and lifecycle from the CLI or SDK.
-- **Multi-language SDKs.** Rust, TypeScript, Python, Go, and Ruby expose the same core model.
+- **Multi-language SDKs.** TypeScript, Rust, Python, Go, and Ruby expose the same core model.
 
 ## Example use cases
 
@@ -58,6 +58,17 @@ msb run debian
 ## Minimal example
 
 <CodeGroup>
+```typescript TypeScript
+import { Sandbox } from "microsandbox";
+
+await using sb = await Sandbox.builder("hello")
+    .image("python")
+    .create();
+
+const output = await sb.exec("python", ["-c", "print('Hello from a microVM!')"]);
+console.log(output.stdout());
+```
+
 ```rust Rust
 use microsandbox::Sandbox;
 
@@ -70,17 +81,6 @@ let output = sb.exec("python", ["-c", "print('Hello from a microVM!')"]).await?;
 println!("{}", output.stdout()?);
 
 sb.stop().await?;
-```
-
-```typescript TypeScript
-import { Sandbox } from "microsandbox";
-
-await using sb = await Sandbox.builder("hello")
-    .image("python")
-    .create();
-
-const output = await sb.exec("python", ["-c", "print('Hello from a microVM!')"]);
-console.log(output.stdout());
 ```
 
 ```python Python

--- a/docs/getting-started/quickstart.mdx
+++ b/docs/getting-started/quickstart.mdx
@@ -44,12 +44,12 @@ Having trouble with a local installation? Choose your platform for setup checks 
     For application code, install the SDK for your language. For terminal workflows, use one of the CLI options above. Both run microsandbox locally by default; there is no separate server or daemon to set up. The same installation also drives [microsandbox cloud](/cloud/overview) when an API key is set.
 
     <CodeGroup>
-    ```bash Rust
-    cargo add microsandbox
-    ```
-
     ```bash TypeScript
     npm install microsandbox
+    ```
+
+    ```bash Rust
+    cargo add microsandbox
     ```
 
     ```bash Python
@@ -79,6 +79,18 @@ Having trouble with a local installation? Choose your platform for setup checks 
     Create a sandbox, execute code inside it, and get the result back.
 
     <CodeGroup>
+    ```typescript TypeScript
+    import { Sandbox } from "microsandbox";
+
+    await using sb = await Sandbox.builder("hello")
+        .image("python")
+        .memory(512)
+        .create();
+
+    const output = await sb.exec("python", ["-c", "print('Hello from a microVM!')"]);
+    console.log(output.stdout()); // Hello from a microVM!
+    ```
+
     ```rust Rust
     use microsandbox::Sandbox;
 
@@ -96,18 +108,6 @@ Having trouble with a local installation? Choose your platform for setup checks 
         sb.stop().await?;
         Ok(())
     }
-    ```
-
-    ```typescript TypeScript
-    import { Sandbox } from "microsandbox";
-
-    await using sb = await Sandbox.builder("hello")
-        .image("python")
-        .memory(512)
-        .create();
-
-    const output = await sb.exec("python", ["-c", "print('Hello from a microVM!')"]);
-    console.log(output.stdout()); // Hello from a microVM!
     ```
 
     ```python Python

--- a/docs/images/overview.mdx
+++ b/docs/images/overview.mdx
@@ -21,14 +21,6 @@ By default, microsandbox pulls an image only if it isn't already cached. You can
 | `"never"` | Use local cache only, fail if missing |
 
 <CodeGroup>
-```rust Rust
-let sb = Sandbox::builder("worker")
-    .image("python")
-    .pull_policy(PullPolicy::Always)
-    .create()
-    .await?;
-```
-
 ```typescript TypeScript
 import { Sandbox } from "microsandbox";
 
@@ -36,6 +28,14 @@ await using sb = await Sandbox.builder("worker")
     .image("python")
     .pullPolicy("always")
     .create();
+```
+
+```rust Rust
+let sb = Sandbox::builder("worker")
+    .image("python")
+    .pull_policy(PullPolicy::Always)
+    .create()
+    .await?;
 ```
 
 ```python Python
@@ -61,18 +61,6 @@ sb, err := m.CreateSandbox(ctx, "worker",
 Authenticate to private registries by passing credentials.
 
 <CodeGroup>
-```rust Rust
-let sb = Sandbox::builder("worker")
-    .image("registry.corp.io/team/app:latest")
-    .registry(|r| r.auth(RegistryAuth::Basic {
-        username: "deploy".into(),
-        password: std::env::var("REGISTRY_PASSWORD")?,
-    }))
-    .pull_policy(PullPolicy::Always)
-    .create()
-    .await?;
-```
-
 ```typescript TypeScript
 await using sb = await Sandbox.builder("worker")
     .image("registry.corp.io/team/app:latest")
@@ -83,6 +71,18 @@ await using sb = await Sandbox.builder("worker")
     }))
     .pullPolicy("always")
     .create();
+```
+
+```rust Rust
+let sb = Sandbox::builder("worker")
+    .image("registry.corp.io/team/app:latest")
+    .registry(|r| r.auth(RegistryAuth::Basic {
+        username: "deploy".into(),
+        password: std::env::var("REGISTRY_PASSWORD")?,
+    }))
+    .pull_policy(PullPolicy::Always)
+    .create()
+    .await?;
 ```
 
 ```python Python
@@ -143,7 +143,7 @@ For registries using self-signed or internal CA certificates, point `ca_certs` t
 }
 ```
 
-microsandbox adds these certificates to the default system roots, so public registries continue to work normally. The same roots can be supplied per-sandbox through the SDK instead: `ca_certs` in Rust, `caCerts` in TypeScript, `registry_ca_certs` in Python, and `WithRegistryCACerts` / `WithRegistryCACertsPath` in Go.
+microsandbox adds these certificates to the default system roots, so public registries continue to work normally. The same roots can be supplied per-sandbox through the SDK instead: `caCerts` in TypeScript, `ca_certs` in Rust, `registry_ca_certs` in Python, and `WithRegistryCACerts` / `WithRegistryCACertsPath` in Go.
 
 #### Combined configuration
 
@@ -167,19 +167,19 @@ microsandbox adds these certificates to the default system roots, so public regi
 These settings can also be set per-sandbox via the SDK, overriding global config:
 
 <CodeGroup>
+```typescript TypeScript
+await using sb = await Sandbox.builder("worker")
+    .image("localhost:5050/my-app:latest")
+    .registry((r) => r.insecure())
+    .create();
+```
+
 ```rust Rust
 let sb = Sandbox::builder("worker")
     .image("localhost:5050/my-app:latest")
     .registry(|r| r.insecure())
     .create()
     .await?;
-```
-
-```typescript TypeScript
-await using sb = await Sandbox.builder("worker")
-    .image("localhost:5050/my-app:latest")
-    .registry((r) => r.insecure())
-    .create();
 ```
 
 ```python Python
@@ -246,6 +246,24 @@ Use disk images when you need a pre-built VM template, a custom kernel configura
 When you pass a file path ending in `.qcow2`, `.raw`, or `.vmdk`, microsandbox auto-detects the format. For disk-image roots, rename ambiguous files with one of those extensions and set the filesystem type when auto-detection needs a hint.
 
 <CodeGroup>
+```typescript TypeScript
+import { Sandbox } from "microsandbox";
+
+// Auto-detect format from the file extension
+await using sb = await Sandbox.builder("custom-vm")
+    .image("./ubuntu-22.04.qcow2")
+    .cpus(2)
+    .memory(2048)
+    .create();
+
+// Explicit filesystem type via the ImageBuilder
+await using sb2 = await Sandbox.builder("custom-vm")
+    .imageWith((i) => i.disk("./alpine.raw").fstype("ext4"))
+    .cpus(1)
+    .memory(512)
+    .create();
+```
+
 ```rust Rust
 use microsandbox::size::SizeExt;
 
@@ -264,24 +282,6 @@ let sb2 = Sandbox::builder("custom-vm")
     .memory(512)
     .create()
     .await?;
-```
-
-```typescript TypeScript
-import { Sandbox } from "microsandbox";
-
-// Auto-detect format from the file extension
-await using sb = await Sandbox.builder("custom-vm")
-    .image("./ubuntu-22.04.qcow2")
-    .cpus(2)
-    .memory(2048)
-    .create();
-
-// Explicit filesystem type via the ImageBuilder
-await using sb2 = await Sandbox.builder("custom-vm")
-    .imageWith((i) => i.disk("./alpine.raw").fstype("ext4"))
-    .cpus(1)
-    .memory(512)
-    .create();
 ```
 
 ```python Python

--- a/docs/networking/dns.mdx
+++ b/docs/networking/dns.mdx
@@ -28,6 +28,18 @@ DNS rebinding protection is separate from query access. Private or reserved answ
 Denied domains receive a local `NXDOMAIN` response and are never sent to the upstream resolver. The same rules also protect connections that use TLS SNI or a recently resolved IP address.
 
 <CodeGroup>
+```typescript TypeScript
+import { Sandbox } from "microsandbox";
+
+await using sb = await Sandbox.builder("safe-agent")
+  .image("python")
+  .network({
+    denyDomains: ["malware.example.com"],
+    denyDomainSuffixes: [".tracking.com"],
+  })
+  .create();
+```
+
 ```rust Rust
 let policy = NetworkPolicy::builder()
     .default_allow()
@@ -41,18 +53,6 @@ let sb = Sandbox::builder("safe-agent")
     .network(|n| n.policy(policy))
     .create()
     .await?;
-```
-
-```typescript TypeScript
-import { Sandbox } from "microsandbox";
-
-await using sb = await Sandbox.builder("safe-agent")
-  .image("python")
-  .network({
-    denyDomains: ["malware.example.com"],
-    denyDomainSuffixes: [".tracking.com"],
-  })
-  .create();
 ```
 
 ```python Python
@@ -95,6 +95,18 @@ Nameservers can be IP addresses, hostnames, or either form with a port. Hostname
 Resolvers are tried in order. A timeout or connection failure moves to the next resolver. DNS responses such as `SERVFAIL` and `REFUSED` do not. Each unreachable resolver can delay the query by up to `query_timeout_ms`.
 
 <CodeGroup>
+```typescript TypeScript
+import { Sandbox } from "microsandbox";
+
+await using sb = await Sandbox.builder("safe-agent")
+  .image("python")
+  .network((n) => n.dns((d) =>
+    d.nameservers(["1.1.1.1", "1.0.0.1"])
+      .queryTimeoutMs(3000),
+  ))
+  .create();
+```
+
 ```rust Rust
 use microsandbox_network::dns::Nameserver;
 
@@ -109,18 +121,6 @@ let sb = Sandbox::builder("safe-agent")
     ))
     .create()
     .await?;
-```
-
-```typescript TypeScript
-import { Sandbox } from "microsandbox";
-
-await using sb = await Sandbox.builder("safe-agent")
-  .image("python")
-  .network((n) => n.dns((d) =>
-    d.nameservers(["1.1.1.1", "1.0.0.1"])
-      .queryTimeoutMs(3000),
-  ))
-  .create();
 ```
 
 ```python Python

--- a/docs/networking/host-sockets.mdx
+++ b/docs/networking/host-sockets.mdx
@@ -36,19 +36,19 @@ Datagrams are best effort and limited to 64 KiB. They require the kernel bundled
 ## SDKs
 
 <CodeGroup>
+```typescript TypeScript
+const sandbox = await Sandbox.builder("worker")
+  .image("alpine")
+  .vsock("/run/host-api.sock", 5000)
+  .create();
+```
+
 ```rust Rust
 let sandbox = Sandbox::builder("worker")
     .image("alpine")
     .vsock("/run/host-api.sock", 5000)
     .create()
     .await?;
-```
-
-```typescript TypeScript
-const sandbox = await Sandbox.builder("worker")
-  .image("alpine")
-  .vsock("/run/host-api.sock", 5000)
-  .create();
 ```
 
 ```python Python

--- a/docs/networking/overview.mdx
+++ b/docs/networking/overview.mdx
@@ -14,19 +14,19 @@ By default, sandboxes can reach the public internet but cannot reach private net
 To block network access:
 
 <CodeGroup>
+```typescript TypeScript
+await using sb = await Sandbox.builder("isolated")
+    .image("python")
+    .disableNetwork()
+    .create();
+```
+
 ```rust Rust
 let sb = Sandbox::builder("isolated")
     .image("python")
     .network(|n| n.enabled(false))
     .create()
     .await?;
-```
-
-```typescript TypeScript
-await using sb = await Sandbox.builder("isolated")
-    .image("python")
-    .disableNetwork()
-    .create();
 ```
 
 ```python Python
@@ -47,7 +47,7 @@ msb create python --name isolated --no-net
 ```
 </CodeGroup>
 
-The Rust and TypeScript examples disable the network device. Python `Network.none()`, Go `NetworkPolicy.None()`, and CLI `--no-net` retain the device but deny traffic in both directions through policy.
+The TypeScript and Rust examples disable the network device. Python `Network.none()`, Go `NetworkPolicy.None()`, and CLI `--no-net` retain the device but deny traffic in both directions through policy.
 
 ## Deployment profiles
 
@@ -56,6 +56,13 @@ The Rust and TypeScript examples disable the network device. Python `Network.non
 `single-tenant` is the default and preserves the network configuration requested by the sandbox. `multi-tenant` adds a host-runtime isolation floor: traffic must pass both the platform public-network policy and the sandbox's policy, DNS rebinding protection is forced on, custom DNS servers and interface overrides are removed, host CA import and published ports are disabled, and connection limits are capped. Sandbox policy can further restrict this floor but cannot broaden it.
 
 <CodeGroup>
+```typescript TypeScript
+await using sb = await Sandbox.builder("shared-worker")
+    .image("python")
+    .deploymentProfile("multi-tenant")
+    .create();
+```
+
 ```rust Rust
 use microsandbox::sandbox::DeploymentProfile;
 
@@ -64,13 +71,6 @@ let sb = Sandbox::builder("shared-worker")
     .deployment_profile(DeploymentProfile::MultiTenant)
     .create()
     .await?;
-```
-
-```typescript TypeScript
-await using sb = await Sandbox.builder("shared-worker")
-    .image("python")
-    .deploymentProfile("multi-tenant")
-    .create();
 ```
 
 ```python Python
@@ -102,15 +102,15 @@ An operator can set an authoritative profile with the top-level `deployment_prof
 For common access shapes, compose high-level profiles. Every non-empty profile set automatically adds narrow DNS access through the sandbox gateway.
 
 <CodeGroup>
+```typescript TypeScript
+const policy = NetworkPolicy.fromProfiles(["public", "private"]);
+```
+
 ```rust Rust
 let policy = NetworkPolicy::from_profiles([
     NetworkProfile::Public,
     NetworkProfile::Private,
 ]);
-```
-
-```typescript TypeScript
-const policy = NetworkPolicy.fromProfiles(["public", "private"]);
 ```
 
 ```python Python
@@ -144,20 +144,6 @@ rules           : first match wins
 For example, this creates a deny-by-default sandbox that can make HTTPS requests to the public internet and DNS requests through the host gateway:
 
 <CodeGroup>
-```rust Rust
-let policy = NetworkPolicy::builder()
-    .default_deny()
-    .egress(|e| e.tcp().port(443).allow_public())
-    .egress(|e| e.udp().tcp().port(53).allow_host())
-    .build()?;
-
-let sb = Sandbox::builder("restricted-worker")
-    .image("alpine")
-    .network(|n| n.policy(policy))
-    .create()
-    .await?;
-```
-
 ```typescript TypeScript
 import { NetworkPolicy, Sandbox } from "microsandbox";
 
@@ -171,6 +157,20 @@ await using sb = await Sandbox.builder("restricted-worker")
             .build(),
     ))
     .create();
+```
+
+```rust Rust
+let policy = NetworkPolicy::builder()
+    .default_deny()
+    .egress(|e| e.tcp().port(443).allow_public())
+    .egress(|e| e.udp().tcp().port(53).allow_host())
+    .build()?;
+
+let sb = Sandbox::builder("restricted-worker")
+    .image("alpine")
+    .network(|n| n.policy(policy))
+    .create()
+    .await?;
 ```
 
 ```python Python
@@ -218,19 +218,19 @@ Rules can target groups like `public`, `private`, and `host`, or specific IPs, C
 Publish a guest port when a service inside the sandbox should be reachable from the host. Published ports bind to `127.0.0.1` by default.
 
 <CodeGroup>
+```typescript TypeScript
+await using sb = await Sandbox.builder("api")
+    .image("python")
+    .port(8080, 80)
+    .create();
+```
+
 ```rust Rust
 let sb = Sandbox::builder("api")
     .image("python")
     .port(8080, 80)
     .create()
     .await?;
-```
-
-```typescript TypeScript
-await using sb = await Sandbox.builder("api")
-    .image("python")
-    .port(8080, 80)
-    .create();
 ```
 
 ```python Python
@@ -264,6 +264,16 @@ Network rate limits apply only to traffic crossing a sandbox's virtual network d
 For each direction, you can configure a bandwidth bucket measured in bytes per refill interval, a packet-rate bucket measured in packets per interval, or both. An omitted direction or bucket remains unthrottled. Buckets start full, refill continuously, and can include a one-time startup burst that does not refill. Limits are set at creation and take effect on the next sandbox start.
 
 <CodeGroup>
+```typescript TypeScript
+await using sb = await Sandbox.builder("throttled")
+    .image("python")
+    .network((n) => n.rateLimiter((r) => r.egress((r) => r
+        .bandwidth(1_048_576, 1_000)
+        .bandwidthBurst(524_288)
+        .ops(1_000, 1_000))))
+    .create();
+```
+
 ```rust Rust
 use std::time::Duration;
 use microsandbox::size::SizeExt;
@@ -276,16 +286,6 @@ let sb = Sandbox::builder("throttled")
         .ops(1_000, Duration::from_secs(1)))))
     .create()
     .await?;
-```
-
-```typescript TypeScript
-await using sb = await Sandbox.builder("throttled")
-    .image("python")
-    .network((n) => n.rateLimiter((r) => r.egress((r) => r
-        .bandwidth(1_048_576, 1_000)
-        .bandwidthBurst(524_288)
-        .ops(1_000, 1_000))))
-    .create();
 ```
 
 ```python Python

--- a/docs/networking/tls.mdx
+++ b/docs/networking/tls.mdx
@@ -22,6 +22,17 @@ The default CA is stored at `~/.microsandbox/tls/ca.{crt,key}` and reused by loc
 ## Enabling interception
 
 <CodeGroup>
+```typescript TypeScript
+import { Sandbox } from "microsandbox";
+
+await using sb = await Sandbox.builder("worker")
+  .image("python")
+  .network((n) => n.tls((t) =>
+    t.bypass("pinned-api.example.com").bypass("*.gov"),
+  ))
+  .create();
+```
+
 ```rust Rust
 use microsandbox::Sandbox;
 
@@ -33,17 +44,6 @@ let sb = Sandbox::builder("worker")
     ))
     .create()
     .await?;
-```
-
-```typescript TypeScript
-import { Sandbox } from "microsandbox";
-
-await using sb = await Sandbox.builder("worker")
-  .image("python")
-  .network((n) => n.tls((t) =>
-    t.bypass("pinned-api.example.com").bypass("*.gov"),
-  ))
-  .create();
 ```
 
 ```python Python
@@ -92,6 +92,19 @@ The proxy verifies upstream certificates with the host's root store by default. 
 - a host pattern that skips upstream verification
 
 <CodeGroup>
+```typescript TypeScript
+import { Sandbox } from "microsandbox";
+
+await using sb = await Sandbox.builder("agent")
+  .image("python")
+  .network((n) => n.tls((t) =>
+    t.upstreamCaCert("/etc/ssl/corp-root.pem")
+      .upstreamCaCertFor("api.internal.example.com", "./certs/api-ca.pem")
+      .verifyUpstreamFor("*.preview.internal", false),
+  ))
+  .create();
+```
+
 ```rust Rust
 let sb = Sandbox::builder("agent")
     .image("python")
@@ -129,19 +142,19 @@ Corporate proxies often replace server certificates with certificates signed by 
 Enable host CA trust to copy trusted host roots into the guest when it starts:
 
 <CodeGroup>
+```typescript TypeScript
+await using sb = await Sandbox.builder("devbox")
+  .image("alpine")
+  .network((n) => n.trustHostCAs(true))
+  .create();
+```
+
 ```rust Rust
 let sb = Sandbox::builder("devbox")
     .image("alpine")
     .network(|n| n.trust_host_cas(true))
     .create()
     .await?;
-```
-
-```typescript TypeScript
-await using sb = await Sandbox.builder("devbox")
-  .image("alpine")
-  .network((n) => n.trustHostCAs(true))
-  .create();
 ```
 
 ```python Python

--- a/docs/operations/backends.mdx
+++ b/docs/operations/backends.mdx
@@ -30,6 +30,15 @@ Cloud selection and credentials are separate. `MSB_API_KEY` does not select clou
 Programmatic selection wins over environment and profile resolution. Use it when the application should decide regardless of where it is launched:
 
 <CodeGroup>
+```typescript TypeScript
+import { setDefaultBackend } from "microsandbox";
+
+setDefaultBackend({ kind: "cloud", apiKey: process.env.MSB_API_KEY! });
+
+// Or force the local runtime.
+setDefaultBackend("local");
+```
+
 ```rust Rust
 use microsandbox::{set_default_backend, CloudBackend, LocalBackend};
 
@@ -41,15 +50,6 @@ set_default_backend(CloudBackend::with_api_key(api_key)?);
 
 // Or force the local runtime.
 set_default_backend(LocalBackend::lazy());
-```
-
-```typescript TypeScript
-import { setDefaultBackend } from "microsandbox";
-
-setDefaultBackend({ kind: "cloud", apiKey: process.env.MSB_API_KEY! });
-
-// Or force the local runtime.
-setDefaultBackend("local");
 ```
 
 ```python Python
@@ -123,17 +123,17 @@ msb context --format json
 Use the SDK accessors to inspect the active backend without exposing its API key. Detailed backend info includes the kind, cloud API URL, selection source, and profile when applicable:
 
 <CodeGroup>
-```rust Rust
-let info = microsandbox::default_backend_info();
-println!("{}", info.kind.as_str());
-println!("{}", sandbox.backend_kind().as_str());
-```
-
 ```typescript TypeScript
 import { defaultBackendInfo } from "microsandbox";
 
 console.log(defaultBackendInfo());
 console.log(sandbox.backendKind);
+```
+
+```rust Rust
+let info = microsandbox::default_backend_info();
+println!("{}", info.kind.as_str());
+println!("{}", sandbox.backend_kind().as_str());
 ```
 
 ```python Python

--- a/docs/sandboxes/bootstrap.mdx
+++ b/docs/sandboxes/bootstrap.mdx
@@ -13,6 +13,15 @@ Before a sandbox starts doing real work, you can choose its root storage and pre
 OCI sandboxes use stitched EROFS lower layers with a writable ext4 upper and guest OverlayFS by default. A flat root disk is an explicit alternative: microsandbox merges the OCI layers into one deterministic ext4 base, caches it by content, creates a private clone for each sandbox, grows that clone to the requested capacity, and mounts it directly as the guest root. The immutable cached base is never attached writable.
 
 <CodeGroup>
+```typescript TypeScript
+import { Sandbox } from "microsandbox";
+
+await using sb = await Sandbox.builder("worker")
+    .image("python:3.12")
+    .rootDisk((disk) => disk.flat().size(8192).cloneStrategy("auto"))
+    .create();
+```
+
 ```rust Rust
 use microsandbox::sandbox::FlatClone;
 use microsandbox::Sandbox;
@@ -22,15 +31,6 @@ let sb = Sandbox::builder("worker")
     .root_disk_with(|disk| disk.flat().size(8192).clone_strategy(FlatClone::Auto))
     .create()
     .await?;
-```
-
-```typescript TypeScript
-import { Sandbox } from "microsandbox";
-
-await using sb = await Sandbox.builder("worker")
-    .image("python:3.12")
-    .rootDisk((disk) => disk.flat().size(8192).cloneStrategy("auto"))
-    .create();
 ```
 
 ```python Python
@@ -69,6 +69,19 @@ Scripts are files mounted at `/.msb/scripts/` inside the sandbox. The directory 
 It provides a clean way to bundle setup procedures or entry points with a sandbox without baking them into the image.
 
 <CodeGroup>
+```typescript TypeScript
+import { Sandbox } from "microsandbox";
+
+await using sb = await Sandbox.builder("worker")
+    .image("ubuntu")
+    .script("setup", "#!/bin/bash\napt-get update && apt-get install -y python3 curl")
+    .script("run",   "#!/bin/bash\nexec python3 /app/main.py")
+    .create();
+
+await sb.shell("setup");
+const output = await sb.shell("run");
+```
+
 ```rust Rust
 use indoc::indoc;
 use microsandbox::Sandbox;
@@ -88,19 +101,6 @@ let sb = Sandbox::builder("worker")
 
 sb.shell("setup").await?;
 let output = sb.shell("start").await?;
-```
-
-```typescript TypeScript
-import { Sandbox } from "microsandbox";
-
-await using sb = await Sandbox.builder("worker")
-    .image("ubuntu")
-    .script("setup", "#!/bin/bash\napt-get update && apt-get install -y python3 curl")
-    .script("run",   "#!/bin/bash\nexec python3 /app/main.py")
-    .create();
-
-await sb.shell("setup");
-const output = await sb.shell("run");
 ```
 
 ```python Python
@@ -145,6 +145,22 @@ Patches are applied in order and work with OCI images and bind-mounted rootfs. T
 </Tip>
 
 <CodeGroup>
+```typescript TypeScript
+import { Sandbox } from "microsandbox";
+
+await using sb = await Sandbox.builder("worker")
+    .image("alpine")
+    .patch((p) => p
+        .text("/etc/greeting.txt", "Hello from a patched rootfs!\n")
+        .text("/etc/motd", "Custom message of the day.\n", { replace: true })
+        .mkdir("/app", { mode: 0o755 })
+        .text("/app/config.json", '{"debug": true}', { mode: 0o644 })
+        .copyFile("./cert.pem", "/etc/ssl/cert.pem")
+        .append("/etc/hosts", "127.0.0.1 myapp.local\n"),
+    )
+    .create();
+```
+
 ```rust Rust
 use microsandbox::Sandbox;
 
@@ -160,22 +176,6 @@ let sb = Sandbox::builder("worker")
     )
     .create()
     .await?;
-```
-
-```typescript TypeScript
-import { Sandbox } from "microsandbox";
-
-await using sb = await Sandbox.builder("worker")
-    .image("alpine")
-    .patch((p) => p
-        .text("/etc/greeting.txt", "Hello from a patched rootfs!\n")
-        .text("/etc/motd", "Custom message of the day.\n", { replace: true })
-        .mkdir("/app", { mode: 0o755 })
-        .text("/app/config.json", '{"debug": true}', { mode: 0o644 })
-        .copyFile("./cert.pem", "/etc/ssl/cert.pem")
-        .append("/etc/hosts", "127.0.0.1 myapp.local\n"),
-    )
-    .create();
 ```
 
 ```python Python
@@ -231,6 +231,13 @@ Transparent huge pages (THP) let the guest kernel back eligible anonymous memory
 The selected value is applied as the Linux `transparent_hugepage=` kernel boot parameter before agentd or the user workload starts. It is persisted with the sandbox and takes effect again on every start. It cannot be changed with `msb modify`; create or replace the sandbox to select another policy.
 
 <CodeGroup>
+```typescript TypeScript
+const sb = await Sandbox.builder("memory-worker")
+  .image("python:3.12")
+  .thp("always")
+  .create();
+```
+
 ```rust Rust
 use microsandbox::{Sandbox, sandbox::TransparentHugePagePolicy};
 
@@ -239,13 +246,6 @@ let sb = Sandbox::builder("memory-worker")
     .thp(TransparentHugePagePolicy::Always)
     .create()
     .await?;
-```
-
-```typescript TypeScript
-const sb = await Sandbox.builder("memory-worker")
-  .image("python:3.12")
-  .thp("always")
-  .create();
 ```
 
 ```python Python
@@ -279,6 +279,17 @@ Common reasons to opt in: long-lived daemons, system service tests, anything tha
 Use `auto` to pick a known init binary from the image, or pass an absolute path when you need to pin the entry point for reproducible CI. When an OCI image declares a known init path as the first ENTRYPOINT token, such as `/init` in s6-overlay images, `auto` hands PID 1 to that path. For attached `msb run`, microsandbox preserves the OCI launch contract by passing the remaining ENTRYPOINT plus CMD or trailing command to that init instead of direct-executing the wrapper through agentd. Otherwise, `auto` falls back to probing common distro paths: `/sbin/init`, `/lib/systemd/systemd`, and `/usr/lib/systemd/systemd`.
 
 <CodeGroup>
+```typescript TypeScript
+import { MiB, Sandbox } from "microsandbox";
+
+await using sb = await Sandbox.builder("worker")
+    .image("ghcr.io/superradcompany/debian-systemd:12")
+    .memory(MiB(1024))
+    .cpus(2)
+    .init("auto")
+    .create();
+```
+
 ```rust Rust
 use microsandbox::Sandbox;
 
@@ -289,17 +300,6 @@ let sb = Sandbox::builder("worker")
     .init("auto")
     .create()
     .await?;
-```
-
-```typescript TypeScript
-import { MiB, Sandbox } from "microsandbox";
-
-await using sb = await Sandbox.builder("worker")
-    .image("ghcr.io/superradcompany/debian-systemd:12")
-    .memory(MiB(1024))
-    .cpus(2)
-    .init("auto")
-    .create();
 ```
 
 ```python Python
@@ -344,13 +344,22 @@ If `--init=auto` cannot find an init binary from the image ENTRYPOINT or the gue
 
 Pass extra argv and env to the init:
 
-- **Rust / TypeScript**: `init_with(...)` / `initWith(...)`.
+- **TypeScript / Rust**: `initWith(...)` / `init_with(...)`.
 - **Python**: pass an `InitConfig` to `init=`.
 - **CLI**: repeat `--init-arg` once per entry, and `--init-env KEY=VAL` once per env var.
 
 `argv[0]` is the init command; extra argv entries are appended after it. Env is merged on top of the inherited environment.
 
 <CodeGroup>
+```typescript TypeScript
+await using sb = await Sandbox.builder("worker")
+    .image("ghcr.io/superradcompany/debian-systemd:12")
+    .initWith("/lib/systemd/systemd", (i) => i
+        .args(["--unit=multi-user.target"])
+        .env("container", "microsandbox"))
+    .create();
+```
+
 ```rust Rust
 let sb = Sandbox::builder("worker")
     .image("ghcr.io/superradcompany/debian-systemd:12")
@@ -359,15 +368,6 @@ let sb = Sandbox::builder("worker")
         .env("container", "microsandbox"))
     .create()
     .await?;
-```
-
-```typescript TypeScript
-await using sb = await Sandbox.builder("worker")
-    .image("ghcr.io/superradcompany/debian-systemd:12")
-    .initWith("/lib/systemd/systemd", (i) => i
-        .args(["--unit=multi-user.target"])
-        .env("container", "microsandbox"))
-    .create();
 ```
 
 ```python Python

--- a/docs/sandboxes/commands.mdx
+++ b/docs/sandboxes/commands.mdx
@@ -13,6 +13,14 @@ One nice consequence: `exec` works even when a sandbox has networking fully disa
 Sandbox creation is boot-only: configuring an image, ENTRYPOINT, or CMD does not execute that workload. Use the default-workload methods when you want the SDK to resolve the effective OCI `ENTRYPOINT + CMD` and run it. A configured CMD override replaces the image CMD, while the effective entrypoint is preserved. If neither field supplies an executable, these methods return the typed `NoDefaultCommand` error instead of falling back to a shell.
 
 <CodeGroup>
+```typescript TypeScript
+const sb = await Sandbox.builder("worker")
+  .image("example/worker:latest")
+  .cmd(["worker.py", "--once"])
+  .create();
+const output = await sb.execDefault();
+```
+
 ```rust Rust
 let sb = Sandbox::builder("worker")
     .image("example/worker:latest")
@@ -20,14 +28,6 @@ let sb = Sandbox::builder("worker")
     .create()
     .await?;
 let output = sb.exec_default().await?;
-```
-
-```typescript TypeScript
-const sb = await Sandbox.builder("worker")
-  .image("example/worker:latest")
-  .cmd(["worker.py", "--once"])
-  .create();
-const output = await sb.execDefault();
 ```
 
 ```python Python
@@ -55,17 +55,17 @@ Streaming variants are `exec_default_stream`, `execDefaultStream`, and `ExecDefa
 Run a command and wait for it to complete. You get back the exit code, stdout, and stderr.
 
 <CodeGroup>
-```rust Rust
-let output = sb.exec("python", ["-c", "print('hello')"]).await?;
-println!("{}", output.stdout()?);     // "hello\n"
-println!("{}", output.status().code); // 0
-```
-
 ```typescript TypeScript
 const output = await sb.exec("python", ["-c", "print('hello')"]);
 console.log(output.stdout()); // "hello\n"
 console.log(output.success);  // true
 console.log(output.code);     // 0
+```
+
+```rust Rust
+let output = sb.exec("python", ["-c", "print('hello')"]).await?;
+println!("{}", output.stdout()?);     // "hello\n"
+println!("{}", output.status().code); // 0
 ```
 
 ```python Python
@@ -93,16 +93,6 @@ msb exec worker -- python -c "print('hello')"
 These options apply to a single execution and don't change the sandbox's defaults.
 
 <CodeGroup>
-```rust Rust
-let output = sb.exec_with("python", |e| e
-    .args(["compute.py"])
-    .cwd("/app")
-    .env("PYTHONPATH", "/app/lib")
-    .timeout(Duration::from_secs(30))
-    .rlimit(RlimitResource::Nofile, 1024)
-).await?;
-```
-
 ```typescript TypeScript
 const output = await sb.execWith("python", (e) =>
     e.args(["compute.py"])
@@ -111,6 +101,16 @@ const output = await sb.execWith("python", (e) =>
         .timeout(30_000)
         .rlimit("nofile", 1024),
 );
+```
+
+```rust Rust
+let output = sb.exec_with("python", |e| e
+    .args(["compute.py"])
+    .cwd("/app")
+    .env("PYTHONPATH", "/app/lib")
+    .timeout(Duration::from_secs(30))
+    .rlimit(RlimitResource::Nofile, 1024)
+).await?;
 ```
 
 ```python Python
@@ -150,12 +150,12 @@ msb exec worker \
 Run a command through the sandbox's configured shell (defaults to `/bin/sh`). Useful for pipelines, redirects, and other shell syntax that `exec` doesn't interpret.
 
 <CodeGroup>
-```rust Rust
-let output = sb.shell("ls -la /app && echo done").await?;
-```
-
 ```typescript TypeScript
 const output = await sb.shell("ls -la /app && echo done")
+```
+
+```rust Rust
+let output = sb.shell("ls -la /app && echo done").await?;
 ```
 
 ```python Python
@@ -177,6 +177,18 @@ msb exec worker -- sh -c "ls -la /app && echo done"
 For long-running processes or large output, streaming gives you stdout, stderr, and exit events as they happen instead of buffering everything until the command finishes.
 
 <CodeGroup>
+```typescript TypeScript
+const handle = await sb.execStream("tail", ["-f", "/var/log/app.log"]);
+
+for await (const event of handle) {
+    switch (event.kind) {
+        case "stdout": process.stdout.write(event.data); break;
+        case "stderr": process.stderr.write(event.data); break;
+        case "exited": console.log(`Exited: ${event.code}`); break;
+    }
+}
+```
+
 ```rust Rust
 let mut handle = sb.exec_stream("tail", ["-f", "/var/log/app.log"]).await?;
 
@@ -186,18 +198,6 @@ while let Some(event) = handle.recv().await {
         ExecEvent::Stderr(data) => eprint!("{}", String::from_utf8_lossy(&data)),
         ExecEvent::Exited { code } => break,
         _ => {}
-    }
-}
-```
-
-```typescript TypeScript
-const handle = await sb.execStream("tail", ["-f", "/var/log/app.log"]);
-
-for await (const event of handle) {
-    switch (event.kind) {
-        case "stdout": process.stdout.write(event.data); break;
-        case "stderr": process.stderr.write(event.data); break;
-        case "exited": console.log(`Exited: ${event.code}`); break;
     }
 }
 ```
@@ -241,16 +241,6 @@ for {
 Bridges your terminal directly to a process inside the sandbox for a fully interactive PTY session. Useful for debugging, running REPLs, or anything that expects a real terminal.
 
 <CodeGroup>
-```rust Rust
-let exit_code = sb.attach_shell().await?;
-
-let exit_code = sb.attach_with("python", |a| a
-    .env("DEBUG", "1")
-    .cwd("/app")
-    .detach_keys("ctrl-q")
-).await?;
-```
-
 ```typescript TypeScript
 // Attach to the default shell
 const exitCode = await sb.attachShell();
@@ -259,6 +249,16 @@ const exitCode = await sb.attachShell();
 await sb.attachWith("bash", (a) =>
     a.env("DEBUG", "1").cwd("/app").detachKeys("ctrl-q"),
 );
+```
+
+```rust Rust
+let exit_code = sb.attach_shell().await?;
+
+let exit_code = sb.attach_with("python", |a| a
+    .env("DEBUG", "1")
+    .cwd("/app")
+    .detach_keys("ctrl-q")
+).await?;
 ```
 
 ```python Python
@@ -314,14 +314,6 @@ msb exec -t worker -e DEBUG=1 -w /app -- python
 Streaming handles can also accept stdin. Enable `stdin_pipe` and write bytes to it. Combined with `tty: true`, this lets you drive interactive processes programmatically.
 
 <CodeGroup>
-```rust Rust
-let mut handle = sb.exec_stream_with("python", |e| e.stdin_pipe().tty(true)).await?;
-let stdin = handle.take_stdin().unwrap();
-stdin.write(b"print('hello')\n").await?;
-stdin.write(b"exit()\n").await?;
-handle.wait().await?;
-```
-
 ```typescript TypeScript
 const handle = await sb.execStreamWith("python", (e) => e.stdinPipe().tty(true));
 const stdin = await handle.takeStdin();
@@ -329,6 +321,14 @@ await stdin!.write("print('hello')\n");
 await stdin!.write("exit()\n");
 await stdin!.close();
 await handle.wait();
+```
+
+```rust Rust
+let mut handle = sb.exec_stream_with("python", |e| e.stdin_pipe().tty(true)).await?;
+let stdin = handle.take_stdin().unwrap();
+stdin.write(b"print('hello')\n").await?;
+stdin.write(b"exit()\n").await?;
+handle.wait().await?;
 ```
 
 ```python Python
@@ -358,14 +358,14 @@ _, err = handle.Wait(ctx)
 Each streaming exec creates a session ID that you can use to correlate stream events and persisted log entries.
 
 <CodeGroup>
-```rust Rust
-let handle = sb.exec_stream("python", ["server.py"]).await?;
-let session_id = handle.id().to_string();
-```
-
 ```typescript TypeScript
 const handle = await sb.execStream("python", ["server.py"])
 const sessionId = handle.id
+```
+
+```rust Rust
+let handle = sb.exec_stream("python", ["server.py"]).await?;
+let session_id = handle.id().to_string();
 ```
 
 ```python Python

--- a/docs/sandboxes/filesystem.mdx
+++ b/docs/sandboxes/filesystem.mdx
@@ -12,12 +12,12 @@ Handy for pushing generated code into a sandbox, pulling back results, or inspec
 ## Write a file
 
 <CodeGroup>
-```rust Rust
-sb.fs().write("/app/config.json", r#"{"debug": true}"#).await?;
-```
-
 ```typescript TypeScript
 await sb.fs().write("/app/config.json", '{"debug": true}');
+```
+
+```rust Rust
+sb.fs().write("/app/config.json", r#"{"debug": true}"#).await?;
 ```
 
 ```python Python
@@ -33,12 +33,12 @@ err := sb.FS().WriteString(ctx, "/app/config.json", `{"debug": true}`)
 ## Read a file
 
 <CodeGroup>
-```rust Rust
-let content = sb.fs().read_to_string("/app/config.json").await?;
-```
-
 ```typescript TypeScript
 const content = await sb.fs().readToString("/app/config.json");
+```
+
+```rust Rust
+let content = sb.fs().read_to_string("/app/config.json").await?;
 ```
 
 ```python Python
@@ -54,17 +54,17 @@ content, err := sb.FS().ReadString(ctx, "/app/config.json")
 ## List a directory
 
 <CodeGroup>
-```rust Rust
-let entries = sb.fs().list("/app").await?;
-for entry in entries {
-    println!("{}: {:?}", entry.path, entry.kind);
-}
-```
-
 ```typescript TypeScript
 const entries = await sb.fs().list("/app");
 for (const entry of entries) {
     console.log(`${entry.path}: ${entry.kind}`);
+}
+```
+
+```rust Rust
+let entries = sb.fs().list("/app").await?;
+for entry in entries {
+    println!("{}: {:?}", entry.path, entry.kind);
 }
 ```
 
@@ -88,17 +88,17 @@ for _, entry := range entries {
 For files too large to fit in memory, use streaming. Data is transferred in chunks of approximately 3 MiB each.
 
 <CodeGroup>
-```rust Rust
-let mut stream = sb.fs().read_stream("/app/data.bin").await?;
-while let Some(chunk) = stream.recv().await? {
-    process(&chunk);
-}
-```
-
 ```typescript TypeScript
 const stream = await sb.fs().readStream("/app/data.bin");
 for await (const chunk of stream) {
     processChunk(chunk); // chunk is a Uint8Array
+}
+```
+
+```rust Rust
+let mut stream = sb.fs().read_stream("/app/data.bin").await?;
+while let Some(chunk) = stream.recv().await? {
+    process(&chunk);
 }
 ```
 
@@ -129,12 +129,12 @@ for {
 Copy a file from the host machine into the sandbox in a single call.
 
 <CodeGroup>
-```rust Rust
-sb.fs().copy_from_host("./local-file.txt", "/app/remote-file.txt").await?;
-```
-
 ```typescript TypeScript
 await sb.fs().copyFromHost("./local-file.txt", "/app/remote-file.txt");
+```
+
+```rust Rust
+sb.fs().copy_from_host("./local-file.txt", "/app/remote-file.txt").await?;
 ```
 
 ```python Python

--- a/docs/sandboxes/labels.mdx
+++ b/docs/sandboxes/labels.mdx
@@ -17,6 +17,14 @@ Values may be empty. A valueless label such as `--label gpu` is stored as `gpu="
 Attach labels when you create a sandbox. Labels are repeatable, and a bare key with no value is allowed:
 
 <CodeGroup>
+```typescript TypeScript
+const sb = await Sandbox.builder("worker")
+    .image("python")
+    .label("app", "engine")
+    .label("user.id", "alice")
+    .create();
+```
+
 ```rust Rust
 let sb = Sandbox::builder("worker")
     .image("python")
@@ -24,14 +32,6 @@ let sb = Sandbox::builder("worker")
     .label("user.id", "alice")
     .create()
     .await?;
-```
-
-```typescript TypeScript
-const sb = await Sandbox.builder("worker")
-    .image("python")
-    .label("app", "engine")
-    .label("user.id", "alice")
-    .create();
 ```
 
 ```python Python
@@ -66,12 +66,12 @@ The OCI image's own labels (`LABEL` instructions, `org.opencontainers.image.*`, 
 Add, change, or remove labels without recreating the sandbox:
 
 <CodeGroup>
-```rust Rust
-sb.modify().label("tier", "web").remove_label("stale").apply().await?;
-```
-
 ```typescript TypeScript
 await sandbox.modify({ labels: { tier: "web" }, labelsRemove: ["stale"] });
+```
+
+```rust Rust
+sb.modify().label("tier", "web").remove_label("stale").apply().await?;
 ```
 
 ```python Python
@@ -100,12 +100,12 @@ msb ps --label app=engine                    # matching sandboxes
 msb ps --label app=engine --label tier=web   # only those with both
 ```
 
-```rust Rust
-let page = Sandbox::list_with(|list| list.label("app", "engine")).await?;
-```
-
 ```typescript TypeScript
 const page = await Sandbox.listWith((list) => list.label("app", "engine"));
+```
+
+```rust Rust
+let page = Sandbox::list_with(|list| list.label("app", "engine")).await?;
 ```
 
 ```python Python

--- a/docs/sandboxes/lifecycle.mdx
+++ b/docs/sandboxes/lifecycle.mdx
@@ -38,6 +38,17 @@ stateDiagram-v2
 Creating a sandbox boots the microVM, mounts the filesystem, initializes the guest agent, and waits until it's ready to accept commands. Names must be non-empty and no longer than 128 UTF-8 bytes.
 
 <CodeGroup>
+```typescript TypeScript
+// Local attached handle: sandbox stops when your process exits
+await using sb = await Sandbox.builder("worker").image("python").create();
+
+// Detached: sandbox survives after your process exits
+const detached = await Sandbox.builder("worker")
+  .image("python")
+  .detached(true)
+  .create();
+```
+
 ```rust Rust
 // Local attached handle: sandbox stops when your process exits
 let sb = Sandbox::builder("worker").image("python").create().await?;
@@ -48,17 +59,6 @@ let sb = Sandbox::builder("worker")
     .detached(true)
     .create()
     .await?;
-```
-
-```typescript TypeScript
-// Local attached handle: sandbox stops when your process exits
-await using sb = await Sandbox.builder("worker").image("python").create();
-
-// Detached: sandbox survives after your process exits
-const detached = await Sandbox.builder("worker")
-  .image("python")
-  .detached(true)
-  .create();
 ```
 
 ```python Python
@@ -96,17 +96,17 @@ msb run -d python --name worker
 Stopping gracefully terminates guest processes and shuts down the VM. The sandbox moves to `Stopped` and can be restarted later with all its configuration preserved.
 
 <CodeGroup>
-```rust Rust
-sb.stop().await?;
-
-let sb = Sandbox::start("worker").await?;
-```
-
 ```typescript TypeScript
 await sb.stop()
 
 // Later, resume where you left off
 const sb = await Sandbox.start("worker")
+```
+
+```rust Rust
+sb.stop().await?;
+
+let sb = Sandbox::start("worker").await?;
 ```
 
 ```python Python
@@ -142,16 +142,16 @@ msb restart worker
 Use `msb modify`, or the SDK `modify()` methods, to change an existing sandbox without recreating it. Some changes apply live, some affect future execs only, and some need a restart or the next start.
 
 <CodeGroup>
+```typescript TypeScript
+const plan = await sandbox.modify({ cpus: 4, memory: 4096 });
+```
+
 ```rust Rust
 let plan = sb.modify()
     .cpus(4)
     .memory(4096)
     .apply()
     .await?;
-```
-
-```typescript TypeScript
-const plan = await sandbox.modify({ cpus: 4, memory: 4096 });
 ```
 
 ```python Python
@@ -176,6 +176,13 @@ See [Live Modify](/sandboxes/tuning) for the change model, CPU and memory resize
 Use `ping` to check that a running sandbox's guest agent is reachable, and `touch` to intentionally refresh its idle timer. Ping is a health check only: it does not count as sandbox activity and will not keep an idle sandbox alive by itself. Touch is the explicit keepalive.
 
 <CodeGroup>
+```typescript TypeScript
+const ping = await sb.ping();
+console.log(`agent reachable in ${ping.latencyMs.toFixed(1)} ms`);
+
+await sb.touch();
+```
+
 ```rust Rust
 let ping = sb.ping().await?;
 println!("agent reachable in {:?}", ping.latency);
@@ -200,12 +207,12 @@ msb ping worker --touch
 If a sandbox is unresponsive (e.g., stuck in a tight loop or a panic), force-kill it. The sandbox is terminated immediately with no graceful shutdown.
 
 <CodeGroup>
-```rust Rust
-sb.kill().await?;
-```
-
 ```typescript TypeScript
 await sb.kill()
+```
+
+```rust Rust
+sb.kill().await?;
 ```
 
 ```python Python
@@ -227,12 +234,12 @@ msb stop --force worker
 Keeps a sandbox running after the parent process exits. It becomes a background process that you can reconnect to later with `Sandbox::get("worker")`.
 
 <CodeGroup>
-```rust Rust
-sb.detach().await;
-```
-
 ```typescript TypeScript
 await sb.detach()
+```
+
+```rust Rust
+sb.detach().await;
 ```
 
 ```python Python
@@ -252,12 +259,12 @@ err := sb.Detach(ctx)
 Trigger a graceful shutdown that lets existing commands finish but rejects new ones. The sandbox moves to `Draining` and transitions to `Stopped` when all in-flight commands complete. This is useful for zero-downtime rotation of worker sandboxes.
 
 <CodeGroup>
-```rust Rust
-sb.request_drain().await?;
-```
-
 ```typescript TypeScript
 await sb.requestDrain()
+```
+
+```rust Rust
+sb.request_drain().await?;
 ```
 
 ```python Python
@@ -275,12 +282,12 @@ err := sb.RequestDrain(ctx)
 Block until the sandbox is observed in a terminal non-running state, without triggering a stop or kill request.
 
 <CodeGroup>
-```rust Rust
-let result = sb.wait_until_stopped().await?;
-```
-
 ```typescript TypeScript
 const result = await sb.waitUntilStopped()
+```
+
+```rust Rust
+let result = sb.wait_until_stopped().await?;
 ```
 
 ```python Python
@@ -298,12 +305,12 @@ result, err := sb.WaitUntilStopped(ctx)
 Delete a stopped sandbox. Every local SDK entry point and `msb rm` uses the same deletion scope.
 
 <CodeGroup>
-```rust Rust
-Sandbox::remove("worker").await?;
-```
-
 ```typescript TypeScript
 await Sandbox.remove("worker")
+```
+
+```rust Rust
+Sandbox::remove("worker").await?;
 ```
 
 ```python Python
@@ -335,12 +342,6 @@ Removing a sandbox does not undo writes made to a named volume, bind mount, or u
 ## List and inspect
 
 <CodeGroup>
-```rust Rust
-for handle in Sandbox::list().await?.sandboxes {
-    println!("{}: {:?}", handle.name(), handle.status_snapshot());
-}
-```
-
 ```typescript TypeScript
 const page = await Sandbox.list();
 for (const handle of page.sandboxes) {
@@ -349,6 +350,12 @@ for (const handle of page.sandboxes) {
 
 const handle = await Sandbox.get("worker");
 console.log(handle.status); // "running" | "stopped" | ...
+```
+
+```rust Rust
+for handle in Sandbox::list().await?.sandboxes {
+    println!("{}: {:?}", handle.name(), handle.status_snapshot());
+}
 ```
 
 ```python Python
@@ -417,6 +424,14 @@ Use [`msb logs`](/cli/sandbox-commands#msb-logs) or the SDK `logs()` method to r
 For production workloads, configure how the sandbox process handles shutdown, idle detection, and maximum lifetime.
 
 <CodeGroup>
+```typescript TypeScript
+await using sb = await Sandbox.builder("worker")
+    .image("python")
+    .maxDuration(3600)   // maximum sandbox lifetime in seconds
+    .idleTimeout(300)    // auto-drain after 5 minutes of inactivity
+    .create();
+```
+
 ```rust Rust
 let sb = Sandbox::builder("worker")
     .image("python")
@@ -424,14 +439,6 @@ let sb = Sandbox::builder("worker")
     .idle_timeout(300)
     .create()
     .await?;
-```
-
-```typescript TypeScript
-await using sb = await Sandbox.builder("worker")
-    .image("python")
-    .maxDuration(3600)   // maximum sandbox lifetime in seconds
-    .idleTimeout(300)    // auto-drain after 5 minutes of inactivity
-    .create();
 ```
 
 ```python Python

--- a/docs/sandboxes/logs.mdx
+++ b/docs/sandboxes/logs.mdx
@@ -28,14 +28,14 @@ msb logs devbox --source all
 ## Read from the SDK
 
 <CodeGroup>
-```rust Rust
-let handle = Sandbox::get("web").await?;
-let entries = handle.logs(&LogOptions::default())?;
-```
-
 ```typescript TypeScript
 const handle = await Sandbox.get("web");
 const entries = await handle.logs();
+```
+
+```rust Rust
+let handle = Sandbox::get("web").await?;
+let entries = handle.logs(&LogOptions::default())?;
 ```
 
 ```python Python
@@ -52,19 +52,19 @@ entries, err := handle.Logs(ctx, m.LogOptions{})
 Use log options to filter at read time:
 
 <CodeGroup>
+```typescript TypeScript
+const recent = await handle.logs({
+    tail: 50,
+    sources: ["stdout", "stderr"],
+});
+```
+
 ```rust Rust
 let recent = handle.logs(&LogOptions {
     tail: Some(50),
     sources: vec![LogSource::Stdout, LogSource::Stderr],
     ..Default::default()
 })?;
-```
-
-```typescript TypeScript
-const recent = await handle.logs({
-    tail: 50,
-    sources: ["stdout", "stderr"],
-});
 ```
 
 ```python Python

--- a/docs/sandboxes/metrics.mdx
+++ b/docs/sandboxes/metrics.mdx
@@ -17,16 +17,16 @@ Need continuous shipping to Grafana, Datadog, Prometheus, or any other OTel-comp
 ## Point-in-time
 
 <CodeGroup>
+```typescript TypeScript
+const metrics = await sb.metrics();
+console.log(`CPU: ${metrics.cpuPercent.toFixed(1)}%, Mem: ${Math.floor(metrics.memoryBytes / 1024 / 1024)} MB`);
+```
+
 ```rust Rust
 use microsandbox::Sandbox;
 
 let metrics = sb.metrics().await?;
 println!("CPU: {:.1}%, Mem: {} MB", metrics.cpu_percent, metrics.memory_bytes / 1024 / 1024);
-```
-
-```typescript TypeScript
-const metrics = await sb.metrics();
-console.log(`CPU: ${metrics.cpuPercent.toFixed(1)}%, Mem: ${Math.floor(metrics.memoryBytes / 1024 / 1024)} MB`);
 ```
 
 ```python Python
@@ -46,6 +46,12 @@ fmt.Printf("CPU: %.1f%%, Mem: %d MB\n", metrics.CPUPercent, metrics.MemoryBytes/
 Subscribe to metric updates at a regular interval. Each update arrives as a separate event.
 
 <CodeGroup>
+```typescript TypeScript
+for await (const m of await sb.metricsStream(1000)) {
+    console.log(`[${m.timestamp.toISOString()}] CPU: ${m.cpuPercent.toFixed(1)}%`);
+}
+```
+
 ```rust Rust
 use std::time::Duration;
 use futures::StreamExt;
@@ -54,12 +60,6 @@ let mut stream = sb.metrics_stream(Duration::from_secs(1));
 while let Some(m) = stream.next().await {
     let m = m?;
     println!("CPU: {:.1}%, Mem: {} MB", m.cpu_percent, m.memory_bytes / 1024 / 1024);
-}
-```
-
-```typescript TypeScript
-for await (const m of await sb.metricsStream(1000)) {
-    console.log(`[${m.timestamp.toISOString()}] CPU: ${m.cpuPercent.toFixed(1)}%`);
 }
 ```
 
@@ -90,16 +90,16 @@ for {
 Get the latest metrics for every running sandbox at once. Useful for dashboards or capacity planning.
 
 <CodeGroup>
-```rust Rust
-use microsandbox::all_sandbox_metrics;
-
-let all = all_sandbox_metrics().await?;
-```
-
 ```typescript TypeScript
 import { allSandboxMetrics } from "microsandbox";
 
 const all = await allSandboxMetrics();
+```
+
+```rust Rust
+use microsandbox::all_sandbox_metrics;
+
+let all = all_sandbox_metrics().await?;
 ```
 
 ```python Python

--- a/docs/sandboxes/optimization.mdx
+++ b/docs/sandboxes/optimization.mdx
@@ -58,6 +58,16 @@ Start with `auto` on a dedicated host. Use `spread` for CPU-heavy throughput wor
 msb create python:3.12 --name worker --cpus 2 --cpu-placement spread
 ```
 
+```typescript TypeScript
+import { Sandbox } from "microsandbox";
+
+await using sb = await Sandbox.builder("worker")
+  .image("python:3.12")
+  .cpus(2)
+  .cpuPlacement("spread")
+  .create();
+```
+
 ```rust Rust
 use microsandbox::sandbox::{CpuPlacement, Sandbox};
 
@@ -67,16 +77,6 @@ let sb = Sandbox::builder("worker")
     .cpu_placement(CpuPlacement::Spread)
     .create()
     .await?;
-```
-
-```typescript TypeScript
-import { Sandbox } from "microsandbox";
-
-await using sb = await Sandbox.builder("worker")
-  .image("python:3.12")
-  .cpus(2)
-  .cpuPlacement("spread")
-  .create();
 ```
 
 ```python Python

--- a/docs/sandboxes/overview.mdx
+++ b/docs/sandboxes/overview.mdx
@@ -14,17 +14,17 @@ The security boundary is hardware virtualization, not Linux namespaces. That mak
 At minimum, a sandbox needs a name and an image. Everything else has defaults: 1 vCPU, 512 MiB memory, public-only networking, and `/bin/sh` as the default shell.
 
 <CodeGroup>
+```typescript TypeScript
+await using sb = await Sandbox.builder("worker")
+    .image("python")
+    .create();
+```
+
 ```rust Rust
 let sb = Sandbox::builder("worker")
     .image("python")
     .create()
     .await?;
-```
-
-```typescript TypeScript
-await using sb = await Sandbox.builder("worker")
-    .image("python")
-    .create();
 ```
 
 ```python Python
@@ -47,6 +47,17 @@ Sandbox names must be non-empty and no longer than 128 UTF-8 bytes.
 <Tooltip tip="max_cpus and max_memory are not carried on microsandbox cloud; set the CPU and memory you need at creation and recreate the sandbox to resize."><span className="msb-badge-limited">Limited on cloud <Icon icon="circle-info" size={11} /></span></Tooltip>
 
 <CodeGroup>
+```typescript TypeScript
+await using sb = await Sandbox.builder("worker")
+    .image("python")
+    .memory(1024)
+    .cpus(2)
+    .env("DEBUG", "true")
+    .label("user.id", "alice")
+    .volume("/tmp/scratch", (m) => m.tmpfs().size(100))
+    .create();
+```
+
 ```rust Rust
 let sb = Sandbox::builder("worker")
     .image("python")
@@ -57,17 +68,6 @@ let sb = Sandbox::builder("worker")
     .volume("/tmp/scratch", |v| v.tmpfs().size(100))
     .create()
     .await?;
-```
-
-```typescript TypeScript
-await using sb = await Sandbox.builder("worker")
-    .image("python")
-    .memory(1024)
-    .cpus(2)
-    .env("DEBUG", "true")
-    .label("user.id", "alice")
-    .volume("/tmp/scratch", (m) => m.tmpfs().size(100))
-    .create();
 ```
 
 ```python Python
@@ -168,19 +168,19 @@ See [Images](/images/overview) for the full OCI and disk image model.
 Creating a sandbox fails if another sandbox already has the same name. Use replace when you want a fresh sandbox with that name:
 
 <CodeGroup>
+```typescript TypeScript
+await using sb = await Sandbox.builder("worker")
+    .image("python")
+    .replace()
+    .create();
+```
+
 ```rust Rust
 let sb = Sandbox::builder("worker")
     .image("python")
     .replace()
     .create()
     .await?;
-```
-
-```typescript TypeScript
-await using sb = await Sandbox.builder("worker")
-    .image("python")
-    .replace()
-    .create();
 ```
 
 ```python Python

--- a/docs/sandboxes/secrets.mdx
+++ b/docs/sandboxes/secrets.mdx
@@ -18,6 +18,21 @@ Allowed hosts are checked against the sandbox's observed DNS and TLS identity. K
 Bind secrets to environment variables when you create the sandbox, each scoped to the hosts allowed to receive it:
 
 <CodeGroup>
+```typescript TypeScript
+import { Sandbox } from "microsandbox";
+
+await using sb = await Sandbox.builder("worker")
+    .image("python")
+    .secret((s) =>
+        s.env("GITHUB_TOKEN")
+            .value(process.env.GITHUB_TOKEN!)
+            .allowHost("api.github.com")
+            .allowHostPattern("*.githubusercontent.com"),
+    )
+    .secretEnv("SERVICE_API_KEY", process.env.SERVICE_API_KEY!, "api.example.com")
+    .create();
+```
+
 ```rust Rust
 use microsandbox::Sandbox;
 
@@ -32,21 +47,6 @@ let sb = Sandbox::builder("worker")
     .secret_env("SERVICE_API_KEY", service_api_key, "api.example.com")
     .create()
     .await?;
-```
-
-```typescript TypeScript
-import { Sandbox } from "microsandbox";
-
-await using sb = await Sandbox.builder("worker")
-    .image("python")
-    .secret((s) =>
-        s.env("GITHUB_TOKEN")
-            .value(process.env.GITHUB_TOKEN!)
-            .allowHost("api.github.com")
-            .allowHostPattern("*.githubusercontent.com"),
-    )
-    .secretEnv("SERVICE_API_KEY", process.env.SERVICE_API_KEY!, "api.example.com")
-    .create();
 ```
 
 ```python Python
@@ -109,17 +109,6 @@ In the CLI form, `ENV@HOST[,HOST...]` records a host-side source reference: the 
 Rotate or remove existing secrets without a restart. Adding a secret or changing its guest-visible placeholder requires a restart so the new environment reaches the guest. Later rotations keep that placeholder stable and only change the value injected at the network boundary.
 
 <CodeGroup>
-```rust Rust
-let plan = sb.modify()
-    .secret(|s| s
-        .env("API_KEY")
-        .source(SecretSource::Env { var: "API_KEY".into() })
-        .allow_host("api.example.com"))
-    .restart()
-    .apply()
-    .await?;
-```
-
 ```typescript TypeScript
 await sandbox.modify({
   secrets: {
@@ -129,6 +118,17 @@ await sandbox.modify({
 });
 
 await sandbox.modify({ secretsRemove: ["SERVICE_API_KEY"] });
+```
+
+```rust Rust
+let plan = sb.modify()
+    .secret(|s| s
+        .env("API_KEY")
+        .source(SecretSource::Env { var: "API_KEY".into() })
+        .allow_host("api.example.com"))
+    .restart()
+    .apply()
+    .await?;
 ```
 
 ```python Python
@@ -171,4 +171,4 @@ msb modify worker --secret-rm SERVICE_API_KEY                       # remove
 
 Secret modification is available through every SDK and the CLI. See [Live Modify](/sandboxes/tuning) for how changes are planned and applied.
 
-For API details, see the SDK references: [Rust](/sdk/rust/secrets) | [TypeScript](/sdk/typescript/secrets) | [Python](/sdk/python/secrets) | [Go](/sdk/go/secrets).
+For API details, see the SDK references: [TypeScript](/sdk/typescript/secrets) | [Rust](/sdk/rust/secrets) | [Python](/sdk/python/secrets) | [Go](/sdk/go/secrets).

--- a/docs/sandboxes/snapshots.mdx
+++ b/docs/sandboxes/snapshots.mdx
@@ -50,17 +50,6 @@ By default, the snapshot lives at `~/.microsandbox/snapshots/after-pip-install/`
 Snapshot under a bare name, resolved to `~/.microsandbox/snapshots/<name>/` by default. The name is the snapshot's identity; pass a destination directory to create the artifact on a different volume (`DIR/<name>`). Either way the directory is the whole artifact; move it with save/load (or plain `mv`):
 
 <CodeGroup>
-```rust Rust
-use microsandbox::Sandbox;
-
-let h = Sandbox::get("baseline").await?;
-
-// Resolves under ~/.microsandbox/snapshots/<name>/
-let snap = h.snapshot("after-pip-install").await?;
-
-println!("{}", snap.digest()); // sha256:...
-```
-
 ```typescript TypeScript
 import { Sandbox } from "microsandbox";
 
@@ -70,6 +59,17 @@ const h = await Sandbox.get("baseline");
 const snap = await h.snapshot("after-pip-install");
 
 console.log(snap.digest); // sha256:...
+```
+
+```rust Rust
+use microsandbox::Sandbox;
+
+let h = Sandbox::get("baseline").await?;
+
+// Resolves under ~/.microsandbox/snapshots/<name>/
+let snap = h.snapshot("after-pip-install").await?;
+
+println!("{}", snap.digest()); // sha256:...
 ```
 
 ```python Python
@@ -112,6 +112,14 @@ The sandbox must be stopped or crashed; running sandboxes are rejected.
 A snapshot already pins its image, so booting from one is mutually exclusive with the image source:
 
 <CodeGroup>
+```typescript TypeScript
+import { Sandbox } from "microsandbox";
+
+const sb = await Sandbox.builder("worker")
+    .fromSnapshot("after-pip-install")
+    .create();
+```
+
 ```rust Rust
 use microsandbox::Sandbox;
 
@@ -119,14 +127,6 @@ let sb = Sandbox::builder("worker")
     .from_snapshot("after-pip-install")
     .create()
     .await?;
-```
-
-```typescript TypeScript
-import { Sandbox } from "microsandbox";
-
-const sb = await Sandbox.builder("worker")
-    .fromSnapshot("after-pip-install")
-    .create();
 ```
 
 ```python Python
@@ -153,17 +153,6 @@ Booting validates the snapshot, resolves the pinned image, and gives the new san
 ## List, inspect, and remove
 
 <CodeGroup>
-```rust Rust
-use microsandbox::Snapshot;
-
-let all = Snapshot::list().await?; // Indexed snapshots
-let h = Snapshot::get("after-pip-install").await?; // By name, digest, or path
-println!("{} ({})", h.name().unwrap_or("-"), h.digest());
-
-Snapshot::remove("after-pip-install", false).await?;
-Snapshot::reindex("/data/snapshots").await?;
-```
-
 ```typescript TypeScript
 import { Snapshot } from "microsandbox";
 
@@ -173,6 +162,17 @@ console.log(`${h.name ?? "-"} (${h.digest})`);
 
 await Snapshot.remove("after-pip-install");
 await Snapshot.reindex();                               // Default snapshots directory
+```
+
+```rust Rust
+use microsandbox::Snapshot;
+
+let all = Snapshot::list().await?; // Indexed snapshots
+let h = Snapshot::get("after-pip-install").await?; // By name, digest, or path
+println!("{} ({})", h.name().unwrap_or("-"), h.digest());
+
+Snapshot::remove("after-pip-install", false).await?;
+Snapshot::reindex("/data/snapshots").await?;
 ```
 
 ```python Python
@@ -242,6 +242,19 @@ Archives default to `.tar.zst`. Pass `--plain-tar` for a plain `.tar`. SDKs expo
 By default, snapshot creation records structural metadata without hashing the writable layer. Opt in when you need a persistent content check. Current snapshots use a fixed 64 KiB-leaf BLAKE3 Merkle tree: known sparse holes collapse into precomputed zero subtrees, while allocated bytes are read and hashed.
 
 <CodeGroup>
+```typescript TypeScript
+import { Snapshot } from "microsandbox";
+
+// Compute and record an integrity hash at create time
+const snap = await Snapshot.builder("after-pip-install")
+  .fromSandbox("baseline")
+  .recordIntegrity()
+  .create();
+
+// Verify a snapshot's recorded integrity on demand
+const report = await snap.verify();
+```
+
 ```rust Rust
 use microsandbox::Snapshot;
 
@@ -255,19 +268,6 @@ let snap = Snapshot::builder("after-pip-install")
 // Verify a snapshot's recorded integrity on demand
 let report = snap.verify().await?;
 
-```
-
-```typescript TypeScript
-import { Snapshot } from "microsandbox";
-
-// Compute and record an integrity hash at create time
-const snap = await Snapshot.builder("after-pip-install")
-  .fromSandbox("baseline")
-  .recordIntegrity()
-  .create();
-
-// Verify a snapshot's recorded integrity on demand
-const report = await snap.verify();
 ```
 
 ```python Python

--- a/docs/sandboxes/ssh.mdx
+++ b/docs/sandboxes/ssh.mdx
@@ -44,16 +44,6 @@ msb ssh --name authorize -- uptime
 ### SDK
 
 <CodeGroup>
-```rust Rust
-let sb = Sandbox::start("devbox").await?;
-let ssh = sb.ssh().open_client().await?;
-
-let output = ssh.exec("uname -a").await?;
-println!("{}", String::from_utf8_lossy(&output.stdout));
-
-ssh.close().await?;
-```
-
 ```typescript TypeScript
 const sb = await Sandbox.start("devbox");
 const ssh = await sb.ssh().open_client();
@@ -62,6 +52,16 @@ const output = await ssh.exec("uname -a");
 console.log(output.stdout.toString());
 
 await ssh.close();
+```
+
+```rust Rust
+let sb = Sandbox::start("devbox").await?;
+let ssh = sb.ssh().open_client().await?;
+
+let output = ssh.exec("uname -a").await?;
+println!("{}", String::from_utf8_lossy(&output.stdout));
+
+ssh.close().await?;
 ```
 
 ```python Python
@@ -100,6 +100,11 @@ fmt.Print(string(output.Stdout))
 SDK clients can attach the local terminal to an SSH shell. This requires a real terminal.
 
 <CodeGroup>
+```typescript TypeScript
+const ssh = await sb.ssh().open_client({ term: "xterm-256color" });
+const code = await ssh.attach({ detachKeys: "ctrl-]" });
+```
+
 ```rust Rust
 let code = sb
     .ssh()
@@ -107,11 +112,6 @@ let code = sb
     .await?
     .attach()
     .await?;
-```
-
-```typescript TypeScript
-const ssh = await sb.ssh().open_client({ term: "xterm-256color" });
-const code = await ssh.attach({ detachKeys: "ctrl-]" });
 ```
 
 ```python Python
@@ -133,18 +133,18 @@ code, err := ssh.Attach(ctx, m.WithSSHDetachKeys("ctrl-]"))
 The native SSH client can open SFTP over the same SSH connection.
 
 <CodeGroup>
-```rust Rust
-let sftp = ssh.sftp().await?;
-sftp.write("/tmp/hello.txt", b"hello").await?;
-let data = sftp.read("/tmp/hello.txt").await?;
-sftp.close().await?;
-```
-
 ```typescript TypeScript
 const sftp = await ssh.sftp();
 await sftp.write("/tmp/hello.txt", Buffer.from("hello"));
 const data = await sftp.read("/tmp/hello.txt");
 await sftp.close();
+```
+
+```rust Rust
+let sftp = ssh.sftp().await?;
+sftp.write("/tmp/hello.txt", b"hello").await?;
+let data = sftp.read("/tmp/hello.txt").await?;
+sftp.close().await?;
 ```
 
 ```python Python
@@ -260,6 +260,11 @@ Set a global default in `~/.microsandbox/config.json`. Use `0` to disable the ti
 Override the global value for one CLI session with `--inactivity-timeout 30m`, or disable it with `--no-inactivity-timeout`. The same overrides are available when opening native clients or preparing server endpoints through an SDK:
 
 <CodeGroup>
+```typescript TypeScript
+const ssh = await sb.ssh().openClient({ inactivityTimeoutSecs: 1800 });
+const persistent = await sb.ssh().openClient({ inactivityTimeoutSecs: 0 });
+```
+
 ```rust Rust
 use std::time::Duration;
 
@@ -270,11 +275,6 @@ let ssh = sb.ssh()
 let persistent = sb.ssh()
     .connect_with(|opts| opts.disable_inactivity_timeout())
     .await?;
-```
-
-```typescript TypeScript
-const ssh = await sb.ssh().openClient({ inactivityTimeoutSecs: 1800 });
-const persistent = await sb.ssh().openClient({ inactivityTimeoutSecs: 0 });
 ```
 
 ```python Python
@@ -288,4 +288,4 @@ persistent, err := sb.SSH().OpenClient(ctx, m.WithSSHClientInactivityTimeout(0))
 ```
 </CodeGroup>
 
-For exact SDK signatures, see the SSH reference for [Rust](/sdk/rust/ssh), [TypeScript](/sdk/typescript/ssh), [Python](/sdk/python/ssh), or [Go](/sdk/go/ssh).
+For exact SDK signatures, see the SSH reference for [TypeScript](/sdk/typescript/ssh), [Rust](/sdk/rust/ssh), [Python](/sdk/python/ssh), or [Go](/sdk/go/ssh).

--- a/docs/sandboxes/tuning.mdx
+++ b/docs/sandboxes/tuning.mdx
@@ -37,6 +37,14 @@ This patch doubles the running sandbox's CPU and memory and updates a label in t
 msb modify worker --cpus 4 --memory 2G --label tier=web
 ```
 
+```typescript TypeScript
+const plan = await sandbox.modify({
+  cpus: 4,
+  memory: 2048,
+  labels: { tier: "web" },
+});
+```
+
 ```rust Rust
 let plan = sb.modify()
     .cpus(4)
@@ -44,14 +52,6 @@ let plan = sb.modify()
     .label("tier", "web")
     .apply()
     .await?;
-```
-
-```typescript TypeScript
-const plan = await sandbox.modify({
-  cpus: 4,
-  memory: 2048,
-  labels: { tier: "web" },
-});
 ```
 
 ```python Python
@@ -84,6 +84,16 @@ msb create python --name worker \
   --max-cpus 8 --max-memory 4G
 ```
 
+```typescript TypeScript
+await using sandbox = await Sandbox.builder("worker")
+  .image("python")
+  .cpus(2)
+  .memory(1024)
+  .maxCpus(8)
+  .maxMemory(4096)
+  .create();
+```
+
 ```rust Rust
 let sb = Sandbox::builder("worker")
     .image("python")
@@ -93,16 +103,6 @@ let sb = Sandbox::builder("worker")
     .max_memory(4096)
     .create()
     .await?;
-```
-
-```typescript TypeScript
-await using sandbox = await Sandbox.builder("worker")
-  .image("python")
-  .cpus(2)
-  .memory(1024)
-  .maxCpus(8)
-  .maxMemory(4096)
-  .create();
 ```
 
 ```python Python
@@ -140,18 +140,18 @@ Use a dry run when a patch mixes settings or you are unsure whether a restart is
 msb modify worker --max-memory 16G --dry-run
 ```
 
-```rust Rust
-let plan = sb.modify()
-    .max_memory(16_384)
-    .dry_run()
-    .await?;
-```
-
 ```typescript TypeScript
 const plan = await sandbox.modify({
   maxMemory: 16_384,
   dryRun: true,
 });
+```
+
+```rust Rust
+let plan = sb.modify()
+    .max_memory(16_384)
+    .dry_run()
+    .await?;
 ```
 
 ```python Python
@@ -186,16 +186,16 @@ Raise or lower CPU and memory while the workload runs:
 msb modify worker --cpus 4 --memory 2G
 ```
 
+```typescript TypeScript
+const plan = await sandbox.modify({ cpus: 4, memory: 2048 });
+```
+
 ```rust Rust
 let plan = sb.modify()
     .cpus(4)
     .memory(2048)
     .apply()
     .await?;
-```
-
-```typescript TypeScript
-const plan = await sandbox.modify({ cpus: 4, memory: 2048 });
 ```
 
 ```python Python
@@ -221,19 +221,19 @@ Labels are host-side metadata, so adding, changing, or removing one is immediate
 msb modify worker --label tier=web --label-rm stale
 ```
 
+```typescript TypeScript
+const plan = await sandbox.modify({
+  labels: { tier: "web" },
+  labelsRemove: ["stale"],
+});
+```
+
 ```rust Rust
 let plan = sb.modify()
     .label("tier", "web")
     .remove_label("stale")
     .apply()
     .await?;
-```
-
-```typescript TypeScript
-const plan = await sandbox.modify({
-  labels: { tier: "web" },
-  labelsRemove: ["stale"],
-});
 ```
 
 ```python Python
@@ -263,6 +263,15 @@ msb modify worker --env MODE=prod --workdir /app
 msb exec worker -- printenv MODE
 ```
 
+```typescript TypeScript
+await sandbox.modify({
+  env: { MODE: "prod" },
+  workdir: "/app",
+});
+
+const output = await sandbox.exec("printenv", ["MODE"]);
+```
+
 ```rust Rust
 sb.modify()
     .env("MODE", "prod")
@@ -271,15 +280,6 @@ sb.modify()
     .await?;
 
 let output = sb.exec("printenv", ["MODE"]).await?;
-```
-
-```typescript TypeScript
-await sandbox.modify({
-  env: { MODE: "prod" },
-  workdir: "/app",
-});
-
-const output = await sandbox.exec("printenv", ["MODE"]);
 ```
 
 ```python Python
@@ -307,6 +307,17 @@ Rotating the value of an existing secret is live because substitution happens at
 msb modify worker --secret GITHUB_TOKEN@api.github.com
 ```
 
+```typescript TypeScript
+const plan = await sandbox.modify({
+  secrets: {
+    GITHUB_TOKEN: {
+      env: "GITHUB_TOKEN",
+      allowedHosts: ["api.github.com"],
+    },
+  },
+});
+```
+
 ```rust Rust
 use microsandbox::sandbox::SecretSource;
 
@@ -317,17 +328,6 @@ let plan = sb.modify()
         .allow_host("api.github.com"))
     .apply()
     .await?;
-```
-
-```typescript TypeScript
-const plan = await sandbox.modify({
-  secrets: {
-    GITHUB_TOKEN: {
-      env: "GITHUB_TOKEN",
-      allowedHosts: ["api.github.com"],
-    },
-  },
-});
 ```
 
 ```python Python
@@ -372,6 +372,18 @@ msb modify worker --max-memory 16G --next-start
 msb modify worker --root-disk 8G --restart
 ```
 
+```typescript TypeScript
+await sandbox.modify({
+  maxMemory: 16_384,
+  policy: "next_start",
+});
+
+await sandbox.modify({
+  rootDiskSize: 8192,
+  policy: "restart",
+});
+```
+
 ```rust Rust
 sb.modify()
     .max_memory(16_384)
@@ -384,18 +396,6 @@ sb.modify()
     .restart()
     .apply()
     .await?;
-```
-
-```typescript TypeScript
-await sandbox.modify({
-  maxMemory: 16_384,
-  policy: "next_start",
-});
-
-await sandbox.modify({
-  rootDiskSize: 8192,
-  policy: "restart",
-});
 ```
 
 ```python Python
@@ -431,4 +431,4 @@ Root disk resizing remains conservative: managed and flat OCI disks grow only, t
 
 ## Reference
 
-For every CLI flag and result state, see [`msb modify`](/cli/sandbox-commands#msb-modify). The SDK sandbox references expose the same planner and policies for [Rust](/sdk/rust/sandbox), [TypeScript](/sdk/typescript/sandbox), [Python](/sdk/python/sandbox), and [Go](/sdk/go/sandbox).
+For every CLI flag and result state, see [`msb modify`](/cli/sandbox-commands#msb-modify). The SDK sandbox references expose the same planner and policies for [TypeScript](/sdk/typescript/sandbox), [Rust](/sdk/rust/sandbox), [Python](/sdk/python/sandbox), and [Go](/sdk/go/sandbox).

--- a/docs/sandboxes/volumes.mdx
+++ b/docs/sandboxes/volumes.mdx
@@ -20,14 +20,14 @@ microsandbox supports four mount types on both backends: bind mounts, named volu
 Every cloud organization has an always-present default volume. You can read and write it directly without starting a sandbox:
 
 <CodeGroup>
-```rust Rust
-let volume = Volume::get_default().await?;
-volume.fs().write("state.json", br#"{"ready":true}"#).await?;
-```
-
 ```typescript TypeScript
 const volume = await Volume.getDefault();
 await volume.fs().write("state.json", JSON.stringify({ ready: true }));
+```
+
+```rust Rust
+let volume = Volume::get_default().await?;
+volume.fs().write("state.json", br#"{"ready":true}"#).await?;
 ```
 
 ```python Python
@@ -50,15 +50,6 @@ The default volume is isolated to the authenticated cloud organization and canno
 Mount a directory from the host directly into the sandbox. Changes inside the sandbox are reflected on the host, and vice versa.
 
 <CodeGroup>
-```rust Rust
-let sb = Sandbox::builder("dev")
-    .image("python")
-    .volume("/app/src", |v| v.bind("./src").readonly().noexec())
-    .volume("/app/data", |v| v.bind("./data"))
-    .create()
-    .await?;
-```
-
 ```typescript TypeScript
 import { Sandbox } from "microsandbox";
 
@@ -67,6 +58,15 @@ await using sb = await Sandbox.builder("dev")
     .volume("/app/src",  (m) => m.bind("./src").readonly().noexec())
     .volume("/app/data", (m) => m.bind("./data"))
     .create();
+```
+
+```rust Rust
+let sb = Sandbox::builder("dev")
+    .image("python")
+    .volume("/app/src", |v| v.bind("./src").readonly().noexec())
+    .volume("/app/data", |v| v.bind("./data"))
+    .create()
+    .await?;
 ```
 
 ```python Python
@@ -124,16 +124,16 @@ SDK `named(...)` mount helpers are existing-only. They fail if the named volume 
 ### Create a volume
 
 <CodeGroup>
-```rust Rust
-let cache = Volume::builder("pip-cache")
-    .create()
-    .await?;
-```
-
 ```typescript TypeScript
 import { Volume } from "microsandbox";
 
 const cache = await Volume.builder("pip-cache").create();
+```
+
+```rust Rust
+let cache = Volume::builder("pip-cache")
+    .create()
+    .await?;
 ```
 
 ```python Python
@@ -153,19 +153,19 @@ msb volume create pip-cache
 Create a disk-backed named volume when a workload needs a real guest block filesystem, such as Docker's data root:
 
 <CodeGroup>
+```typescript TypeScript
+const dockerData = await Volume.builder("docker-data")
+  .disk()
+  .size(20 * 1024)
+  .create();
+```
+
 ```rust Rust
 let docker_data = Volume::builder("docker-data")
     .disk()
     .size(20.gib())
     .create()
     .await?;
-```
-
-```typescript TypeScript
-const dockerData = await Volume.builder("docker-data")
-  .disk()
-  .size(20 * 1024)
-  .create();
 ```
 
 ```python Python
@@ -193,19 +193,19 @@ msb volume create docker-data --kind disk --size 20G
 ### Mount in a sandbox
 
 <CodeGroup>
+```typescript TypeScript
+await using sb = await Sandbox.builder("worker")
+    .image("python")
+    .volume("/root/.cache/pip", (m) => m.named(cache.name))
+    .create();
+```
+
 ```rust Rust
 let sb = Sandbox::builder("worker")
     .image("python")
     .volume("/root/.cache/pip", |v| v.named(cache.name()))
     .create()
     .await?;
-```
-
-```typescript TypeScript
-await using sb = await Sandbox.builder("worker")
-    .image("python")
-    .volume("/root/.cache/pip", (m) => m.named(cache.name))
-    .create();
 ```
 
 ```python Python
@@ -250,14 +250,14 @@ Directory-backed named volumes are also accessible without a running sandbox, so
 ### Manage volumes
 
 <CodeGroup>
-```rust Rust
-let volumes = Volume::list().await?;
-Volume::remove("old-cache").await?;
-```
-
 ```typescript TypeScript
 const volumes = await Volume.list();
 await Volume.remove("old-cache");
+```
+
+```rust Rust
+let volumes = Volume::list().await?;
+Volume::remove("old-cache").await?;
 ```
 
 ```python Python
@@ -284,19 +284,19 @@ msb volume rm old-cache
 Disk-image volumes attach a host disk image as a virtio-blk device and mount its inner filesystem at a guest path. Use them when you want persistent state isolated from ordinary host filesystem metadata, or when distributing a prebuilt filesystem image. The disk format defaults from the file extension (`.qcow2`, `.raw`, `.vmdk`; otherwise raw), and the inner filesystem type is auto-detected unless you set `fstype`.
 
 <CodeGroup>
+```typescript TypeScript
+await using sb = await Sandbox.builder("seeded")
+    .image("alpine")
+    .volume("/seed", (m) => m.disk("./seed.raw").readonly().noexec())
+    .create();
+```
+
 ```rust Rust
 let sb = Sandbox::builder("seeded")
     .image("alpine")
     .volume("/seed", |v| v.disk("./seed.raw").readonly().noexec())
     .create()
     .await?;
-```
-
-```typescript TypeScript
-await using sb = await Sandbox.builder("seeded")
-    .image("alpine")
-    .volume("/seed", (m) => m.disk("./seed.raw").readonly().noexec())
-    .create();
 ```
 
 ```python Python
@@ -327,14 +327,6 @@ msb create alpine --name seeded \
 An in-memory filesystem that disappears when the sandbox stops. Useful for scratch space, build artifacts, or anything that doesn't need to outlive the sandbox.
 
 <CodeGroup>
-```rust Rust
-let sb = Sandbox::builder("worker")
-    .image("alpine")
-    .volume("/tmp/scratch", |v| v.tmpfs().size(100).noexec())
-    .create()
-    .await?;
-```
-
 ```typescript TypeScript
 import { Sandbox } from "microsandbox";
 
@@ -342,6 +334,14 @@ await using sb = await Sandbox.builder("worker")
     .image("alpine")
     .volume("/tmp/scratch", (m) => m.tmpfs().size(100).noexec())
     .create();
+```
+
+```rust Rust
+let sb = Sandbox::builder("worker")
+    .image("alpine")
+    .volume("/tmp/scratch", |v| v.tmpfs().size(100).noexec())
+    .create()
+    .await?;
 ```
 
 ```python Python
@@ -400,6 +400,21 @@ CLI mount flags use `SOURCE:DEST[:OPTIONS]`. The `:` before `OPTIONS` starts the
 Mount flags may be repeated, so a sandbox can combine host directories, individual files, named volumes, disk images, and tmpfs scratch space.
 
 <CodeGroup>
+```typescript TypeScript
+await using sb = await Sandbox.builder("full")
+  .image("python")
+  .volume("/app/src", (v) => v.bind("./src").readonly().noexec())
+  .volume("/app/pyproject.toml", (v) => v.bind("./pyproject.toml").readonly())
+  .volume("/root/.cache/pip", (v) =>
+    v.named("pip-cache").statVirtualization("relaxed"),
+  )
+  .volume("/dataset", (v) =>
+    v.disk("./dataset.qcow2").format("qcow2").fstype("ext4").readonly(),
+  )
+  .volume("/tmp", (v) => v.tmpfs().size(1024).noexec().nosuid().nodev())
+  .create();
+```
+
 ```rust Rust
 let sb = Sandbox::builder("full")
     .image("python")

--- a/docs/sdk/errors.mdx
+++ b/docs/sdk/errors.mdx
@@ -9,32 +9,6 @@ SDKs surface failures through language-idiomatic error values. Match documented 
 ## Matching errors
 
 <CodeGroup>
-```rust Rust
-use microsandbox::{Sandbox, Error};
-
-async fn get_or_create(name: &str) -> Result<Sandbox, Error> {
-    match Sandbox::get(name).await {
-        Ok(handle) => handle.start().await,
-        Err(Error::SandboxNotFound(_)) => {
-            Sandbox::builder(name).image("python").create().await
-        }
-        Err(e) => Err(e),
-    }
-}
-
-match sb.exec("python", ["script.py"]).await {
-    Ok(output) if output.status().success => {
-        println!("{}", output.stdout()?);
-    }
-    Ok(output) => {
-        eprintln!("Exit {}: {}", output.status().code, output.stderr()?);
-    }
-    Err(Error::ExecTimeout(_)) => eprintln!("Timed out"),
-    Err(Error::Runtime(msg)) => eprintln!("Runtime: {msg}"),
-    Err(e) => return Err(e),
-}
-```
-
 ```typescript TypeScript
 import {
     ExecTimeoutError,
@@ -68,6 +42,32 @@ try {
     } else {
         throw e;
     }
+}
+```
+
+```rust Rust
+use microsandbox::{Sandbox, Error};
+
+async fn get_or_create(name: &str) -> Result<Sandbox, Error> {
+    match Sandbox::get(name).await {
+        Ok(handle) => handle.start().await,
+        Err(Error::SandboxNotFound(_)) => {
+            Sandbox::builder(name).image("python").create().await
+        }
+        Err(e) => Err(e),
+    }
+}
+
+match sb.exec("python", ["script.py"]).await {
+    Ok(output) if output.status().success => {
+        println!("{}", output.stdout()?);
+    }
+    Ok(output) => {
+        eprintln!("Exit {}: {}", output.status().code, output.stderr()?);
+    }
+    Err(Error::ExecTimeout(_)) => eprintln!("Timed out"),
+    Err(Error::Runtime(msg)) => eprintln!("Runtime: {msg}"),
+    Err(e) => return Err(e),
 }
 ```
 
@@ -139,6 +139,15 @@ case err != nil:
 Rust exposes a structured `ExecFailed` payload, and Go exposes the same detail on streaming execution events. Common failure kinds include `NotFound` (binary missing on `PATH`), `PermissionDenied`, `NotExecutable`, `BadCwd`, `BadArgs`, `ResourceLimit`, `UserSetupFailed`, `OutOfMemory`, `PtySetupFailed`, and `Other`.
 
 <CodeGroup>
+```typescript TypeScript
+try {
+    const output = await sb.exec("nonexistent");
+    // program ran, check output.success / output.code
+} catch (e) {
+    console.error("Program could not be started:", e);
+}
+```
+
 ```rust Rust
 use microsandbox::{protocol::exec::ExecFailureKind, Error};
 
@@ -159,15 +168,6 @@ match sb.exec("nonexistent", []).await {
         // payload.errno, payload.errno_name, payload.stage are also available
     }
     Err(e) => return Err(e),
-}
-```
-
-```typescript TypeScript
-try {
-    const output = await sb.exec("nonexistent");
-    // program ran, check output.success / output.code
-} catch (e) {
-    console.error("Program could not be started:", e);
 }
 ```
 
@@ -233,18 +233,6 @@ The CLI maps these kinds to POSIX-style exit codes: `127` for `NotFound`, `126` 
 Creating a sandbox with a name that's already in use (and without `replace`) surfaces a typed error you can branch on to decide whether to recover (resume the existing one, regenerate the name, etc.).
 
 <CodeGroup>
-```rust Rust
-use microsandbox::{Error, Sandbox};
-
-match Sandbox::builder("worker").image("alpine").create().await {
-    Ok(sb) => { /* ... */ }
-    Err(Error::SandboxAlreadyExists(name)) => {
-        eprintln!("sandbox {name} already exists; resume or pass .replace()");
-    }
-    Err(e) => return Err(e),
-}
-```
-
 ```typescript TypeScript
 import { Sandbox, SandboxAlreadyExistsError } from "microsandbox";
 
@@ -256,6 +244,18 @@ try {
     } else {
         throw e;
     }
+}
+```
+
+```rust Rust
+use microsandbox::{Error, Sandbox};
+
+match Sandbox::builder("worker").image("alpine").create().await {
+    Ok(sb) => { /* ... */ }
+    Err(Error::SandboxAlreadyExists(name)) => {
+        eprintln!("sandbox {name} already exists; resume or pass .replace()");
+    }
+    Err(e) => return Err(e),
 }
 ```
 
@@ -277,6 +277,16 @@ Pass `replace()` / `replace=True` / `--replace` / `WithReplace()` to stop the ex
 When a sandbox process exits before the agent relay is ready, creation returns or raises an SDK error. Rust exposes a structured `BootStart` payload with the failure stage and underlying message.
 
 <CodeGroup>
+```typescript TypeScript
+import { Sandbox } from "microsandbox";
+
+try {
+    const sb = await Sandbox.builder("svc").image("alpine").create();
+} catch (e) {
+    console.error("Sandbox failed to start:", e);
+}
+```
+
 ```rust Rust
 use microsandbox::{Error, Sandbox};
 
@@ -286,16 +296,6 @@ match Sandbox::builder("svc").image("alpine").create().await {
         eprintln!("Sandbox {name:?} failed at stage {:?}: {}", err.stage, err.message);
     }
     Err(e) => return Err(e),
-}
-```
-
-```typescript TypeScript
-import { Sandbox } from "microsandbox";
-
-try {
-    const sb = await Sandbox.builder("svc").image("alpine").create();
-} catch (e) {
-    console.error("Sandbox failed to start:", e);
 }
 ```
 
@@ -330,11 +330,24 @@ The CLI prints the startup failure before any captured log output so the immedia
 
 ## Resource cleanup
 
-<Tooltip tip="Rust drop and TypeScript await using do not stop microsandbox cloud sandboxes, because cloud handles do not own the host process; call stop() or remove() explicitly."><span className="msb-badge-limited">Limited on cloud <Icon icon="circle-info" size={11} /></span></Tooltip>
+<Tooltip tip="TypeScript await using and Rust drop do not stop microsandbox cloud sandboxes, because cloud handles do not own the host process; call stop() or remove() explicitly."><span className="msb-badge-limited">Limited on cloud <Icon icon="circle-info" size={11} /></span></Tooltip>
 
-Sandboxes hold compute resources, so release them when done. In Rust, `Drop` handles cleanup when the sandbox goes out of scope. In TypeScript, prefer `await using` (Node 22+) which calls `Sandbox.stop()` automatically when the binding leaves scope. In Go, pair every `CreateSandbox` with a `defer` that calls `Stop` + `Close`.
+Sandboxes hold compute resources, so release them when done. In TypeScript, prefer `await using` (Node 22+) which calls `Sandbox.stop()` automatically when the binding leaves scope. In Rust, `Drop` handles cleanup when the sandbox goes out of scope. In Go, pair every `CreateSandbox` with a `defer` that calls `Stop` + `Close`.
 
 <CodeGroup>
+```typescript TypeScript
+async function runTemporary(): Promise<string> {
+    // `await using` calls Sandbox.stop() when the binding leaves scope.
+    await using sb = await Sandbox.builder("temp")
+        .image("python")
+        .replace()
+        .create();
+
+    const out = await sb.exec("python", ["-c", "print('hello')"]);
+    return out.stdout();
+}
+```
+
 ```rust Rust
 use microsandbox::Sandbox;
 
@@ -348,19 +361,6 @@ use microsandbox::Sandbox;
 
     let output = sb.exec("python", ["-c", "print('hello')"]).await?;
 } // sb is dropped here, resources are cleaned up
-```
-
-```typescript TypeScript
-async function runTemporary(): Promise<string> {
-    // `await using` calls Sandbox.stop() when the binding leaves scope.
-    await using sb = await Sandbox.builder("temp")
-        .image("python")
-        .replace()
-        .create();
-
-    const out = await sb.exec("python", ["-c", "print('hello')"]);
-    return out.stdout();
-}
 ```
 
 ```python Python

--- a/docs/sdk/overview.mdx
+++ b/docs/sdk/overview.mdx
@@ -10,12 +10,12 @@ The SDK embeds the microsandbox runtime directly into your application. Running 
 ## Installation
 
 <CodeGroup>
-```bash Rust
-cargo add microsandbox
-```
-
 ```bash TypeScript
 npm install microsandbox
+```
+
+```bash Rust
+cargo add microsandbox
 ```
 
 ```bash Python
@@ -38,6 +38,17 @@ For explicit runtime installation, verification, custom install locations, and e
 Create a sandbox from a container image, run a command, print the output, and stop it.
 
 <CodeGroup>
+```typescript TypeScript
+import { Sandbox } from "microsandbox";
+
+await using sb = await Sandbox.builder("hello")
+    .image("python")
+    .create();
+
+const output = await sb.exec("python", ["-c", "print('Hello, World!')"]);
+console.log("Output:", output.stdout());
+```
+
 ```rust Rust
 use microsandbox::Sandbox;
 
@@ -54,17 +65,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     sb.stop().await?;
     Ok(())
 }
-```
-
-```typescript TypeScript
-import { Sandbox } from "microsandbox";
-
-await using sb = await Sandbox.builder("hello")
-    .image("python")
-    .create();
-
-const output = await sb.exec("python", ["-c", "print('Hello, World!')"]);
-console.log("Output:", output.stdout());
 ```
 
 ```python Python
@@ -137,10 +137,10 @@ end
 
 Choose the SDK for your language:
 
-- [Rust SDK](/sdk/rust/sandbox)
 - [TypeScript SDK](/sdk/typescript/sandbox)
+- [Rust SDK](/sdk/rust/sandbox)
 - [Python SDK](/sdk/python/sandbox)
 - [Go SDK](/sdk/go/sandbox)
 - [Ruby SDK](https://github.com/superradcompany/microsandbox/tree/main/sdk/ruby)
 
-For low-level protocol integrations, see the Agent Client references for [Rust](/sdk/rust/agent-client), [TypeScript](/sdk/typescript/agent-client), [Python](/sdk/python/agent-client), and [Go](/sdk/go/agent-client). See also [error handling](/sdk/errors).
+For low-level protocol integrations, see the Agent Client references for [TypeScript](/sdk/typescript/agent-client), [Rust](/sdk/rust/agent-client), [Python](/sdk/python/agent-client), and [Go](/sdk/go/agent-client). See also [error handling](/sdk/errors).

--- a/docs/sdk/setup.mdx
+++ b/docs/sdk/setup.mdx
@@ -13,19 +13,19 @@ The default install root is `~/.microsandbox/` (`%USERPROFILE%\.microsandbox` on
 Check for the runtime and install it only when needed. These installation helpers are idempotent and reuse a matching installation.
 
 <CodeGroup>
-```rust Rust
-use microsandbox::setup;
-
-if !setup::is_installed() {
-    setup::install().await?;
-}
-```
-
 ```typescript TypeScript
 import { install, isInstalled } from "microsandbox";
 
 if (!isInstalled()) {
   await install();
+}
+```
+
+```rust Rust
+use microsandbox::setup;
+
+if !setup::is_installed() {
+    setup::install().await?;
 }
 ```
 
@@ -55,17 +55,28 @@ Microsandbox.install unless Microsandbox.installed?
 
 | SDK | Install | Check | Behavior |
 |-----|---------|-------|----------|
-| Rust | `setup::install() -> MicrosandboxResult<()>` | `setup::is_installed() -> bool` | Downloads the SDK's pinned runtime and verifies it. |
 | TypeScript | `install(): Promise<void>` | `isInstalled(): boolean` | Downloads the package's pinned runtime and verifies it. |
+| Rust | `setup::install() -> MicrosandboxResult<()>` | `setup::is_installed() -> bool` | Downloads the SDK's pinned runtime and verifies it. |
 | Python | `install() -> Awaitable[None]` | `is_installed() -> bool` | Installs and verifies the runtime; release wheels normally bundle matching files. |
 | Go | `EnsureInstalled(ctx, ...SetupOption) error` | `IsInstalled() bool` | Installs `msb` and `libkrunfw`; the Go FFI library is embedded separately. |
 | Ruby | `install -> nil` | `installed? -> bool` | Installs and verifies the runtime used by the native extension. |
 
 ## Customize installation
 
-Rust and TypeScript expose builders for custom install roots, versions, verification, and forced downloads. Go exposes `WithSkipDownload()` for pre-provisioned or air-gapped environments. Python's setup helper uses the default installation behavior.
+TypeScript and Rust expose builders for custom install roots, versions, verification, and forced downloads. Go exposes `WithSkipDownload()` for pre-provisioned or air-gapped environments. Python's setup helper uses the default installation behavior.
 
 <CodeGroup>
+```typescript TypeScript
+import { setup } from "microsandbox";
+
+await setup()
+  .baseDir("/opt/microsandbox")
+  .version("0.6.8")
+  .skipVerify(false)
+  .force(true)
+  .install();
+```
+
 ```rust Rust
 use microsandbox::setup::Setup;
 
@@ -77,17 +88,6 @@ Setup::builder()
     .build()
     .install()
     .await?;
-```
-
-```typescript TypeScript
-import { setup } from "microsandbox";
-
-await setup()
-  .baseDir("/opt/microsandbox")
-  .version("0.6.8")
-  .skipVerify(false)
-  .force(true)
-  .install();
 ```
 
 ```go Go
@@ -102,10 +102,10 @@ if err := m.EnsureInstalled(ctx, m.WithSkipDownload()); err != nil {
 
 | Option | SDKs | Description |
 |--------|------|-------------|
-| Install root | Rust: `base_dir(path)`<br />TypeScript: `baseDir(path)` | Override `~/.microsandbox/`. |
-| Runtime version | Rust: `version(version)`<br />TypeScript: `version(version)` | Install a specific runtime version instead of the SDK's pinned version. |
-| Skip verification | Rust: `skip_verify(enabled)`<br />TypeScript: `skipVerify(enabled)` | Skip post-install verification. |
-| Force download | Rust: `force(enabled)`<br />TypeScript: `force(enabled)` | Download again even when matching files are present. |
+| Install root | TypeScript: `baseDir(path)`<br />Rust: `base_dir(path)` | Override `~/.microsandbox/`. |
+| Runtime version | TypeScript: `version(version)`<br />Rust: `version(version)` | Install a specific runtime version instead of the SDK's pinned version. |
+| Skip verification | TypeScript: `skipVerify(enabled)`<br />Rust: `skip_verify(enabled)` | Skip post-install verification. |
+| Force download | TypeScript: `force(enabled)`<br />Rust: `force(enabled)` | Download again even when matching files are present. |
 | Skip download | Go: `WithSkipDownload()` | Require the runtime to be present without fetching it. |
 
 <span id="go-with-skip-download"></span>
@@ -115,19 +115,19 @@ In Go, `WithSkipDownload()` returns a `SetupOption`, whose exported type is `fun
 
 ## Override runtime paths
 
-The Rust, TypeScript, Python, and Ruby SDKs can override the process-wide `libkrunfw` path directly. Call the setter before creating a local sandbox.
+The TypeScript, Rust, Python, and Ruby SDKs can override the process-wide `libkrunfw` path directly. Call the setter before creating a local sandbox.
 
 <CodeGroup>
-```rust Rust
-use microsandbox::set_libkrunfw_path;
-
-set_libkrunfw_path("/opt/microsandbox/lib/libkrunfw.dylib");
-```
-
 ```typescript TypeScript
 import { setRuntimeLibkrunfwPath } from "microsandbox";
 
 setRuntimeLibkrunfwPath("/opt/microsandbox/lib/libkrunfw.dylib");
+```
+
+```rust Rust
+use microsandbox::set_libkrunfw_path;
+
+set_libkrunfw_path("/opt/microsandbox/lib/libkrunfw.dylib");
 ```
 
 ```python Python

--- a/docs/security/hardening.mdx
+++ b/docs/security/hardening.mdx
@@ -15,19 +15,19 @@ If a workload doesn't need the network, remove it. Nothing to filter is the stro
 msb create python --name isolated --no-net
 ```
 
+```typescript TypeScript
+await using sb = await Sandbox.builder("isolated")
+    .image("python")
+    .disableNetwork()
+    .create();
+```
+
 ```rust Rust
 let sb = Sandbox::builder("isolated")
     .image("python")
     .network(|n| n.enabled(false))
     .create()
     .await?;
-```
-
-```typescript TypeScript
-await using sb = await Sandbox.builder("isolated")
-    .image("python")
-    .disableNetwork()
-    .create();
 ```
 
 ```python Python

--- a/docs/security/isolation.mdx
+++ b/docs/security/isolation.mdx
@@ -64,6 +64,14 @@ Inside the guest the default is permissive, and that is intentional, because the
 For defense-in-depth *inside* the guest, opt into the **restricted security profile**. It sets `no_new_privs`, drops the mount-admin capability from user commands, and forces `nosuid,nodev` on user mounts. It is incompatible with workloads that need those, such as `sudo` or Docker-in-Docker.
 
 <CodeGroup>
+```typescript TypeScript
+await using sb = await Sandbox.builder("worker")
+    .image("python")
+    .user("app")
+    .security("restricted")
+    .create();
+```
+
 ```rust Rust
 use microsandbox::{Sandbox, SecurityProfile};
 
@@ -73,14 +81,6 @@ let sb = Sandbox::builder("worker")
     .security(SecurityProfile::Restricted)
     .create()
     .await?;
-```
-
-```typescript TypeScript
-await using sb = await Sandbox.builder("worker")
-    .image("python")
-    .user("app")
-    .security("restricted")
-    .create();
 ```
 
 ```python Python

--- a/docs/security/network.mdx
+++ b/docs/security/network.mdx
@@ -51,6 +51,13 @@ msb create python --name worker \
     --net-rule "deny@meta"
 ```
 
+```typescript TypeScript
+NetworkPolicy.builder()
+  .defaultAllow()
+  .egress((rule) => rule.denyMeta())
+  .build();
+```
+
 ```rust Rust
 NetworkPolicy::builder()
     .default_allow()

--- a/scripts/check-docs-language-order.py
+++ b/scripts/check-docs-language-order.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Check that generic documentation presents TypeScript before Rust."""
+
+import json
+import re
+import sys
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+
+REPO = Path(__file__).resolve().parent.parent
+DOCS = REPO / "docs"
+CODE_GROUP = re.compile(r"<CodeGroup>(.*?)</CodeGroup>", re.DOTALL)
+CODE_FENCE = re.compile(r"^\s*```(\S+)(?:\s+([^\n]+))?", re.MULTILINE)
+EXCLUDED_PREFIXES = (
+    Path("changelog"),
+    Path("sdk/rust"),
+    Path("sdk/typescript"),
+    Path("sdk/python"),
+    Path("sdk/go"),
+)
+
+
+def language(lexer: str, label: Optional[str]) -> Optional[str]:
+    """Return the SDK language represented by a labeled code fence."""
+
+    clean_label = label.strip() if label else ""
+    if lexer == "typescript" or clean_label == "TypeScript":
+        return "typescript"
+    if lexer == "rust" or clean_label == "Rust":
+        return "rust"
+    return None
+
+
+def check_code_groups() -> Tuple[List[str], int]:
+    """Find generic code groups that put Rust before TypeScript."""
+
+    failures = []
+    checked = 0
+    for path in sorted(DOCS.rglob("*.mdx")):
+        relative = path.relative_to(DOCS)
+        if any(
+            relative.parts[: len(prefix.parts)] == prefix.parts
+            for prefix in EXCLUDED_PREFIXES
+        ):
+            continue
+
+        text = path.read_text()
+        for group in CODE_GROUP.finditer(text):
+            languages = [
+                detected
+                for fence in CODE_FENCE.finditer(group.group(1))
+                if (detected := language(fence.group(1), fence.group(2))) is not None
+            ]
+            if "typescript" not in languages or "rust" not in languages:
+                continue
+
+            checked += 1
+            if languages.index("rust") < languages.index("typescript"):
+                line = text.count("\n", 0, group.start()) + 1
+                failures.append(f"{relative}:{line}: place TypeScript before Rust")
+
+    return failures, checked
+
+
+def check_navigation() -> List[str]:
+    """Verify that the TypeScript SDK is the first SDK navigation group."""
+
+    config = json.loads((DOCS / "docs.json").read_text())
+    sdk_tab = next(tab for tab in config["navigation"]["tabs"] if tab["tab"] == "SDKs & CLI")
+    sdk_group = next(group for group in sdk_tab["groups"] if group["group"] == "SDKs")
+    first_sdk = sdk_group["pages"][0]["group"]
+    if first_sdk == "TypeScript":
+        return []
+    return [f"docs.json: SDK navigation starts with {first_sdk}, expected TypeScript"]
+
+
+def main() -> int:
+    """Run all TypeScript-first documentation checks."""
+
+    failures, checked = check_code_groups()
+    failures.extend(check_navigation())
+    if failures:
+        for failure in failures:
+            print(f"error: {failure}", file=sys.stderr)
+        return 1
+
+    print(f"checked {checked} multilingual code groups and SDK navigation")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## TL;DR
Make the deployed Mintlify documentation lead with the TypeScript SDK while keeping Rust available throughout.

## Description
- Put TypeScript before Rust in 105 generic multilingual code groups across the current Mintlify documentation tree.
- Put TypeScript first in SDK navigation, installation tables, reference lists, and generic language descriptions.
- Add TypeScript counterparts for upstream CA configuration, sandbox health checks, combined mounts, and metadata-network policy.
- Keep language-specific references and historical changelog entries in their existing order.
- Add a CI check that prevents generic documentation and SDK navigation from reverting to Rust-first ordering.
- Keep the repository-facing README changes in the separate main-based PR #1440.

## Test Plan
- [x] `python3 scripts/check-docs-language-order.py` checks 105 multilingual code groups and SDK navigation.
- [x] `PYTHONPYCACHEPREFIX=/private/tmp/microsandbox-pycache python3 -m py_compile scripts/check-docs-language-order.py` passes.
- [x] `python3 -c 'import json; json.load(open("docs/docs.json"))'` parses the Mintlify configuration.
- [x] `git diff --check origin/mintlify...HEAD` passes.
- [x] Mintlify preview deployment succeeds for the docs commit.
