### PR TITLE
fix(filesystem): avoid write probes on readonly mounts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3964,6 +3964,7 @@ dependencies = [
  "scopeguard",
  "tempfile",
  "tracing",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/filesystem/Cargo.toml
+++ b/crates/filesystem/Cargo.toml
@@ -24,3 +24,6 @@ prebuilt = ["microsandbox-utils/http-client"]
 
 [build-dependencies]
 microsandbox-utils.workspace = true
+
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.61.2", features = ["Win32_Storage_FileSystem", "Win32_System_SystemServices"] }

--- a/crates/filesystem/lib/backends/passthroughfs/unix/builder.rs
+++ b/crates/filesystem/lib/backends/passthroughfs/unix/builder.rs
@@ -29,7 +29,7 @@ use super::{
 };
 #[cfg(target_os = "linux")]
 use crate::backends::shared::platform;
-use crate::backends::shared::{init_binary, inode_table::MultikeyBTreeMap, stat_override};
+use crate::backends::shared::{init_binary, inode_table::MultikeyBTreeMap};
 
 //--------------------------------------------------------------------------------------------------
 // Types
@@ -175,16 +175,7 @@ impl PassthroughFsBuilder {
         // Open the root directory, contained beneath the anchor when one is set.
         let root_fd = super::open_root(&cfg_probe)?;
 
-        // Probe xattr support if strict mode is enabled.
-        if cfg_probe.strict_enabled() && cfg_probe.xattr_enabled() {
-            let supported = stat_override::probe_xattr_support(root_fd.as_raw_fd())?;
-            if !supported {
-                return Err(io::Error::new(
-                    io::ErrorKind::Unsupported,
-                    "xattr not supported on root filesystem and stat_virtualization is Strict",
-                ));
-            }
-        }
+        super::probe_strict_xattr_support(&cfg_probe, root_fd.as_raw_fd())?;
 
         // Create the init binary file.
         let init_file = init_binary::create_init_file()?;

--- a/crates/filesystem/lib/backends/passthroughfs/unix/mod.rs
+++ b/crates/filesystem/lib/backends/passthroughfs/unix/mod.rs
@@ -20,7 +20,7 @@ use std::{
     ffi::{CStr, CString},
     fs::File,
     io,
-    os::fd::{AsRawFd, FromRawFd},
+    os::fd::{AsRawFd, FromRawFd, RawFd},
     os::unix::ffi::OsStrExt,
     path::{Component, Path, PathBuf},
     sync::{
@@ -67,8 +67,8 @@ pub enum CachePolicy {
 pub enum StatVirtualization {
     /// Fail-closed: require xattr support; eager probe at mount time.
     ///
-    /// Reads and writes the override xattr. Mount fails if the host
-    /// filesystem cannot store `user.*` xattrs on the bind root.
+    /// Read-only mounts require readable xattrs. Writable mounts require
+    /// writable xattrs so every guest metadata operation can be persisted.
     Strict,
 
     /// Opportunistic: apply the overlay if present; tolerate missing xattr support.
@@ -267,16 +267,7 @@ impl PassthroughFs {
         // Open the root directory, contained beneath the anchor when one is set.
         let root_fd = open_root(&cfg)?;
 
-        // Probe xattr support if strict mode is enabled.
-        if cfg.strict_enabled() && cfg.xattr_enabled() {
-            let supported = stat_override::probe_xattr_support(root_fd.as_raw_fd())?;
-            if !supported {
-                return Err(io::Error::new(
-                    io::ErrorKind::Unsupported,
-                    "xattr not supported on root filesystem and stat_virtualization is Strict",
-                ));
-            }
-        }
+        probe_strict_xattr_support(&cfg, root_fd.as_raw_fd())?;
 
         // Create the init binary file.
         let init_file = init_binary::create_init_file()?;
@@ -883,6 +874,44 @@ impl DynFileSystem for PassthroughFs {
 //--------------------------------------------------------------------------------------------------
 // Functions
 //--------------------------------------------------------------------------------------------------
+
+/// Verify the xattr capability required by a strict mount's access mode.
+///
+/// A read-only mount only consumes existing stat overrides, so requiring a
+/// write would reject readable paths such as foreign-owned sticky directories.
+/// Writable mounts retain the stronger write probe because guest metadata
+/// changes must be persisted on every exposed inode, including the mount root.
+pub(crate) fn probe_strict_xattr_support(
+    cfg: &PassthroughConfig,
+    root_fd: RawFd,
+) -> io::Result<()> {
+    if !cfg.strict_enabled() || !cfg.xattr_enabled() {
+        return Ok(());
+    }
+
+    let (operation, supported) = if cfg.readonly() {
+        ("read", stat_override::probe_xattr_read_support(root_fd))
+    } else {
+        ("write", stat_override::probe_xattr_write_support(root_fd))
+    };
+    let supported = supported.map_err(|error| {
+        io::Error::new(
+            error.kind(),
+            format!("strict stat virtualization {operation} probe failed: {error}"),
+        )
+    })?;
+
+    if !supported {
+        return Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            format!(
+                "strict stat virtualization requires xattr {operation} support on the mount root"
+            ),
+        ));
+    }
+
+    Ok(())
+}
 
 /// Open the mount root directory.
 ///

--- a/crates/filesystem/lib/backends/passthroughfs/unix/tests/test_config.rs
+++ b/crates/filesystem/lib/backends/passthroughfs/unix/tests/test_config.rs
@@ -15,6 +15,26 @@ fn test_strict_succeeds_on_xattr_capable_fs() {
 }
 
 #[test]
+#[cfg(target_os = "linux")]
+fn test_readonly_strict_does_not_require_xattr_write_access() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::set_permissions(tmp.path(), std::fs::Permissions::from_mode(0o555)).unwrap();
+
+    let cfg = PassthroughConfig {
+        root_dir: tmp.path().to_path_buf(),
+        stat_virtualization: StatVirtualization::Strict,
+        readonly: true,
+        ..Default::default()
+    };
+
+    // The root is readable but cannot accept the write probe used by writable
+    // strict mounts. Read-only strict construction must remain non-mutating.
+    let _fs = PassthroughFs::new(cfg).unwrap();
+}
+
+#[test]
 fn test_relaxed_skips_eager_probe() {
     // Relaxed never probes the bind root.
     let sb = TestSandbox::with_config(|mut cfg| {

--- a/crates/filesystem/lib/backends/passthroughfs/windows/builder.rs
+++ b/crates/filesystem/lib/backends/passthroughfs/windows/builder.rs
@@ -117,7 +117,7 @@ impl PassthroughFs {
             }
             root
         };
-        let stat_store = StatStore::new(&root, cfg.stat_virtualization)?;
+        let stat_store = StatStore::new(&root, cfg.stat_virtualization, cfg.readonly)?;
 
         let init_file = if cfg.inject_init {
             let mut file = tempfile::tempfile().map_err(host_error)?;
@@ -182,7 +182,7 @@ impl PassthroughFs {
         let path = std::fs::canonicalize(path).map_err(host_error)?;
         let metadata = safe_metadata_under_root(&root, &path)?;
         let mode = (mode_from_metadata(&metadata) & S_IFMT) | (permissions & 0o7777);
-        let store = StatStore::new(&root, StatVirtualization::Strict)?
+        let store = StatStore::new(&root, StatVirtualization::Strict, false)?
             .ok_or_else(|| linux_error(LINUX_EIO))?;
         store.write(&path, uid, gid, mode, 0)
     }

--- a/crates/filesystem/lib/backends/passthroughfs/windows/mod.rs
+++ b/crates/filesystem/lib/backends/passthroughfs/windows/mod.rs
@@ -49,6 +49,7 @@ const FALLBACK_METADATA_DIR_NAME: &str = ".msb_override_stat";
 const METADATA_ROOT_NAME: &str = "__root";
 const METADATA_STAT_NAME: &str = "stat.bin";
 const ADS_STREAM_NAME: &str = "msb.override_stat";
+const ADS_PROBE_STREAM_NAME: &str = "msb._probe";
 
 const DT_UNKNOWN: u32 = 0;
 const DT_FIFO: u32 = 1;
@@ -574,9 +575,21 @@ fn write_override_sidecar_file(path: &Path, override_stat: OverrideStat) -> io::
 }
 
 fn ads_override_path(path: &Path) -> PathBuf {
+    ads_stream_path(path, ADS_STREAM_NAME)
+}
+
+fn ads_probe_path(path: &Path) -> PathBuf {
+    ads_stream_path(path, ADS_PROBE_STREAM_NAME)
+}
+
+/// Build an alternate-data-stream path without changing the base path.
+///
+/// Capability probes must use their own stream name: writing to the real
+/// override stream would destroy persisted metadata for the mount root.
+fn ads_stream_path(path: &Path, stream_name: &str) -> PathBuf {
     let mut encoded: Vec<u16> = path.as_os_str().encode_wide().collect();
     encoded.push(b':' as u16);
-    encoded.extend(ADS_STREAM_NAME.encode_utf16());
+    encoded.extend(stream_name.encode_utf16());
     PathBuf::from(OsString::from_wide(&encoded))
 }
 

--- a/crates/filesystem/lib/backends/passthroughfs/windows/stat_store.rs
+++ b/crates/filesystem/lib/backends/passthroughfs/windows/stat_store.rs
@@ -1,19 +1,30 @@
 //! Windows stat-virtualization store for the passthrough backend.
 
 use super::*;
+use windows_sys::Win32::Storage::FileSystem::{GetVolumeInformationW, GetVolumePathNameW};
+use windows_sys::Win32::System::SystemServices::FILE_NAMED_STREAMS;
 
 //--------------------------------------------------------------------------------------------------
 // Methods
 //--------------------------------------------------------------------------------------------------
 
 impl StatStore {
-    pub(super) fn new(root: &Path, policy: StatVirtualization) -> io::Result<Option<Self>> {
+    pub(super) fn new(
+        root: &Path,
+        policy: StatVirtualization,
+        readonly: bool,
+    ) -> io::Result<Option<Self>> {
         if matches!(policy, StatVirtualization::Off) {
             return Ok(None);
         }
 
         let ads_store = Self::ads(root);
-        match ads_store.probe() {
+        let ads_probe = if readonly && matches!(policy, StatVirtualization::Strict) {
+            ads_store.probe_ads_read()
+        } else {
+            ads_store.probe()
+        };
+        match ads_probe {
             Ok(()) => return Ok(Some(ads_store)),
             Err(error) if matches!(policy, StatVirtualization::Strict) => return Err(error),
             Err(error) => {
@@ -68,6 +79,21 @@ impl StatStore {
             Err(error) => return Err(host_error(error)),
         }
         Ok(())
+    }
+
+    /// Verify that a read-only strict mount can consume ADS metadata without
+    /// creating or deleting a stream on the host directory.
+    fn probe_ads_read(&self) -> io::Result<()> {
+        if !volume_supports_named_streams(&self.root)? {
+            return Err(linux_error(LINUX_EOPNOTSUPP));
+        }
+
+        let probe_path = ads_override_path(&self.root);
+        match read_override_stream(&probe_path) {
+            Ok(_) => Ok(()),
+            Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+            Err(error) => Err(error),
+        }
     }
 
     fn probe_sidecar(&self, dir: &Path) -> io::Result<()> {
@@ -231,4 +257,43 @@ impl OverrideStat {
         }
         buf
     }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+/// Query the backing volume instead of creating a probe ADS on a read-only mount.
+fn volume_supports_named_streams(path: &Path) -> io::Result<bool> {
+    let path_wide: Vec<u16> = path.as_os_str().encode_wide().chain(Some(0)).collect();
+    let mut volume_path = [0u16; 32_768];
+    let found = unsafe {
+        GetVolumePathNameW(
+            path_wide.as_ptr(),
+            volume_path.as_mut_ptr(),
+            volume_path.len() as u32,
+        )
+    };
+    if found == 0 {
+        return Err(host_error(io::Error::last_os_error()));
+    }
+
+    let mut flags = 0u32;
+    let queried = unsafe {
+        GetVolumeInformationW(
+            volume_path.as_ptr(),
+            std::ptr::null_mut(),
+            0,
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+            &mut flags,
+            std::ptr::null_mut(),
+            0,
+        )
+    };
+    if queried == 0 {
+        return Err(host_error(io::Error::last_os_error()));
+    }
+
+    Ok(flags & FILE_NAMED_STREAMS != 0)
 }

--- a/crates/filesystem/lib/backends/passthroughfs/windows/stat_store.rs
+++ b/crates/filesystem/lib/backends/passthroughfs/windows/stat_store.rs
@@ -19,8 +19,8 @@ impl StatStore {
         }
 
         let ads_store = Self::ads(root);
-        let ads_probe = if readonly && matches!(policy, StatVirtualization::Strict) {
-            ads_store.probe_ads_read()
+        let ads_probe = if readonly {
+            ads_store.probe_read()
         } else {
             ads_store.probe()
         };
@@ -33,7 +33,12 @@ impl StatStore {
         }
 
         let sidecar_store = Self::sidecar(root);
-        match sidecar_store.probe() {
+        let sidecar_probe = if readonly {
+            sidecar_store.probe_read()
+        } else {
+            sidecar_store.probe()
+        };
+        match sidecar_probe {
             Ok(()) => Ok(Some(sidecar_store)),
             Err(error) => {
                 tracing::debug!(?error, "windows passthrough sidecar stat store unavailable");
@@ -65,34 +70,64 @@ impl StatStore {
         }
     }
 
+    /// Verify that an existing metadata store can be consumed without
+    /// creating, replacing, or deleting anything beneath a read-only mount.
+    fn probe_read(&self) -> io::Result<()> {
+        match &self.backend {
+            StatStoreBackend::AlternateDataStream => self.probe_ads_read(),
+            StatStoreBackend::Sidecar { dir } => self.probe_sidecar_read(dir),
+        }
+    }
+
     fn probe_ads(&self) -> io::Result<()> {
-        let probe_path = ads_override_path(&self.root);
+        // Never probe through `msb.override_stat`: that is the persistent
+        // metadata stream for the mount root and may already contain a guest
+        // chown/chmod override that must survive remounting.
+        let probe_path = ads_probe_path(&self.root);
         let probe = OverrideStat::new(0, 0, S_IFDIR | 0o700, 0);
         write_override_stream(&probe_path, probe)?;
-        let read_back = read_override_stream(&probe_path)?;
-        if read_back.version != OVERRIDE_VERSION {
-            return Err(linux_error(LINUX_EIO));
-        }
+        let validation = read_override_stream(&probe_path).and_then(|read_back| {
+            if read_back.version == OVERRIDE_VERSION {
+                Ok(())
+            } else {
+                Err(linux_error(LINUX_EIO))
+            }
+        });
         match std::fs::remove_file(&probe_path) {
             Ok(()) => {}
             Err(error) if error.kind() == io::ErrorKind::NotFound => {}
             Err(error) => return Err(host_error(error)),
         }
+        validation?;
         Ok(())
     }
 
-    /// Verify that a read-only strict mount can consume ADS metadata without
-    /// creating or deleting a stream on the host directory.
+    /// Verify that a read-only mount can consume ADS metadata without creating
+    /// or deleting a stream on the host directory.
     fn probe_ads_read(&self) -> io::Result<()> {
         if !volume_supports_named_streams(&self.root)? {
             return Err(linux_error(LINUX_EOPNOTSUPP));
         }
 
         let probe_path = ads_override_path(&self.root);
-        match read_override_stream(&probe_path) {
+        match StdOpenOptions::new()
+            .read(true)
+            .custom_flags(FILE_FLAG_OPEN_REPARSE_POINT | FILE_FLAG_BACKUP_SEMANTICS)
+            .open(&probe_path)
+        {
             Ok(_) => Ok(()),
             Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
-            Err(error) => Err(error),
+            Err(error) => Err(host_error(error)),
+        }
+    }
+
+    fn probe_sidecar_read(&self, dir: &Path) -> io::Result<()> {
+        // A missing sidecar is a valid empty store. If it exists, opening its
+        // directory verifies read access without leaving a probe artifact.
+        match std::fs::read_dir(dir) {
+            Ok(_) => Ok(()),
+            Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+            Err(error) => Err(host_error(error)),
         }
     }
 

--- a/crates/filesystem/lib/backends/passthroughfs/windows/tests.rs
+++ b/crates/filesystem/lib/backends/passthroughfs/windows/tests.rs
@@ -479,6 +479,31 @@ fn strict_uses_ads_and_does_not_create_sidecar() {
 }
 
 #[test]
+fn readonly_strict_probe_does_not_create_ads() {
+    let temp = TempDir::new();
+    let probe_path = ads_override_path(&temp.path);
+    assert_eq!(
+        std::fs::metadata(&probe_path).unwrap_err().kind(),
+        io::ErrorKind::NotFound
+    );
+
+    let fs = PassthroughFs::new(PassthroughConfig {
+        root_dir: temp.path.clone(),
+        inject_init: false,
+        readonly: true,
+        stat_virtualization: StatVirtualization::Strict,
+        ..Default::default()
+    })
+    .unwrap();
+
+    assert_ads_store(&fs);
+    assert_eq!(
+        std::fs::metadata(&probe_path).unwrap_err().kind(),
+        io::ErrorKind::NotFound
+    );
+}
+
+#[test]
 fn ads_stat_virtualization_persists_for_directories() {
     let temp = TempDir::new();
     {

--- a/crates/filesystem/lib/backends/passthroughfs/windows/tests.rs
+++ b/crates/filesystem/lib/backends/passthroughfs/windows/tests.rs
@@ -479,26 +479,79 @@ fn strict_uses_ads_and_does_not_create_sidecar() {
 }
 
 #[test]
-fn readonly_strict_probe_does_not_create_ads() {
+fn readonly_probes_do_not_create_metadata() {
     let temp = TempDir::new();
-    let probe_path = ads_override_path(&temp.path);
-    assert_eq!(
-        std::fs::metadata(&probe_path).unwrap_err().kind(),
-        io::ErrorKind::NotFound
-    );
+    let override_path = ads_override_path(&temp.path);
+    let probe_path = ads_probe_path(&temp.path);
+
+    for policy in [StatVirtualization::Strict, StatVirtualization::Relaxed] {
+        let fs = PassthroughFs::new(PassthroughConfig {
+            root_dir: temp.path.clone(),
+            inject_init: false,
+            readonly: true,
+            stat_virtualization: policy,
+            ..Default::default()
+        })
+        .unwrap();
+
+        assert_ads_store(&fs);
+    }
+
+    for path in [override_path, probe_path] {
+        assert_eq!(
+            std::fs::metadata(path).unwrap_err().kind(),
+            io::ErrorKind::NotFound
+        );
+    }
+    assert!(!temp.path.join(FALLBACK_METADATA_DIR_NAME).exists());
+}
+
+#[test]
+fn readonly_relaxed_probe_preserves_mount_root_override() {
+    let temp = TempDir::new();
+    write_override_stream(
+        &ads_override_path(&temp.path),
+        OverrideStat::new(1234, 2345, S_IFDIR | 0o1755, 0),
+    )
+    .unwrap();
 
     let fs = PassthroughFs::new(PassthroughConfig {
         root_dir: temp.path.clone(),
         inject_init: false,
         readonly: true,
-        stat_virtualization: StatVirtualization::Strict,
+        stat_virtualization: StatVirtualization::Relaxed,
         ..Default::default()
     })
     .unwrap();
 
     assert_ads_store(&fs);
+    assert_override(&temp.path, 1234, 2345, S_IFDIR | 0o1755, 0);
     assert_eq!(
-        std::fs::metadata(&probe_path).unwrap_err().kind(),
+        std::fs::metadata(ads_probe_path(&temp.path))
+            .unwrap_err()
+            .kind(),
+        io::ErrorKind::NotFound
+    );
+    assert!(!temp.path.join(FALLBACK_METADATA_DIR_NAME).exists());
+}
+
+#[test]
+fn writable_probe_preserves_mount_root_override() {
+    let temp = TempDir::new();
+    write_override_stream(
+        &ads_override_path(&temp.path),
+        OverrideStat::new(1234, 2345, S_IFDIR | 0o1755, 0),
+    )
+    .unwrap();
+
+    let fs = fs_for(&temp.path);
+    assert_ads_store(&fs);
+
+    assert_override(&temp.path, 1234, 2345, S_IFDIR | 0o1755, 0);
+    assert_eq!(
+        std::fs::metadata(ads_probe_path(&temp.path))
+            .unwrap_err()
+            .kind(),
         io::ErrorKind::NotFound
     );
 }

--- a/crates/filesystem/lib/backends/shared/stat_override.rs
+++ b/crates/filesystem/lib/backends/shared/stat_override.rs
@@ -412,10 +412,60 @@ pub(crate) fn get_override(
     read_override(fd, strict)
 }
 
-/// Check if the xattr system is functional by probing the given directory.
+/// Check whether xattrs can be read from the given directory without mutating it.
 ///
-/// Returns `Ok(true)` if xattrs work, `Ok(false)` if not supported.
-pub(crate) fn probe_xattr_support(dirfd: RawFd) -> io::Result<bool> {
+/// An absent override still proves that the lookup reached an xattr-capable
+/// filesystem. Read-only passthrough mounts use this probe because they never
+/// need to persist guest metadata changes.
+///
+/// Returns `Ok(true)` if xattr reads work, `Ok(false)` if they are unsupported.
+pub(crate) fn probe_xattr_read_support(dirfd: RawFd) -> io::Result<bool> {
+    #[cfg(target_os = "linux")]
+    let ret = {
+        let mut path_buf = [0u8; PROC_SELF_FD_PATH_BUF_LEN];
+        let path = format_proc_self_fd_path(dirfd, &mut path_buf)?;
+        unsafe { libc::getxattr(path, OVERRIDE_XATTR_KEY.as_ptr(), std::ptr::null_mut(), 0) }
+    };
+
+    #[cfg(target_os = "macos")]
+    let ret = unsafe {
+        libc::fgetxattr(
+            dirfd,
+            OVERRIDE_XATTR_KEY.as_ptr(),
+            std::ptr::null_mut(),
+            0,
+            0,
+            0,
+        )
+    };
+
+    if ret >= 0 {
+        return Ok(true);
+    }
+
+    let err = io::Error::last_os_error();
+    let errno = err.raw_os_error().unwrap_or(0);
+
+    #[cfg(target_os = "linux")]
+    if errno == libc::ENODATA {
+        return Ok(true);
+    }
+    #[cfg(target_os = "macos")]
+    if errno == libc::ENOATTR {
+        return Ok(true);
+    }
+
+    if errno == libc::EOPNOTSUPP || errno == libc::ENOTSUP {
+        return Ok(false);
+    }
+
+    Err(platform::linux_error(err))
+}
+
+/// Check if xattrs can be written by probing the given directory.
+///
+/// Returns `Ok(true)` if xattr writes work, `Ok(false)` if they are unsupported.
+pub(crate) fn probe_xattr_write_support(dirfd: RawFd) -> io::Result<bool> {
     let probe_val: [u8; 1] = [1];
 
     #[cfg(target_os = "linux")]

--- a/crates/runtime/lib/vm.rs
+++ b/crates/runtime/lib/vm.rs
@@ -1610,12 +1610,25 @@ fn build_vm(
             ..Default::default()
         };
         let backend = PassthroughFs::new(cfg).map_err(|e| {
-            // Name the folder on a permission error, usually an OS access restriction.
+            // Name the folder on a permission error. The underlying error
+            // distinguishes path access from a strict metadata probe failure.
             if e.kind() == std::io::ErrorKind::PermissionDenied {
+                #[cfg(target_os = "macos")]
+                let platform_hint =
+                    " On macOS, grant access in System Settings > Privacy & Security.";
+                #[cfg(not(target_os = "macos"))]
+                let platform_hint = "";
+                let policy_hint = if matches!(
+                    parsed.stat_virtualization,
+                    StatVirtualization::Strict
+                ) {
+                    " For a foreign-owned path, use stat-virt=relaxed if full metadata virtualization is not required."
+                } else {
+                    ""
+                };
                 RuntimeError::Custom(format!(
-                    "mount {tag}: permission denied reading host folder {} ({e}). \
-                     On macOS, grant access in System Settings > Privacy & Security.",
-                    host_path.display()
+                    "mount {tag}: permission denied accessing host folder {} ({e}).{platform_hint}{policy_hint}",
+                    host_path.display(),
                 ))
             } else {
                 RuntimeError::Custom(format!("mount {tag}: {e}"))


### PR DESCRIPTION
## TL;DR
Allow read-only strict passthrough mounts to verify stat-override metadata support without writing to the host mount root, while preserving the existing fail-closed write probe for writable mounts.

## Description
- Use a non-mutating `getxattr` capability check for read-only strict mounts on Linux and macOS.
- Query named-stream support and read any existing override ADS without creating one on Windows.
- Keep the write-and-remove probe for writable strict mounts because guest metadata changes must remain persistable.
- Clarify permission diagnostics and only show the macOS privacy hint on macOS.
- Add Unix and Windows regressions covering non-mutating read-only construction.
- Fixes #1441.

## Test Plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p microsandbox-filesystem` (618 passed)
- [x] `cargo test -p microsandbox-runtime --lib` (138 passed)
- [x] `cargo clippy -p microsandbox-filesystem -p microsandbox-runtime --lib -- -D warnings`
- [x] Cross-compile the isolated Windows volume-capability API path for `x86_64-pc-windows-msvc`.
- [ ] Run the Linux sticky-directory regression in CI; the current host is macOS.
- [ ] Run the native Windows filesystem suite in CI; the macOS cross-build lacks the MSVC SDK required by native dependencies.
