### PR TITLE
fix(logs): route retrieval through SDK backends

### DIFF
--- a/crates/cli/lib/commands/logs.rs
+++ b/crates/cli/lib/commands/logs.rs
@@ -1,12 +1,8 @@
 //! `msb logs` command — read the captured output of a sandbox.
 //!
-//! Backed by `microsandbox::logs::read_logs` for the historical
-//! snapshot and `microsandbox::logs::log_stream` for `--follow`. Both
-//! read `<sandbox-dir>/logs/exec.log` (the JSON Lines file produced by
-//! the runtime's relay tap, see `crates/runtime/lib/exec_log.rs`),
-//! plus `runtime.log` and `kernel.log` when `--source system` is in
-//! scope. This command decodes each entry and renders it to the
-//! terminal per `design/runtime/sandbox-logs.md` D5.
+//! Log retrieval is delegated to the selected SDK backend. This command
+//! translates CLI filters into SDK options, then renders the returned entries
+//! per `design/runtime/sandbox-logs.md` D5.
 //!
 //! Supports filtering by source (stdout/stderr/system), time window,
 //! tail count, regex search, follow mode (filesystem-watch driven),
@@ -15,7 +11,6 @@
 //! `ls`/`grep` convention).
 
 use std::io::{IsTerminal, Write};
-use std::path::Path;
 use std::pin::pin;
 use std::time::Duration;
 
@@ -26,10 +21,7 @@ use clap::{Args, ValueEnum};
 use console::style;
 use futures::StreamExt;
 use microsandbox::MicrosandboxError;
-use microsandbox::logs::{
-    self, LogEntry as EngineLogEntry, LogOptions, LogSource, LogStreamOptions, LogStreamStart,
-};
-use microsandbox_runtime::boot_error::BootError;
+use microsandbox::logs::{self, BootError, LogEntry as EngineLogEntry, LogOptions, LogSource};
 use microsandbox_utils::log_text::{base64_decode, strip_ansi};
 use regex::Regex;
 use serde::Deserialize;
@@ -173,12 +165,8 @@ struct LogEntry {
 
 /// Execute the `msb logs` command.
 pub async fn run(args: LogsArgs) -> anyhow::Result<()> {
-    let log_dir = logs::log_dir_for(&args.name);
-    if !log_dir.exists() {
-        return Err(anyhow!(
-            "no logs directory for sandbox {:?} (sandbox not found?)",
-            args.name
-        ));
+    if let Some(boot_error) = logs::boot_error(&args.name).await? {
+        render_boot_error(&boot_error, &args.name, args.json)?;
     }
 
     let mask = resolve_sources(&args.source);
@@ -196,47 +184,25 @@ pub async fn run(args: LogsArgs) -> anyhow::Result<()> {
         args.color
     };
 
-    // Render the boot-error block first if present (Phase B's
-    // boot-error.json sits next to exec.log in the same log_dir).
-    render_boot_error_if_present(&log_dir, &args.name, args.json)?;
-
-    // Snapshot: drain the chronologically-sorted history. `read_logs`
-    // applies tail / since / until / source filtering; --grep is
-    // applied locally so it can match against the decoded body string.
-    let snapshot_opts = LogOptions {
+    let opts = LogOptions {
         tail: args.tail,
         since,
         until,
-        sources: engine_sources.clone(),
+        sources: engine_sources,
     };
-    let snapshot = logs::read_logs_snapshot(&args.name, &snapshot_opts)
-        .await
-        .context("reading logs")?;
-    for entry in &snapshot.entries {
-        let cli_entry = engine_entry_to_cli(entry);
-        if grep_matches(grep_re.as_ref(), &cli_entry.d) {
-            render_entry(&cli_entry, &args, color_policy)?;
-        }
-    }
 
     if !args.follow {
+        let entries = logs::read_logs(&args.name, &opts).await?;
+        for entry in &entries {
+            let cli_entry = engine_entry_to_cli(entry);
+            if grep_matches(grep_re.as_ref(), &cli_entry.d) {
+                render_entry(&cli_entry, &args, color_policy)?;
+            }
+        }
         return Ok(());
     }
 
-    // Follow: resume from the exact snapshot end cursor so entries
-    // written between the snapshot drain and stream startup are not
-    // skipped.
-    let stream_opts = LogStreamOptions {
-        sources: engine_sources,
-        start: LogStreamStart::From(snapshot.cursor),
-        until,
-        follow: true,
-    };
-    let mut stream = pin!(
-        logs::log_stream(&args.name, &stream_opts)
-            .await
-            .context("starting log stream")?
-    );
+    let mut stream = pin!(logs::follow_logs(&args.name, &opts).await?);
     while let Some(item) = stream.next().await {
         match item {
             Ok(entry) => {
@@ -327,18 +293,12 @@ impl SourceMask {
 // Functions: Helpers — boot-error block
 //--------------------------------------------------------------------------------------------------
 
-fn render_boot_error_if_present(log_dir: &Path, name: &str, json_mode: bool) -> anyhow::Result<()> {
-    let boot_err = match BootError::read(log_dir) {
-        Ok(Some(b)) => b,
-        Ok(None) => return Ok(()),
-        Err(_) => return Ok(()),
-    };
-
+fn render_boot_error(boot_err: &BootError, name: &str, json_mode: bool) -> anyhow::Result<()> {
     if json_mode {
         // Emit as a synthetic JSON Lines entry tagged s: "boot-error".
         // `d` is a string per the documented schema; consumers that
         // need the structured fields can `JSON.parse(d)`.
-        let payload = serde_json::to_string(&boot_err).unwrap_or_default();
+        let payload = serde_json::to_string(boot_err).unwrap_or_default();
         let line = serde_json::json!({
             "t": boot_err.t,
             "s": "boot-error",
@@ -348,7 +308,7 @@ fn render_boot_error_if_present(log_dir: &Path, name: &str, json_mode: bool) -> 
         return Ok(());
     }
 
-    crate::boot_error_render::render(name, &boot_err);
+    crate::boot_error_render::render(name, boot_err);
     eprintln!();
     Ok(())
 }

--- a/docs/cli/sandbox-commands.mdx
+++ b/docs/cli/sandbox-commands.mdx
@@ -362,9 +362,9 @@ Host-to-sandbox and sandbox-to-host forms follow `docker cp` syntax. Same-sandbo
 
 ## msb logs
 
-<Tooltip tip="Not yet available on microsandbox cloud; follow output live with the SDK and persist it externally."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
+<Tooltip tip="On microsandbox cloud, use msb logs -f for a live stream. Bounded and historical reads remain local-only."><span className="msb-badge-limited">Limited on cloud <Icon icon="circle-info" size={11} /></span></Tooltip>
 
-Read captured output from a sandbox. Each sandbox stores its captured stdio under `<sandbox-dir>/logs/exec.log` as JSON Lines, plus runtime/kernel diagnostics in `runtime.log`/`kernel.log`. The command works on running and stopped sandboxes alike; there is no protocol traffic, just a file read.
+Read captured output from a sandbox. Local sandboxes store their captured stdio under `<sandbox-dir>/logs/exec.log` as JSON Lines, plus runtime/kernel diagnostics in `runtime.log`/`kernel.log`; these bounded reads work on running and stopped sandboxes. On microsandbox cloud, `msb logs -f <name>` streams a running sandbox through the cloud API. Cloud bounded reads and the `--tail`, `--since`, and `--until` filters are not yet available.
 
 ```bash
 # Captured user-program output (default sources: stdout + stderr + output)

--- a/docs/cloud/overview.mdx
+++ b/docs/cloud/overview.mdx
@@ -112,7 +112,7 @@ Across the docs, no badge means a feature works everywhere. Exceptions use only 
 | Volume and host paths | **Limited on cloud** | Bind and disk-image source paths resolve against the organization's host volume, not the machine running the client. |
 | Network policy and secrets | **Works everywhere** | Egress policies and hostname-scoped secret substitution carry across backends. |
 | Custom networking | **Local-only** | Published ports, custom nameservers, interface overrides, rate limiters, TLS interception, and host-CA trust are not accepted by cloud create. |
-| Logs | **Limited on cloud** | SDK live-follow works. Bounded or historical reads and the `msb logs` command are local-only; persist followed output externally when retention matters. |
+| Logs | **Limited on cloud** | SDK live-follow and `msb logs -f` work. Bounded or historical reads are local-only; persist followed output externally when retention matters. |
 | SSH | **Limited on cloud** | Native SDK sessions and `msb ssh` work. `msb ssh serve` is local-only; reusable SDK servers require explicit key material. |
 | Images | **Limited on cloud** | OCI image references and registry credentials work. Local cache commands, host-directory or disk-image roots, plain-HTTP registries, and custom registry CAs are local-only. |
 | Reconfiguration | **Local-only** | Recreate the sandbox with the new CPU, memory, mounts, or other settings instead of using `modify`. |

--- a/docs/sandboxes/logs.mdx
+++ b/docs/sandboxes/logs.mdx
@@ -4,9 +4,9 @@ description: Capture, read, and diagnose sandbox output
 icon: "scroll"
 ---
 
-<Tooltip tip="Live SDK log following works on microsandbox cloud; historical and bounded log reads are not yet available. Persist followed output externally when you need retention."><span className="msb-badge-limited">Limited on cloud <Icon icon="circle-info" size={11} /></span></Tooltip>
+<Tooltip tip="Live SDK log following and msb logs -f work on microsandbox cloud; historical and bounded reads are not yet available. Persist followed output externally when you need retention."><span className="msb-badge-limited">Limited on cloud <Icon icon="circle-info" size={11} /></span></Tooltip>
 
-Every sandbox records captured output to disk so you can read it later, even after the sandbox stops or crashes. Use `msb logs <name>` from the CLI or `logs()` from the SDK.
+Local sandboxes record captured output to disk so you can read it later, even after the sandbox stops or crashes. Use `msb logs <name>` from the CLI or `logs()` from the SDK. For a running cloud sandbox, use `msb logs -f <name>` or the SDK's live log stream; bounded cloud history is not yet available.
 
 ## Read logs
 

--- a/sdk/rust/lib/backend/cloud/sandbox.rs
+++ b/sdk/rust/lib/backend/cloud/sandbox.rs
@@ -13,7 +13,7 @@ use crate::backend::{
     sandbox::{LogStream, MetricsStream, SandboxBackend},
 };
 use crate::error::{Operation, UnsupportedReason};
-use crate::logs::{LogEntry, LogOptions, LogStreamOptions};
+use crate::logs::{BootError, LogEntry, LogOptions, LogStreamOptions};
 use crate::sandbox::metrics::SandboxMetrics;
 use crate::sandbox::{
     RootfsSource, Sandbox, SandboxConfig, SandboxHandle, SandboxListBuilder, SandboxPage,
@@ -210,6 +210,16 @@ impl SandboxBackend for CloudBackend {
         })
     }
 
+    fn boot_error<'a>(
+        &'a self,
+        _backend: Arc<dyn Backend>,
+        _name: &'a str,
+    ) -> BoxFuture<'a, MicrosandboxResult<Option<BootError>>> {
+        // The cloud API does not currently expose a boot-error concept. Keep
+        // the optional backend contract so it can provide one in the future.
+        Box::pin(async { Ok(None) })
+    }
+
     fn logs<'a>(
         &'a self,
         _backend: Arc<dyn Backend>,
@@ -226,6 +236,30 @@ impl SandboxBackend for CloudBackend {
         opts: &'a LogStreamOptions,
     ) -> BoxFuture<'a, MicrosandboxResult<LogStream>> {
         Box::pin(async move { CloudBackend::log_stream(self, name, opts).await })
+    }
+
+    fn follow_logs<'a>(
+        &'a self,
+        _backend: Arc<dyn Backend>,
+        name: &'a str,
+        opts: &'a LogOptions,
+    ) -> BoxFuture<'a, MicrosandboxResult<LogStream>> {
+        Box::pin(async move {
+            if opts.tail.is_some() || opts.since.is_some() || opts.until.is_some() {
+                return Err(MicrosandboxError::unsupported(
+                    Operation::SandboxFollowLogs,
+                    UnsupportedReason::NotAvailable(
+                        "cloud log stream is not yet available".to_string(),
+                    ),
+                ));
+            }
+            let stream_opts = LogStreamOptions {
+                sources: opts.sources.clone(),
+                follow: true,
+                ..Default::default()
+            };
+            CloudBackend::log_stream(self, name, &stream_opts).await
+        })
     }
 
     fn metrics<'a>(
@@ -566,13 +600,67 @@ pub(crate) fn sandbox_config_from_cloud_spec(
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use microsandbox_types::{
         CloudSandboxSpec, HostPermissions, MountOptions, NamedVolumeCreate, NamedVolumeMode,
         StatVirtualization, VolumeKind, VolumeMount,
     };
 
     use super::*;
+    use crate::backend::{Backend, SandboxBackend};
     use crate::sandbox::{EnvVar, OciRootfsSource, RootDisk, SandboxBuilder, SandboxSpec};
+
+    #[tokio::test]
+    async fn cloud_boot_error_is_absent_until_the_api_exposes_diagnostics() {
+        let backend = Arc::new(CloudBackend::new("http://127.0.0.1:1", "test-key").unwrap());
+        let backend_dyn: Arc<dyn Backend> = backend.clone();
+
+        let boot_error = backend
+            .boot_error(backend_dyn, "cloud-sandbox")
+            .await
+            .unwrap();
+
+        assert!(boot_error.is_none());
+    }
+
+    #[tokio::test]
+    async fn cloud_follow_logs_rejects_bounded_filters_before_opening_stream() {
+        let backend = Arc::new(CloudBackend::new("http://127.0.0.1:1", "test-key").unwrap());
+        let now = chrono::Utc::now();
+
+        for opts in [
+            LogOptions {
+                tail: Some(10),
+                ..Default::default()
+            },
+            LogOptions {
+                since: Some(now),
+                ..Default::default()
+            },
+            LogOptions {
+                until: Some(now),
+                ..Default::default()
+            },
+        ] {
+            let backend_dyn: Arc<dyn Backend> = backend.clone();
+            let error = match backend
+                .follow_logs(backend_dyn, "cloud-sandbox", &opts)
+                .await
+            {
+                Ok(_) => panic!("bounded cloud follow should be unsupported"),
+                Err(error) => error,
+            };
+
+            assert!(matches!(
+                error,
+                MicrosandboxError::Unsupported {
+                    op: Operation::SandboxFollowLogs,
+                    ..
+                }
+            ));
+        }
+    }
 
     #[tokio::test]
     async fn cloud_create_request_maps_common_fields() {

--- a/sdk/rust/lib/backend/cloud/sandbox.rs
+++ b/sdk/rust/lib/backend/cloud/sandbox.rs
@@ -249,7 +249,7 @@ impl SandboxBackend for CloudBackend {
                 return Err(MicrosandboxError::unsupported(
                     Operation::SandboxFollowLogs,
                     UnsupportedReason::NotAvailable(
-                        "cloud log stream is not yet available".to_string(),
+                        "bounded cloud log follow filters are not yet available".to_string(),
                     ),
                 ));
             }
@@ -656,8 +656,8 @@ mod tests {
                 error,
                 MicrosandboxError::Unsupported {
                     op: Operation::SandboxFollowLogs,
-                    ..
-                }
+                    reason: UnsupportedReason::NotAvailable(ref reason),
+                } if reason == "bounded cloud log follow filters are not yet available"
             ));
         }
     }

--- a/sdk/rust/lib/backend/local/sandbox/create.rs
+++ b/sdk/rust/lib/backend/local/sandbox/create.rs
@@ -556,11 +556,8 @@ impl LocalBackend {
 
                         // Prefer the structured boot-error record if the
                         // sandbox got far enough to write one.
-                        if let Some(boot_err) = Self::read_boot_error(log_dir) {
-                            return Err(crate::MicrosandboxError::BootStart {
-                                name: sandbox_name.to_string(),
-                                err: boot_err,
-                            });
+                        if let Some(error) = Self::read_boot_start_error(log_dir, sandbox_name) {
+                            return Err(error);
                         }
 
                         // No structured boot-error.json — the sandbox died
@@ -595,11 +592,8 @@ impl LocalBackend {
                         error = %e,
                         "wait_for_relay: agent connection failed"
                     );
-                    if let Some(boot_err) = Self::read_boot_error(log_dir) {
-                        return Err(crate::MicrosandboxError::BootStart {
-                            name: sandbox_name.to_string(),
-                            err: boot_err,
-                        });
+                    if let Some(error) = Self::read_boot_start_error(log_dir, sandbox_name) {
+                        return Err(error);
                     }
                     return Err(e.into());
                 }
@@ -615,11 +609,8 @@ impl LocalBackend {
                     // and never produced the handshake bytes). Prefer that
                     // typed record over the raw IO/timeout error so the CLI
                     // can render the styled boot-error block.
-                    if let Some(boot_err) = Self::read_boot_error(log_dir) {
-                        return Err(crate::MicrosandboxError::BootStart {
-                            name: sandbox_name.to_string(),
-                            err: boot_err,
-                        });
+                    if let Some(error) = Self::read_boot_start_error(log_dir, sandbox_name) {
+                        return Err(error);
                     }
                     return Err(crate::MicrosandboxError::Runtime(format!(
                         "timed out waiting for agent relay: {e}"
@@ -634,12 +625,24 @@ impl LocalBackend {
     /// Returns `None` when the directory is unknown, the file is missing, or
     /// the contents cannot be deserialized — callers fall back to a raw
     /// error in those cases.
-    fn read_boot_error(
+    pub(crate) fn read_boot_error(
         log_dir: &std::path::Path,
     ) -> Option<microsandbox_runtime::boot_error::BootError> {
         microsandbox_runtime::boot_error::BootError::read(log_dir)
             .ok()
             .flatten()
+    }
+
+    /// Read a persisted boot error and attach the sandbox name expected by
+    /// SDK create/start callers.
+    fn read_boot_start_error(
+        log_dir: &std::path::Path,
+        sandbox_name: &str,
+    ) -> Option<crate::MicrosandboxError> {
+        Self::read_boot_error(log_dir).map(|err| crate::MicrosandboxError::BootStart {
+            name: sandbox_name.to_string(),
+            err,
+        })
     }
 
     /// Resolve a fresh create by tag, but restore a snapshot by its captured

--- a/sdk/rust/lib/backend/local/sandbox/mod.rs
+++ b/sdk/rust/lib/backend/local/sandbox/mod.rs
@@ -14,6 +14,7 @@ use std::time::Duration;
 
 use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
 use futures::future::BoxFuture;
+use futures::{StreamExt, stream};
 use microsandbox_db::pool::DbPools;
 use microsandbox_db::{DbReadConnection, DbWriteConnection};
 use microsandbox_image::{Digest, GlobalCache};
@@ -36,7 +37,7 @@ use crate::backend::{
 use crate::db::entity::{
     run as run_entity, sandbox as sandbox_entity, sandbox_label as sandbox_label_entity,
 };
-use crate::logs::{LogEntry, LogOptions, LogStreamOptions};
+use crate::logs::{BootError, LogEntry, LogOptions, LogStreamOptions};
 use crate::runtime::SpawnMode;
 use crate::sandbox::metrics::SandboxMetrics;
 use crate::sandbox::{
@@ -970,6 +971,18 @@ impl SandboxBackend for LocalBackend {
         Box::pin(async move { self.drain_sandbox(name).await })
     }
 
+    fn boot_error<'a>(
+        &'a self,
+        _backend: Arc<dyn Backend>,
+        name: &'a str,
+    ) -> BoxFuture<'a, MicrosandboxResult<Option<BootError>>> {
+        Box::pin(async move {
+            crate::sandbox::validate_sandbox_name(name)?;
+            let log_dir = crate::logs::log_dir_for_local(self, name);
+            Ok(Self::read_boot_error(&log_dir))
+        })
+    }
+
     fn logs<'a>(
         &'a self,
         _backend: Arc<dyn Backend>,
@@ -988,6 +1001,26 @@ impl SandboxBackend for LocalBackend {
         Box::pin(async move {
             let stream = crate::logs::log_stream_local(self, name, opts).await?;
             Ok(Box::pin(stream) as LogStream)
+        })
+    }
+
+    fn follow_logs<'a>(
+        &'a self,
+        _backend: Arc<dyn Backend>,
+        name: &'a str,
+        opts: &'a LogOptions,
+    ) -> BoxFuture<'a, MicrosandboxResult<LogStream>> {
+        Box::pin(async move {
+            let snapshot = crate::logs::read_logs_snapshot_local(self, name, opts).await?;
+            let follow_opts = LogStreamOptions {
+                sources: opts.sources.clone(),
+                start: crate::logs::LogStreamStart::From(snapshot.cursor),
+                until: opts.until,
+                follow: true,
+            };
+            let follow = crate::logs::log_stream_local(self, name, &follow_opts).await?;
+            let history = stream::iter(snapshot.entries.into_iter().map(Ok));
+            Ok(Box::pin(history.chain(follow)) as LogStream)
         })
     }
 
@@ -1069,9 +1102,12 @@ async fn filter_sandbox_ids(
 #[cfg(test)]
 mod tests {
     use std::fs;
+    use std::io::Write;
     #[cfg(unix)]
     use std::process::Command;
+    use std::sync::Arc;
 
+    use futures::StreamExt;
     use microsandbox_db::entity::run as run_entity;
     use microsandbox_db::pool::DbPools;
     use microsandbox_migration::{Migrator, MigratorTrait};
@@ -1081,7 +1117,8 @@ mod tests {
     use tempfile::tempdir;
 
     use super::sandbox_entity;
-    use crate::backend::LocalBackend;
+    use crate::backend::{Backend, LocalBackend, SandboxBackend};
+    use crate::logs::{LogOptions, LogSource};
     use crate::sandbox::{
         OciRootfsSource, RootfsSource, SandboxConfig, SandboxListBuilder, SandboxStatus,
     };
@@ -1130,6 +1167,58 @@ mod tests {
             pid += 1;
         }
         pid
+    }
+
+    #[tokio::test]
+    async fn follow_logs_replays_filtered_history_then_streams_from_snapshot_cursor() {
+        let temp = tempdir().unwrap();
+        let backend = Arc::new(
+            LocalBackend::builder()
+                .home(temp.path())
+                .build()
+                .await
+                .unwrap(),
+        );
+        let log_dir = crate::logs::log_dir_for_local(&backend, "follow-test");
+        fs::create_dir_all(&log_dir).unwrap();
+        let exec_log = log_dir.join("exec.log");
+        fs::write(
+            &exec_log,
+            concat!(
+                "{\"t\":\"2026-08-24T10:00:00.000Z\",\"s\":\"stdout\",\"d\":\"first\",\"id\":1}\n",
+                "{\"t\":\"2026-08-24T10:00:01.000Z\",\"s\":\"stdout\",\"d\":\"second\",\"id\":1}\n",
+            ),
+        )
+        .unwrap();
+
+        let backend_dyn: Arc<dyn Backend> = backend.clone();
+        let opts = LogOptions {
+            tail: Some(1),
+            sources: vec![LogSource::Stdout],
+            ..Default::default()
+        };
+        let mut stream = backend
+            .follow_logs(backend_dyn, "follow-test", &opts)
+            .await
+            .unwrap();
+
+        let history = stream.next().await.unwrap().unwrap();
+        assert_eq!(history.data.as_ref(), b"second");
+
+        let mut file = fs::OpenOptions::new().append(true).open(exec_log).unwrap();
+        writeln!(
+            file,
+            "{{\"t\":\"2026-08-24T10:00:02.000Z\",\"s\":\"stdout\",\"d\":\"third\",\"id\":1}}"
+        )
+        .unwrap();
+        file.flush().unwrap();
+
+        let live = tokio::time::timeout(std::time::Duration::from_secs(5), stream.next())
+            .await
+            .expect("follow stream should observe appended entry")
+            .unwrap()
+            .unwrap();
+        assert_eq!(live.data.as_ref(), b"third");
     }
 
     #[test]

--- a/sdk/rust/lib/backend/local/sandbox/mod.rs
+++ b/sdk/rust/lib/backend/local/sandbox/mod.rs
@@ -13,8 +13,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
-use futures::future::BoxFuture;
-use futures::{StreamExt, stream};
+use futures::{StreamExt, future::BoxFuture, stream};
 use microsandbox_db::pool::DbPools;
 use microsandbox_db::{DbReadConnection, DbWriteConnection};
 use microsandbox_image::{Digest, GlobalCache};

--- a/sdk/rust/lib/backend/misconfigured.rs
+++ b/sdk/rust/lib/backend/misconfigured.rs
@@ -8,7 +8,7 @@ use futures::stream;
 
 use super::sandbox::{LogStream, MetricsStream};
 use super::{Backend, BackendKind, SandboxBackend, VolumeBackend};
-use crate::logs::{LogEntry, LogOptions, LogStreamOptions};
+use crate::logs::{BootError, LogEntry, LogOptions, LogStreamOptions};
 use crate::sandbox::metrics::SandboxMetrics;
 use crate::sandbox::{Sandbox, SandboxConfig, SandboxHandle, SandboxListBuilder, SandboxPage};
 use crate::volume::{Volume, VolumeConfig, VolumeFsReadStream, VolumeFsWriteSink, VolumeHandle};
@@ -164,6 +164,14 @@ impl SandboxBackend for ConfigurationErrorBackend {
         self.fail()
     }
 
+    fn boot_error<'a>(
+        &'a self,
+        _backend: Arc<dyn Backend>,
+        _name: &'a str,
+    ) -> BoxFuture<'a, MicrosandboxResult<Option<BootError>>> {
+        self.fail()
+    }
+
     fn logs<'a>(
         &'a self,
         _backend: Arc<dyn Backend>,
@@ -178,6 +186,15 @@ impl SandboxBackend for ConfigurationErrorBackend {
         _backend: Arc<dyn Backend>,
         _name: &'a str,
         _opts: &'a LogStreamOptions,
+    ) -> BoxFuture<'a, MicrosandboxResult<LogStream>> {
+        self.fail()
+    }
+
+    fn follow_logs<'a>(
+        &'a self,
+        _backend: Arc<dyn Backend>,
+        _name: &'a str,
+        _opts: &'a LogOptions,
     ) -> BoxFuture<'a, MicrosandboxResult<LogStream>> {
         self.fail()
     }

--- a/sdk/rust/lib/backend/sandbox.rs
+++ b/sdk/rust/lib/backend/sandbox.rs
@@ -20,7 +20,7 @@ use futures::future::BoxFuture;
 use super::Backend;
 use crate::MicrosandboxResult;
 use crate::agent::AgentClient;
-use crate::logs::{LogEntry, LogOptions, LogStreamOptions};
+use crate::logs::{BootError, LogEntry, LogOptions, LogStreamOptions};
 use crate::runtime::ProcessHandle;
 use crate::sandbox::exec::{ExecHandle, ExecOptions, ExecOutput};
 use crate::sandbox::fs::{FsEntry, FsMetadata, FsReadStream, FsWriteSink};
@@ -271,6 +271,14 @@ pub trait SandboxBackend: Send + Sync {
     // Logs / metrics
     // ============================================================
 
+    /// Return the most recent startup diagnostic for the named sandbox, when
+    /// the selected backend provides one.
+    fn boot_error<'a>(
+        &'a self,
+        backend: Arc<dyn Backend>,
+        name: &'a str,
+    ) -> BoxFuture<'a, MicrosandboxResult<Option<BootError>>>;
+
     /// Read captured output for the named sandbox.
     fn logs<'a>(
         &'a self,
@@ -285,6 +293,17 @@ pub trait SandboxBackend: Send + Sync {
         backend: Arc<dyn Backend>,
         name: &'a str,
         opts: &'a LogStreamOptions,
+    ) -> BoxFuture<'a, MicrosandboxResult<LogStream>>;
+
+    /// Replay a filtered snapshot, then follow new log entries.
+    ///
+    /// The backend owns the snapshot-to-stream handoff so callers do not need
+    /// backend-specific cursor or transport logic.
+    fn follow_logs<'a>(
+        &'a self,
+        backend: Arc<dyn Backend>,
+        name: &'a str,
+        opts: &'a LogOptions,
     ) -> BoxFuture<'a, MicrosandboxResult<LogStream>>;
 
     /// Latest metrics sample for the named sandbox.

--- a/sdk/rust/lib/error.rs
+++ b/sdk/rust/lib/error.rs
@@ -267,6 +267,8 @@ pub enum Operation {
     SandboxLogStreamNoFollow,
     /// `Sandbox::log_stream` with `follow: true`.
     SandboxLogStreamFollow,
+    /// `Sandbox::follow_logs`.
+    SandboxFollowLogs,
     /// `Sandbox::logger`.
     SandboxLogger,
     /// `Sandbox::metrics`.
@@ -421,6 +423,7 @@ impl Operation {
             Operation::SandboxLogStream => "Sandbox::log_stream",
             Operation::SandboxLogStreamNoFollow => "Sandbox::log_stream(follow=false)",
             Operation::SandboxLogStreamFollow => "Sandbox::log_stream(follow=true)",
+            Operation::SandboxFollowLogs => "Sandbox::follow_logs",
             Operation::SandboxLogger => "Sandbox::logger",
             Operation::SandboxMetrics => "Sandbox::metrics",
             Operation::SandboxMetricsStream => "Sandbox::metrics_stream",

--- a/sdk/rust/lib/logs/mod.rs
+++ b/sdk/rust/lib/logs/mod.rs
@@ -1,12 +1,13 @@
 //! Rotation-aware multi-file log streaming.
 //!
-//! Two public entry points keyed by sandbox name:
+//! The public entry points are keyed by sandbox name:
 //!
-//! - [`read_logs`] returns a snapshot `Vec<LogEntry>` filtered with
-//!   [`LogOptions`]. Reads everything currently on disk, sorts by
-//!   timestamp, and returns.
+//! - [`boot_error`] returns the latest backend-provided startup diagnostic.
+//! - [`read_logs`] routes a bounded snapshot through the selected backend.
+//! - [`follow_logs`] routes filtered history plus live output through the
+//!   selected backend.
 //! - [`log_stream`] returns a [`futures::Stream`] over the same
-//!   files, suitable for live-tailing or replaying a fixed range.
+//!   local files, suitable for live-tailing or replaying a fixed range.
 //!   Uses filesystem change notifications (the `notify` crate) for
 //!   live updates with a fallback poll, and stamps each entry with
 //!   an opaque [`LogCursor`] for exact per-source resume.
@@ -63,6 +64,7 @@ mod watch;
 
 pub use cursor::{LogCursor, LogCursorParseError};
 pub use logger::{RegisteredSandboxLogger, SandboxLogger};
+pub use microsandbox_runtime::boot_error::{BootError, BootErrorStage};
 pub use stream::{LogStreamOptions, LogStreamStart};
 pub use types::{LogEntry, LogOptions, LogSource};
 pub use watch::{LogRegistration, LogRegistry, RegistryStatsSnapshot};
@@ -74,6 +76,7 @@ use futures::Stream;
 use stream::{LogEngine, LogFileConfig, LogFileFormat};
 
 use crate::backend::LocalBackend;
+use crate::backend::sandbox::LogStream;
 use crate::{MicrosandboxError, MicrosandboxResult};
 
 //--------------------------------------------------------------------------------------------------
@@ -149,17 +152,42 @@ pub(crate) fn log_dir_for_local(local: &LocalBackend, name: &str) -> PathBuf {
 ///
 /// Sandbox names are limited to 128 UTF-8 bytes.
 ///
-/// Returns entries sorted by timestamp (strict chronological order
-/// across all sources). Returns
-/// [`MicrosandboxError::SandboxNotFound`] if the sandbox's log
-/// directory doesn't exist.
+/// Routes through the selected backend. Local entries are sorted by timestamp
+/// (strict chronological order across all sources) and return
+/// [`MicrosandboxError::SandboxNotFound`] if the sandbox's log directory does
+/// not exist. Backends without bounded log snapshots return a typed
+/// [`MicrosandboxError::Unsupported`] error.
 ///
-/// Implemented as a drain of [`log_stream`] with `follow: false`,
-/// sorted post-collect; `until` and `tail` are applied
-/// post-collect because the stream's per-source ordering doesn't
-/// match snapshot's "filter after sort" contract.
+/// The local implementation drains [`log_stream`] with `follow: false` and
+/// sorts post-collect; `until` and `tail` are applied post-collect because the
+/// stream's per-source ordering doesn't match snapshot's "filter after sort"
+/// contract.
 pub async fn read_logs(name: &str, opts: &LogOptions) -> MicrosandboxResult<Vec<LogEntry>> {
-    Ok(read_logs_snapshot(name, opts).await?.entries)
+    let backend = crate::backend::default_backend();
+    backend.sandboxes().logs(backend.clone(), name, opts).await
+}
+
+/// Replay filtered history, then follow new entries through the selected backend.
+///
+/// The backend owns any snapshot-to-stream cursor handoff. Backends that cannot
+/// satisfy a requested filter return a typed [`MicrosandboxError::Unsupported`]
+/// error.
+pub async fn follow_logs(name: &str, opts: &LogOptions) -> MicrosandboxResult<LogStream> {
+    let backend = crate::backend::default_backend();
+    backend
+        .sandboxes()
+        .follow_logs(backend.clone(), name, opts)
+        .await
+}
+
+/// Return the most recent startup diagnostic for the named sandbox, when any.
+///
+/// Local sandboxes read the same persisted record used to produce
+/// [`MicrosandboxError::BootStart`] during create/start. The cloud backend
+/// currently returns `None` because its API has no boot-error concept yet.
+pub async fn boot_error(name: &str) -> MicrosandboxResult<Option<BootError>> {
+    let backend = crate::backend::default_backend();
+    backend.sandboxes().boot_error(backend.clone(), name).await
 }
 
 /// Read all matching log entries through an explicit local backend.
@@ -168,14 +196,19 @@ pub(crate) async fn read_logs_local(
     name: &str,
     opts: &LogOptions,
 ) -> MicrosandboxResult<Vec<LogEntry>> {
-    Ok(
-        read_logs_snapshot_from_dir(name, log_dir_for_local(local, name), opts)
-            .await?
-            .entries,
-    )
+    Ok(read_logs_snapshot_local(local, name, opts).await?.entries)
 }
 
-/// Read all matching log entries and return the snapshot end cursor.
+/// Read a filtered snapshot and cursor through an explicit local backend.
+pub(crate) async fn read_logs_snapshot_local(
+    local: &LocalBackend,
+    name: &str,
+    opts: &LogOptions,
+) -> MicrosandboxResult<LogSnapshot> {
+    read_logs_snapshot_from_dir(name, log_dir_for_local(local, name), opts).await
+}
+
+/// Read all matching local log entries and return the snapshot end cursor.
 ///
 /// This is useful when handing a bounded historical read to
 /// [`log_stream`] with [`LogStreamStart::From`] without losing log

--- a/sdk/rust/lib/sandbox/handle.rs
+++ b/sdk/rust/lib/sandbox/handle.rs
@@ -297,6 +297,19 @@ impl SandboxHandle {
             .await
     }
 
+    /// Replay a filtered log snapshot, then follow new entries.
+    ///
+    /// The backend owns the cursor handoff and transport selection.
+    pub async fn follow_logs(
+        &self,
+        opts: &crate::logs::LogOptions,
+    ) -> MicrosandboxResult<crate::backend::sandbox::LogStream> {
+        self.backend
+            .sandboxes()
+            .follow_logs(self.backend.clone(), &self.name, opts)
+            .await
+    }
+
     /// Get the latest metrics snapshot for this sandbox. **Local handles only**.
     pub async fn metrics(&self) -> MicrosandboxResult<super::SandboxMetrics> {
         let local = self

--- a/sdk/rust/lib/sandbox/mod.rs
+++ b/sdk/rust/lib/sandbox/mod.rs
@@ -712,6 +712,22 @@ impl Sandbox {
             .await
     }
 
+    /// Replay a filtered log snapshot, then follow new entries.
+    ///
+    /// The backend performs the snapshot-to-stream handoff. Local backends
+    /// preserve the exact snapshot cursor; cloud backends use their live SSE
+    /// transport and return a typed unsupported error for bounded-history
+    /// filters.
+    pub async fn follow_logs(
+        &self,
+        opts: &LogOptions,
+    ) -> MicrosandboxResult<crate::backend::sandbox::LogStream> {
+        self.backend
+            .sandboxes()
+            .follow_logs(self.backend.clone(), &self.name, opts)
+            .await
+    }
+
     /// A local logger handle over this sandbox's on-disk logs.
     ///
     /// Used directly, followed streams each own a private filesystem watcher.


### PR DESCRIPTION
## TL;DR

Route sandbox log retrieval and following through the selected SDK backend so `msb logs` works consistently for local and cloud sandboxes without backend-specific CLI logic.

## Description

- Move bounded log reads and follow orchestration behind `SandboxBackend`.
- Preserve the exact local snapshot cursor when transitioning from filtered history to live output.
- Use the cloud SSE transport for follow mode and return a typed unsupported error for bounded cloud-follow filters that cannot yet be honored.
- Expose `logs::boot_error()` as an optional SDK diagnostic: local reads the persisted startup record and cloud explicitly returns `None` until the API gains that concept.
- Keep boot-error rendering and log filtering in the CLI while removing direct local filesystem routing.
- Update CLI, sandbox, cloud, and observability documentation for the backend-neutral behavior.

## Root Cause

The CLI previously assembled snapshots and follow streams directly from local log directories. That bypassed the SDK backend abstraction, so cloud-selected commands still behaved as if every sandbox lived on the local machine.

## Test Plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p microsandbox -p microsandbox-cli -- -D warnings`
- [x] `cargo test -p microsandbox --lib` (634 passed, 3 ignored)
- [x] `cargo check -p microsandbox-cli`
- [x] Repository commit hooks: workspace/agentd formatting and clippy, workspace docs, and `msb` build
