### PR TITLE
feat(mounts): support guest uid and gid overrides

### DIFF
--- a/crates/cli/lib/commands/common.rs
+++ b/crates/cli/lib/commands/common.rs
@@ -549,6 +549,8 @@ struct CliMountOptions {
     follow_root_symlinks: bool,
     stat_virtualization: Option<microsandbox::sandbox::StatVirtualization>,
     host_permissions: Option<microsandbox::sandbox::HostPermissions>,
+    uid: Option<u32>,
+    gid: Option<u32>,
     size_mib: Option<u32>,
     quota_mib: Option<u32>,
     named_kind: Option<VolumeKind>,
@@ -1391,7 +1393,7 @@ fn validate_guest_path(context: &str, path: &str) -> anyhow::Result<()> {
 
 /// Parse a volume spec and apply it to the builder.
 ///
-/// Accepts: `SRC:DST[:ro|rw][,noexec][,nosuid][,nodev][,follow-root-symlinks][,stat-virt=...][,host-perms=...]`.
+/// Accepts: `SRC:DST[:ro|rw][,noexec][,nosuid][,nodev][,follow-root-symlinks][,stat-virt=...][,host-perms=...][,uid=...][,gid=...]`.
 pub fn apply_volume(builder: SandboxBuilder, spec: &str) -> anyhow::Result<SandboxBuilder> {
     let parsed = parse_cli_mount_spec(
         "volume",
@@ -1446,6 +1448,12 @@ pub fn apply_volume(builder: SandboxBuilder, spec: &str) -> anyhow::Result<Sandb
         }
         if let Some(hp) = options.host_permissions {
             m = m.host_permissions(hp);
+        }
+        if let Some(uid) = options.uid {
+            m = m.uid(uid);
+        }
+        if let Some(gid) = options.gid {
+            m = m.gid(gid);
         }
         m
     }))
@@ -1595,9 +1603,13 @@ pub fn apply_explicit_named_mount(
     }
     if matches!(parsed.options.named_kind, Some(VolumeKind::Disk))
         && (parsed.options.stat_virtualization.is_some()
-            || parsed.options.host_permissions.is_some())
+            || parsed.options.host_permissions.is_some()
+            || parsed.options.uid.is_some()
+            || parsed.options.gid.is_some())
     {
-        anyhow::bail!("mount-named kind=disk does not support stat-virt=... or host-perms=...");
+        anyhow::bail!(
+            "mount-named kind=disk does not support stat-virt=..., host-perms=..., uid=..., or gid=..."
+        );
     }
 
     let source = parsed.source.to_string();
@@ -1648,6 +1660,12 @@ fn apply_common_mount_options(mut mount: MountBuilder, options: CliMountOptions)
     }
     if let Some(hp) = options.host_permissions {
         mount = mount.host_permissions(hp);
+    }
+    if let Some(uid) = options.uid {
+        mount = mount.uid(uid);
+    }
+    if let Some(gid) = options.gid {
+        mount = mount.gid(gid);
     }
     if let Some(quota) = options.quota_mib {
         mount = mount.quota(quota);
@@ -1746,6 +1764,8 @@ fn parse_cli_mount_options(
     let mut seen_follow_root = false;
     let mut seen_stat_virt = false;
     let mut seen_host_perms = false;
+    let mut seen_uid = false;
+    let mut seen_gid = false;
     let mut seen_size = false;
     let mut seen_quota = false;
     let mut seen_named_kind = false;
@@ -1832,6 +1852,24 @@ fn parse_cli_mount_options(
                             ),
                         });
                     }
+                    "uid" if support.policies => {
+                        if seen_uid {
+                            anyhow::bail!("mount option `uid` specified more than once");
+                        }
+                        seen_uid = true;
+                        parsed.uid = Some(value.parse::<u32>().map_err(|_| {
+                            anyhow::anyhow!("invalid uid {value:?} (expected an unsigned integer)")
+                        })?);
+                    }
+                    "gid" if support.policies => {
+                        if seen_gid {
+                            anyhow::bail!("mount option `gid` specified more than once");
+                        }
+                        seen_gid = true;
+                        parsed.gid = Some(value.parse::<u32>().map_err(|_| {
+                            anyhow::anyhow!("invalid gid {value:?} (expected an unsigned integer)")
+                        })?);
+                    }
                     "size" if support.size => {
                         if seen_size {
                             anyhow::bail!("mount option `size` specified more than once");
@@ -1878,14 +1916,21 @@ fn parse_cli_mount_options(
                             anyhow::anyhow!("invalid disk image format {value:?}: {e}")
                         })?);
                     }
-                    "stat-virt" | "host-perms" | "size" | "quota" | "kind" | "fstype"
-                    | "format" => {
+                    "stat-virt" | "host-perms" | "uid" | "gid" | "size" | "quota" | "kind"
+                    | "fstype" | "format" => {
                         anyhow::bail!("mount option `{key}` is not valid here");
                     }
                     other => anyhow::bail!("unknown mount option {other:?}"),
                 }
             }
         }
+    }
+
+    if parsed.uid.is_some() != parsed.gid.is_some() {
+        anyhow::bail!("mount options `uid` and `gid` must be specified together");
+    }
+    if parsed.uid.is_some() && matches!(parsed.stat_virtualization, Some(StatVirtualization::Off)) {
+        anyhow::bail!("mount options `uid` and `gid` cannot be combined with stat-virt=off");
     }
 
     Ok(parsed)
@@ -3580,6 +3625,18 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_apply_volume_guest_ownership() {
+        let mount = build_one("/host:/guest:stat-virt=relaxed,uid=1000,gid=1001").await;
+        match mount {
+            VolumeMount::Bind { options, .. } => {
+                assert_eq!(options.uid, Some(1000));
+                assert_eq!(options.gid, Some(1001));
+            }
+            other => panic!("expected Bind, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
     async fn test_apply_volume_host_perms_mirror() {
         let mount = build_one("./project:/work:host-perms=mirror").await;
         match mount {
@@ -3866,6 +3923,18 @@ mod tests {
     fn test_apply_volume_rejects_unknown_stat_virt() {
         let err = expect_apply_volume_err("/host:/guest:stat-virt=bogus");
         assert!(err.contains("invalid stat-virt"), "got: {err}");
+    }
+
+    #[test]
+    fn test_apply_volume_rejects_partial_guest_ownership() {
+        let err = expect_apply_volume_err("/host:/guest:uid=1000");
+        assert!(err.contains("must be specified together"), "got: {err}");
+    }
+
+    #[test]
+    fn test_apply_volume_rejects_guest_ownership_with_stat_virt_off() {
+        let err = expect_apply_volume_err("/host:/guest:uid=1000,gid=1000,stat-virt=off");
+        assert!(err.contains("stat-virt=off"), "got: {err}");
     }
 
     #[test]

--- a/crates/cli/lib/commands/inspect.rs
+++ b/crates/cli/lib/commands/inspect.rs
@@ -41,15 +41,21 @@ fn mount_policy_suffix(
 
 /// Render mount access and execution flags for `msb inspect` output.
 fn mount_flags_suffix(options: MountOptions) -> String {
-    let mut flags = vec![if options.readonly { "ro" } else { "rw" }];
+    let mut flags = vec![if options.readonly { "ro" } else { "rw" }.to_string()];
     if options.noexec {
-        flags.push("noexec");
+        flags.push("noexec".to_string());
     }
     if options.nosuid {
-        flags.push("nosuid");
+        flags.push("nosuid".to_string());
     }
     if options.nodev {
-        flags.push("nodev");
+        flags.push("nodev".to_string());
+    }
+    if let Some(uid) = options.uid {
+        flags.push(format!("uid={uid}"));
+    }
+    if let Some(gid) = options.gid {
+        flags.push(format!("gid={gid}"));
     }
     format!(" ({})", flags.join(","))
 }

--- a/crates/cli/lib/sandbox_config.rs
+++ b/crates/cli/lib/sandbox_config.rs
@@ -237,6 +237,8 @@ struct MountObject {
     nodev: Option<bool>,
     stat_virtualization: Option<StatVirtualizationInput>,
     host_permissions: Option<HostPermissionsInput>,
+    uid: Option<u32>,
+    gid: Option<u32>,
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -1503,12 +1505,15 @@ fn materialize_mount_object(object: &MountObject) -> anyhow::Result<VolumeMount>
     if (object.format.is_some() || object.fstype.is_some()) && object.disk.is_none() {
         anyhow::bail!("mount.format and mount.fstype are only valid for a disk mount");
     }
-    if (object.stat_virtualization.is_some() || object.host_permissions.is_some())
+    if (object.stat_virtualization.is_some()
+        || object.host_permissions.is_some()
+        || object.uid.is_some()
+        || object.gid.is_some())
         && object.bind.is_none()
         && object.named.is_none()
     {
         anyhow::bail!(
-            "mount.stat_virtualization and mount.host_permissions are only valid for bind or named mounts"
+            "mount.stat_virtualization, mount.host_permissions, mount.uid, and mount.gid are only valid for bind or named mounts"
         );
     }
 
@@ -1560,6 +1565,12 @@ fn materialize_mount_object(object: &MountObject) -> anyhow::Result<VolumeMount>
     }
     if let Some(policy) = object.host_permissions {
         mount = mount.host_permissions(policy.into());
+    }
+    if let Some(uid) = object.uid {
+        mount = mount.uid(uid);
+    }
+    if let Some(gid) = object.gid {
+        mount = mount.gid(gid);
     }
     mount.build().map_err(Into::into)
 }

--- a/crates/filesystem/lib/backends/passthroughfs/unix/tests/test_stat_virt.rs
+++ b/crates/filesystem/lib/backends/passthroughfs/unix/tests/test_stat_virt.rs
@@ -91,6 +91,20 @@ fn test_identity_map_applies_to_no_xattr_host_owner() {
 }
 
 #[test]
+fn test_fixed_identity_map_applies_to_every_host_owner() {
+    let sb = TestSandbox::with_config(|mut cfg| {
+        cfg.bind_identity_map = Some(identity_handle(BindIdentityMap::fixed(2468, 1357)));
+        cfg
+    });
+
+    sb.host_create_file("fixed.txt", b"data");
+
+    let entry = sb.lookup_root("fixed.txt").unwrap();
+    assert_eq!(entry.attr.st_uid, 2468);
+    assert_eq!(entry.attr.st_gid, 1357);
+}
+
+#[test]
 fn test_identity_map_preserves_xattr_precedence() {
     let host_uid = current_host_uid();
     let sb = TestSandbox::with_config(|mut cfg| {

--- a/crates/filesystem/lib/backends/passthroughfs/windows/builder.rs
+++ b/crates/filesystem/lib/backends/passthroughfs/windows/builder.rs
@@ -61,6 +61,12 @@ pub struct PassthroughConfig {
     /// Whether mutating guest filesystem operations should be rejected.
     pub readonly: bool,
 
+    /// Guest-visible fallback uid for host paths without an override stream.
+    pub mount_uid: Option<u32>,
+
+    /// Guest-visible fallback gid for host paths without an override stream.
+    pub mount_gid: Option<u32>,
+
     /// FUSE entry cache timeout.
     pub entry_timeout: Duration,
 
@@ -200,6 +206,8 @@ impl Default for PassthroughConfig {
             stat_virtualization: StatVirtualization::Strict,
             host_permissions: HostPermissions::Private,
             readonly: false,
+            mount_uid: None,
+            mount_gid: None,
             entry_timeout: Duration::from_secs(5),
             attr_timeout: Duration::from_secs(5),
             inject_init: true,

--- a/crates/filesystem/lib/backends/passthroughfs/windows/inode.rs
+++ b/crates/filesystem/lib/backends/passthroughfs/windows/inode.rs
@@ -46,7 +46,7 @@ impl PassthroughFs {
         let data = Arc::new(InodeData {
             inode: ROOT_INODE,
             path: self.root.clone(),
-            virtual_meta: RwLock::new(VirtualMetadata::default()),
+            virtual_meta: RwLock::new(self.default_virtual_metadata()),
         });
 
         let mut inodes = self.inodes.write().unwrap();
@@ -78,11 +78,22 @@ impl PassthroughFs {
         let data = Arc::new(InodeData {
             inode,
             path: path.clone(),
-            virtual_meta: RwLock::new(VirtualMetadata::default()),
+            virtual_meta: RwLock::new(self.default_virtual_metadata()),
         });
         inodes.by_inode.insert(inode, data.clone());
         inodes.by_path.insert(path, data.clone());
         data
+    }
+
+    /// Seed in-memory fallback metadata for hosts where persistent stat
+    /// virtualization is unavailable in relaxed mode.
+    fn default_virtual_metadata(&self) -> VirtualMetadata {
+        let (uid, gid) = self.mount_ownership().unwrap_or((0, 0));
+        VirtualMetadata {
+            uid,
+            gid,
+            ..VirtualMetadata::default()
+        }
     }
 
     pub(super) fn child_path(&self, parent: u64, name: &CStr) -> io::Result<PathBuf> {

--- a/crates/filesystem/lib/backends/passthroughfs/windows/metadata.rs
+++ b/crates/filesystem/lib/backends/passthroughfs/windows/metadata.rs
@@ -25,6 +25,8 @@ impl PassthroughFs {
             let mut st = host_stat_from_metadata(metadata, data.inode);
             if let Some(override_stat) = store.read(&data.path)? {
                 apply_override_stat(&mut st, override_stat);
+            } else {
+                self.apply_mount_ownership(&mut st);
             }
             return Ok(st);
         }
@@ -59,7 +61,8 @@ impl PassthroughFs {
         }
 
         if self.stat_store.is_some() {
-            return Ok(OverrideStat::new(0, 0, mode_from_metadata(metadata), 0));
+            let (uid, gid) = self.mount_ownership().unwrap_or((0, 0));
+            return Ok(OverrideStat::new(uid, gid, mode_from_metadata(metadata), 0));
         }
 
         let virtual_meta = data.virtual_meta.read().unwrap();

--- a/crates/filesystem/lib/backends/passthroughfs/windows/mod.rs
+++ b/crates/filesystem/lib/backends/passthroughfs/windows/mod.rs
@@ -207,6 +207,19 @@ impl PassthroughFs {
             quota.ensure_baseline();
         }
     }
+
+    /// Return the configured mount-wide guest ownership fallback.
+    fn mount_ownership(&self) -> Option<(u32, u32)> {
+        self.cfg.mount_uid.zip(self.cfg.mount_gid)
+    }
+
+    /// Apply mount-wide ownership only when no per-inode override exists.
+    fn apply_mount_ownership(&self, st: &mut stat64) {
+        if let Some((uid, gid)) = self.mount_ownership() {
+            st.st_uid = uid;
+            st.st_gid = gid;
+        }
+    }
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/crates/filesystem/lib/backends/passthroughfs/windows/tests.rs
+++ b/crates/filesystem/lib/backends/passthroughfs/windows/tests.rs
@@ -433,6 +433,26 @@ fn host_files_without_override_are_executable() {
 }
 
 #[test]
+fn mount_ownership_applies_without_override() {
+    let temp = TempDir::new();
+    std::fs::write(temp.path.join("owned.txt"), b"data").unwrap();
+
+    let fs = PassthroughFs::new(PassthroughConfig {
+        root_dir: temp.path.clone(),
+        inject_init: false,
+        mount_uid: Some(2468),
+        mount_gid: Some(1357),
+        ..Default::default()
+    })
+    .unwrap();
+    fs.init(FsOptions::empty()).unwrap();
+
+    let entry = fs.lookup(context(), ROOT_INODE, c"owned.txt").unwrap();
+    assert_eq!(entry.attr.st_uid, 2468);
+    assert_eq!(entry.attr.st_gid, 1357);
+}
+
+#[test]
 fn readonly_host_files_without_override_are_read_execute_only() {
     let temp = TempDir::new();
     let file = temp.path.join("locked");

--- a/crates/filesystem/lib/backends/shared/stat_override.rs
+++ b/crates/filesystem/lib/backends/shared/stat_override.rs
@@ -107,6 +107,21 @@ impl BindIdentityMap {
         }
     }
 
+    /// Create a map that presents every host owner as one guest uid/gid pair.
+    ///
+    /// This is used by explicit per-mount ownership. Both mapping branches use
+    /// the same identity so foreign-owned host files do not fall back to the
+    /// overflow user.
+    pub fn fixed(guest_uid: u32, guest_gid: u32) -> Self {
+        Self {
+            host_owner_uid: 0,
+            guest_uid,
+            guest_gid,
+            overflow_uid: guest_uid,
+            overflow_gid: guest_gid,
+        }
+    }
+
     /// Apply this map to a stat result in place.
     pub fn apply(&self, st: &mut stat64) {
         if st.st_uid == self.host_owner_uid {

--- a/crates/runtime/lib/vm.rs
+++ b/crates/runtime/lib/vm.rs
@@ -18,7 +18,7 @@ use std::time::Duration;
 use microsandbox_db::DbWriteConnection;
 use microsandbox_db::entity::run as run_entity;
 #[cfg(unix)]
-use microsandbox_filesystem::{BindIdentityMapHandle, DynFileSystem};
+use microsandbox_filesystem::{BindIdentityMap, BindIdentityMapHandle, DynFileSystem};
 use microsandbox_filesystem::{
     HostPermissions, PassthroughConfig, PassthroughFs, StatVirtualization,
 };
@@ -1593,8 +1593,12 @@ fn build_vm(
         // without relying on the string-only mount spec field.
         let host_path = PathBuf::from(&parsed.host_path);
         #[cfg(unix)]
-        let mount_bind_identity_map =
-            bind_identity_map_for_mount(&mut bind_identity_map, parsed.stat_virtualization);
+        let mount_bind_identity_map = bind_identity_map_for_mount(
+            &mut bind_identity_map,
+            parsed.stat_virtualization,
+            parsed.uid,
+            parsed.gid,
+        );
         let cfg = PassthroughConfig {
             root_dir: host_path.clone(),
             inject_init: false,
@@ -1606,6 +1610,10 @@ fn build_vm(
             no_symlink_root: !parsed.follow_root_symlinks,
             #[cfg(unix)]
             bind_identity_map: mount_bind_identity_map,
+            #[cfg(windows)]
+            mount_uid: parsed.uid,
+            #[cfg(windows)]
+            mount_gid: parsed.gid,
             quota_bytes: parsed.quota_bytes,
             ..Default::default()
         };
@@ -2081,9 +2089,15 @@ fn release_reserved_metrics_slot(handoff: Option<&MetricsSlotHandoff>) {
 fn bind_identity_map_for_mount(
     registration: &mut BindIdentityMapRegistration,
     stat_virtualization: StatVirtualization,
+    uid: Option<u32>,
+    gid: Option<u32>,
 ) -> Option<BindIdentityMapHandle> {
     if matches!(stat_virtualization, StatVirtualization::Off) {
         return None;
+    }
+
+    if let (Some(uid), Some(gid)) = (uid, gid) {
+        return Some(Arc::new(OnceLock::from(BindIdentityMap::fixed(uid, gid))));
     }
 
     registration.mount_count += 1;
@@ -2412,13 +2426,16 @@ struct ParsedMountSpec {
     readonly: bool,
     follow_root_symlinks: bool,
     quota_bytes: Option<u64>,
+    uid: Option<u32>,
+    gid: Option<u32>,
 }
 
 /// Parse a `--mount` spec into [`ParsedMountSpec`].
 ///
 /// Wire grammar: `tag:host_path[:opts]`, where `opts` is a comma-separated
 /// option block of flags (`ro`, `rw`, `noexec`, `nosuid`, `nodev`,
-/// `follow-root-symlinks`) and keyed policies (`stat-virt=...`, `host-perms=...`).
+/// `follow-root-symlinks`) and keyed policies (`stat-virt=...`, `host-perms=...`,
+/// `uid=...`, `gid=...`).
 /// The `follow-root-symlinks` flag opts the mount out of the default no-follow
 /// root resolution; its absence keeps the protective default on.
 fn parse_mount_spec(spec: &str) -> Result<ParsedMountSpec, String> {
@@ -2445,6 +2462,8 @@ fn parse_mount_spec(spec: &str) -> Result<ParsedMountSpec, String> {
     let mut readonly = false;
     let mut follow_root_symlinks = false;
     let mut quota_bytes = None;
+    let mut uid = None;
+    let mut gid = None;
     let mut seen_stat_virt = false;
     let mut seen_host_perms = false;
     let mut seen_access = false;
@@ -2453,6 +2472,8 @@ fn parse_mount_spec(spec: &str) -> Result<ParsedMountSpec, String> {
     let mut seen_nodev = false;
     let mut seen_follow_root = false;
     let mut seen_quota = false;
+    let mut seen_uid = false;
+    let mut seen_gid = false;
 
     if let Some(opts) = options {
         for opt in opts.split(',') {
@@ -2552,11 +2573,42 @@ fn parse_mount_spec(spec: &str) -> Result<ParsedMountSpec, String> {
                             })?;
                             quota_bytes = Some(mib.saturating_mul(1024 * 1024));
                         }
+                        "uid" => {
+                            if seen_uid {
+                                return Err(
+                                    "mount option `uid` specified more than once".to_string()
+                                );
+                            }
+                            seen_uid = true;
+                            uid = Some(value.parse::<u32>().map_err(|_| {
+                                format!("invalid uid {value:?} (expected an unsigned integer)")
+                            })?);
+                        }
+                        "gid" => {
+                            if seen_gid {
+                                return Err(
+                                    "mount option `gid` specified more than once".to_string()
+                                );
+                            }
+                            seen_gid = true;
+                            gid = Some(value.parse::<u32>().map_err(|_| {
+                                format!("invalid gid {value:?} (expected an unsigned integer)")
+                            })?);
+                        }
                         other => return Err(format!("unknown mount option {other:?}")),
                     }
                 }
             }
         }
+    }
+
+    if uid.is_some() != gid.is_some() {
+        return Err("mount options `uid` and `gid` must be specified together".to_string());
+    }
+    if uid.is_some() && matches!(stat_virtualization, StatVirtualization::Off) {
+        return Err(
+            "mount options `uid` and `gid` cannot be combined with stat-virt=off".to_string(),
+        );
     }
 
     Ok(ParsedMountSpec {
@@ -2567,6 +2619,8 @@ fn parse_mount_spec(spec: &str) -> Result<ParsedMountSpec, String> {
         readonly,
         follow_root_symlinks,
         quota_bytes,
+        uid,
+        gid,
     })
 }
 
@@ -2852,6 +2906,25 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_mount_spec_guest_ownership() {
+        let p = parse_mount_spec("foo:/host/data:stat-virt=relaxed,uid=1000,gid=1001").unwrap();
+        assert_eq!(p.uid, Some(1000));
+        assert_eq!(p.gid, Some(1001));
+    }
+
+    #[test]
+    fn test_parse_mount_spec_rejects_partial_guest_ownership() {
+        let err = parse_mount_spec("foo:/host/data:uid=1000").unwrap_err();
+        assert!(err.contains("must be specified together"), "got: {err}");
+    }
+
+    #[test]
+    fn test_parse_mount_spec_rejects_guest_ownership_with_stat_virt_off() {
+        let err = parse_mount_spec("foo:/host/data:uid=1000,gid=1000,stat-virt=off").unwrap_err();
+        assert!(err.contains("stat-virt=off"), "got: {err}");
+    }
+
+    #[test]
     fn test_parse_mount_spec_rejects_duplicate_quota() {
         let err = parse_mount_spec("foo:/host/data:quota=1,quota=2").unwrap_err();
         assert!(
@@ -2946,12 +3019,25 @@ mod tests {
         };
 
         let first =
-            bind_identity_map_for_mount(&mut registration, StatVirtualization::Strict).unwrap();
+            bind_identity_map_for_mount(&mut registration, StatVirtualization::Strict, None, None)
+                .unwrap();
         let second =
-            bind_identity_map_for_mount(&mut registration, StatVirtualization::Relaxed).unwrap();
-        let off = bind_identity_map_for_mount(&mut registration, StatVirtualization::Off);
+            bind_identity_map_for_mount(&mut registration, StatVirtualization::Relaxed, None, None)
+                .unwrap();
+        let fixed = bind_identity_map_for_mount(
+            &mut registration,
+            StatVirtualization::Relaxed,
+            Some(1000),
+            Some(1001),
+        )
+        .unwrap();
+        let off =
+            bind_identity_map_for_mount(&mut registration, StatVirtualization::Off, None, None);
 
         assert!(Arc::ptr_eq(&first, &second));
+        assert!(!Arc::ptr_eq(&first, &fixed));
+        assert_eq!(fixed.get().unwrap().guest_uid, 1000);
+        assert_eq!(fixed.get().unwrap().guest_gid, 1001);
         assert!(off.is_none());
         assert_eq!(registration.mount_count, 2);
     }

--- a/docs/cli/configuration.mdx
+++ b/docs/cli/configuration.mdx
@@ -212,6 +212,8 @@ mounts:
     target: "/app"
     stat_virtualization: strict
     host_permissions: private
+    uid: 1000
+    gid: 1000
   - named: cache
     target: "/var/cache/app"
     create: ensure-exists
@@ -225,7 +227,7 @@ mounts:
     readonly: true
 ```
 
-All mount kinds accept `readonly`, `noexec`, `nosuid`, and `nodev`. `stat_virtualization` and `host_permissions` apply only to bind and named mounts. Duplicate guest targets are rejected.
+All mount kinds accept `readonly`, `noexec`, `nosuid`, and `nodev`. `stat_virtualization`, `host_permissions`, and paired `uid`/`gid` apply only to bind and directory-backed named mounts. `uid`/`gid` change only guest-visible fallback ownership, never host inode ownership, and cannot be combined with `stat_virtualization: off`. Duplicate guest targets are rejected.
 
 ### Rootfs patches
 

--- a/docs/sandboxes/volumes.mdx
+++ b/docs/sandboxes/volumes.mdx
@@ -377,6 +377,7 @@ Mounts use normal Linux behavior by default: writable, executable, suid-enabled,
 - `noexec` when files on the mount should not be executed directly.
 - `nosuid` when setuid/setgid bits should be ignored.
 - `nodev` when device files should be ignored.
+- `uid` and `gid` together to present host files without virtual metadata as a fixed guest owner. This is guest-visible only and never calls `chown` on the host.
 
 `noexec` does not stop interpreters from reading scripts from the mount, for example `sh /app/src/script.sh`.
 
@@ -388,9 +389,9 @@ CLI mount flags use `SOURCE:DEST[:OPTIONS]`. The `:` before `OPTIONS` starts the
 
 | Flag | Source | Options |
 |------|--------|---------|
-| `--mount-dir` | Host directory | `ro`, `rw`, `noexec`, `nosuid`, `nodev`, `stat-virt=strict\|relaxed\|off`, `host-perms=private\|mirror` |
-| `--mount-file` | Host file | `ro`, `rw`, `noexec`, `nosuid`, `nodev`, `stat-virt=strict\|relaxed\|off`, `host-perms=private\|mirror` |
-| `--mount-named` | Named volume | `ro`, `rw`, `noexec`, `nosuid`, `nodev`, `kind=dir\|disk`, `size=<size>` for `kind=disk`, `quota=<size>` for directory volumes; directory-backed named volumes also support `stat-virt=strict\|relaxed\|off`, `host-perms=private\|mirror` |
+| `--mount-dir` | Host directory | `ro`, `rw`, `noexec`, `nosuid`, `nodev`, `stat-virt=strict\|relaxed\|off`, `host-perms=private\|mirror`, paired `uid=<id>,gid=<id>` |
+| `--mount-file` | Host file | `ro`, `rw`, `noexec`, `nosuid`, `nodev`, `stat-virt=strict\|relaxed\|off`, `host-perms=private\|mirror`, paired `uid=<id>,gid=<id>` |
+| `--mount-named` | Named volume | `ro`, `rw`, `noexec`, `nosuid`, `nodev`, `kind=dir\|disk`, `size=<size>` for `kind=disk`, `quota=<size>` for directory volumes; directory-backed named volumes also support `stat-virt=strict\|relaxed\|off`, `host-perms=private\|mirror`, and paired `uid=<id>,gid=<id>` |
 | `--mount-disk` | Host disk image | `ro`, `rw`, `noexec`, `nosuid`, `nodev`, `format=raw\|qcow2\|vmdk`, `fstype=<type>` |
 | `--tmpfs` | Guest path | `ro`, `rw`, `noexec`, `nosuid`, `nodev`; size may be passed as `PATH:SIZE[:OPTIONS]` |
 
@@ -402,7 +403,14 @@ Mount flags may be repeated, so a sandbox can combine host directories, individu
 ```rust Rust
 let sb = Sandbox::builder("full")
     .image("python")
-    .volume("/app/src", |v| v.bind("./src").readonly().noexec())
+    .volume("/app/src", |v| {
+        v.bind("./src")
+            .readonly()
+            .noexec()
+            .stat_virtualization(StatVirtualization::Relaxed)
+            .uid(1000)
+            .gid(1000)
+    })
     .volume("/app/pyproject.toml", |v| v.bind("./pyproject.toml").readonly())
     .volume("/root/.cache/pip", |v| {
         v.named("pip-cache")
@@ -421,7 +429,7 @@ let sb = Sandbox::builder("full")
 
 ```bash CLI
 msb create python --name full \
-  --mount-dir ./src:/app/src:ro,noexec \
+  --mount-dir ./src:/app/src:ro,noexec,stat-virt=relaxed,uid=1000,gid=1000 \
   --mount-file ./pyproject.toml:/app/pyproject.toml:ro \
   --mount-named pip-cache:/root/.cache/pip:stat-virt=relaxed \
   --mount-disk ./dataset.qcow2:/dataset:ro,format=qcow2,fstype=ext4 \

--- a/docs/sdk/go/volumes.mdx
+++ b/docs/sdk/go/volumes.mdx
@@ -836,6 +836,18 @@ Per-mount stat-virtualization policy (bind / named only)
 
 Per-mount host-permission propagation policy (bind / named only)
 
+#### <span className="msb-recv">mount.</span><span className="msb-hn">UID</span>
+
+`*uint32`
+
+Guest-visible fallback uid for virtiofs-backed mounts. Set together with `GID`; never changes host ownership.
+
+#### <span className="msb-recv">mount.</span><span className="msb-hn">GID</span>
+
+`*uint32`
+
+Guest-visible fallback gid for virtiofs-backed mounts. Set together with `UID`; never changes host ownership.
+
 
 #### <span className="msb-recv">mount.</span><span className="msb-hn">Kind()</span>
 

--- a/docs/sdk/go/volumes.mdx
+++ b/docs/sdk/go/volumes.mdx
@@ -924,7 +924,7 @@ Discriminates between the four mount flavours. Inspect via `mount.Kind()`.
 
 ### MountOptions
 
-Tuning struct for [`Mount.Bind`](#mount-bind), [`Mount.Named`](#mount-named), and [`Mount.NamedWith`](#mount-namedwith). `StatVirtualization` and `HostPermissions` are virtiofs-only and rejected at build time if combined with a tmpfs or disk-image mount; their zero values preserve the conservative defaults (strict, private).
+Tuning struct for [`Mount.Bind`](#mount-bind), [`Mount.Named`](#mount-named), and [`Mount.NamedWith`](#mount-namedwith). `StatVirtualization`, `HostPermissions`, `UID`, and `GID` are virtiofs-only. `UID` and `GID` are pointers so zero remains a valid explicit identity; set both or neither. They affect guest-visible fallback ownership only and never host ownership.
 
 <p className="msb-backref">Used by <a href="#mount-bind">Mount.Bind()</a> · <a href="#mount-named">Mount.Named()</a> · <a href="#mount-namedwith">Mount.NamedWith()</a></p>
 
@@ -937,6 +937,8 @@ Tuning struct for [`Mount.Bind`](#mount-bind), [`Mount.Named`](#mount-named), an
 | `QuotaMiB` | `uint32` | Guest-write quota in MiB, bounding growth beyond the host directory's existing contents; zero keeps the protective default (bind mounts only; named volumes use [`NamedVolumeOptions.QuotaMiB`](#namedvolumeoptions)) |
 | `StatVirtualization` | `StatVirtualization` | Per-mount stat-virtualization policy (virtiofs only) |
 | `HostPermissions` | `HostPermissions` | Per-mount host-permission propagation policy (virtiofs only) |
+| `UID` | `*uint32` | Guest-visible fallback uid; must be paired with `GID` and cannot be used with stat virtualization off |
+| `GID` | `*uint32` | Guest-visible fallback gid; must be paired with `UID` and cannot be used with stat virtualization off |
 
 ### NamedVolumeOptions
 

--- a/docs/sdk/python/volumes.mdx
+++ b/docs/sdk/python/volumes.mdx
@@ -209,6 +209,10 @@ def bind(
     noexec: bool = False,
     nosuid: bool = False,
     nodev: bool = False,
+    stat_virtualization: StatVirtualization | None = None,
+    host_permissions: HostPermissions | None = None,
+    uid: int | None = None,
+    gid: int | None = None,
 ) -> MountConfig
 ```
 
@@ -249,6 +253,22 @@ Mount a host directory into the sandbox. Changes in the guest are reflected on t
     <div className="msb-param-key"><code>nodev</code><span className="msb-type">bool</span></div>
     <div className="msb-param-desc">Ignore device files on the mount.</div>
   </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>stat_virtualization</code><a className="msb-type" href="#statvirtualization">StatVirtualization | None</a></div>
+    <div className="msb-param-desc">Guest metadata virtualization policy; defaults to strict.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>host_permissions</code><a className="msb-type" href="#hostpermissions">HostPermissions | None</a></div>
+    <div className="msb-param-desc">Whether guest permission changes stay private or mirror to the host.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>uid</code><span className="msb-type">int | None</span></div>
+    <div className="msb-param-desc">Guest-visible fallback uid. Set together with <code>gid</code>; never changes host ownership.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>gid</code><span className="msb-type">int | None</span></div>
+    <div className="msb-param-desc">Guest-visible fallback gid. Set together with <code>uid</code>; never changes host ownership.</div>
+  </div>
 </div>
 
 <p className="msb-label">Returns</p>
@@ -276,6 +296,10 @@ def named(
     noexec: bool = False,
     nosuid: bool = False,
     nodev: bool = False,
+    stat_virtualization: StatVirtualization | None = None,
+    host_permissions: HostPermissions | None = None,
+    uid: int | None = None,
+    gid: int | None = None,
 ) -> MountConfig
 ```
 
@@ -340,6 +364,22 @@ Mount a named volume. By default the volume must already exist; set `mode` to co
   <div className="msb-param">
     <div className="msb-param-key"><code>nodev</code><span className="msb-type">bool</span></div>
     <div className="msb-param-desc">Ignore device files on the mount.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>stat_virtualization</code><a className="msb-type" href="#statvirtualization">StatVirtualization | None</a></div>
+    <div className="msb-param-desc">Guest metadata virtualization policy; defaults to strict.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>host_permissions</code><a className="msb-type" href="#hostpermissions">HostPermissions | None</a></div>
+    <div className="msb-param-desc">Whether guest permission changes stay private or mirror to the host.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>uid</code><span className="msb-type">int | None</span></div>
+    <div className="msb-param-desc">Guest-visible fallback uid for directory-backed volumes. Set together with <code>gid</code>.</div>
+  </div>
+  <div className="msb-param">
+    <div className="msb-param-key"><code>gid</code><span className="msb-type">int | None</span></div>
+    <div className="msb-param-desc">Guest-visible fallback gid for directory-backed volumes. Set together with <code>uid</code>.</div>
   </div>
 </div>
 

--- a/docs/sdk/python/volumes.mdx
+++ b/docs/sdk/python/volumes.mdx
@@ -753,7 +753,7 @@ Check whether a path exists within the volume.
 
 <p className="msb-backref">Returned by <a href="#volume-bind">Volume.bind()</a>, <a href="#volume-named">Volume.named()</a>, <a href="#volume-tmpfs">Volume.tmpfs()</a>, <a href="#volume-disk">Volume.disk()</a></p>
 
-Frozen dataclass representing a mount configuration. Build one with a [mount factory](#mount-factories) and pass it as a value in the sandbox `volumes` dict. `stat_virtualization` and `host_permissions` apply only to virtiofs-backed mounts (`BIND` and `NAMED`); setting either on a `TMPFS` or `DISK` mount raises `ValueError`.
+Frozen dataclass representing a mount configuration. Build one with a [mount factory](#mount-factories) and pass it as a value in the sandbox `volumes` dict. `stat_virtualization`, `host_permissions`, and paired `uid`/`gid` apply only to virtiofs-backed mounts (`BIND` and directory-backed `NAMED`). `uid`/`gid` change guest-visible fallback ownership only and never host ownership.
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
@@ -773,6 +773,8 @@ Frozen dataclass representing a mount configuration. Build one with a [mount fac
 | fstype | `str \| None` | `None` | Inner filesystem type for disk mounts |
 | stat_virtualization | [`StatVirtualization`](#statvirtualization)` \| None` | `None` | Per-mount stat-virtualization policy (virtiofs-backed only) |
 | host_permissions | [`HostPermissions`](#hostpermissions)` \| None` | `None` | Per-mount host-permission policy (virtiofs-backed only) |
+| uid | `int \| None` | `None` | Guest-visible fallback uid; must be paired with `gid` and cannot be used with stat virtualization off |
+| gid | `int \| None` | `None` | Guest-visible fallback gid; must be paired with `uid` and cannot be used with stat virtualization off |
 
 ### MountKind
 

--- a/docs/sdk/rust/volumes.mdx
+++ b/docs/sdk/rust/volumes.mdx
@@ -1419,6 +1419,22 @@ fn nodev(self) -> Self
 
 Ignore device files on this mount.
 
+#### <span className="msb-recv">mount.</span><span className="msb-hn">uid()</span>
+
+```rust
+fn uid(self, uid: u32) -> Self
+```
+
+Set the guest-visible fallback uid for host files without per-file virtual metadata. This never changes host ownership. It must be paired with [`gid()`](#gid), is valid only for bind and directory-backed named mounts, and cannot be combined with [`StatVirtualization::Off`](#statvirtualization).
+
+#### <span className="msb-recv">mount.</span><span className="msb-hn">gid()</span>
+
+```rust
+fn gid(self, gid: u32) -> Self
+```
+
+Set the guest-visible fallback gid for host files without per-file virtual metadata. This never changes host ownership and must be paired with [`uid()`](#uid).
+
 #### <span className="msb-recv">mount.</span><span className="msb-hn">stat_virtualization()</span>
 
 ```rust
@@ -1721,7 +1737,7 @@ Configuration for creating a named volume. Re-exported as both `VolumeSpec` and 
 
 ### MountOptions
 
-Guest mount behavior shared by every mount kind. Set via the [`MountBuilder`](#mountbuilder-2) toggles; all fields default to `false`.
+Guest mount behavior shared by every mount kind. Set via the [`MountBuilder`](#mountbuilder-2) methods. Boolean fields default to `false`; ownership fields default to `None`.
 
 | Field | Type | Description |
 |-------|------|-------------|
@@ -1729,6 +1745,8 @@ Guest mount behavior shared by every mount kind. Set via the [`MountBuilder`](#m
 | `noexec` | `bool` | Direct execution from the mount is disabled |
 | `nosuid` | `bool` | setuid/setgid elevation from files on the mount is ignored |
 | `nodev` | `bool` | Device files on the mount are ignored |
+| `uid` | `Option<u32>` | Guest-visible fallback uid for virtiofs host files without an override; must be paired with `gid` |
+| `gid` | `Option<u32>` | Guest-visible fallback gid for virtiofs host files without an override; must be paired with `uid` |
 
 ### StatVirtualization
 

--- a/docs/sdk/typescript/volumes.mdx
+++ b/docs/sdk/typescript/volumes.mdx
@@ -351,6 +351,43 @@ Build and create the volume on disk, returning a [`Volume`](#instance-methods).
   </div>
 </div>
 
+## MountBuilder
+
+Fluent builder passed to [`SandboxBuilder.volume()`](/sdk/typescript/sandbox#volume). Select one mount kind, then chain mount options. Guest ownership applies only to bind and directory-backed named mounts with stat virtualization enabled.
+
+<Accordion title="Example">
+
+```typescript
+const sandbox = await Sandbox.builder("worker")
+  .image("python")
+  .volume("/workspace", (mount) =>
+    mount
+      .bind("./workspace")
+      .statVirtualization("relaxed")
+      .uid(1000)
+      .gid(1000),
+  )
+  .create();
+```
+
+</Accordion>
+
+#### <span className="msb-recv">mount.</span><span className="msb-hn">uid()</span>
+
+```typescript
+uid(uid: number): this
+```
+
+Set the guest-visible fallback uid for host files without virtual metadata. The value must be an integer from `0` through `4294967295`, must be paired with [`gid()`](#gid), and never changes host ownership.
+
+#### <span className="msb-recv">mount.</span><span className="msb-hn">gid()</span>
+
+```typescript
+gid(gid: number): this
+```
+
+Set the guest-visible fallback gid for host files without virtual metadata. The value must be an integer from `0` through `4294967295` and must be paired with [`uid()`](#uid).
+
 ## VolumeFs
 
 <p className="msb-backref">Returned by <a href="#volume-fs">volume.fs()</a> · <a href="#volumehandle">VolumeHandle.fs()</a></p>

--- a/packages/microsandbox-types/rust/lib/domain.rs
+++ b/packages/microsandbox-types/rust/lib/domain.rs
@@ -273,6 +273,22 @@ pub struct MountOptions {
 
     /// Whether device files on the mount are ignored.
     pub nodev: bool,
+
+    /// Guest-visible fallback uid for host inodes without virtual stat metadata.
+    ///
+    /// This never changes host ownership. It is valid only for virtiofs-backed
+    /// mounts, must be paired with [`gid`](Self::gid), and requires stat
+    /// virtualization to remain enabled.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub uid: Option<u32>,
+
+    /// Guest-visible fallback gid for host inodes without virtual stat metadata.
+    ///
+    /// This never changes host ownership. It is valid only for virtiofs-backed
+    /// mounts, must be paired with [`uid`](Self::uid), and requires stat
+    /// virtualization to remain enabled.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub gid: Option<u32>,
 }
 
 /// Storage kind for a named volume.

--- a/packages/microsandbox-types/rust/lib/domain.rs
+++ b/packages/microsandbox-types/rust/lib/domain.rs
@@ -279,7 +279,7 @@ pub struct MountOptions {
     /// This never changes host ownership. It is valid only for virtiofs-backed
     /// mounts, must be paired with [`gid`](Self::gid), and requires stat
     /// virtualization to remain enabled.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub uid: Option<u32>,
 
     /// Guest-visible fallback gid for host inodes without virtual stat metadata.
@@ -287,7 +287,7 @@ pub struct MountOptions {
     /// This never changes host ownership. It is valid only for virtiofs-backed
     /// mounts, must be paired with [`uid`](Self::uid), and requires stat
     /// virtualization to remain enabled.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub gid: Option<u32>,
 }
 

--- a/packages/microsandbox-types/rust/lib/typescript.rs
+++ b/packages/microsandbox-types/rust/lib/typescript.rs
@@ -250,4 +250,14 @@ mod tests {
         assert!(!domain.contains("SandboxModificationPlan"));
         assert!(!domain.contains("export type SandboxSpec ="));
     }
+
+    #[test]
+    fn mount_ownership_is_optional_in_the_typescript_wire_shape() {
+        let domain = render_domain();
+
+        // Rust omits unset ownership fields, so TypeScript callers must not be
+        // forced to provide nullable keys that are absent on the wire.
+        assert!(domain.contains("uid?: number | null;"));
+        assert!(domain.contains("gid?: number | null;"));
+    }
 }

--- a/packages/microsandbox-types/typescript/src/domain.ts
+++ b/packages/microsandbox-types/typescript/src/domain.ts
@@ -75,6 +75,22 @@ export type MountOptions = {
    * Whether device files on the mount are ignored.
    */
   nodev: boolean;
+  /**
+   * Guest-visible fallback uid for host inodes without virtual stat metadata.
+   *
+   * This never changes host ownership. It is valid only for virtiofs-backed
+   * mounts, must be paired with [`gid`](Self::gid), and requires stat
+   * virtualization to remain enabled.
+   */
+  uid: number | null;
+  /**
+   * Guest-visible fallback gid for host inodes without virtual stat metadata.
+   *
+   * This never changes host ownership. It is valid only for virtiofs-backed
+   * mounts, must be paired with [`uid`](Self::uid), and requires stat
+   * virtualization to remain enabled.
+   */
+  gid: number | null;
 };
 
 export type StatVirtualization = "strict" | "relaxed" | "off";

--- a/packages/microsandbox-types/typescript/src/domain.ts
+++ b/packages/microsandbox-types/typescript/src/domain.ts
@@ -82,7 +82,7 @@ export type MountOptions = {
    * mounts, must be paired with [`gid`](Self::gid), and requires stat
    * virtualization to remain enabled.
    */
-  uid: number | null;
+  uid?: number | null;
   /**
    * Guest-visible fallback gid for host inodes without virtual stat metadata.
    *
@@ -90,7 +90,7 @@ export type MountOptions = {
    * mounts, must be paired with [`uid`](Self::uid), and requires stat
    * virtualization to remain enabled.
    */
-  gid: number | null;
+  gid?: number | null;
 };
 
 export type StatVirtualization = "strict" | "relaxed" | "off";

--- a/sdk/go/internal/ffi/ffi.go
+++ b/sdk/go/internal/ffi/ffi.go
@@ -1615,22 +1615,24 @@ type RootDiskSpec struct {
 
 // MountSpec describes a volume mount for a sandbox.
 type MountSpec struct {
-	Bind               string `json:"bind,omitempty"`
-	Named              string `json:"named,omitempty"`
-	NamedMode          string `json:"named_mode,omitempty"`
-	NamedKind          string `json:"named_kind,omitempty"`
-	Tmpfs              bool   `json:"tmpfs,omitempty"`
-	Disk               string `json:"disk,omitempty"`
-	Format             string `json:"format,omitempty"`
-	Fstype             string `json:"fstype,omitempty"`
-	Readonly           bool   `json:"readonly,omitempty"`
-	Noexec             bool   `json:"noexec,omitempty"`
-	Nosuid             bool   `json:"nosuid,omitempty"`
-	Nodev              bool   `json:"nodev,omitempty"`
-	SizeMiB            uint32 `json:"size_mib,omitempty"`
-	QuotaMiB           uint32 `json:"quota_mib,omitempty"`
-	StatVirtualization string `json:"stat_virtualization,omitempty"`
-	HostPermissions    string `json:"host_permissions,omitempty"`
+	Bind               string  `json:"bind,omitempty"`
+	Named              string  `json:"named,omitempty"`
+	NamedMode          string  `json:"named_mode,omitempty"`
+	NamedKind          string  `json:"named_kind,omitempty"`
+	Tmpfs              bool    `json:"tmpfs,omitempty"`
+	Disk               string  `json:"disk,omitempty"`
+	Format             string  `json:"format,omitempty"`
+	Fstype             string  `json:"fstype,omitempty"`
+	Readonly           bool    `json:"readonly,omitempty"`
+	Noexec             bool    `json:"noexec,omitempty"`
+	Nosuid             bool    `json:"nosuid,omitempty"`
+	Nodev              bool    `json:"nodev,omitempty"`
+	SizeMiB            uint32  `json:"size_mib,omitempty"`
+	QuotaMiB           uint32  `json:"quota_mib,omitempty"`
+	StatVirtualization string  `json:"stat_virtualization,omitempty"`
+	HostPermissions    string  `json:"host_permissions,omitempty"`
+	UID                *uint32 `json:"uid,omitempty"`
+	GID                *uint32 `json:"gid,omitempty"`
 }
 
 // NetworkOptions is the JSON representation of the network config block.

--- a/sdk/go/native/src/lib.rs
+++ b/sdk/go/native/src/lib.rs
@@ -1183,6 +1183,10 @@ struct MountSpec {
     /// Per-mount host-permission policy ("private" | "mirror").
     /// Only valid for bind / named mounts.
     host_permissions: Option<String>,
+    /// Guest-visible fallback uid. Must be paired with `gid`.
+    uid: Option<u32>,
+    /// Guest-visible fallback gid. Must be paired with `uid`.
+    gid: Option<u32>,
 }
 
 #[derive(Clone, Copy)]
@@ -1903,6 +1907,8 @@ fn apply_volume(
     let nodev = m.nodev;
     let size_mib = m.size_mib;
     let quota_mib = m.quota_mib;
+    let uid = m.uid;
+    let gid = m.gid;
     let raw_named_mode = m.named_mode.clone();
     let raw_named_kind = m.named_kind.clone();
 
@@ -2010,6 +2016,12 @@ fn apply_volume(
         }
         if let Some(p) = host_perms {
             mb = mb.host_permissions(p);
+        }
+        if let Some(uid) = uid {
+            mb = mb.uid(uid);
+        }
+        if let Some(gid) = gid {
+            mb = mb.gid(gid);
         }
         mb
     }))

--- a/sdk/go/options.go
+++ b/sdk/go/options.go
@@ -1600,6 +1600,12 @@ type MountConfig struct {
 	// Only meaningful for Bind and Named mounts. Zero value preserves the
 	// conservative default (Private).
 	HostPermissions HostPermissions
+
+	// UID and GID set the guest-visible fallback ownership for host files
+	// without virtual stat metadata. They must either both be nil or both be
+	// non-nil. Host ownership is never changed.
+	UID *uint32
+	GID *uint32
 }
 
 // MountKind discriminates between the four mount flavours.
@@ -1631,6 +1637,10 @@ type MountOptions struct {
 	Nodev              bool
 	StatVirtualization StatVirtualization
 	HostPermissions    HostPermissions
+	// UID and GID set guest-visible fallback ownership. Use pointers so uid 0
+	// and gid 0 remain distinguishable from an unset option.
+	UID *uint32
+	GID *uint32
 	// QuotaMiB sets a guest-write quota for a bind mount, bounding how much
 	// the guest may add beyond the host directory's existing contents. Zero
 	// keeps the runtime's protective default. Bind mounts only; named volume
@@ -1690,6 +1700,8 @@ func (mountFactory) Bind(hostPath string, opts MountOptions) MountConfig {
 		Nodev:              opts.Nodev,
 		StatVirtualization: opts.StatVirtualization,
 		HostPermissions:    opts.HostPermissions,
+		UID:                opts.UID,
+		GID:                opts.GID,
 		QuotaMiB:           opts.QuotaMiB,
 	}
 }
@@ -1705,6 +1717,8 @@ func (mountFactory) Named(name string, opts MountOptions) MountConfig {
 		Nodev:              opts.Nodev,
 		StatVirtualization: opts.StatVirtualization,
 		HostPermissions:    opts.HostPermissions,
+		UID:                opts.UID,
+		GID:                opts.GID,
 	}
 }
 
@@ -1724,6 +1738,8 @@ func (mountFactory) NamedWith(name string, opts MountOptions, namedOpts NamedVol
 		Nodev:              opts.Nodev,
 		StatVirtualization: opts.StatVirtualization,
 		HostPermissions:    opts.HostPermissions,
+		UID:                opts.UID,
+		GID:                opts.GID,
 	}
 }
 

--- a/sdk/go/options_test.go
+++ b/sdk/go/options_test.go
@@ -947,6 +947,22 @@ func TestMountBindPropagatesPolicies(t *testing.T) {
 	}
 }
 
+func TestMountBindPropagatesGuestOwnership(t *testing.T) {
+	uid := uint32(1000)
+	gid := uint32(1001)
+	m := Mount.Bind("/host/data", MountOptions{
+		StatVirtualization: StatVirtualizationRelaxed,
+		UID:                &uid,
+		GID:                &gid,
+	})
+	if m.UID == nil || *m.UID != uid {
+		t.Errorf("UID: got %v, want %d", m.UID, uid)
+	}
+	if m.GID == nil || *m.GID != gid {
+		t.Errorf("GID: got %v, want %d", m.GID, gid)
+	}
+}
+
 func TestMountNamedPropagatesPolicies(t *testing.T) {
 	m := Mount.Named("cache", MountOptions{
 		StatVirtualization: StatVirtualizationOff,

--- a/sdk/go/sandbox.go
+++ b/sdk/go/sandbox.go
@@ -169,6 +169,8 @@ func buildFFICreateOptions(o SandboxConfig) ffi.CreateOptions {
 				QuotaMiB:           m.QuotaMiB,
 				StatVirtualization: string(m.StatVirtualization),
 				HostPermissions:    string(m.HostPermissions),
+				UID:                m.UID,
+				GID:                m.GID,
 			}
 		}
 	}

--- a/sdk/node-ts/README.md
+++ b/sdk/node-ts/README.md
@@ -13,7 +13,7 @@ For the full API reference and longer guides, use the docs site:
 ## Features
 
 - Hardware VM isolation with a guest Linux kernel
-- ESM-first TypeScript API with generated native bindings
+- ESM-first API with CommonJS `require()` support and generated native bindings
 - Collected and streaming command execution
 - Guest filesystem read, write, list, copy, stat, and stream operations
 - Named volumes, bind mounts, tmpfs mounts, and disk-image mounts
@@ -28,10 +28,14 @@ For the full API reference and longer guides, use the docs site:
 - Linux with KVM, macOS with Apple Silicon, or Windows 10+ with WHP enabled
 - Windows support is currently preview; see the [Windows troubleshooting guide](https://docs.microsandbox.dev/troubleshooting/windows) for WHP and runtime setup notes.
 
-The package root is ESM-only for normal imports:
+The package root supports both ESM imports and CommonJS `require()` on Node.js 22+:
 
 ```typescript
 import { Sandbox } from "microsandbox";
+```
+
+```javascript
+const { Sandbox } = require("microsandbox");
 ```
 
 ## Supported Platforms

--- a/sdk/node-ts/native/index.d.ts
+++ b/sdk/node-ts/native/index.d.ts
@@ -416,6 +416,10 @@ export declare class MountBuilder {
   nosuid(): this
   /** Ignore device files on the mount. */
   nodev(): this
+  /** Set the guest-visible fallback uid for host files without an override. */
+  uid(uid: number): this
+  /** Set the guest-visible fallback gid for host files without an override. */
+  gid(gid: number): this
   /** Tmpfs size cap in MiB (only valid with `.tmpfs()`). */
   size(mib: number): this
   /**
@@ -2474,6 +2478,10 @@ export interface VolumeMount {
   noexec: boolean
   nosuid: boolean
   nodev: boolean
+  /** Guest-visible fallback uid for virtiofs-backed mounts. */
+  uid?: number
+  /** Guest-visible fallback gid for virtiofs-backed mounts. */
+  gid?: number
   host?: string
   name?: string
   namedMode?: string

--- a/sdk/node-ts/native/mount_builder.rs
+++ b/sdk/node-ts/native/mount_builder.rs
@@ -212,18 +212,20 @@ impl JsMountBuilder {
 
     /// Set the guest-visible fallback uid for host files without an override.
     #[napi]
-    pub fn uid(&mut self, uid: u32) -> &Self {
+    pub fn uid(&mut self, uid: f64) -> Result<&Self> {
+        let uid = mount_identity("uid", uid)?;
         let prev = self.take_inner();
         self.inner = Some(prev.uid(uid));
-        self
+        Ok(self)
     }
 
     /// Set the guest-visible fallback gid for host files without an override.
     #[napi]
-    pub fn gid(&mut self, gid: u32) -> &Self {
+    pub fn gid(&mut self, gid: f64) -> Result<&Self> {
+        let gid = mount_identity("gid", gid)?;
         let prev = self.take_inner();
         self.inner = Some(prev.gid(gid));
-        self
+        Ok(self)
     }
 
     /// Tmpfs size cap in MiB (only valid with `.tmpfs()`).
@@ -298,6 +300,22 @@ impl JsMountBuilder {
             .map_err(to_napi_error)?;
         Ok(to_built_mount(mount))
     }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+/// Convert a JavaScript number to a Linux uid/gid without N-API's lossy
+/// `ToUint32` coercion of fractions, negative numbers, or overflowing values.
+fn mount_identity(name: &str, value: f64) -> Result<u32> {
+    if !value.is_finite() || value.fract() != 0.0 || !(0.0..=f64::from(u32::MAX)).contains(&value) {
+        return Err(napi::Error::from_reason(format!(
+            "{name} must be an integer between 0 and {}",
+            u32::MAX
+        )));
+    }
+    Ok(value as u32)
 }
 
 fn to_built_mount(mount: RustVolumeMount) -> JsBuiltVolumeMount {

--- a/sdk/node-ts/native/mount_builder.rs
+++ b/sdk/node-ts/native/mount_builder.rs
@@ -29,6 +29,10 @@ pub struct JsBuiltVolumeMount {
     pub noexec: bool,
     pub nosuid: bool,
     pub nodev: bool,
+    /// Guest-visible fallback uid for virtiofs-backed mounts.
+    pub uid: Option<u32>,
+    /// Guest-visible fallback gid for virtiofs-backed mounts.
+    pub gid: Option<u32>,
     pub host: Option<String>,
     pub name: Option<String>,
     pub named_mode: Option<String>,
@@ -206,6 +210,22 @@ impl JsMountBuilder {
         self
     }
 
+    /// Set the guest-visible fallback uid for host files without an override.
+    #[napi]
+    pub fn uid(&mut self, uid: u32) -> &Self {
+        let prev = self.take_inner();
+        self.inner = Some(prev.uid(uid));
+        self
+    }
+
+    /// Set the guest-visible fallback gid for host files without an override.
+    #[napi]
+    pub fn gid(&mut self, gid: u32) -> &Self {
+        let prev = self.take_inner();
+        self.inner = Some(prev.gid(gid));
+        self
+    }
+
     /// Tmpfs size cap in MiB (only valid with `.tmpfs()`).
     #[napi]
     pub fn size(&mut self, mib: u32) -> &Self {
@@ -314,6 +334,8 @@ fn to_built_mount(mount: RustVolumeMount) -> JsBuiltVolumeMount {
             noexec: options.noexec,
             nosuid: options.nosuid,
             nodev: options.nodev,
+            uid: options.uid,
+            gid: options.gid,
             host: Some(host.to_string_lossy().into_owned()),
             name: None,
             named_mode: None,
@@ -353,6 +375,8 @@ fn to_built_mount(mount: RustVolumeMount) -> JsBuiltVolumeMount {
                 noexec: options.noexec,
                 nosuid: options.nosuid,
                 nodev: options.nodev,
+                uid: options.uid,
+                gid: options.gid,
                 host: None,
                 name: Some(name),
                 named_mode,
@@ -376,6 +400,8 @@ fn to_built_mount(mount: RustVolumeMount) -> JsBuiltVolumeMount {
             noexec: options.noexec,
             nosuid: options.nosuid,
             nodev: options.nodev,
+            uid: options.uid,
+            gid: options.gid,
             host: None,
             name: None,
             named_mode: None,
@@ -400,6 +426,8 @@ fn to_built_mount(mount: RustVolumeMount) -> JsBuiltVolumeMount {
             noexec: options.noexec,
             nosuid: options.nosuid,
             nodev: options.nodev,
+            uid: options.uid,
+            gid: options.gid,
             host: Some(host.to_string_lossy().into_owned()),
             name: None,
             named_mode: None,

--- a/sdk/node-ts/src/internal/napi.ts
+++ b/sdk/node-ts/src/internal/napi.ts
@@ -1123,6 +1123,8 @@ export interface NapiMountBuilder {
   noexec(): this;
   nosuid(): this;
   nodev(): this;
+  uid(uid: number): this;
+  gid(gid: number): this;
   size(mib: number): this;
   statVirtualization(policy: string): this;
   hostPermissions(policy: string): this;
@@ -1136,6 +1138,8 @@ export interface NapiVolumeMount {
   readonly noexec: boolean;
   readonly nosuid: boolean;
   readonly nodev: boolean;
+  readonly uid?: number;
+  readonly gid?: number;
   readonly host?: string;
   readonly name?: string;
   readonly namedMode?: "existing" | "create" | "ensure-exists";

--- a/sdk/node-ts/tests/unit/builders.test.ts
+++ b/sdk/node-ts/tests/unit/builders.test.ts
@@ -232,6 +232,30 @@ describe("MountBuilder", () => {
     });
   });
 
+  it("propagates guest-visible uid and gid on a bind mount", () => {
+    const m = new MountBuilder("/work")
+      .bind("./project")
+      .statVirtualization("relaxed")
+      .uid(1000)
+      .gid(1001)
+      .build();
+    expect(m).toMatchObject({ kind: "bind", uid: 1000, gid: 1001 });
+  });
+
+  it("rejects partial guest ownership at build time", () => {
+    const builder = new MountBuilder("/data").bind("/host").uid(1000);
+    expect(() => builder.build()).toThrow(/must be specified together/);
+  });
+
+  it("rejects guest ownership with stat virtualization off", () => {
+    const builder = new MountBuilder("/data")
+      .bind("/host")
+      .uid(1000)
+      .gid(1000)
+      .statVirtualization("off");
+    expect(() => builder.build()).toThrow(/literal host metadata/);
+  });
+
   it("propagates stat-virt + host-perms on a named volume", () => {
     const m = new MountBuilder("/cache")
       .named("my-cache")

--- a/sdk/node-ts/tests/unit/builders.test.ts
+++ b/sdk/node-ts/tests/unit/builders.test.ts
@@ -247,6 +247,32 @@ describe("MountBuilder", () => {
     expect(() => builder.build()).toThrow(/must be specified together/);
   });
 
+  it("rejects uid and gid values that cannot be represented as u32", () => {
+    for (const value of [
+      -1,
+      1.5,
+      0x1_0000_0000,
+      Number.NaN,
+      Number.POSITIVE_INFINITY,
+    ]) {
+      expect(() => new MountBuilder("/data").bind("/host").uid(value)).toThrow(
+        /uid must be an integer between 0 and 4294967295/,
+      );
+      expect(() => new MountBuilder("/data").bind("/host").gid(value)).toThrow(
+        /gid must be an integer between 0 and 4294967295/,
+      );
+    }
+  });
+
+  it("accepts the maximum u32 uid and gid", () => {
+    const m = new MountBuilder("/data")
+      .bind("/host")
+      .uid(0xffff_ffff)
+      .gid(0xffff_ffff)
+      .build();
+    expect(m).toMatchObject({ uid: 0xffff_ffff, gid: 0xffff_ffff });
+  });
+
   it("rejects guest ownership with stat virtualization off", () => {
     const builder = new MountBuilder("/data")
       .bind("/host")
@@ -397,6 +423,17 @@ describe("SandboxBuilder.build", () => {
     expect(cfg.mounts[1]).toMatchObject({
       type: "Tmpfs",
       sizeMib: 64,
+    });
+  });
+
+  it("collects mount ownership through the MountBuilder callback", async () => {
+    const cfg = await Sandbox.builder("x")
+      .image("alpine")
+      .volume("/data", (m) => m.bind("/host").uid(1000).gid(1001))
+      .build();
+    expect(cfg.mounts[0]).toMatchObject({
+      type: "Bind",
+      options: { uid: 1000, gid: 1001 },
     });
   });
 

--- a/sdk/node-ts/tests/unit/package-exports.test.ts
+++ b/sdk/node-ts/tests/unit/package-exports.test.ts
@@ -1,0 +1,30 @@
+import { execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const PACKAGE_ROOT = fileURLToPath(new URL("../..", import.meta.url));
+
+function loadPackageRoot(inputType: "commonjs" | "module", source: string): string {
+  return execFileSync(process.execPath, [`--input-type=${inputType}`, "--eval", source], {
+    cwd: PACKAGE_ROOT,
+    encoding: "utf8",
+  });
+}
+
+describe("package root exports", () => {
+  it("loads through ESM import", () => {
+    const output = loadPackageRoot(
+      "module",
+      'import { Sandbox } from "microsandbox"; process.stdout.write(typeof Sandbox);',
+    );
+    expect(output).toBe("function");
+  });
+
+  it("loads through CommonJS require", () => {
+    const output = loadPackageRoot(
+      "commonjs",
+      'const { Sandbox } = require("microsandbox"); process.stdout.write(typeof Sandbox);',
+    );
+    expect(output).toBe("function");
+  });
+});

--- a/sdk/python/microsandbox/_microsandbox.pyi
+++ b/sdk/python/microsandbox/_microsandbox.pyi
@@ -12,6 +12,7 @@ from microsandbox.types import (
     ExecEventType,
     ExecOptions,
     FsEntryKind,
+    HostPermissions,
     ImageArchiveFormat,
     ImageSource,
     InitConfig,
@@ -38,6 +39,7 @@ from microsandbox.types import (
     SnapshotFormat,
     SnapshotScope,
     SnapshotStateKind,
+    StatVirtualization,
     Stdin,
     ViolationAction,
     ViolationPolicy,
@@ -619,6 +621,10 @@ class Volume:
         noexec: bool = False,
         nosuid: bool = False,
         nodev: bool = False,
+        stat_virtualization: StatVirtualization | None = None,
+        host_permissions: HostPermissions | None = None,
+        uid: int | None = None,
+        gid: int | None = None,
     ) -> MountConfig: ...
     @staticmethod
     def named(
@@ -632,6 +638,10 @@ class Volume:
         noexec: bool = False,
         nosuid: bool = False,
         nodev: bool = False,
+        stat_virtualization: StatVirtualization | None = None,
+        host_permissions: HostPermissions | None = None,
+        uid: int | None = None,
+        gid: int | None = None,
     ) -> MountConfig: ...
     @staticmethod
     def tmpfs(

--- a/sdk/python/microsandbox/types.py
+++ b/sdk/python/microsandbox/types.py
@@ -307,6 +307,7 @@ class DiskImageFormat(StrEnum):
     RAW = "raw"
     VMDK = "vmdk"
 
+
 class VolumeKind(StrEnum):
     DIRECTORY = "dir"
     DISK = "disk"
@@ -375,6 +376,7 @@ class SnapshotFormat(StrEnum):
 class SnapshotScope(StrEnum):
     DISK = "disk"
     RESUMABLE = "resumable"
+
 
 class RlimitResource(StrEnum):
     CPU = "cpu"
@@ -681,9 +683,9 @@ class InitConfig:
 class MountConfig:
     """Volume mount configuration.
 
-    ``stat_virtualization`` and ``host_permissions`` are only meaningful for
-    virtiofs-backed mounts (``BIND`` and ``NAMED``). Setting either on a
-    ``TMPFS`` or ``DISK`` mount raises ``ValueError`` at serialization time.
+    ``stat_virtualization``, ``host_permissions``, ``uid``, and ``gid`` are
+    only meaningful for virtiofs-backed mounts (``BIND`` and ``NAMED``).
+    ``uid`` and ``gid`` are guest-visible only and never change host ownership.
     """
 
     kind: MountKind
@@ -702,6 +704,8 @@ class MountConfig:
     fstype: str | None = None
     stat_virtualization: StatVirtualization | None = None
     host_permissions: HostPermissions | None = None
+    uid: int | None = None
+    gid: int | None = None
 
     def _to_dict(self) -> dict:
         # Validate every supplied enum before selecting a mount arm. This
@@ -741,6 +745,15 @@ class MountConfig:
             if self.host_permissions is not None
             else None
         )
+        if (self.uid is None) != (self.gid is None):
+            raise ValueError("MountConfig.uid and MountConfig.gid must be specified together")
+        for field_name, value in (("uid", self.uid), ("gid", self.gid)):
+            if value is not None and (isinstance(value, bool) or not isinstance(value, int)):
+                raise TypeError(f"MountConfig.{field_name} must be int")
+            if value is not None and not 0 <= value <= 0xFFFFFFFF:
+                raise ValueError(f"MountConfig.{field_name} must be between 0 and 4294967295")
+        if self.uid is not None and stat_virtualization == StatVirtualization.OFF.value:
+            raise ValueError("MountConfig.uid/gid cannot be combined with stat_virtualization=OFF")
         # Drive emission off `kind` exclusively so a `MountConfig` with
         # contradictory fields (e.g. kind=DISK + bind=...) raises here
         # rather than silently letting the wrong arm of `apply_mount` win.
@@ -789,9 +802,23 @@ class MountConfig:
                 d["stat_virtualization"] = stat_virtualization
             if host_permissions is not None:
                 d["host_permissions"] = host_permissions
-        elif self.stat_virtualization is not None or self.host_permissions is not None:
+            if self.uid is not None:
+                d["uid"] = self.uid
+                d["gid"] = self.gid
+            if (
+                self.kind == MountKind.NAMED
+                and named_kind == VolumeKind.DISK.value
+                and self.uid is not None
+            ):
+                raise ValueError("MountConfig.uid/gid are only valid for directory named volumes")
+        elif (
+            self.stat_virtualization is not None
+            or self.host_permissions is not None
+            or self.uid is not None
+            or self.gid is not None
+        ):
             raise ValueError(
-                f"stat_virtualization/host_permissions are only valid for "
+                f"stat_virtualization/host_permissions/uid/gid are only valid for "
                 f"BIND/NAMED mounts (got kind={self.kind.value})"
             )
         return d
@@ -867,7 +894,6 @@ class RootDisk:
         derived from the file extension unless given (vmdk is not supported)."""
         return RootDiskConfig(kind=RootDiskKind.DISK_IMAGE, path=path, format=format, fstype=fstype)
 
-
     @staticmethod
     def flat(
         size_mib: int | None = None,
@@ -882,6 +908,7 @@ class RootDisk:
             fstype=fstype,
             clone=clone,
         )
+
 
 @dataclass(frozen=True, slots=True)
 class ImageSource:
@@ -1518,6 +1545,7 @@ class TokenBucket:
     ``refill_time_ms``. ``one_time_burst`` grants extra startup tokens that
     are spent before the regular budget and never refill.
     """
+
     size: int
     """Bucket capacity in tokens: bytes for bandwidth, frames for ops."""
     refill_time_ms: int
@@ -1539,6 +1567,7 @@ class RateLimiter:
     Caps bandwidth (bytes) and packet rate (frames) independently; a
     missing bucket leaves that dimension unlimited.
     """
+
     bandwidth: TokenBucket | None = None
     """Bandwidth bucket. One token is one byte of frame data."""
     ops: TokenBucket | None = None

--- a/sdk/python/src/helpers.rs
+++ b/sdk/python/src/helpers.rs
@@ -806,6 +806,8 @@ fn apply_mount(
     let host_perms = extract_opt::<String>(mount, "host_permissions")?
         .map(parse_host_perms)
         .transpose()?;
+    let uid = extract_opt::<u32>(mount, "uid")?;
+    let gid = extract_opt::<u32>(mount, "gid")?;
 
     if let Some(bind_path) = extract_opt::<String>(mount, "bind")? {
         let quota_mib = extract_opt::<u32>(mount, "quota_mib")?;
@@ -828,6 +830,12 @@ fn apply_mount(
             }
             if let Some(p) = host_perms {
                 m = m.host_permissions(p);
+            }
+            if let Some(uid) = uid {
+                m = m.uid(uid);
+            }
+            if let Some(gid) = gid {
+                m = m.gid(gid);
             }
             if let Some(quota_mib) = quota_mib {
                 m = m.quota(quota_mib);
@@ -889,6 +897,12 @@ fn apply_mount(
             }
             if let Some(p) = host_perms {
                 m = m.host_permissions(p);
+            }
+            if let Some(uid) = uid {
+                m = m.uid(uid);
+            }
+            if let Some(gid) = gid {
+                m = m.gid(gid);
             }
             m
         }))

--- a/sdk/python/src/volume.rs
+++ b/sdk/python/src/volume.rs
@@ -159,7 +159,8 @@ impl PyVolume {
 
     /// Create a bind mount config.
     #[staticmethod]
-    #[pyo3(signature = (path, *, readonly = false, noexec = false, nosuid = false, nodev = false))]
+    #[allow(clippy::too_many_arguments)]
+    #[pyo3(signature = (path, *, readonly = false, noexec = false, nosuid = false, nodev = false, stat_virtualization = None, host_permissions = None, uid = None, gid = None))]
     fn bind(
         py: Python<'_>,
         path: String,
@@ -167,6 +168,10 @@ impl PyVolume {
         noexec: bool,
         nosuid: bool,
         nodev: bool,
+        stat_virtualization: Option<Py<PyAny>>,
+        host_permissions: Option<Py<PyAny>>,
+        uid: Option<Py<PyAny>>,
+        gid: Option<Py<PyAny>>,
     ) -> PyResult<PyObject> {
         let kwargs = PyDict::new(py);
         kwargs.set_item("kind", mount_kind(py, "BIND")?)?;
@@ -175,13 +180,14 @@ impl PyVolume {
         kwargs.set_item("noexec", noexec)?;
         kwargs.set_item("nosuid", nosuid)?;
         kwargs.set_item("nodev", nodev)?;
+        set_mount_metadata_options(py, &kwargs, stat_virtualization, host_permissions, uid, gid)?;
         Ok(mount_config_class(py)?.call((), Some(&kwargs))?.unbind())
     }
 
     /// Create a named volume mount config.
     #[staticmethod]
     #[allow(clippy::too_many_arguments)]
-    #[pyo3(signature = (name, *, mode = None, kind = None, size_mib = None, quota_mib = None, readonly = false, noexec = false, nosuid = false, nodev = false))]
+    #[pyo3(signature = (name, *, mode = None, kind = None, size_mib = None, quota_mib = None, readonly = false, noexec = false, nosuid = false, nodev = false, stat_virtualization = None, host_permissions = None, uid = None, gid = None))]
     fn named(
         py: Python<'_>,
         name: String,
@@ -193,6 +199,10 @@ impl PyVolume {
         noexec: bool,
         nosuid: bool,
         nodev: bool,
+        stat_virtualization: Option<Py<PyAny>>,
+        host_permissions: Option<Py<PyAny>>,
+        uid: Option<Py<PyAny>>,
+        gid: Option<Py<PyAny>>,
     ) -> PyResult<PyObject> {
         let kwargs = PyDict::new(py);
         kwargs.set_item("kind", mount_kind(py, "NAMED")?)?;
@@ -215,6 +225,7 @@ impl PyVolume {
         kwargs.set_item("noexec", noexec)?;
         kwargs.set_item("nosuid", nosuid)?;
         kwargs.set_item("nodev", nodev)?;
+        set_mount_metadata_options(py, &kwargs, stat_virtualization, host_permissions, uid, gid)?;
         Ok(mount_config_class(py)?.call((), Some(&kwargs))?.unbind())
     }
 
@@ -497,4 +508,32 @@ fn mount_config_class<'py>(py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
 fn mount_kind<'py>(py: Python<'py>, variant: &str) -> PyResult<Bound<'py, PyAny>> {
     let types = PyModule::import(py, "microsandbox.types")?;
     types.getattr("MountKind")?.getattr(variant)
+}
+
+/// Forward the shared virtiofs metadata options through the public mount
+/// factories. Enum values are checked here so malformed policies fail at the
+/// factory boundary; ownership validation remains centralized in MountConfig.
+fn set_mount_metadata_options(
+    py: Python<'_>,
+    kwargs: &Bound<'_, PyDict>,
+    stat_virtualization: Option<Py<PyAny>>,
+    host_permissions: Option<Py<PyAny>>,
+    uid: Option<Py<PyAny>>,
+    gid: Option<Py<PyAny>>,
+) -> PyResult<()> {
+    if let Some(policy) = stat_virtualization {
+        extract_str_enum(policy.bind(py), "StatVirtualization")?;
+        kwargs.set_item("stat_virtualization", policy)?;
+    }
+    if let Some(policy) = host_permissions {
+        extract_str_enum(policy.bind(py), "HostPermissions")?;
+        kwargs.set_item("host_permissions", policy)?;
+    }
+    if let Some(uid) = uid {
+        kwargs.set_item("uid", uid)?;
+    }
+    if let Some(gid) = gid {
+        kwargs.set_item("gid", gid)?;
+    }
+    Ok(())
 }

--- a/sdk/python/tests/test_mount_policies.py
+++ b/sdk/python/tests/test_mount_policies.py
@@ -17,6 +17,7 @@ from microsandbox import (
     NamedVolumeMode,
     SecurityProfile,
     StatVirtualization,
+    Volume,
 )
 
 
@@ -75,6 +76,28 @@ def test_bind_serializes_guest_ownership() -> None:
     d = mc._to_dict()
     assert d["uid"] == 1000
     assert d["gid"] == 1001
+
+
+def test_bind_factory_exposes_metadata_policies_and_guest_ownership() -> None:
+    mc = Volume.bind(
+        "/host/data",
+        stat_virtualization=StatVirtualization.RELAXED,
+        host_permissions=HostPermissions.MIRROR,
+        uid=1000,
+        gid=1001,
+    )
+    d = mc._to_dict()
+    assert d["stat_virtualization"] == "relaxed"
+    assert d["host_permissions"] == "mirror"
+    assert d["uid"] == 1000
+    assert d["gid"] == 1001
+
+
+def test_named_factory_exposes_guest_ownership() -> None:
+    mc = Volume.named("cache", uid=0, gid=0)
+    d = mc._to_dict()
+    assert d["uid"] == 0
+    assert d["gid"] == 0
 
 
 def test_bind_rejects_partial_guest_ownership() -> None:

--- a/sdk/python/tests/test_mount_policies.py
+++ b/sdk/python/tests/test_mount_policies.py
@@ -64,6 +64,37 @@ def test_bind_with_relaxed_and_mirror_serializes_lowercase() -> None:
     assert d["host_permissions"] == "mirror"
 
 
+def test_bind_serializes_guest_ownership() -> None:
+    mc = MountConfig(
+        kind=MountKind.BIND,
+        bind="/host/data",
+        stat_virtualization=StatVirtualization.RELAXED,
+        uid=1000,
+        gid=1001,
+    )
+    d = mc._to_dict()
+    assert d["uid"] == 1000
+    assert d["gid"] == 1001
+
+
+def test_bind_rejects_partial_guest_ownership() -> None:
+    mc = MountConfig(kind=MountKind.BIND, bind="/host/data", uid=1000)
+    with pytest.raises(ValueError, match="must be specified together"):
+        mc._to_dict()
+
+
+def test_bind_rejects_guest_ownership_with_stat_virt_off() -> None:
+    mc = MountConfig(
+        kind=MountKind.BIND,
+        bind="/host/data",
+        stat_virtualization=StatVirtualization.OFF,
+        uid=1000,
+        gid=1000,
+    )
+    with pytest.raises(ValueError, match="cannot be combined"):
+        mc._to_dict()
+
+
 def test_named_with_off_serializes() -> None:
     mc = MountConfig(
         kind=MountKind.NAMED,

--- a/sdk/rust/lib/runtime/spawn.rs
+++ b/sdk/rust/lib/runtime/spawn.rs
@@ -1475,6 +1475,7 @@ async fn resolve_named_volumes(
     for mount in &config.spec.mounts {
         let VolumeMount::Named {
             name,
+            options,
             stat_virtualization,
             host_permissions,
             ..
@@ -1485,7 +1486,12 @@ async fn resolve_named_volumes(
 
         if let Some(volume) = resolved.get(name) {
             if volume.kind == VolumeKind::Disk {
-                validate_named_disk_mount_options(name, *stat_virtualization, *host_permissions)?;
+                validate_named_disk_mount_options(
+                    name,
+                    *stat_virtualization,
+                    *host_permissions,
+                    options,
+                )?;
             }
             continue;
         }
@@ -1508,7 +1514,12 @@ async fn resolve_named_volumes(
                 quota_mib: model.quota_mib.map(|value| value.max(0) as u32),
             },
             VolumeKind::Disk => {
-                validate_named_disk_mount_options(name, *stat_virtualization, *host_permissions)?;
+                validate_named_disk_mount_options(
+                    name,
+                    *stat_virtualization,
+                    *host_permissions,
+                    options,
+                )?;
                 let format = model
                     .disk_format
                     .as_deref()
@@ -2312,6 +2323,12 @@ fn mount_option_tokens(options: MountOptions) -> Vec<String> {
     }
     if options.nodev {
         tokens.push("nodev".to_string());
+    }
+    if let Some(uid) = options.uid {
+        tokens.push(format!("uid={uid}"));
+    }
+    if let Some(gid) = options.gid {
+        tokens.push(format!("gid={gid}"));
     }
     tokens
 }
@@ -4140,6 +4157,34 @@ mod tests {
                 .windows(2)
                 .any(|pair| pair[0] == "--mount" && pair[1] == expected),
             "missing override-quota --mount arg in {rendered:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_sandbox_cli_args_bind_mount_guest_ownership() {
+        let config = SandboxBuilder::new("test")
+            .image("/tmp/rootfs")
+            .volume("/data", |m| {
+                m.bind("/host/data")
+                    .stat_virtualization(StatVirtualization::Relaxed)
+                    .uid(1000)
+                    .gid(1001)
+            })
+            .build()
+            .await
+            .unwrap();
+
+        let rendered = render_args(&config);
+        let data_tag = super::guest_mount_tag("/data");
+        let expected = format!(
+            "{data_tag}:/host/data:uid=1000,gid=1001,stat-virt=relaxed,quota={}",
+            crate::sandbox::config::DEFAULT_BIND_QUOTA_MIB
+        );
+        assert!(
+            rendered
+                .windows(2)
+                .any(|pair| pair[0] == "--mount" && pair[1] == expected),
+            "missing guest ownership --mount arg in {rendered:?}"
         );
     }
 

--- a/sdk/rust/lib/sandbox/types.rs
+++ b/sdk/rust/lib/sandbox/types.rs
@@ -331,6 +331,26 @@ impl MountBuilder {
         self
     }
 
+    /// Set the guest-visible fallback uid for host files without an override.
+    ///
+    /// This does not change host ownership. It must be paired with
+    /// [`Self::gid`] and is valid only for bind and directory-backed named
+    /// mounts with stat virtualization enabled.
+    pub fn uid(mut self, uid: u32) -> Self {
+        self.options.uid = Some(uid);
+        self
+    }
+
+    /// Set the guest-visible fallback gid for host files without an override.
+    ///
+    /// This does not change host ownership. It must be paired with
+    /// [`Self::uid`] and is valid only for bind and directory-backed named
+    /// mounts with stat virtualization enabled.
+    pub fn gid(mut self, gid: u32) -> Self {
+        self.options.gid = Some(gid);
+        self
+    }
+
     /// Set the guest stat virtualization policy. Default: [`StatVirtualization::Strict`].
     ///
     /// Valid only for bind and named-directory/file mounts. Calling this on
@@ -453,6 +473,12 @@ impl MountBuilder {
                     .into(),
             ));
         }
+        if (self.options.uid.is_some() || self.options.gid.is_some()) && !is_virtiofs {
+            return Err(crate::MicrosandboxError::InvalidConfig(
+                ".uid() and .gid() are only valid for bind and directory-backed named volume mounts"
+                    .into(),
+            ));
+        }
         if let MountKind::Named {
             name,
             create: Some(create),
@@ -472,7 +498,14 @@ impl MountBuilder {
                     "host_permissions is only valid for directory named volumes: {name}"
                 )));
             }
+            if self.options.uid.is_some() || self.options.gid.is_some() {
+                return Err(crate::MicrosandboxError::InvalidConfig(format!(
+                    "uid and gid are only valid for directory named volumes: {name}"
+                )));
+            }
         }
+
+        validate_mount_ownership(&self.options, self.stat_virtualization)?;
 
         // `Off + Mirror` is a contradiction. With xattr disabled there is no
         // overlay to keep guest chmod private, so chmod always hits the host —
@@ -1119,15 +1152,17 @@ fn validate_volume_mount(mount: &VolumeMount) -> crate::MicrosandboxResult<()> {
     match mount {
         VolumeMount::Bind {
             host,
+            options,
             stat_virtualization,
             host_permissions,
             ..
         } => {
             validate_host_path_wire_safe(host, "bind host path")?;
-            validate_virtiofs_policies(*stat_virtualization, *host_permissions)?;
+            validate_virtiofs_policies(*stat_virtualization, *host_permissions, options)?;
         }
         VolumeMount::Named {
             name,
+            options,
             stat_virtualization,
             host_permissions,
             create,
@@ -1138,14 +1173,25 @@ fn validate_volume_mount(mount: &VolumeMount) -> crate::MicrosandboxResult<()> {
                 .as_ref()
                 .is_some_and(|create| create.kind() == VolumeKind::Disk)
             {
-                validate_named_disk_mount_options(name, *stat_virtualization, *host_permissions)?;
+                validate_named_disk_mount_options(
+                    name,
+                    *stat_virtualization,
+                    *host_permissions,
+                    options,
+                )?;
             } else {
-                validate_virtiofs_policies(*stat_virtualization, *host_permissions)?;
+                validate_virtiofs_policies(*stat_virtualization, *host_permissions, options)?;
             }
         }
-        VolumeMount::Tmpfs { .. } => {}
-        VolumeMount::DiskImage { host, fstype, .. } => {
+        VolumeMount::Tmpfs { options, .. } => validate_non_virtiofs_ownership(options)?,
+        VolumeMount::DiskImage {
+            host,
+            fstype,
+            options,
+            ..
+        } => {
             validate_host_path_wire_safe(host, "disk image host path")?;
+            validate_non_virtiofs_ownership(options)?;
             if let Some(fstype) = fstype {
                 validate_fstype(fstype)?;
             }
@@ -1203,6 +1249,7 @@ fn validate_fstype(fstype: &str) -> crate::MicrosandboxResult<()> {
 fn validate_virtiofs_policies(
     stat_virtualization: StatVirtualization,
     host_permissions: HostPermissions,
+    options: &MountOptions,
 ) -> crate::MicrosandboxResult<()> {
     if stat_virtualization == StatVirtualization::Off && host_permissions == HostPermissions::Mirror
     {
@@ -1213,6 +1260,35 @@ fn validate_virtiofs_policies(
                 .into(),
         ));
     }
+    validate_mount_ownership(options, Some(stat_virtualization))?;
+    Ok(())
+}
+
+fn validate_mount_ownership(
+    options: &MountOptions,
+    stat_virtualization: Option<StatVirtualization>,
+) -> crate::MicrosandboxResult<()> {
+    if options.uid.is_some() != options.gid.is_some() {
+        return Err(crate::MicrosandboxError::InvalidConfig(
+            "mount uid and gid must be specified together".into(),
+        ));
+    }
+    if options.uid.is_some() && matches!(stat_virtualization, Some(StatVirtualization::Off)) {
+        return Err(crate::MicrosandboxError::InvalidConfig(
+            "mount uid and gid cannot be combined with stat_virtualization=Off because Off exposes literal host metadata"
+                .into(),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_non_virtiofs_ownership(options: &MountOptions) -> crate::MicrosandboxResult<()> {
+    if options.uid.is_some() || options.gid.is_some() {
+        return Err(crate::MicrosandboxError::InvalidConfig(
+            "mount uid and gid are only valid for bind and directory-backed named volume mounts"
+                .into(),
+        ));
+    }
     Ok(())
 }
 
@@ -1220,6 +1296,7 @@ pub(crate) fn validate_named_disk_mount_options(
     name: &str,
     stat_virtualization: StatVirtualization,
     host_permissions: HostPermissions,
+    options: &MountOptions,
 ) -> crate::MicrosandboxResult<()> {
     if stat_virtualization != StatVirtualization::Strict {
         return Err(crate::MicrosandboxError::InvalidConfig(format!(
@@ -1229,6 +1306,11 @@ pub(crate) fn validate_named_disk_mount_options(
     if host_permissions != HostPermissions::Private {
         return Err(crate::MicrosandboxError::InvalidConfig(format!(
             "host_permissions is only valid for directory named volumes: {name}"
+        )));
+    }
+    if options.uid.is_some() || options.gid.is_some() {
+        return Err(crate::MicrosandboxError::InvalidConfig(format!(
+            "uid and gid are only valid for directory named volumes: {name}"
         )));
     }
     Ok(())
@@ -1405,6 +1487,58 @@ mod tests {
             }
             other => panic!("expected Named, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn test_mount_builder_sets_guest_ownership() {
+        let mount = MountBuilder::new("/data")
+            .bind("/host/data")
+            .uid(1000)
+            .gid(1001)
+            .stat_virtualization(StatVirtualization::Relaxed)
+            .build()
+            .unwrap();
+
+        match mount {
+            VolumeMount::Bind { options, .. } => {
+                assert_eq!(options.uid, Some(1000));
+                assert_eq!(options.gid, Some(1001));
+            }
+            other => panic!("expected Bind, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_mount_builder_rejects_partial_guest_ownership() {
+        let err = MountBuilder::new("/data")
+            .bind("/host/data")
+            .uid(1000)
+            .build()
+            .unwrap_err();
+        assert!(err.to_string().contains("must be specified together"));
+    }
+
+    #[test]
+    fn test_mount_builder_rejects_guest_ownership_with_stat_virt_off() {
+        let err = MountBuilder::new("/data")
+            .bind("/host/data")
+            .uid(1000)
+            .gid(1000)
+            .stat_virtualization(StatVirtualization::Off)
+            .build()
+            .unwrap_err();
+        assert!(err.to_string().contains("literal host metadata"));
+    }
+
+    #[test]
+    fn test_mount_builder_rejects_guest_ownership_on_tmpfs() {
+        let err = MountBuilder::new("/data")
+            .tmpfs()
+            .uid(1000)
+            .gid(1000)
+            .build()
+            .unwrap_err();
+        assert!(err.to_string().contains("only valid for bind"));
     }
 
     #[test]
@@ -1666,6 +1800,12 @@ mod tests {
 
         assert!(options.readonly);
         assert!(!options.noexec);
+        assert_eq!(options.uid, None);
+        assert_eq!(options.gid, None);
+
+        let encoded = serde_json::to_value(options).unwrap();
+        assert!(encoded.get("uid").is_none());
+        assert!(encoded.get("gid").is_none());
     }
 
     #[test]


### PR DESCRIPTION
## TL;DR
Add paired per-mount `uid`/`gid` options that present virtiofs-backed host files with a fixed guest-visible owner without changing host ownership.

## Description
- Accept paired `uid=<id>,gid=<id>` options for bind mounts and directory-backed named volumes in the CLI and YAML configuration.
- Preserve per-inode `user.msb.override_stat` metadata as the highest-precedence source; the mount identity is only the fallback for paths without an override.
- Use a dedicated fixed identity map on Unix and equivalent ADS/in-memory fallback behavior on Windows.
- Expose the options through the Rust, Node.js, Python, and Go SDKs, including validation, generated types, inspect output, and documentation.
- Reject partial pairs, non-virtiofs mounts, directory-incompatible named disk volumes, and `stat-virt=off`, which promises literal host metadata.
- Omit unset ownership fields from serialized mount options so existing wire payloads remain unchanged.

The new optional fields extend the public Rust `MountOptions` struct. Builder-based callers are unaffected; callers using exhaustive struct literals may need to add `..Default::default()`.

## Test Plan
- [x] `cargo fmt --all --check`
- [x] `cargo test -p microsandbox-filesystem -p microsandbox-runtime -p microsandbox -p microsandbox-cli -p microsandbox-types --features microsandbox-types/ts`
- [x] `cargo clippy -p microsandbox-filesystem -p microsandbox-runtime -p microsandbox -p microsandbox-cli --lib -- -D warnings`
- [x] `go test ./...` in `sdk/go`
- [x] `pytest tests/test_mount_policies.py`, `ruff check`, and `ruff format --check` in `sdk/python`
- [x] `npm run typecheck` and `npm run test:unit` against a freshly rebuilt native addon in `sdk/node-ts` (130 tests)
- [x] `git diff --check`
- [ ] Run the native Windows filesystem suite in CI; the current macOS host cannot compile the Windows-native dependencies without the MSVC SDK.
