### PR TITLE
fix(filesystem): isolate single-file mounts

### DIFF
--- a/crates/cli/lib/commands/common.rs
+++ b/crates/cli/lib/commands/common.rs
@@ -130,15 +130,15 @@ pub struct SandboxOpts {
 
     /// Explicitly mount a host directory into the sandbox (`SOURCE:DEST[:OPTIONS]`).
     ///
-    /// OPTIONS may include `uid=<N>,gid=<N>` to present host-created files (no
-    /// per-file stat override) as that guest owner; both are required together.
+    /// OPTIONS may include `quota=<size>` and `uid=<N>,gid=<N>` to present
+    /// host-created files as that guest owner; both IDs are required together.
     #[arg(long = "mount-dir", value_name = "SOURCE:DEST[:OPTIONS]")]
     pub mount_dir: Vec<String>,
 
     /// Explicitly mount a host file into the sandbox (`SOURCE:DEST[:OPTIONS]`).
     ///
-    /// OPTIONS may include `uid=<N>,gid=<N>` to present the host file (no
-    /// per-file stat override) as that guest owner; both are required together.
+    /// OPTIONS may include `quota=<size>` and `uid=<N>,gid=<N>` to present the
+    /// host file as that guest owner; both IDs are required together.
     #[arg(long = "mount-file", value_name = "SOURCE:DEST[:OPTIONS]")]
     pub mount_file: Vec<String>,
 
@@ -1536,6 +1536,7 @@ pub fn apply_explicit_file_mount(
         spec,
         CliMountOptionSupport {
             policies: true,
+            quota: true,
             owner: true,
             ..CliMountOptionSupport::default()
         },
@@ -3742,19 +3743,21 @@ mod tests {
     #[tokio::test]
     async fn test_apply_explicit_file_mount() {
         let file = write_temp("fixture");
-        let spec = format!("{}:/fixture:ro,noexec", file.display());
+        let spec = format!("{}:/fixture:ro,noexec,quota=32M", file.display());
         let mount = build_explicit(&spec, apply_explicit_file_mount).await;
         match mount {
             VolumeMount::Bind {
                 host,
                 guest,
                 options,
+                quota_mib,
                 ..
             } => {
                 assert_eq!(host, file);
                 assert_eq!(guest, "/fixture");
                 assert!(options.readonly);
                 assert!(options.noexec);
+                assert_eq!(quota_mib, Some(32));
             }
             other => panic!("expected Bind, got {other:?}"),
         }

--- a/crates/cli/lib/commands/install.rs
+++ b/crates/cli/lib/commands/install.rs
@@ -64,10 +64,12 @@ pub struct InstallArgs {
     pub volume: Vec<String>,
 
     /// Explicitly mount a host directory into the sandbox (`SOURCE:DEST[:OPTIONS]`).
+    /// OPTIONS may include `quota=<size>`.
     #[arg(long = "mount-dir", value_name = "SOURCE:DEST[:OPTIONS]")]
     pub mount_dir: Vec<String>,
 
     /// Explicitly mount a host file into the sandbox (`SOURCE:DEST[:OPTIONS]`).
+    /// OPTIONS may include `quota=<size>`.
     #[arg(long = "mount-file", value_name = "SOURCE:DEST[:OPTIONS]")]
     pub mount_file: Vec<String>,
 

--- a/crates/cli/lib/sandbox_cmd.rs
+++ b/crates/cli/lib/sandbox_cmd.rs
@@ -242,6 +242,7 @@ pub fn run(args: SandboxArgs) -> ! {
         },
         rootfs_disk_readonly: launch.rootfs.disk_readonly,
         mounts: launch.mounts,
+        file_mounts: launch.file_mounts,
         disks,
         vsock: launch.vsock,
         #[cfg(unix)]

--- a/crates/filesystem/lib/backends/mod.rs
+++ b/crates/filesystem/lib/backends/mod.rs
@@ -1,7 +1,7 @@
 //! Filesystem backends for microsandbox.
 //!
-//! Currently provides [`PassthroughFs`](passthroughfs::PassthroughFs), which exposes
-//! a single host directory to the guest VM via virtio-fs.
+//! Provides host-directory passthrough, isolated single-file views, and the
+//! in-memory composition backends used by the runtime.
 
 #[cfg(unix)]
 pub mod dualfs;
@@ -10,3 +10,4 @@ pub mod memfs;
 pub mod passthroughfs;
 #[cfg(unix)]
 pub(crate) mod shared;
+pub mod singlefilefs;

--- a/crates/filesystem/lib/backends/passthroughfs/quota.rs
+++ b/crates/filesystem/lib/backends/passthroughfs/quota.rs
@@ -1,8 +1,8 @@
-//! Directory byte-budget quota for the passthrough filesystem.
+//! Path byte-budget quota for the passthrough filesystem.
 //!
-//! A passthrough mount shares a host directory directly, so without a budget a
-//! guest can write unbounded data straight onto the host disk. [`DirQuota`]
-//! bounds the *guest-attributable* growth of one mount's subtree.
+//! A passthrough mount shares a host path directly, so without a budget a guest
+//! can write unbounded data straight onto the host disk. [`DirQuota`] bounds the
+//! *guest-attributable* growth of either one selected file or a directory tree.
 //!
 //! ## Accounting model
 //!
@@ -62,12 +62,12 @@ use crate::statvfs64;
 // Types
 //--------------------------------------------------------------------------------------------------
 
-/// A delta-charged byte budget for one passthrough mount subtree.
+/// A delta-charged byte budget for one passthrough mount path.
 pub(crate) struct DirQuota {
     /// Hard ceiling in bytes for guest additions. Growth past this returns `ENOSPC`.
     limit: u64,
 
-    /// Host directory whose subtree is bounded.
+    /// Host file or directory tree whose growth is bounded.
     root: PathBuf,
 
     /// Subtree size at first guest write-access. Never counts against the
@@ -83,7 +83,7 @@ pub(crate) struct DirQuota {
 //--------------------------------------------------------------------------------------------------
 
 impl DirQuota {
-    /// Create a budget of `limit` guest-addable bytes over the subtree at `root`.
+    /// Create a budget of `limit` guest-addable bytes over the path at `root`.
     ///
     /// Does not walk the directory — the baseline is captured lazily on the
     /// first guest write-access (see [`Self::ensure_baseline`]).
@@ -182,11 +182,21 @@ fn enospc() -> io::Error {
     }
 }
 
-/// Sum the logical size of every regular file beneath `root`.
+/// Return a file's logical size, or sum every regular file beneath a directory.
 ///
 /// Best-effort: unreadable directories and entries are skipped. Symlinks are
 /// not followed, so the walk stays within the mount subtree.
 fn subtree_size(root: &Path) -> u64 {
+    let Ok(root_metadata) = std::fs::symlink_metadata(root) else {
+        return 0;
+    };
+    if root_metadata.file_type().is_file() {
+        return root_metadata.len();
+    }
+    if !root_metadata.file_type().is_dir() {
+        return 0;
+    }
+
     let mut total = 0u64;
     let mut stack = vec![root.to_path_buf()];
     while let Some(dir) = stack.pop() {
@@ -311,6 +321,20 @@ mod tests {
         std::fs::write(dir.path().join("late"), vec![0u8; 800]).unwrap();
         q.ensure_baseline();
         assert_eq!(q.baseline(), 800);
+    }
+
+    #[test]
+    fn file_scope_ignores_siblings_in_the_parent_directory() {
+        let dir = tempfile::tempdir().unwrap();
+        let selected = dir.path().join("selected");
+        std::fs::write(&selected, b"base").unwrap();
+        std::fs::write(dir.path().join("sibling"), vec![0u8; 8192]).unwrap();
+
+        let q = DirQuota::new(selected, 1024);
+        q.ensure_baseline();
+
+        assert_eq!(q.baseline(), 4);
+        assert!(q.charge(1024).is_ok());
     }
 
     #[test]

--- a/crates/filesystem/lib/backends/passthroughfs/unix/builder.rs
+++ b/crates/filesystem/lib/backends/passthroughfs/unix/builder.rs
@@ -178,6 +178,7 @@ impl PassthroughFsBuilder {
             inject_init: self.inject_init,
             bind_identity_map: self.bind_identity_map,
             quota_bytes: self.quota_bytes,
+            quota_root: None,
         };
 
         // Open the root directory, contained beneath the anchor when one is set.
@@ -205,9 +206,14 @@ impl PassthroughFsBuilder {
 
         let cfg = cfg_probe;
 
-        let quota = cfg
-            .quota_bytes
-            .map(|limit| super::super::quota::DirQuota::new(cfg.root_dir.clone(), limit));
+        let quota = cfg.quota_bytes.map(|limit| {
+            super::super::quota::DirQuota::new(
+                cfg.quota_root
+                    .clone()
+                    .unwrap_or_else(|| cfg.root_dir.clone()),
+                limit,
+            )
+        });
 
         Ok(PassthroughFs {
             cfg,

--- a/crates/filesystem/lib/backends/passthroughfs/unix/metadata.rs
+++ b/crates/filesystem/lib/backends/passthroughfs/unix/metadata.rs
@@ -11,7 +11,12 @@
 //! (the host process lacks `CAP_CHOWN`). Size changes use real `ftruncate`, and timestamp
 //! changes use real `futimens`.
 
-use std::{io, os::fd::AsRawFd, time::Duration};
+use std::{
+    fs::File,
+    io,
+    os::fd::{AsRawFd, FromRawFd},
+    time::Duration,
+};
 
 use super::host_mode::{fchmod_mirror, fchmod_raw, host_strip_priv_bits, mirror_eligible_type};
 use super::{PassthroughFs, inode};
@@ -49,7 +54,7 @@ pub(crate) fn do_setattr(
     _ctx: Context,
     ino: u64,
     attr: stat64,
-    _handle: Option<u64>,
+    handle: Option<u64>,
     valid: SetattrValid,
 ) -> io::Result<(stat64, Duration)> {
     if fs.is_virtual_init_inode(ino) {
@@ -66,7 +71,13 @@ pub(crate) fn do_setattr(
     }
 
     #[cfg(target_os = "macos")]
-    let guest_file_type = platform::mode_file_type(inode::stat_inode(fs, ino)?.st_mode);
+    let guest_file_type = platform::mode_file_type(
+        match handle {
+            Some(handle) => stat_handle(fs, handle)?,
+            None => inode::stat_inode(fs, ino)?,
+        }
+        .st_mode,
+    );
 
     #[cfg(target_os = "macos")]
     if guest_file_type == platform::MODE_LNK && valid.contains(SetattrValid::SIZE) {
@@ -82,18 +93,27 @@ pub(crate) fn do_setattr(
         libc::O_RDONLY
     };
 
-    #[cfg(target_os = "linux")]
-    let fd = inode::open_inode_fd(fs, ino, open_flags)?;
+    let file = match handle {
+        // A supplied FUSE handle is the authoritative object. In particular,
+        // it remains valid after an atomic host replacement detaches the inode
+        // from the namespace, when reopening by inode can no longer succeed.
+        Some(handle) => clone_handle_file(fs, handle)?,
+        None => {
+            #[cfg(target_os = "linux")]
+            let fd = inode::open_inode_fd(fs, ino, open_flags)?;
 
-    #[cfg(target_os = "macos")]
-    let fd = if guest_file_type == platform::MODE_LNK {
-        open_symlink_inode_fd_macos(fs, ino)?
-    } else {
-        inode::open_inode_fd(fs, ino, open_flags)?
+            #[cfg(target_os = "macos")]
+            let fd = if guest_file_type == platform::MODE_LNK {
+                open_symlink_inode_fd_macos(fs, ino)?
+            } else {
+                inode::open_inode_fd(fs, ino, open_flags)?
+            };
+
+            // SAFETY: each open helper returns a newly owned descriptor.
+            unsafe { File::from_raw_fd(fd) }
+        }
     };
-    let close_fd = scopeguard::guard(fd, |fd| unsafe {
-        libc::close(fd);
-    });
+    let fd = file.as_raw_fd();
 
     // FUSE expects setattr-triggered truncate/chown to clear suid/sgid when
     // requested. UID/GID changes always clear them; SIZE changes only do so
@@ -107,15 +127,12 @@ pub(crate) fn do_setattr(
     //   - kill_priv            : kernel asked us to clear setuid/setgid
     if valid.intersects(SetattrValid::UID | SetattrValid::GID | SetattrValid::MODE) || kill_priv {
         if fs.cfg.xattr_enabled() {
-            let current = stat_override::get_override(
-                *close_fd,
-                fs.cfg.xattr_enabled(),
-                fs.cfg.strict_enabled(),
-            )?;
+            let current =
+                stat_override::get_override(fd, fs.cfg.xattr_enabled(), fs.cfg.strict_enabled())?;
             let (cur_uid, cur_gid, cur_mode, cur_rdev) = match current {
                 Some(ovr) => (ovr.uid, ovr.gid, ovr.mode, ovr.rdev),
                 None => {
-                    let mut st = platform::fstat(*close_fd)?;
+                    let mut st = platform::fstat(fd)?;
                     stat_override::apply_bind_identity_map(
                         &mut st,
                         fs.cfg.bind_identity_map.as_ref(),
@@ -153,10 +170,10 @@ pub(crate) fn do_setattr(
                 && valid.contains(SetattrValid::MODE)
                 && mirror_eligible_type(new_mode & platform::MODE_TYPE_MASK)
             {
-                fchmod_mirror(*close_fd, new_mode, new_mode & platform::MODE_TYPE_MASK)?;
+                fchmod_mirror(fd, new_mode, new_mode & platform::MODE_TYPE_MASK)?;
             }
 
-            stat_override::set_override(*close_fd, new_uid, new_gid, new_mode, cur_rdev)?;
+            stat_override::set_override(fd, new_uid, new_gid, new_mode, cur_rdev)?;
         } else if valid.contains(SetattrValid::MODE) {
             // xattr off: guest sees real host stat. Apply chmod directly.
             // For REG/DIR we keep the owner-access floor so the host process
@@ -164,22 +181,22 @@ pub(crate) fn do_setattr(
             // symlinks) we pass the raw perms because clamping symlink mode
             // bits would silently corrupt link state.
             let attr_mode = platform::mode_u32(attr.st_mode);
-            let host_st = platform::fstat(*close_fd)?;
+            let host_st = platform::fstat(fd)?;
             let file_type = platform::mode_u32(host_st.st_mode) & platform::MODE_TYPE_MASK;
             let mut perms = attr_mode & 0o7777;
             if kill_priv {
                 perms &= !(platform::MODE_SETUID | platform::MODE_SETGID);
             }
             if mirror_eligible_type(file_type) {
-                fchmod_mirror(*close_fd, perms, file_type)?;
+                fchmod_mirror(fd, perms, file_type)?;
             } else {
-                fchmod_raw(*close_fd, perms)?;
+                fchmod_raw(fd, perms)?;
             }
         } else if kill_priv {
             // xattr off + kill_priv with no MODE bit (typical: SIZE truncate
             // of a setuid binary). Strip setuid/setgid on the host inode so
             // we honor HANDLE_KILLPRIV_V2 semantics for `Off` mounts too.
-            host_strip_priv_bits(*close_fd)?;
+            host_strip_priv_bits(fd)?;
         }
     }
 
@@ -192,9 +209,9 @@ pub(crate) fn do_setattr(
 
         // Quota: an extending truncate grows the file. Charge the growth past
         // EOF before ftruncate (a shrinking truncate charges nothing).
-        fs.quota_charge_to(*close_fd, attr.st_size.max(0) as u64)?;
+        fs.quota_charge_to(fd, attr.st_size.max(0) as u64)?;
 
-        let ret = unsafe { libc::ftruncate(*close_fd, attr.st_size) };
+        let ret = unsafe { libc::ftruncate(fd, attr.st_size) };
         if ret < 0 {
             return Err(platform::linux_error(io::Error::last_os_error()));
         }
@@ -208,7 +225,7 @@ pub(crate) fn do_setattr(
         if guest_file_type == platform::MODE_LNK {
             set_symlink_times_macos(fs, ino, &times)?;
         } else {
-            let ret = unsafe { libc::futimens(*close_fd, times.as_ptr()) };
+            let ret = unsafe { libc::futimens(fd, times.as_ptr()) };
             if ret < 0 {
                 return Err(platform::linux_error(io::Error::last_os_error()));
             }
@@ -216,17 +233,20 @@ pub(crate) fn do_setattr(
 
         #[cfg(target_os = "linux")]
         {
-            let ret = unsafe { libc::futimens(*close_fd, times.as_ptr()) };
+            let ret = unsafe { libc::futimens(fd, times.as_ptr()) };
             if ret < 0 {
                 return Err(platform::linux_error(io::Error::last_os_error()));
             }
         }
     }
 
-    drop(close_fd);
+    drop(file);
 
     // Return updated attributes.
-    let st = inode::stat_inode(fs, ino)?;
+    let st = match handle {
+        Some(handle) => stat_handle(fs, handle)?,
+        None => inode::stat_inode(fs, ino)?,
+    };
     Ok((st, fs.cfg.attr_timeout))
 }
 
@@ -307,6 +327,13 @@ fn stat_handle(fs: &PassthroughFs, handle: u64) -> io::Result<stat64> {
         fs.cfg.strict_enabled(),
         fs.cfg.bind_identity_map.as_ref(),
     )
+}
+
+fn clone_handle_file(fs: &PassthroughFs, handle: u64) -> io::Result<File> {
+    let handles = fs.handles.read().unwrap();
+    let data = handles.get(&handle).ok_or_else(platform::ebadf)?;
+    let file = data.file.read().unwrap();
+    file.try_clone().map_err(platform::linux_error)
 }
 
 #[cfg(target_os = "macos")]

--- a/crates/filesystem/lib/backends/passthroughfs/unix/mod.rs
+++ b/crates/filesystem/lib/backends/passthroughfs/unix/mod.rs
@@ -171,6 +171,12 @@ pub struct PassthroughConfig {
     /// `None` means unbounded. When set, guest-attributable growth past this
     /// many bytes is rejected with `ENOSPC`.
     pub quota_bytes: Option<u64>,
+
+    /// Optional quota accounting root when it differs from `root_dir`.
+    ///
+    /// Single-file mounts anchor pathname resolution at the parent directory,
+    /// while accounting only the selected file. `None` uses `root_dir`.
+    pub quota_root: Option<PathBuf>,
 }
 
 /// Passthrough filesystem backend.
@@ -323,9 +329,14 @@ impl PassthroughFs {
             unsafe { File::from_raw_fd(fd) }
         };
 
-        let quota = cfg
-            .quota_bytes
-            .map(|limit| super::quota::DirQuota::new(cfg.root_dir.clone(), limit));
+        let quota = cfg.quota_bytes.map(|limit| {
+            super::quota::DirQuota::new(
+                cfg.quota_root
+                    .clone()
+                    .unwrap_or_else(|| cfg.root_dir.clone()),
+                limit,
+            )
+        });
 
         Ok(Self {
             cfg,
@@ -504,6 +515,7 @@ impl Default for PassthroughConfig {
             inject_init: true,
             bind_identity_map: None,
             quota_bytes: None,
+            quota_root: None,
         }
     }
 }

--- a/crates/filesystem/lib/backends/passthroughfs/unix/mod.rs
+++ b/crates/filesystem/lib/backends/passthroughfs/unix/mod.rs
@@ -264,10 +264,46 @@ impl PassthroughFs {
     ///
     /// Opens the root directory and optionally probes for xattr support.
     pub fn new(cfg: PassthroughConfig) -> io::Result<Self> {
+        Self::new_with_stat_probe(cfg, None)
+    }
+
+    /// Create a passthrough backend whose strict-stat probe targets one child.
+    ///
+    /// A single-file facade uses this to verify the only exposed inode instead
+    /// of the otherwise-hidden parent directory. The normal directory backend
+    /// continues to probe its root because every child is guest-visible.
+    pub(crate) fn new_with_stat_probe(
+        cfg: PassthroughConfig,
+        probe_name: Option<&CStr>,
+    ) -> io::Result<Self> {
         // Open the root directory, contained beneath the anchor when one is set.
         let root_fd = open_root(&cfg)?;
 
-        probe_strict_xattr_support(&cfg, root_fd.as_raw_fd())?;
+        let probe_file = match probe_name {
+            Some(name) => {
+                let access_mode = if cfg.readonly() {
+                    libc::O_RDONLY
+                } else {
+                    libc::O_WRONLY
+                };
+                let fd = unsafe {
+                    libc::openat(
+                        root_fd.as_raw_fd(),
+                        name.as_ptr(),
+                        access_mode | libc::O_CLOEXEC | libc::O_NOFOLLOW,
+                    )
+                };
+                if fd < 0 {
+                    return Err(platform::linux_error(io::Error::last_os_error()));
+                }
+                Some(unsafe { File::from_raw_fd(fd) })
+            }
+            None => None,
+        };
+        let probe_fd = probe_file
+            .as_ref()
+            .map_or_else(|| root_fd.as_raw_fd(), AsRawFd::as_raw_fd);
+        probe_strict_xattr_support(&cfg, probe_fd)?;
 
         // Create the init binary file.
         let init_file = init_binary::create_init_file()?;

--- a/crates/filesystem/lib/backends/passthroughfs/unix/tests/test_metadata.rs
+++ b/crates/filesystem/lib/backends/passthroughfs/unix/tests/test_metadata.rs
@@ -175,6 +175,41 @@ fn test_setattr_size_expand() {
 }
 
 #[test]
+fn test_setattr_uses_handle_after_external_replacement() {
+    let sb = TestSandbox::new();
+    let (entry, handle) = sb.fuse_create_root("selected.txt").unwrap();
+    sb.fuse_write(entry.inode, handle, b"old contents", 0)
+        .unwrap();
+    let replacement = sb.host_create_file("replacement.txt", b"new contents");
+
+    // Simulate an atomic host update followed by the guest dropping its
+    // pathname lookup. Only the already-open descriptor still owns the old
+    // object, so handle-based setattr must not try to reopen its inode.
+    std::fs::rename(replacement, sb.root.join("selected.txt")).unwrap();
+    sb.fs.forget(sb.ctx(), entry.inode, 1);
+
+    let mut attr: stat64 = unsafe { std::mem::zeroed() };
+    attr.st_size = 3;
+    let (st, _timeout) = sb
+        .fs
+        .setattr(
+            sb.ctx(),
+            entry.inode,
+            attr,
+            Some(handle),
+            SetattrValid::SIZE,
+        )
+        .unwrap();
+
+    assert_eq!(st.st_size, 3);
+    assert_eq!(sb.fuse_read(entry.inode, handle, 64, 0).unwrap(), b"old");
+    assert_eq!(
+        std::fs::read(sb.root.join("selected.txt")).unwrap(),
+        b"new contents"
+    );
+}
+
+#[test]
 fn test_setattr_timestamps() {
     let sb = TestSandbox::new();
     let (entry, _handle) = sb.fuse_create_root("file.txt").unwrap();

--- a/crates/filesystem/lib/backends/passthroughfs/windows/builder.rs
+++ b/crates/filesystem/lib/backends/passthroughfs/windows/builder.rs
@@ -113,6 +113,14 @@ impl PassthroughConfig {
 impl PassthroughFs {
     /// Create a Windows passthrough filesystem rooted at `cfg.root_dir`.
     pub fn new(cfg: PassthroughConfig) -> io::Result<Self> {
+        Self::new_with_stat_probe(cfg, None)
+    }
+
+    /// Create a passthrough backend whose read-only metadata probe targets one child.
+    pub(crate) fn new_with_stat_probe(
+        cfg: PassthroughConfig,
+        probe_name: Option<&CStr>,
+    ) -> io::Result<Self> {
         // Reject contradictory metadata policy before resolving or probing the
         // host root. Direct backend callers must receive the same guarantee as
         // the SDK and runtime boundaries.
@@ -134,7 +142,16 @@ impl PassthroughFs {
             }
             root
         };
-        let stat_store = StatStore::new(&root, cfg.stat_virtualization, cfg.readonly)?;
+        let probe_path = probe_name
+            .map(|name| std::str::from_utf8(name.to_bytes()).map(|name| root.join(name)))
+            .transpose()
+            .map_err(|_| linux_error(LINUX_EINVAL))?;
+        let stat_store = StatStore::new(
+            &root,
+            probe_path.as_deref(),
+            cfg.stat_virtualization,
+            cfg.readonly,
+        )?;
 
         let init_file = if cfg.inject_init {
             let mut file = tempfile::tempfile().map_err(host_error)?;
@@ -199,7 +216,7 @@ impl PassthroughFs {
         let path = std::fs::canonicalize(path).map_err(host_error)?;
         let metadata = safe_metadata_under_root(&root, &path)?;
         let mode = (mode_from_metadata(&metadata) & S_IFMT) | (permissions & 0o7777);
-        let store = StatStore::new(&root, StatVirtualization::Strict, false)?
+        let store = StatStore::new(&root, None, StatVirtualization::Strict, false)?
             .ok_or_else(|| linux_error(LINUX_EIO))?;
         store.write(&path, uid, gid, mode, 0)
     }

--- a/crates/filesystem/lib/backends/passthroughfs/windows/builder.rs
+++ b/crates/filesystem/lib/backends/passthroughfs/windows/builder.rs
@@ -76,6 +76,12 @@ pub struct PassthroughConfig {
     /// many bytes is rejected with `ENOSPC`.
     pub quota_bytes: Option<u64>,
 
+    /// Optional quota accounting root when it differs from `root_dir`.
+    ///
+    /// Single-file mounts anchor pathname resolution at the parent directory,
+    /// while accounting only the selected file. `None` uses `root_dir`.
+    pub quota_root: Option<PathBuf>,
+
     /// Guest `(uid, gid)` to present for host files that carry no per-file
     /// override in the metadata store.
     ///
@@ -162,9 +168,12 @@ impl PassthroughFs {
             None
         };
 
-        let quota = cfg
-            .quota_bytes
-            .map(|limit| super::super::quota::DirQuota::new(root.clone(), limit));
+        let quota = cfg.quota_bytes.map(|limit| {
+            super::super::quota::DirQuota::new(
+                cfg.quota_root.clone().unwrap_or_else(|| root.clone()),
+                limit,
+            )
+        });
 
         Ok(Self {
             cfg,
@@ -238,6 +247,7 @@ impl Default for PassthroughConfig {
             attr_timeout: Duration::from_secs(5),
             inject_init: true,
             quota_bytes: None,
+            quota_root: None,
             default_owner: None,
         }
     }

--- a/crates/filesystem/lib/backends/passthroughfs/windows/stat_store.rs
+++ b/crates/filesystem/lib/backends/passthroughfs/windows/stat_store.rs
@@ -11,6 +11,7 @@ use windows_sys::Win32::System::SystemServices::FILE_NAMED_STREAMS;
 impl StatStore {
     pub(super) fn new(
         root: &Path,
+        readonly_probe: Option<&Path>,
         policy: StatVirtualization,
         readonly: bool,
     ) -> io::Result<Option<Self>> {
@@ -20,7 +21,7 @@ impl StatStore {
 
         let ads_store = Self::ads(root);
         let ads_probe = if readonly {
-            ads_store.probe_read()
+            ads_store.probe_read(readonly_probe.unwrap_or(root))
         } else {
             ads_store.probe()
         };
@@ -34,7 +35,7 @@ impl StatStore {
 
         let sidecar_store = Self::sidecar(root);
         let sidecar_probe = if readonly {
-            sidecar_store.probe_read()
+            sidecar_store.probe_read(readonly_probe.unwrap_or(root))
         } else {
             sidecar_store.probe()
         };
@@ -72,9 +73,9 @@ impl StatStore {
 
     /// Verify that an existing metadata store can be consumed without
     /// creating, replacing, or deleting anything beneath a read-only mount.
-    fn probe_read(&self) -> io::Result<()> {
+    fn probe_read(&self, path: &Path) -> io::Result<()> {
         match &self.backend {
-            StatStoreBackend::AlternateDataStream => self.probe_ads_read(),
+            StatStoreBackend::AlternateDataStream => self.probe_ads_read(path),
             StatStoreBackend::Sidecar { dir } => self.probe_sidecar_read(dir),
         }
     }
@@ -104,12 +105,12 @@ impl StatStore {
 
     /// Verify that a read-only mount can consume ADS metadata without creating
     /// or deleting a stream on the host directory.
-    fn probe_ads_read(&self) -> io::Result<()> {
-        if !volume_supports_named_streams(&self.root)? {
+    fn probe_ads_read(&self, path: &Path) -> io::Result<()> {
+        if !volume_supports_named_streams(path)? {
             return Err(linux_error(LINUX_EOPNOTSUPP));
         }
 
-        let probe_path = ads_override_path(&self.root);
+        let probe_path = ads_override_path(path);
         match StdOpenOptions::new()
             .read(true)
             .custom_flags(FILE_FLAG_OPEN_REPARSE_POINT | FILE_FLAG_BACKUP_SEMANTICS)

--- a/crates/filesystem/lib/backends/singlefilefs/mod.rs
+++ b/crates/filesystem/lib/backends/singlefilefs/mod.rs
@@ -102,6 +102,10 @@ impl SingleFileFs {
         cfg.no_symlink_root = true;
         cfg.inject_init = false;
         cfg.quota_bytes = None;
+        // Host writes bypass FUSE, so expire attributes immediately. With
+        // AUTO_INVAL_DATA negotiated below, each guest read revalidates mtime
+        // and invalidates cached contents when the host changed them.
+        cfg.attr_timeout = Duration::ZERO;
 
         let inner_name = CString::new(inner_name).map_err(|_| {
             io::Error::new(io::ErrorKind::InvalidInput, "host filename contains NUL")
@@ -172,7 +176,15 @@ impl SingleFileFs {
 
 impl DynFileSystem for SingleFileFs {
     fn init(&self, capable: FsOptions) -> io::Result<FsOptions> {
-        self.inner.init(capable)
+        let options = self.inner.init(capable)?;
+        let options = if capable.contains(FsOptions::AUTO_INVAL_DATA) {
+            // Single-file binds are externally mutable. Ask the guest kernel
+            // to compare refreshed attributes before serving cached pages.
+            options | FsOptions::AUTO_INVAL_DATA
+        } else {
+            options
+        };
+        Ok(options)
     }
 
     fn destroy(&self) {
@@ -621,5 +633,27 @@ mod tests {
                 .is_err()
             );
         }
+    }
+
+    #[test]
+    fn negotiates_automatic_data_invalidation() {
+        let temp = tempfile::tempdir().unwrap();
+        let source = temp.path().join("selected.txt");
+        std::fs::write(&source, b"initial").unwrap();
+
+        let fs = SingleFileFs::new(
+            source,
+            "config.txt".to_string(),
+            PassthroughConfig {
+                attr_timeout: Duration::from_secs(60),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let options = fs.init(FsOptions::AUTO_INVAL_DATA).unwrap();
+
+        assert!(options.contains(FsOptions::AUTO_INVAL_DATA));
+        #[cfg(unix)]
+        assert_eq!(fs.inner.cfg.attr_timeout, Duration::ZERO);
     }
 }

--- a/crates/filesystem/lib/backends/singlefilefs/mod.rs
+++ b/crates/filesystem/lib/backends/singlefilefs/mod.rs
@@ -844,7 +844,13 @@ mod tests {
         fs.init(FsOptions::empty()).unwrap();
 
         let old_entry = fs.lookup(context(), ROOT_INODE, c"config.txt").unwrap();
-        let (old_handle, _) = fs.open(context(), old_entry.inode, false, 0).unwrap();
+        #[cfg(unix)]
+        let old_flags = libc::O_RDWR as u32;
+        #[cfg(windows)]
+        let old_flags = 0;
+        let (old_handle, _) = fs
+            .open(context(), old_entry.inode, false, old_flags)
+            .unwrap();
         let old_handle = old_handle.unwrap();
 
         #[cfg(windows)]
@@ -898,6 +904,21 @@ mod tests {
         // FUSE may drop the pathname lookup before the descriptor is closed.
         // The handle admission must independently retain access to that inode.
         fs.forget(context(), old_entry.inode, 1);
+        #[cfg(unix)]
+        {
+            // Handle-based setattr must keep targeting this descriptor after
+            // its inode has been detached from the host namespace.
+            let mut detached_attr: stat64 = unsafe { std::mem::zeroed() };
+            detached_attr.st_size = 3;
+            fs.setattr(
+                context(),
+                old_entry.inode,
+                detached_attr,
+                Some(old_handle),
+                SetattrValid::SIZE,
+            )
+            .unwrap();
+        }
         let mut old_writer = CaptureWriter { bytes: Vec::new() };
         fs.read(
             context(),
@@ -910,6 +931,9 @@ mod tests {
             0,
         )
         .unwrap();
+        #[cfg(unix)]
+        assert_eq!(old_writer.bytes, b"old");
+        #[cfg(windows)]
         assert_eq!(old_writer.bytes, b"old contents");
         fs.release(
             context(),

--- a/crates/filesystem/lib/backends/singlefilefs/mod.rs
+++ b/crates/filesystem/lib/backends/singlefilefs/mod.rs
@@ -885,10 +885,14 @@ mod tests {
             .readdir(context(), ROOT_INODE, ROOT_HANDLE, 4096, 0)
             .unwrap();
         let replacement_inode = directory_entries.last().unwrap().ino;
+        // Unix passthrough identities follow host inodes, while Windows keeps
+        // a stable synthetic node ID for the selected pathname.
+        #[cfg(unix)]
         assert_ne!(old_entry.inode, replacement_inode);
         fs.getattr(context(), replacement_inode, None).unwrap();
 
         let new_entry = fs.lookup(context(), ROOT_INODE, c"config.txt").unwrap();
+        #[cfg(unix)]
         assert_ne!(old_entry.inode, new_entry.inode);
 
         // FUSE may drop the pathname lookup before the descriptor is closed.

--- a/crates/filesystem/lib/backends/singlefilefs/mod.rs
+++ b/crates/filesystem/lib/backends/singlefilefs/mod.rs
@@ -1,0 +1,625 @@
+//! Isolated host-file filesystem backend.
+//!
+//! `SingleFileFs` presents a synthetic directory containing exactly one host
+//! file. The selected file uses the platform passthrough implementation for
+//! data and metadata operations, while this facade prevents the guest from
+//! discovering or mutating any sibling names in the host directory.
+
+use std::{
+    ffi::{CStr, CString},
+    io,
+    path::PathBuf,
+    sync::atomic::{AtomicU64, Ordering},
+    time::Duration,
+};
+
+use super::passthroughfs::{PassthroughConfig, PassthroughFs};
+use crate::{
+    Context, DirEntry, DynFileSystem, Entry, FsOptions, GetxattrReply, ListxattrReply, OpenOptions,
+    SetattrValid, ZeroCopyReader, ZeroCopyWriter, stat64, statvfs64,
+};
+
+//--------------------------------------------------------------------------------------------------
+// Constants
+//--------------------------------------------------------------------------------------------------
+
+const ROOT_INODE: u64 = 1;
+const ROOT_HANDLE: u64 = 0;
+
+const DT_DIR: u32 = 4;
+const DT_REG: u32 = 8;
+
+const S_IFREG: u32 = 0o100000;
+const S_IFDIR: u32 = 0o040000;
+const S_IFMT: u32 = 0o170000;
+
+const LINUX_ENOENT: i32 = 2;
+const LINUX_EBADF: i32 = 9;
+const LINUX_EACCES: i32 = 13;
+const LINUX_ENOTDIR: i32 = 20;
+const LINUX_EISDIR: i32 = 21;
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// A virtio-fs backend exposing one host file beneath a synthetic root.
+pub struct SingleFileFs {
+    inner: PassthroughFs,
+    inner_name: CString,
+    guest_name: &'static [u8],
+    file_inode: AtomicU64,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Methods
+//--------------------------------------------------------------------------------------------------
+
+impl SingleFileFs {
+    /// Create an isolated view of `source` under `guest_name`.
+    ///
+    /// The source is canonicalized once so the passthrough backend is anchored
+    /// to a real parent directory. The guest-facing namespace is synthetic and
+    /// never exposes that parent or any of its other entries.
+    pub fn new(
+        source: PathBuf,
+        guest_name: String,
+        mut cfg: PassthroughConfig,
+    ) -> io::Result<Self> {
+        let source = std::fs::canonicalize(source)?;
+        let metadata = std::fs::metadata(&source)?;
+        if !metadata.is_file() {
+            return Err(linux_error(LINUX_EISDIR));
+        }
+
+        let parent = source
+            .parent()
+            .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "file has no parent"))?;
+        let inner_name = source
+            .file_name()
+            .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "file has no name"))?
+            .to_str()
+            .ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "host filename is not valid UTF-8",
+                )
+            })?
+            .to_string();
+
+        if guest_name.is_empty()
+            || guest_name == "."
+            || guest_name == ".."
+            || guest_name.contains('/')
+        {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "single-file guest name must be a normal path component",
+            ));
+        }
+
+        cfg.root_dir = parent.to_path_buf();
+        cfg.no_symlink_root = true;
+        cfg.inject_init = false;
+        cfg.quota_bytes = None;
+
+        let inner_name = CString::new(inner_name).map_err(|_| {
+            io::Error::new(io::ErrorKind::InvalidInput, "host filename contains NUL")
+        })?;
+        let inner = PassthroughFs::new_with_stat_probe(cfg, Some(&inner_name))?;
+        let guest_name = CString::new(guest_name)
+            .map_err(|_| {
+                io::Error::new(io::ErrorKind::InvalidInput, "guest filename contains NUL")
+            })?
+            .into_bytes()
+            .into_boxed_slice();
+
+        Ok(Self {
+            inner,
+            inner_name,
+            // The backend lives for the VM lifetime. A stable name lets both
+            // vector and streaming readdir callbacks borrow it safely.
+            guest_name: Box::leak(guest_name),
+            file_inode: AtomicU64::new(0),
+        })
+    }
+
+    fn lookup_file(&self, ctx: Context) -> io::Result<Entry> {
+        let entry = self.inner.lookup(ctx, ROOT_INODE, &self.inner_name)?;
+        if u32::from(entry.attr.st_mode) & S_IFMT != S_IFREG {
+            return Err(linux_error(LINUX_ENOENT));
+        }
+        self.file_inode.store(entry.inode, Ordering::Release);
+        Ok(entry)
+    }
+
+    fn require_file_inode(&self, inode: u64) -> io::Result<()> {
+        if inode != 0 && self.file_inode.load(Ordering::Acquire) == inode {
+            Ok(())
+        } else {
+            Err(linux_error(LINUX_ENOENT))
+        }
+    }
+
+    fn root_entries(&self) -> Vec<DirEntry<'static>> {
+        let file_inode = self.file_inode.load(Ordering::Acquire);
+        vec![
+            DirEntry {
+                ino: ROOT_INODE,
+                offset: 1,
+                type_: DT_DIR,
+                name: b".",
+            },
+            DirEntry {
+                ino: ROOT_INODE,
+                offset: 2,
+                type_: DT_DIR,
+                name: b"..",
+            },
+            DirEntry {
+                ino: file_inode,
+                offset: 3,
+                type_: DT_REG,
+                name: self.guest_name,
+            },
+        ]
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Trait Implementations
+//--------------------------------------------------------------------------------------------------
+
+impl DynFileSystem for SingleFileFs {
+    fn init(&self, capable: FsOptions) -> io::Result<FsOptions> {
+        self.inner.init(capable)
+    }
+
+    fn destroy(&self) {
+        self.inner.destroy();
+    }
+
+    fn lookup(&self, ctx: Context, parent: u64, name: &CStr) -> io::Result<Entry> {
+        if parent != ROOT_INODE {
+            return Err(linux_error(LINUX_ENOTDIR));
+        }
+        if name.to_bytes() != self.guest_name {
+            return Err(linux_error(LINUX_ENOENT));
+        }
+        self.lookup_file(ctx)
+    }
+
+    fn forget(&self, ctx: Context, inode: u64, count: u64) {
+        if self.require_file_inode(inode).is_ok() {
+            self.inner.forget(ctx, inode, count);
+        }
+    }
+
+    fn getattr(
+        &self,
+        ctx: Context,
+        inode: u64,
+        handle: Option<u64>,
+    ) -> io::Result<(stat64, Duration)> {
+        if inode == ROOT_INODE {
+            return Ok((root_stat(), Duration::from_secs(5)));
+        }
+        self.require_file_inode(inode)?;
+        self.inner.getattr(ctx, inode, handle)
+    }
+
+    fn setattr(
+        &self,
+        ctx: Context,
+        inode: u64,
+        attr: stat64,
+        handle: Option<u64>,
+        valid: SetattrValid,
+    ) -> io::Result<(stat64, Duration)> {
+        self.require_file_inode(inode)?;
+        self.inner.setattr(ctx, inode, attr, handle, valid)
+    }
+
+    fn open(
+        &self,
+        ctx: Context,
+        inode: u64,
+        kill_priv: bool,
+        flags: u32,
+    ) -> io::Result<(Option<u64>, OpenOptions)> {
+        if inode == ROOT_INODE {
+            return Err(linux_error(LINUX_EISDIR));
+        }
+        self.require_file_inode(inode)?;
+        self.inner.open(ctx, inode, kill_priv, flags)
+    }
+
+    fn read(
+        &self,
+        ctx: Context,
+        inode: u64,
+        handle: u64,
+        writer: &mut dyn ZeroCopyWriter,
+        size: u32,
+        offset: u64,
+        lock_owner: Option<u64>,
+        flags: u32,
+    ) -> io::Result<usize> {
+        self.require_file_inode(inode)?;
+        self.inner
+            .read(ctx, inode, handle, writer, size, offset, lock_owner, flags)
+    }
+
+    fn write(
+        &self,
+        ctx: Context,
+        inode: u64,
+        handle: u64,
+        reader: &mut dyn ZeroCopyReader,
+        size: u32,
+        offset: u64,
+        lock_owner: Option<u64>,
+        delayed_write: bool,
+        kill_priv: bool,
+        flags: u32,
+    ) -> io::Result<usize> {
+        self.require_file_inode(inode)?;
+        self.inner.write(
+            ctx,
+            inode,
+            handle,
+            reader,
+            size,
+            offset,
+            lock_owner,
+            delayed_write,
+            kill_priv,
+            flags,
+        )
+    }
+
+    fn flush(&self, ctx: Context, inode: u64, handle: u64, lock_owner: u64) -> io::Result<()> {
+        self.require_file_inode(inode)?;
+        self.inner.flush(ctx, inode, handle, lock_owner)
+    }
+
+    fn fsync(&self, ctx: Context, inode: u64, datasync: bool, handle: u64) -> io::Result<()> {
+        self.require_file_inode(inode)?;
+        self.inner.fsync(ctx, inode, datasync, handle)
+    }
+
+    fn fallocate(
+        &self,
+        ctx: Context,
+        inode: u64,
+        handle: u64,
+        mode: u32,
+        offset: u64,
+        length: u64,
+    ) -> io::Result<()> {
+        self.require_file_inode(inode)?;
+        self.inner
+            .fallocate(ctx, inode, handle, mode, offset, length)
+    }
+
+    fn release(
+        &self,
+        ctx: Context,
+        inode: u64,
+        flags: u32,
+        handle: u64,
+        flush: bool,
+        flock_release: bool,
+        lock_owner: Option<u64>,
+    ) -> io::Result<()> {
+        self.require_file_inode(inode)?;
+        self.inner
+            .release(ctx, inode, flags, handle, flush, flock_release, lock_owner)
+    }
+
+    fn statfs(&self, ctx: Context, _inode: u64) -> io::Result<statvfs64> {
+        self.inner.statfs(ctx, ROOT_INODE)
+    }
+
+    fn setxattr(
+        &self,
+        ctx: Context,
+        inode: u64,
+        name: &CStr,
+        value: &[u8],
+        flags: u32,
+    ) -> io::Result<()> {
+        self.require_file_inode(inode)?;
+        self.inner.setxattr(ctx, inode, name, value, flags)
+    }
+
+    fn getxattr(
+        &self,
+        ctx: Context,
+        inode: u64,
+        name: &CStr,
+        size: u32,
+    ) -> io::Result<GetxattrReply> {
+        self.require_file_inode(inode)?;
+        self.inner.getxattr(ctx, inode, name, size)
+    }
+
+    fn listxattr(&self, ctx: Context, inode: u64, size: u32) -> io::Result<ListxattrReply> {
+        self.require_file_inode(inode)?;
+        self.inner.listxattr(ctx, inode, size)
+    }
+
+    fn removexattr(&self, ctx: Context, inode: u64, name: &CStr) -> io::Result<()> {
+        self.require_file_inode(inode)?;
+        self.inner.removexattr(ctx, inode, name)
+    }
+
+    fn opendir(
+        &self,
+        _ctx: Context,
+        inode: u64,
+        _flags: u32,
+    ) -> io::Result<(Option<u64>, OpenOptions)> {
+        if inode == ROOT_INODE {
+            Ok((Some(ROOT_HANDLE), OpenOptions::empty()))
+        } else {
+            Err(linux_error(LINUX_ENOTDIR))
+        }
+    }
+
+    fn readdir(
+        &self,
+        ctx: Context,
+        inode: u64,
+        handle: u64,
+        _size: u32,
+        offset: u64,
+    ) -> io::Result<Vec<DirEntry<'static>>> {
+        if inode != ROOT_INODE || handle != ROOT_HANDLE {
+            return Err(linux_error(LINUX_EBADF));
+        }
+        if self.file_inode.load(Ordering::Acquire) == 0 {
+            self.lookup_file(ctx)?;
+        }
+        Ok(self
+            .root_entries()
+            .into_iter()
+            .skip(offset as usize)
+            .collect())
+    }
+
+    fn readdirplus(
+        &self,
+        ctx: Context,
+        inode: u64,
+        handle: u64,
+        _size: u32,
+        offset: u64,
+    ) -> io::Result<Vec<(DirEntry<'static>, Entry)>> {
+        if inode != ROOT_INODE || handle != ROOT_HANDLE {
+            return Err(linux_error(LINUX_EBADF));
+        }
+        let file_entry = self.lookup_file(ctx)?;
+        let mut dir_entries = self.root_entries().into_iter();
+        let entries = vec![
+            (dir_entries.next().unwrap(), root_entry()),
+            (dir_entries.next().unwrap(), root_entry()),
+            (dir_entries.next().unwrap(), file_entry),
+        ];
+        Ok(entries.into_iter().skip(offset as usize).collect())
+    }
+
+    fn fsyncdir(&self, _ctx: Context, inode: u64, _datasync: bool, handle: u64) -> io::Result<()> {
+        if inode == ROOT_INODE && handle == ROOT_HANDLE {
+            Ok(())
+        } else {
+            Err(linux_error(LINUX_EBADF))
+        }
+    }
+
+    fn releasedir(&self, _ctx: Context, inode: u64, _flags: u32, handle: u64) -> io::Result<()> {
+        if inode == ROOT_INODE && handle == ROOT_HANDLE {
+            Ok(())
+        } else {
+            Err(linux_error(LINUX_EBADF))
+        }
+    }
+
+    fn access(&self, ctx: Context, inode: u64, mask: u32) -> io::Result<()> {
+        if inode == ROOT_INODE {
+            return if mask & 0o2 == 0 {
+                Ok(())
+            } else {
+                Err(linux_error(LINUX_EACCES))
+            };
+        }
+        self.require_file_inode(inode)?;
+        self.inner.access(ctx, inode, mask)
+    }
+
+    fn lseek(
+        &self,
+        ctx: Context,
+        inode: u64,
+        handle: u64,
+        offset: u64,
+        whence: u32,
+    ) -> io::Result<u64> {
+        self.require_file_inode(inode)?;
+        self.inner.lseek(ctx, inode, handle, offset, whence)
+    }
+
+    fn copyfilerange(
+        &self,
+        ctx: Context,
+        inode_in: u64,
+        handle_in: u64,
+        offset_in: u64,
+        inode_out: u64,
+        handle_out: u64,
+        offset_out: u64,
+        len: u64,
+        flags: u64,
+    ) -> io::Result<usize> {
+        self.require_file_inode(inode_in)?;
+        self.require_file_inode(inode_out)?;
+        self.inner.copyfilerange(
+            ctx, inode_in, handle_in, offset_in, inode_out, handle_out, offset_out, len, flags,
+        )
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+fn root_entry() -> Entry {
+    Entry {
+        inode: ROOT_INODE,
+        generation: 0,
+        attr: root_stat(),
+        attr_flags: 0,
+        attr_timeout: Duration::from_secs(5),
+        entry_timeout: Duration::from_secs(5),
+    }
+}
+
+fn root_stat() -> stat64 {
+    let mut stat: stat64 = unsafe { std::mem::zeroed() };
+    stat.st_ino = ROOT_INODE;
+    stat.st_mode = (S_IFDIR | 0o555) as _;
+    stat.st_nlink = 2;
+    stat.st_uid = 0;
+    stat.st_gid = 0;
+    stat.st_blksize = 4096;
+    stat
+}
+
+fn linux_error(errno: i32) -> io::Error {
+    io::Error::from_raw_os_error(errno)
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests
+//--------------------------------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use std::io::{Read, Seek, SeekFrom};
+    #[cfg(unix)]
+    use std::os::unix::fs::{MetadataExt, PermissionsExt};
+
+    use super::*;
+
+    const LINUX_EROFS: i32 = 30;
+    const LINUX_O_WRONLY: u32 = 1;
+
+    struct CaptureWriter {
+        bytes: Vec<u8>,
+    }
+
+    impl ZeroCopyWriter for CaptureWriter {
+        fn write_from(
+            &mut self,
+            file: &std::fs::File,
+            count: usize,
+            offset: u64,
+        ) -> io::Result<usize> {
+            let mut file = file.try_clone()?;
+            file.seek(SeekFrom::Start(offset))?;
+            file.take(count as u64).read_to_end(&mut self.bytes)
+        }
+    }
+
+    fn context() -> Context {
+        Context {
+            uid: 0,
+            gid: 0,
+            pid: 1,
+        }
+    }
+
+    #[test]
+    fn exposes_only_the_selected_readonly_file_without_hardlinking() {
+        let temp = tempfile::tempdir().unwrap();
+        let source = temp.path().join("selected.txt");
+        std::fs::write(&source, b"initial").unwrap();
+        std::fs::write(temp.path().join("sibling.txt"), b"secret").unwrap();
+
+        #[cfg(unix)]
+        let links_before = std::fs::metadata(&source).unwrap().nlink();
+        let fs = SingleFileFs::new(
+            source.clone(),
+            "config.txt".to_string(),
+            PassthroughConfig {
+                readonly: true,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        // A source mutation after construction remains visible, proving the
+        // backend did not stage a copy. Read-only permissions also exercise
+        // the same access pattern as foreign-owned system files.
+        std::fs::write(&source, b"updated").unwrap();
+        #[cfg(unix)]
+        std::fs::set_permissions(&source, std::fs::Permissions::from_mode(0o444)).unwrap();
+        fs.init(FsOptions::empty()).unwrap();
+
+        let entry = fs.lookup(context(), ROOT_INODE, c"config.txt").unwrap();
+        #[cfg(unix)]
+        assert_eq!(std::fs::metadata(&source).unwrap().nlink(), links_before);
+        let sibling_error = match fs.lookup(context(), ROOT_INODE, c"sibling.txt") {
+            Ok(_) => panic!("a sibling name must not be guest-visible"),
+            Err(error) => error,
+        };
+        assert_eq!(sibling_error.raw_os_error(), Some(LINUX_ENOENT));
+
+        let (handle, _) = fs.open(context(), entry.inode, false, 0).unwrap();
+        let handle = handle.unwrap();
+        let mut writer = CaptureWriter { bytes: Vec::new() };
+        fs.read(context(), entry.inode, handle, &mut writer, 64, 0, None, 0)
+            .unwrap();
+        fs.release(context(), entry.inode, 0, handle, false, false, None)
+            .unwrap();
+        assert_eq!(writer.bytes, b"updated");
+
+        let write_error = fs
+            .open(context(), entry.inode, false, LINUX_O_WRONLY)
+            .unwrap_err();
+        assert_eq!(write_error.raw_os_error(), Some(LINUX_EROFS));
+
+        let (directory_handle, _) = fs.opendir(context(), ROOT_INODE, 0).unwrap();
+        let entries = fs
+            .readdir(context(), ROOT_INODE, directory_handle.unwrap(), 4096, 0)
+            .unwrap();
+        let names = entries.iter().map(|entry| entry.name).collect::<Vec<_>>();
+        assert_eq!(names, vec![b".".as_slice(), b"..", b"config.txt"]);
+    }
+
+    #[test]
+    fn rejects_directories_and_non_component_guest_names() {
+        let temp = tempfile::tempdir().unwrap();
+        assert!(
+            SingleFileFs::new(
+                temp.path().to_path_buf(),
+                "config.txt".to_string(),
+                PassthroughConfig::default(),
+            )
+            .is_err()
+        );
+
+        let source = temp.path().join("selected.txt");
+        std::fs::write(&source, b"data").unwrap();
+        for name in ["", ".", "..", "nested/config.txt"] {
+            assert!(
+                SingleFileFs::new(
+                    source.clone(),
+                    name.to_string(),
+                    PassthroughConfig::default(),
+                )
+                .is_err()
+            );
+        }
+    }
+}

--- a/crates/filesystem/lib/backends/singlefilefs/mod.rs
+++ b/crates/filesystem/lib/backends/singlefilefs/mod.rs
@@ -6,10 +6,14 @@
 //! discovering or mutating any sibling names in the host directory.
 
 use std::{
+    collections::HashMap,
     ffi::{CStr, CString},
     io,
     path::PathBuf,
-    sync::atomic::{AtomicU64, Ordering},
+    sync::{
+        RwLock,
+        atomic::{AtomicU64, Ordering},
+    },
     time::Duration,
 };
 
@@ -48,7 +52,15 @@ pub struct SingleFileFs {
     inner: PassthroughFs,
     inner_name: CString,
     guest_name: &'static [u8],
-    file_inode: AtomicU64,
+    current_inode: AtomicU64,
+    lookup_refs: RwLock<HashMap<u64, u64>>,
+    open_handles: RwLock<HashMap<u64, OpenHandleAdmission>>,
+}
+
+#[derive(Clone, Copy)]
+struct OpenHandleAdmission {
+    guest_inode: u64,
+    inner_inode: u64,
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -99,9 +111,15 @@ impl SingleFileFs {
         }
 
         cfg.root_dir = parent.to_path_buf();
+        // The passthrough backend needs the parent as its namespace anchor,
+        // but quota accounting must include only the selected file.
+        cfg.quota_root = Some(source.clone());
         cfg.no_symlink_root = true;
         cfg.inject_init = false;
-        cfg.quota_bytes = None;
+        // The host may atomically replace the selected path. Positive dentry
+        // caching would otherwise keep directing new opens to the unlinked
+        // inode, which a pathname-based passthrough backend cannot reopen.
+        cfg.entry_timeout = Duration::ZERO;
         // Host writes bypass FUSE, so expire attributes immediately. With
         // AUTO_INVAL_DATA negotiated below, each guest read revalidates mtime
         // and invalidates cached contents when the host changed them.
@@ -124,29 +142,100 @@ impl SingleFileFs {
             // The backend lives for the VM lifetime. A stable name lets both
             // vector and streaming readdir callbacks borrow it safely.
             guest_name: Box::leak(guest_name),
-            file_inode: AtomicU64::new(0),
+            current_inode: AtomicU64::new(0),
+            lookup_refs: RwLock::new(HashMap::new()),
+            open_handles: RwLock::new(HashMap::new()),
         })
     }
 
-    fn lookup_file(&self, ctx: Context) -> io::Result<Entry> {
+    /// Resolve the selected name and update its admission state.
+    ///
+    /// The current inode owns one inner lookup reference even when the kernel
+    /// owns none. This pin makes the inode emitted by plain `readdir` usable,
+    /// while `lookup_refs` tracks only references that FUSE may later forget.
+    fn admit_file(&self, ctx: Context, kernel_lookup: bool) -> io::Result<Entry> {
         let entry = self.inner.lookup(ctx, ROOT_INODE, &self.inner_name)?;
         if u32::from(entry.attr.st_mode) & S_IFMT != S_IFREG {
+            self.inner.forget(ctx, entry.inode, 1);
             return Err(linux_error(LINUX_ENOENT));
         }
-        self.file_inode.store(entry.inode, Ordering::Release);
+
+        let (release_old_pin, release_redundant_lookup) = {
+            let mut refs = self.lookup_refs.write().unwrap();
+            let old_inode = self.current_inode.load(Ordering::Acquire);
+            let was_current = old_inode == entry.inode;
+            let previous_refs = refs.get(&entry.inode).copied().unwrap_or(0);
+            let previous_inner_refs = previous_refs + u64::from(was_current && previous_refs == 0);
+            let next_refs = previous_refs + u64::from(kernel_lookup);
+            let next_inner_refs = next_refs.max(1);
+
+            let release_old_pin = if old_inode != 0 && !was_current {
+                if refs.get(&old_inode).copied().unwrap_or(0) == 0 {
+                    refs.remove(&old_inode);
+                    Some(old_inode)
+                } else {
+                    None
+                }
+            } else {
+                None
+            };
+
+            refs.insert(entry.inode, next_refs);
+            self.current_inode.store(entry.inode, Ordering::Release);
+
+            // `inner.lookup` added one reference. When an existing reference
+            // can become the current pin, release the newly added surplus.
+            let release_redundant_lookup = previous_inner_refs + 1 > next_inner_refs;
+            (release_old_pin, release_redundant_lookup)
+        };
+
+        if let Some(old_inode) = release_old_pin {
+            self.inner.forget(ctx, old_inode, 1);
+        }
+        if release_redundant_lookup {
+            self.inner.forget(ctx, entry.inode, 1);
+        }
         Ok(entry)
     }
 
-    fn require_file_inode(&self, inode: u64) -> io::Result<()> {
-        if inode != 0 && self.file_inode.load(Ordering::Acquire) == inode {
+    fn lookup_file(&self, ctx: Context) -> io::Result<Entry> {
+        self.admit_file(ctx, true)
+    }
+
+    fn refresh_file(&self, ctx: Context) -> io::Result<Entry> {
+        self.admit_file(ctx, false)
+    }
+
+    fn require_lookup(&self, inode: u64) -> io::Result<()> {
+        if inode != 0
+            && (self.current_inode.load(Ordering::Acquire) == inode
+                || self
+                    .lookup_refs
+                    .read()
+                    .unwrap()
+                    .get(&inode)
+                    .copied()
+                    .unwrap_or(0)
+                    != 0)
+        {
             Ok(())
         } else {
             Err(linux_error(LINUX_ENOENT))
         }
     }
 
+    fn inner_inode_for_handle(&self, inode: u64, handle: u64) -> io::Result<u64> {
+        self.open_handles
+            .read()
+            .unwrap()
+            .get(&handle)
+            .filter(|admission| admission.guest_inode == inode)
+            .map(|admission| admission.inner_inode)
+            .ok_or_else(|| linux_error(LINUX_EBADF))
+    }
+
     fn root_entries(&self) -> Vec<DirEntry<'static>> {
-        let file_inode = self.file_inode.load(Ordering::Acquire);
+        let file_inode = self.current_inode.load(Ordering::Acquire);
         vec![
             DirEntry {
                 ino: ROOT_INODE,
@@ -188,6 +277,8 @@ impl DynFileSystem for SingleFileFs {
     }
 
     fn destroy(&self) {
+        self.open_handles.write().unwrap().clear();
+        self.lookup_refs.write().unwrap().clear();
         self.inner.destroy();
     }
 
@@ -202,8 +293,28 @@ impl DynFileSystem for SingleFileFs {
     }
 
     fn forget(&self, ctx: Context, inode: u64, count: u64) {
-        if self.require_file_inode(inode).is_ok() {
-            self.inner.forget(ctx, inode, count);
+        let forgotten = {
+            let mut refs = self.lookup_refs.write().unwrap();
+            let Some(current) = refs.get_mut(&inode) else {
+                return;
+            };
+            let forgotten = count.min(*current);
+            *current -= forgotten;
+            let exhausted = *current == 0;
+            let is_current = self.current_inode.load(Ordering::Acquire) == inode;
+            if exhausted && !is_current {
+                refs.remove(&inode);
+            }
+            // The final current-inode reference becomes the façade's pin
+            // instead of being released to the inner backend.
+            if is_current && exhausted {
+                forgotten.saturating_sub(1)
+            } else {
+                forgotten
+            }
+        };
+        if forgotten != 0 {
+            self.inner.forget(ctx, inode, forgotten);
         }
     }
 
@@ -216,8 +327,14 @@ impl DynFileSystem for SingleFileFs {
         if inode == ROOT_INODE {
             return Ok((root_stat(), Duration::from_secs(5)));
         }
-        self.require_file_inode(inode)?;
-        self.inner.getattr(ctx, inode, handle)
+        let inner_inode = match handle {
+            Some(handle) => self.inner_inode_for_handle(inode, handle)?,
+            None => {
+                self.require_lookup(inode)?;
+                self.refresh_file(ctx)?.inode
+            }
+        };
+        self.inner.getattr(ctx, inner_inode, handle)
     }
 
     fn setattr(
@@ -228,8 +345,14 @@ impl DynFileSystem for SingleFileFs {
         handle: Option<u64>,
         valid: SetattrValid,
     ) -> io::Result<(stat64, Duration)> {
-        self.require_file_inode(inode)?;
-        self.inner.setattr(ctx, inode, attr, handle, valid)
+        let inner_inode = match handle {
+            Some(handle) => self.inner_inode_for_handle(inode, handle)?,
+            None => {
+                self.require_lookup(inode)?;
+                self.refresh_file(ctx)?.inode
+            }
+        };
+        self.inner.setattr(ctx, inner_inode, attr, handle, valid)
     }
 
     fn open(
@@ -242,8 +365,22 @@ impl DynFileSystem for SingleFileFs {
         if inode == ROOT_INODE {
             return Err(linux_error(LINUX_EISDIR));
         }
-        self.require_file_inode(inode)?;
-        self.inner.open(ctx, inode, kill_priv, flags)
+        self.require_lookup(inode)?;
+        // The FUSE client may reuse a cached node ID without another LOOKUP.
+        // Resolve the selected host path at OPEN so a new descriptor follows
+        // an atomic replacement, independently of already-open descriptors.
+        let inner_inode = self.refresh_file(ctx)?.inode;
+        let opened = self.inner.open(ctx, inner_inode, kill_priv, flags)?;
+        if let Some(handle) = opened.0 {
+            self.open_handles.write().unwrap().insert(
+                handle,
+                OpenHandleAdmission {
+                    guest_inode: inode,
+                    inner_inode,
+                },
+            );
+        }
+        Ok(opened)
     }
 
     fn read(
@@ -257,9 +394,17 @@ impl DynFileSystem for SingleFileFs {
         lock_owner: Option<u64>,
         flags: u32,
     ) -> io::Result<usize> {
-        self.require_file_inode(inode)?;
-        self.inner
-            .read(ctx, inode, handle, writer, size, offset, lock_owner, flags)
+        let inner_inode = self.inner_inode_for_handle(inode, handle)?;
+        self.inner.read(
+            ctx,
+            inner_inode,
+            handle,
+            writer,
+            size,
+            offset,
+            lock_owner,
+            flags,
+        )
     }
 
     fn write(
@@ -275,10 +420,10 @@ impl DynFileSystem for SingleFileFs {
         kill_priv: bool,
         flags: u32,
     ) -> io::Result<usize> {
-        self.require_file_inode(inode)?;
+        let inner_inode = self.inner_inode_for_handle(inode, handle)?;
         self.inner.write(
             ctx,
-            inode,
+            inner_inode,
             handle,
             reader,
             size,
@@ -291,13 +436,13 @@ impl DynFileSystem for SingleFileFs {
     }
 
     fn flush(&self, ctx: Context, inode: u64, handle: u64, lock_owner: u64) -> io::Result<()> {
-        self.require_file_inode(inode)?;
-        self.inner.flush(ctx, inode, handle, lock_owner)
+        let inner_inode = self.inner_inode_for_handle(inode, handle)?;
+        self.inner.flush(ctx, inner_inode, handle, lock_owner)
     }
 
     fn fsync(&self, ctx: Context, inode: u64, datasync: bool, handle: u64) -> io::Result<()> {
-        self.require_file_inode(inode)?;
-        self.inner.fsync(ctx, inode, datasync, handle)
+        let inner_inode = self.inner_inode_for_handle(inode, handle)?;
+        self.inner.fsync(ctx, inner_inode, datasync, handle)
     }
 
     fn fallocate(
@@ -309,9 +454,9 @@ impl DynFileSystem for SingleFileFs {
         offset: u64,
         length: u64,
     ) -> io::Result<()> {
-        self.require_file_inode(inode)?;
+        let inner_inode = self.inner_inode_for_handle(inode, handle)?;
         self.inner
-            .fallocate(ctx, inode, handle, mode, offset, length)
+            .fallocate(ctx, inner_inode, handle, mode, offset, length)
     }
 
     fn release(
@@ -324,9 +469,18 @@ impl DynFileSystem for SingleFileFs {
         flock_release: bool,
         lock_owner: Option<u64>,
     ) -> io::Result<()> {
-        self.require_file_inode(inode)?;
-        self.inner
-            .release(ctx, inode, flags, handle, flush, flock_release, lock_owner)
+        let inner_inode = self.inner_inode_for_handle(inode, handle)?;
+        self.inner.release(
+            ctx,
+            inner_inode,
+            flags,
+            handle,
+            flush,
+            flock_release,
+            lock_owner,
+        )?;
+        self.open_handles.write().unwrap().remove(&handle);
+        Ok(())
     }
 
     fn statfs(&self, ctx: Context, _inode: u64) -> io::Result<statvfs64> {
@@ -341,8 +495,9 @@ impl DynFileSystem for SingleFileFs {
         value: &[u8],
         flags: u32,
     ) -> io::Result<()> {
-        self.require_file_inode(inode)?;
-        self.inner.setxattr(ctx, inode, name, value, flags)
+        self.require_lookup(inode)?;
+        let inner_inode = self.refresh_file(ctx)?.inode;
+        self.inner.setxattr(ctx, inner_inode, name, value, flags)
     }
 
     fn getxattr(
@@ -352,18 +507,21 @@ impl DynFileSystem for SingleFileFs {
         name: &CStr,
         size: u32,
     ) -> io::Result<GetxattrReply> {
-        self.require_file_inode(inode)?;
-        self.inner.getxattr(ctx, inode, name, size)
+        self.require_lookup(inode)?;
+        let inner_inode = self.refresh_file(ctx)?.inode;
+        self.inner.getxattr(ctx, inner_inode, name, size)
     }
 
     fn listxattr(&self, ctx: Context, inode: u64, size: u32) -> io::Result<ListxattrReply> {
-        self.require_file_inode(inode)?;
-        self.inner.listxattr(ctx, inode, size)
+        self.require_lookup(inode)?;
+        let inner_inode = self.refresh_file(ctx)?.inode;
+        self.inner.listxattr(ctx, inner_inode, size)
     }
 
     fn removexattr(&self, ctx: Context, inode: u64, name: &CStr) -> io::Result<()> {
-        self.require_file_inode(inode)?;
-        self.inner.removexattr(ctx, inode, name)
+        self.require_lookup(inode)?;
+        let inner_inode = self.refresh_file(ctx)?.inode;
+        self.inner.removexattr(ctx, inner_inode, name)
     }
 
     fn opendir(
@@ -390,9 +548,9 @@ impl DynFileSystem for SingleFileFs {
         if inode != ROOT_INODE || handle != ROOT_HANDLE {
             return Err(linux_error(LINUX_EBADF));
         }
-        if self.file_inode.load(Ordering::Acquire) == 0 {
-            self.lookup_file(ctx)?;
-        }
+        // Plain readdir does not create a kernel lookup reference, so refresh
+        // only the façade-owned current-inode pin.
+        self.refresh_file(ctx)?;
         Ok(self
             .root_entries()
             .into_iter()
@@ -445,8 +603,9 @@ impl DynFileSystem for SingleFileFs {
                 Err(linux_error(LINUX_EACCES))
             };
         }
-        self.require_file_inode(inode)?;
-        self.inner.access(ctx, inode, mask)
+        self.require_lookup(inode)?;
+        let inner_inode = self.refresh_file(ctx)?.inode;
+        self.inner.access(ctx, inner_inode, mask)
     }
 
     fn lseek(
@@ -457,8 +616,8 @@ impl DynFileSystem for SingleFileFs {
         offset: u64,
         whence: u32,
     ) -> io::Result<u64> {
-        self.require_file_inode(inode)?;
-        self.inner.lseek(ctx, inode, handle, offset, whence)
+        let inner_inode = self.inner_inode_for_handle(inode, handle)?;
+        self.inner.lseek(ctx, inner_inode, handle, offset, whence)
     }
 
     fn copyfilerange(
@@ -473,10 +632,18 @@ impl DynFileSystem for SingleFileFs {
         len: u64,
         flags: u64,
     ) -> io::Result<usize> {
-        self.require_file_inode(inode_in)?;
-        self.require_file_inode(inode_out)?;
+        let inner_inode_in = self.inner_inode_for_handle(inode_in, handle_in)?;
+        let inner_inode_out = self.inner_inode_for_handle(inode_out, handle_out)?;
         self.inner.copyfilerange(
-            ctx, inode_in, handle_in, offset_in, inode_out, handle_out, offset_out, len, flags,
+            ctx,
+            inner_inode_in,
+            handle_in,
+            offset_in,
+            inner_inode_out,
+            handle_out,
+            offset_out,
+            len,
+            flags,
         )
     }
 }
@@ -654,6 +821,128 @@ mod tests {
 
         assert!(options.contains(FsOptions::AUTO_INVAL_DATA));
         #[cfg(unix)]
-        assert_eq!(fs.inner.cfg.attr_timeout, Duration::ZERO);
+        {
+            assert_eq!(fs.inner.cfg.entry_timeout, Duration::ZERO);
+            assert_eq!(fs.inner.cfg.attr_timeout, Duration::ZERO);
+        }
+    }
+
+    #[test]
+    fn replacement_keeps_the_old_open_handle_valid() {
+        let temp = tempfile::tempdir().unwrap();
+        let source = temp.path().join("selected.txt");
+        let replacement = temp.path().join("replacement.txt");
+        std::fs::write(&source, b"old contents").unwrap();
+        std::fs::write(&replacement, b"new contents").unwrap();
+
+        let fs = SingleFileFs::new(
+            source.clone(),
+            "config.txt".to_string(),
+            PassthroughConfig::default(),
+        )
+        .unwrap();
+        fs.init(FsOptions::empty()).unwrap();
+
+        let old_entry = fs.lookup(context(), ROOT_INODE, c"config.txt").unwrap();
+        let (old_handle, _) = fs.open(context(), old_entry.inode, false, 0).unwrap();
+        let old_handle = old_handle.unwrap();
+
+        #[cfg(windows)]
+        std::fs::remove_file(&source).unwrap();
+        std::fs::rename(&replacement, &source).unwrap();
+
+        // Linux may issue OPEN against the cached old node ID without another
+        // LOOKUP. A new descriptor must still follow the selected pathname.
+        let (replacement_attr, _) = fs.getattr(context(), old_entry.inode, None).unwrap();
+        assert_eq!(replacement_attr.st_size, b"new contents".len() as _);
+        let (cached_handle, _) = fs.open(context(), old_entry.inode, false, 0).unwrap();
+        let cached_handle = cached_handle.unwrap();
+        let mut cached_writer = CaptureWriter { bytes: Vec::new() };
+        fs.read(
+            context(),
+            old_entry.inode,
+            cached_handle,
+            &mut cached_writer,
+            64,
+            0,
+            None,
+            0,
+        )
+        .unwrap();
+        assert_eq!(cached_writer.bytes, b"new contents");
+        fs.release(
+            context(),
+            old_entry.inode,
+            0,
+            cached_handle,
+            false,
+            false,
+            None,
+        )
+        .unwrap();
+
+        let directory_entries = fs
+            .readdir(context(), ROOT_INODE, ROOT_HANDLE, 4096, 0)
+            .unwrap();
+        let replacement_inode = directory_entries.last().unwrap().ino;
+        assert_ne!(old_entry.inode, replacement_inode);
+        fs.getattr(context(), replacement_inode, None).unwrap();
+
+        let new_entry = fs.lookup(context(), ROOT_INODE, c"config.txt").unwrap();
+        assert_ne!(old_entry.inode, new_entry.inode);
+
+        // FUSE may drop the pathname lookup before the descriptor is closed.
+        // The handle admission must independently retain access to that inode.
+        fs.forget(context(), old_entry.inode, 1);
+        let mut old_writer = CaptureWriter { bytes: Vec::new() };
+        fs.read(
+            context(),
+            old_entry.inode,
+            old_handle,
+            &mut old_writer,
+            64,
+            0,
+            None,
+            0,
+        )
+        .unwrap();
+        assert_eq!(old_writer.bytes, b"old contents");
+        fs.release(
+            context(),
+            old_entry.inode,
+            0,
+            old_handle,
+            false,
+            false,
+            None,
+        )
+        .unwrap();
+
+        let (new_handle, _) = fs.open(context(), new_entry.inode, false, 0).unwrap();
+        let new_handle = new_handle.unwrap();
+        let mut new_writer = CaptureWriter { bytes: Vec::new() };
+        fs.read(
+            context(),
+            new_entry.inode,
+            new_handle,
+            &mut new_writer,
+            64,
+            0,
+            None,
+            0,
+        )
+        .unwrap();
+        assert_eq!(new_writer.bytes, b"new contents");
+        fs.release(
+            context(),
+            new_entry.inode,
+            0,
+            new_handle,
+            false,
+            false,
+            None,
+        )
+        .unwrap();
+        fs.forget(context(), new_entry.inode, 1);
     }
 }

--- a/crates/filesystem/lib/lib.rs
+++ b/crates/filesystem/lib/lib.rs
@@ -27,6 +27,8 @@ pub mod backends;
 pub use backends::passthroughfs::{
     HostPermissions, PassthroughConfig, PassthroughFs, StatVirtualization,
 };
+#[cfg(windows)]
+pub use backends::singlefilefs::SingleFileFs;
 #[cfg(unix)]
 pub use backends::{
     dualfs::{
@@ -38,6 +40,7 @@ pub use backends::{
         BindIdentityMap, BindIdentityMapHandle, CachePolicy, HostPermissions, PassthroughConfig,
         PassthroughFs, PassthroughFsBuilder, StatVirtualization,
     },
+    singlefilefs::SingleFileFs,
 };
 pub use microsandbox_utils::size::{ByteSize, Bytes, Mebibytes, SizeExt};
 #[cfg(any(unix, windows))]

--- a/crates/protocol/lib/lib.rs
+++ b/crates/protocol/lib/lib.rs
@@ -217,10 +217,9 @@ pub const ENV_DIR_MOUNTS: &str = "MSB_DIR_MOUNTS";
 /// Environment variable carrying virtiofs **file** volume mount specs for guest init.
 ///
 /// Used when the host path is a single file rather than a directory. The SDK
-/// wraps each file in an isolated staging directory (hard-linked to preserve
-/// the same inode) and shares that directory via virtiofs. Agentd mounts the
-/// share at [`FILE_MOUNTS_DIR`]`/<tag>/` and bind-mounts the file to the
-/// guest path.
+/// asks the runtime to expose the source through a synthetic one-entry
+/// filesystem. Agentd mounts that share at [`FILE_MOUNTS_DIR`]`/<tag>/` and
+/// bind-mounts the file to the guest path.
 ///
 /// Format: `tag:filename:guest_path[:opts][;tag:filename:guest_path[:opts];...]`
 ///

--- a/crates/runtime/lib/launch.rs
+++ b/crates/runtime/lib/launch.rs
@@ -97,6 +97,10 @@ pub struct LaunchConfig {
     /// Additional virtio-fs mounts as `tag:host_path[:opts]`.
     pub mounts: Vec<String>,
 
+    /// Isolated host-file mounts handled by the single-file backend.
+    #[serde(default)]
+    pub file_mounts: Vec<FileMountConfig>,
+
     /// Disk-image volume mounts as `id:host_path:format[:ro]`.
     pub disks: Vec<String>,
 
@@ -183,4 +187,14 @@ pub struct RootfsConfig {
     /// root disks so the runner attaches with the right format.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub upper_format: Option<String>,
+}
+
+/// Host-side configuration for one isolated file mount.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FileMountConfig {
+    /// `tag:host_path[:opts]` specification parsed by the runtime.
+    pub mount: String,
+
+    /// Filename presented at the root of the synthetic virtio-fs share.
+    pub filename: String,
 }

--- a/crates/runtime/lib/vm.rs
+++ b/crates/runtime/lib/vm.rs
@@ -1608,6 +1608,7 @@ fn build_vm(
             stat_virtualization: parsed.stat_virtualization,
             host_permissions: parsed.host_permissions,
             readonly: parsed.readonly,
+            quota_bytes: parsed.quota_bytes,
             #[cfg(unix)]
             bind_identity_map: mount_bind_identity_map,
             #[cfg(windows)]

--- a/crates/runtime/lib/vm.rs
+++ b/crates/runtime/lib/vm.rs
@@ -20,7 +20,7 @@ use microsandbox_db::entity::run as run_entity;
 #[cfg(unix)]
 use microsandbox_filesystem::{BindIdentityMap, BindIdentityMapHandle, DynFileSystem};
 use microsandbox_filesystem::{
-    HostPermissions, PassthroughConfig, PassthroughFs, StatVirtualization,
+    HostPermissions, PassthroughConfig, PassthroughFs, SingleFileFs, StatVirtualization,
 };
 use microsandbox_metrics::{ActivateSlot, MetricsRegistry, ReleaseMode};
 use microsandbox_protocol::{
@@ -43,6 +43,7 @@ use crate::bootstrap_fs::AgentBootstrapFs;
 use crate::console::AgentConsolePipeBridge;
 use crate::console::{AgentConsoleBackend, ConsoleSharedState};
 use crate::heartbeat::{self, HeartbeatDecision, HeartbeatReader};
+use crate::launch::FileMountConfig;
 use crate::logging::LogLevel;
 use crate::metrics::run_metrics_sampler;
 use crate::relay::{self, AgentRelay};
@@ -344,6 +345,9 @@ pub struct VmConfig {
 
     /// Additional mounts as `tag:host_path[:opts]` strings.
     pub mounts: Vec<String>,
+
+    /// Isolated host-file mounts backed by synthetic one-entry filesystems.
+    pub file_mounts: Vec<FileMountConfig>,
 
     /// Disk-image volume mounts attached as extra virtio-blk devices.
     pub disks: Vec<DiskMountSpec>,
@@ -1583,7 +1587,44 @@ fn build_vm(
         builder = builder.fs(move |fs| fs.tag(&runtime_tag).custom(Box::new(backend)));
     }
 
-    // Additional mounts.
+    // Isolated file mounts. Each backend exposes a synthetic root containing
+    // only the selected file, so remounting the tag cannot reveal host siblings.
+    for file_mount in &vm.file_mounts {
+        let parsed = parse_mount_spec(&file_mount.mount)
+            .map_err(|e| RuntimeError::Custom(format!("file mount {:?}: {e}", file_mount.mount)))?;
+        let tag = parsed.tag;
+        let host_path = PathBuf::from(&parsed.host_path);
+        let override_owner = match (parsed.override_uid, parsed.override_gid) {
+            (Some(uid), Some(gid)) => Some((uid, gid)),
+            _ => None,
+        };
+        #[cfg(unix)]
+        let mount_bind_identity_map = bind_identity_map_for_mount(
+            &mut bind_identity_map,
+            parsed.stat_virtualization,
+            override_owner,
+        );
+        let cfg = PassthroughConfig {
+            stat_virtualization: parsed.stat_virtualization,
+            host_permissions: parsed.host_permissions,
+            readonly: parsed.readonly,
+            #[cfg(unix)]
+            bind_identity_map: mount_bind_identity_map,
+            #[cfg(windows)]
+            default_owner: override_owner,
+            ..Default::default()
+        };
+        let backend = SingleFileFs::new(host_path.clone(), file_mount.filename.clone(), cfg)
+            .map_err(|e| {
+                RuntimeError::Custom(format!(
+                    "file mount {tag}: failed to open host file {}: {e}",
+                    host_path.display()
+                ))
+            })?;
+        builder = builder.fs(move |fs| fs.tag(&tag).custom(Box::new(backend)));
+    }
+
+    // Additional directory mounts.
     for mount_spec in &vm.mounts {
         let parsed = parse_mount_spec(mount_spec)
             .map_err(|e| RuntimeError::Custom(format!("--mount {mount_spec:?}: {e}")))?;

--- a/docs/cli/sandbox-commands.mdx
+++ b/docs/cli/sandbox-commands.mdx
@@ -52,7 +52,7 @@ Common flags:
 | `--thp` | Guest transparent huge-page policy: `always`, `madvise` (default), or `never` |
 | `--root-disk` | OCI root storage, such as `8G`, `tmpfs:2G`, `flat:8G,clone=auto`, or `./rootfs.qcow2:format=qcow2,fstype=ext4` |
 | `-v`, `--volume` | Mount a host path or named volume, such as `./src:/app:ro` |
-| `--mount-dir`, `--mount-file`, `--mount-disk`, `--mount-named` | Mount a source with an explicit kind (`SOURCE:DEST[:OPTIONS]` or `NAME:DEST[:OPTIONS]`). Directory-backed mounts accept paired `uid=...,gid=...`; `--mount-named` creates missing named volumes idempotently and accepts `kind=dir\|disk`, `size=...`, and `quota=...` |
+| `--mount-dir`, `--mount-file`, `--mount-disk`, `--mount-named` | Mount a source with an explicit kind (`SOURCE:DEST[:OPTIONS]` or `NAME:DEST[:OPTIONS]`). Directory and file mounts accept `quota=...` and paired `uid=...,gid=...`; `--mount-named` creates missing named volumes idempotently and accepts `kind=dir\|disk`, `size=...`, and `quota=...` |
 | `-p`, `--port` | Publish a port, such as `8000:8000` for loopback-only or `0.0.0.0:8000:8000` for all host interfaces |
 | `--vsock` | Expose local host IPC at host CID 2 using `HOST_PATH:PORT[/stream\|/dgram]`; Unix sockets and local Windows named pipes are supported, the flag is repeatable, and stream is the default |
 | `-e`, `--env` | Set an environment variable |
@@ -553,7 +553,7 @@ msb install --list                   # List installed commands
 | `-c`, `--cpus` | Number of virtual CPUs to allocate |
 | `-m`, `--memory` | Amount of memory (e.g. `512M`, `1G`) |
 | `-v`, `--volume` | Mount a host path or named volume (`SOURCE:DEST[:OPTIONS]`, e.g. `./src:/app:ro,noexec`) |
-| `--mount-dir`, `--mount-file`, `--mount-disk`, `--mount-named` | Mount a source with an explicit kind (`SOURCE:DEST[:OPTIONS]` or `NAME:DEST[:OPTIONS]`). Directory-backed mounts accept paired `uid=...,gid=...`; `--mount-named` creates missing named volumes idempotently and accepts `kind=dir\|disk`, `size=...`, and `quota=...` |
+| `--mount-dir`, `--mount-file`, `--mount-disk`, `--mount-named` | Mount a source with an explicit kind (`SOURCE:DEST[:OPTIONS]` or `NAME:DEST[:OPTIONS]`). Directory and file mounts accept `quota=...` and paired `uid=...,gid=...`; `--mount-named` creates missing named volumes idempotently and accepts `kind=dir\|disk`, `size=...`, and `quota=...` |
 | `--security` | In-guest security profile (`default` or `restricted`) |
 | `-w`, `--workdir` | Working directory inside the sandbox |
 | `--shell` | Shell for interactive sessions |

--- a/docs/sandboxes/volumes.mdx
+++ b/docs/sandboxes/volumes.mdx
@@ -103,7 +103,7 @@ Nested destinations are supported. microsandbox canonicalizes guest paths and al
 
 Use `--mount-file` when you want to bind one host file instead of an entire directory.
 
-File mounts expose the selected host inode through an isolated one-entry filesystem. They do not hard-link or copy the source, host changes remain visible, and other files in the source directory are not part of the guest-visible share.
+File mounts expose the selected host inode through an isolated one-entry filesystem. They do not hard-link or copy the source, host changes remain visible, and other files in the source directory are not part of the guest-visible share. Writable file mounts receive the same default quota as directory binds; use `quota=<size>` to set a smaller or larger guest-growth budget.
 
 ```bash
 msb create alpine --name config-reader \
@@ -396,8 +396,8 @@ CLI mount flags use `SOURCE:DEST[:OPTIONS]`. The `:` before `OPTIONS` starts the
 
 | Flag | Source | Options |
 |------|--------|---------|
-| `--mount-dir` | Host directory | `ro`, `rw`, `noexec`, `nosuid`, `nodev`, `stat-virt=strict\|relaxed\|off`, `host-perms=private\|mirror`, paired `uid=<N>,gid=<N>` |
-| `--mount-file` | Host file | `ro`, `rw`, `noexec`, `nosuid`, `nodev`, `stat-virt=strict\|relaxed\|off`, `host-perms=private\|mirror`, paired `uid=<N>,gid=<N>` |
+| `--mount-dir` | Host directory | `ro`, `rw`, `noexec`, `nosuid`, `nodev`, `stat-virt=strict\|relaxed\|off`, `host-perms=private\|mirror`, `quota=<size>`, paired `uid=<N>,gid=<N>` |
+| `--mount-file` | Host file | `ro`, `rw`, `noexec`, `nosuid`, `nodev`, `stat-virt=strict\|relaxed\|off`, `host-perms=private\|mirror`, `quota=<size>`, paired `uid=<N>,gid=<N>` |
 | `--mount-named` | Named volume | `ro`, `rw`, `noexec`, `nosuid`, `nodev`, `kind=dir\|disk`, `size=<size>` for `kind=disk`, `quota=<size>` for directory volumes; directory-backed named volumes also support `stat-virt=strict\|relaxed\|off`, `host-perms=private\|mirror`, paired `uid=<N>,gid=<N>` |
 | `--mount-disk` | Host disk image | `ro`, `rw`, `noexec`, `nosuid`, `nodev`, `format=raw\|qcow2\|vmdk`, `fstype=<type>` |
 | `--tmpfs` | Guest path | `ro`, `rw`, `noexec`, `nosuid`, `nodev`; size may be passed as `PATH:SIZE[:OPTIONS]` |

--- a/docs/sandboxes/volumes.mdx
+++ b/docs/sandboxes/volumes.mdx
@@ -103,6 +103,8 @@ Nested destinations are supported. microsandbox canonicalizes guest paths and al
 
 Use `--mount-file` when you want to bind one host file instead of an entire directory.
 
+File mounts expose the selected host inode through an isolated one-entry filesystem. They do not hard-link or copy the source, host changes remain visible, and other files in the source directory are not part of the guest-visible share.
+
 ```bash
 msb create alpine --name config-reader \
   --mount-file ./config.toml:/etc/app/config.toml:ro,nodev

--- a/sdk/rust/lib/runtime/handle.rs
+++ b/sdk/rust/lib/runtime/handle.rs
@@ -13,7 +13,6 @@ use nix::{
     sys::signal::{self, Signal},
     unistd::Pid,
 };
-use tempfile::TempDir;
 use tokio::process::Child;
 #[cfg(windows)]
 use windows_sys::Win32::Foundation::{CloseHandle, HANDLE};
@@ -61,10 +60,6 @@ pub struct ProcessHandle {
     /// `Reserved` if the runtime exits before activation.
     metrics_reservation: Option<MetricsReservationCleanup>,
 
-    /// Ephemeral staging directory for file mounts. Dropped when the
-    /// process handle is dropped, which auto-removes all staged files.
-    _file_mounts_staging: Option<TempDir>,
-
     /// Open disk-image lock files. Kept for the process lifetime so disk
     /// images cannot be attached with incompatible write modes.
     _disk_locks: Vec<File>,
@@ -98,7 +93,6 @@ impl ProcessHandle {
         pid: u32,
         sandbox_name: String,
         child: Child,
-        file_mounts_staging: Option<TempDir>,
         disk_locks: Vec<File>,
         #[cfg(unix)] parent_watchdog: Option<OwnedFd>,
         #[cfg(windows)] job: Option<WindowsJob>,
@@ -109,7 +103,6 @@ impl ProcessHandle {
             sandbox_name,
             child,
             detached: false,
-            _file_mounts_staging: file_mounts_staging,
             _disk_locks: disk_locks,
             #[cfg(unix)]
             parent_watchdog,
@@ -187,9 +180,6 @@ impl ProcessHandle {
 
     /// Disarm the SIGTERM safety net so the sandbox keeps running after
     /// this handle is dropped. Used by detached sandbox flows.
-    ///
-    /// Also prevents the file-mounts staging directory from being deleted,
-    /// since the detached VM process still needs the backing files.
     pub fn disarm(&mut self) {
         self.detached = true;
 
@@ -204,12 +194,6 @@ impl ProcessHandle {
                     "failed to send parent-watch detach"
                 );
             }
-        }
-
-        // Consume the TempDir without deleting its contents — the detached
-        // VM process still reads from it via virtiofs.
-        if let Some(td) = self._file_mounts_staging.take() {
-            let _ = td.keep();
         }
     }
 

--- a/sdk/rust/lib/runtime/spawn.rs
+++ b/sdk/rust/lib/runtime/spawn.rs
@@ -30,11 +30,9 @@ use std::{
 
 #[cfg(windows)]
 use rand::Rng;
-use rand::RngExt;
 use sea_orm::{ColumnTrait, EntityTrait, QueryFilter, Set};
 use serde::Deserialize;
 use sha2::{Digest as Sha2Digest, Sha256};
-use tempfile::TempDir;
 #[cfg(windows)]
 use tokio::net::windows::named_pipe::{NamedPipeServer, PipeMode, ServerOptions};
 use tokio::{
@@ -66,7 +64,7 @@ use microsandbox_protocol::{
     },
     exec::ExecRlimit,
 };
-use microsandbox_runtime::launch::{LaunchConfig, Lifecycle};
+use microsandbox_runtime::launch::{FileMountConfig, LaunchConfig, Lifecycle};
 use microsandbox_runtime::vm::{MetricsSlotHandoff, StartupCommand};
 use microsandbox_types::{CommandResolutionError, SandboxLogLevel, resolve_default_command};
 use microsandbox_utils::{DB_FILENAME, DB_SUBDIR};
@@ -380,10 +378,9 @@ pub async fn spawn_sandbox(
     #[cfg(windows)]
     ensure_agent_pipe_unclaimed(&agent_sock_path, &config.spec.name).await?;
 
-    // Stage file bind mounts: each file gets its own isolated directory so
-    // that virtio-fs (which requires directories) can share it without
-    // exposing adjacent files on the host.
-    let (staged_file_mounts, file_mounts_staging) = stage_file_mounts(config).await?;
+    // Resolve file mounts separately so the runtime can attach a synthetic
+    // one-entry filesystem instead of exporting the source's parent directory.
+    let file_mounts = resolve_file_mounts(config)?;
     let named_volumes = resolve_named_volumes(local, config).await?;
     let disk_locks = lock_disk_mounts(config, &named_volumes)?;
     let metrics_reservation = if config.effective_metrics_interval().is_some() {
@@ -460,7 +457,7 @@ pub async fn spawn_sandbox(
         &runtime_dir,
         &agent_sock_path,
         &libkrunfw_path,
-        &staged_file_mounts,
+        &file_mounts,
         &named_volumes,
         metrics_reservation.as_ref(),
         parent_watchdog
@@ -713,7 +710,6 @@ pub async fn spawn_sandbox(
         startup.pid,
         config.spec.name.clone(),
         child,
-        file_mounts_staging,
         disk_locks,
         parent_watchdog.map(|pipe| pipe.write_fd),
         metrics_reservation.as_ref().map(|reservation| {
@@ -731,7 +727,6 @@ pub async fn spawn_sandbox(
         startup.pid,
         config.spec.name.clone(),
         child,
-        file_mounts_staging,
         disk_locks,
         child_job,
         metrics_reservation.as_ref().map(|reservation| {
@@ -2135,128 +2130,35 @@ async fn terminate_startup_process(
     child.wait().await.ok()
 }
 
-/// Scan `config.spec.mounts` for file bind mounts and stage each file in its own
-/// isolated directory inside an ephemeral [`TempDir`].
+/// Resolve bind mounts whose host source is a regular file.
 ///
-/// Returns a map from guest path to `(file_mount_dir, filename, tag)` for
-/// each staged file, plus the `TempDir` handle that must be kept alive for
-/// the VM's lifetime.
-async fn stage_file_mounts(
+/// The runtime opens the source directly through `SingleFileFs`; this map only
+/// carries the guest-visible filename and stable virtio-fs tag.
+fn resolve_file_mounts(
     config: &SandboxConfig,
-) -> MicrosandboxResult<(HashMap<String, (PathBuf, String, String)>, Option<TempDir>)> {
-    // Collect file bind mounts first so we can skip TempDir creation when
-    // there are none.
-    let file_mounts: Vec<_> = config
-        .spec
-        .mounts
-        .iter()
-        .filter_map(|m| match m {
-            VolumeMount::Bind {
-                host,
-                guest,
-                options,
-                ..
-            } if host.is_file() => Some((host, guest, options.readonly)),
-            _ => None,
-        })
-        .collect();
-
-    if file_mounts.is_empty() {
-        return Ok((HashMap::new(), None));
-    }
-
-    let tempdir = tempfile::tempdir()?;
-    let mut staged = HashMap::new();
-
-    for (host, guest, readonly) in file_mounts {
-        // Generate a random tag to avoid collisions.
-        let id: u32 = rand::rng().random();
-        let tag = format!("fm_{id:08x}");
-
-        let file_mount_dir = tempdir.path().join(&tag);
-        tokio::fs::create_dir_all(&file_mount_dir).await?;
-
-        // Canonicalize the staging directory so the mount root is symlink-free
-        // (the system temp dir often sits under a symlinked prefix, e.g. macOS
-        // `/var` -> `/private/var`). This resolves the one benign system symlink
-        // here in the trusted host context, so the mount stays under the default
-        // no-follow root protection instead of needing an exemption.
-        let file_mount_dir = tokio::fs::canonicalize(&file_mount_dir).await?;
-
-        let filename_os = host.file_name().ok_or_else(|| {
-            crate::MicrosandboxError::InvalidConfig(format!(
-                "file mount has no filename: {}",
-                host.display()
-            ))
-        })?;
-
-        let filename = filename_os.to_str().ok_or_else(|| {
-            crate::MicrosandboxError::InvalidConfig(format!(
-                "file mount filename is not valid UTF-8: {}",
-                host.display()
-            ))
-        })?;
-
-        let target = file_mount_dir.join(filename);
-
-        // Hard-link preserves the same inode — writes in the guest propagate
-        // to the host and vice-versa. Falls back to copy for cross-filesystem
-        // mounts (different device IDs).
-        match tokio::fs::hard_link(host, &target).await {
-            Ok(()) => {
-                tracing::debug!(
-                    host = %host.display(),
-                    file_mount_dir = %target.display(),
-                    "file mount: hard-linked"
-                );
-            }
-            Err(e) if is_cross_device_link_error(&e) => {
-                if !readonly {
-                    tracing::warn!(
-                        host = %host.display(),
-                        file_mount_dir = %target.display(),
-                        "file mount: cross-filesystem, falling back to copy \
-                         (guest writes will NOT propagate to host)"
-                    );
-                } else {
-                    tracing::debug!(
-                        host = %host.display(),
-                        file_mount_dir = %target.display(),
-                        "file mount: cross-filesystem, copying (read-only)"
-                    );
-                }
-                tokio::fs::copy(host, &target).await?;
-            }
-            Err(e) => return Err(e.into()),
+) -> MicrosandboxResult<HashMap<String, (String, String)>> {
+    let mut file_mounts = HashMap::new();
+    for mount in &config.spec.mounts {
+        let VolumeMount::Bind { host, guest, .. } = mount else {
+            continue;
+        };
+        if !host.is_file() {
+            continue;
         }
 
-        staged.insert(guest.clone(), (file_mount_dir, filename.to_string(), tag));
+        let filename = host
+            .file_name()
+            .and_then(OsStr::to_str)
+            .ok_or_else(|| {
+                MicrosandboxError::InvalidConfig(format!(
+                    "file mount has no valid UTF-8 filename: {}",
+                    host.display()
+                ))
+            })?
+            .to_string();
+        file_mounts.insert(guest.clone(), (filename, guest_mount_tag(guest)));
     }
-
-    Ok((staged, Some(tempdir)))
-}
-
-/// Return whether a host hard-link failed because the target is on another device.
-fn is_cross_device_link_error(error: &std::io::Error) -> bool {
-    error.kind() == std::io::ErrorKind::CrossesDevices || is_platform_cross_device_link_error(error)
-}
-
-#[cfg(unix)]
-fn is_platform_cross_device_link_error(error: &std::io::Error) -> bool {
-    error.raw_os_error() == Some(libc::EXDEV)
-}
-
-#[cfg(windows)]
-fn is_platform_cross_device_link_error(error: &std::io::Error) -> bool {
-    // CreateHardLinkW reports cross-volume links as ERROR_NOT_SAME_DEVICE.
-    const ERROR_NOT_SAME_DEVICE: i32 = 17;
-
-    error.raw_os_error() == Some(ERROR_NOT_SAME_DEVICE)
-}
-
-#[cfg(not(any(unix, windows)))]
-fn is_platform_cross_device_link_error(_error: &std::io::Error) -> bool {
-    false
+    Ok(file_mounts)
 }
 
 /// Push a `--mount tag:host_path[:ro]` arg pair.
@@ -2289,19 +2191,20 @@ fn push_dir_mount_arg(
     mounts.push(arg);
 }
 
-/// Collect a `fm_tag:file_mount_dir[:ro]` mount entry.
+/// Collect a typed host-file mount for the runtime's single-file backend.
 fn push_file_mount_arg(
-    mounts: &mut Vec<String>,
+    mounts: &mut Vec<FileMountConfig>,
     tag: &str,
-    file_mount_dir: &Path,
+    host_file: &Path,
+    filename: &str,
     options: MountOptions,
     stat_virtualization: StatVirtualization,
     host_permissions: HostPermissions,
 ) {
-    let mut arg = format!("{tag}:{}", file_mount_dir.display());
+    let mut arg = format!("{tag}:{}", host_file.display());
     let mut opts = mount_option_tokens(options);
-    // The staging directory is canonicalized at creation, so it is symlink-free
-    // and stays under the default no-follow root protection — no opt-out here.
+    // SingleFileFs canonicalizes the selected source and never exports its
+    // parent namespace, so file mounts do not need the directory-root opt-out.
     append_policy_options(
         &mut opts,
         stat_virtualization,
@@ -2311,7 +2214,10 @@ fn push_file_mount_arg(
         options.override_gid,
     );
     append_option_block(&mut arg, opts);
-    mounts.push(arg);
+    mounts.push(FileMountConfig {
+        mount: arg,
+        filename: filename.to_string(),
+    });
 }
 
 /// Collect a `id:host_path:format[:ro]` disk entry.
@@ -2451,7 +2357,7 @@ fn sandbox_cli_args(
     runtime_dir: &Path,
     agent_sock_path: &Path,
     libkrunfw_path: &Path,
-    staged_file_mounts: &HashMap<String, (PathBuf, String, String)>,
+    file_mounts: &HashMap<String, (String, String)>,
     named_volumes: &HashMap<String, ResolvedNamedVolume>,
     metrics_reservation: Option<&MetricsReservation>,
     parent_watch_fd: Option<i32>,
@@ -2690,11 +2596,12 @@ fn sandbox_cli_args(
                 follow_root_symlinks,
                 quota_mib,
             } => {
-                if let Some((file_mount_dir, filename, tag)) = staged_file_mounts.get(guest) {
+                if let Some((filename, tag)) = file_mounts.get(guest) {
                     push_file_mount_arg(
-                        &mut launch.mounts,
+                        &mut launch.file_mounts,
                         tag,
-                        file_mount_dir,
+                        host,
+                        filename,
                         *options,
                         *stat_virtualization,
                         *host_permissions,
@@ -3082,6 +2989,9 @@ mod tests {
         for m in &launch.mounts {
             pair(&mut out, "--mount", m.clone());
         }
+        for m in &launch.file_mounts {
+            pair(&mut out, "--file-mount", m.mount.clone());
+        }
         for d in &launch.disks {
             pair(&mut out, "--disk", d.clone());
         }
@@ -3341,7 +3251,7 @@ mod tests {
 
     fn render_args_with_file_mounts(
         config: &SandboxConfig,
-        staged_file_mounts: &HashMap<String, (PathBuf, String, String)>,
+        file_mounts: &HashMap<String, (String, String)>,
     ) -> Vec<String> {
         let local = test_local_backend();
         let (visible, launch) = sandbox_cli_args(
@@ -3354,7 +3264,7 @@ mod tests {
             Path::new("/tmp/runtime"),
             Path::new("/tmp/agent.sock"),
             Path::new("/tmp/libkrunfw.dylib"),
-            staged_file_mounts,
+            file_mounts,
             &HashMap::new(),
             None,
             None,
@@ -4044,23 +3954,18 @@ mod tests {
             .await
             .unwrap();
 
-        let mut staged_file_mounts = HashMap::new();
-        staged_file_mounts.insert(
+        let mut file_mounts = HashMap::new();
+        file_mounts.insert(
             "/guest/config.txt".to_string(),
-            (
-                PathBuf::from("/tmp/staging/fm_aabbccdd"),
-                "config.txt".to_string(),
-                "fm_aabbccdd".to_string(),
-            ),
+            ("config.txt".to_string(), "fm_aabbccdd".to_string()),
         );
 
-        let rendered = render_args_with_file_mounts(&config, &staged_file_mounts);
+        let rendered = render_args_with_file_mounts(&config, &file_mounts);
 
-        // File mount should use staging dir in --mount. The staging dir is
-        // canonicalized at creation so it stays under the no-follow default;
-        // the spec carries no opt-out token.
-        assert!(rendered.windows(2).any(|pair| pair[0] == "--mount"
-            && pair[1] == "fm_aabbccdd:/tmp/staging/fm_aabbccdd:ro,noexec"));
+        assert!(
+            rendered.windows(2).any(|pair| pair[0] == "--file-mount"
+                && pair[1] == "fm_aabbccdd:/host/config.txt:ro,noexec")
+        );
         // MSB_FILE_MOUNTS should contain the spec.
         assert!(rendered.contains(
             &"MSB_FILE_MOUNTS=fm_aabbccdd:config.txt:/guest/config.txt:ro,noexec".to_string()
@@ -4079,17 +3984,13 @@ mod tests {
             .await
             .unwrap();
 
-        let mut staged_file_mounts = HashMap::new();
-        staged_file_mounts.insert(
+        let mut file_mounts = HashMap::new();
+        file_mounts.insert(
             "/guest/file.txt".to_string(),
-            (
-                PathBuf::from("/tmp/staging/fm_11223344"),
-                "file.txt".to_string(),
-                "fm_11223344".to_string(),
-            ),
+            ("file.txt".to_string(), "fm_11223344".to_string()),
         );
 
-        let rendered = render_args_with_file_mounts(&config, &staged_file_mounts);
+        let rendered = render_args_with_file_mounts(&config, &file_mounts);
 
         // Directory mount in MSB_DIR_MOUNTS.
         let data_tag = super::guest_mount_tag("/data");
@@ -4265,20 +4166,16 @@ mod tests {
             .await
             .unwrap();
 
-        let mut staged_file_mounts = HashMap::new();
-        staged_file_mounts.insert(
+        let mut file_mounts = HashMap::new();
+        file_mounts.insert(
             "/guest/config.txt".to_string(),
-            (
-                PathBuf::from(r"C:\Users\Stephen\AppData\Local\Temp\msb\fm_deadbeef"),
-                "config.txt".to_string(),
-                "fm_deadbeef".to_string(),
-            ),
+            ("config.txt".to_string(), "fm_deadbeef".to_string()),
         );
 
-        let rendered = render_args_with_file_mounts(&config, &staged_file_mounts);
+        let rendered = render_args_with_file_mounts(&config, &file_mounts);
 
-        assert!(rendered.windows(2).any(|pair| pair[0] == "--mount"
-            && pair[1] == r"fm_deadbeef:C:\Users\Stephen\AppData\Local\Temp\msb\fm_deadbeef:ro"));
+        assert!(rendered.windows(2).any(|pair| pair[0] == "--file-mount"
+            && pair[1] == r"fm_deadbeef:C:\Users\Stephen\config.txt:ro"));
         assert!(
             rendered.contains(
                 &"MSB_FILE_MOUNTS=fm_deadbeef:config.txt:/guest/config.txt:ro".to_string()

--- a/sdk/rust/lib/runtime/spawn.rs
+++ b/sdk/rust/lib/runtime/spawn.rs
@@ -2192,6 +2192,7 @@ fn push_dir_mount_arg(
 }
 
 /// Collect a typed host-file mount for the runtime's single-file backend.
+#[allow(clippy::too_many_arguments)]
 fn push_file_mount_arg(
     mounts: &mut Vec<FileMountConfig>,
     tag: &str,
@@ -2200,6 +2201,7 @@ fn push_file_mount_arg(
     options: MountOptions,
     stat_virtualization: StatVirtualization,
     host_permissions: HostPermissions,
+    quota_mib: u32,
 ) {
     let mut arg = format!("{tag}:{}", host_file.display());
     let mut opts = mount_option_tokens(options);
@@ -2213,6 +2215,7 @@ fn push_file_mount_arg(
         options.override_uid,
         options.override_gid,
     );
+    opts.push(format!("quota={quota_mib}"));
     append_option_block(&mut arg, opts);
     mounts.push(FileMountConfig {
         mount: arg,
@@ -2597,6 +2600,9 @@ fn sandbox_cli_args(
                 quota_mib,
             } => {
                 if let Some((filename, tag)) = file_mounts.get(guest) {
+                    // File binds receive the same default-on host disk
+                    // protection as directory binds.
+                    let quota = quota_mib.unwrap_or(crate::sandbox::config::DEFAULT_BIND_QUOTA_MIB);
                     push_file_mount_arg(
                         &mut launch.file_mounts,
                         tag,
@@ -2605,6 +2611,7 @@ fn sandbox_cli_args(
                         *options,
                         *stat_virtualization,
                         *host_permissions,
+                        quota,
                     );
                     launch.bootstrap.file_mounts.push(BootstrapFileMount {
                         tag: tag.clone(),
@@ -3962,10 +3969,12 @@ mod tests {
 
         let rendered = render_args_with_file_mounts(&config, &file_mounts);
 
-        assert!(
-            rendered.windows(2).any(|pair| pair[0] == "--file-mount"
-                && pair[1] == "fm_aabbccdd:/host/config.txt:ro,noexec")
-        );
+        assert!(rendered.windows(2).any(|pair| pair[0] == "--file-mount"
+            && pair[1]
+                == format!(
+                    "fm_aabbccdd:/host/config.txt:ro,noexec,quota={}",
+                    crate::sandbox::config::DEFAULT_BIND_QUOTA_MIB
+                )));
         // MSB_FILE_MOUNTS should contain the spec.
         assert!(rendered.contains(
             &"MSB_FILE_MOUNTS=fm_aabbccdd:config.txt:/guest/config.txt:ro,noexec".to_string()
@@ -4021,6 +4030,28 @@ mod tests {
                 .windows(2)
                 .any(|pair| pair[0] == "--mount" && pair[1] == expected),
             "missing default-quota --mount arg in {rendered:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_sandbox_cli_args_file_mount_quota_override() {
+        let config = SandboxBuilder::new("test")
+            .image("/tmp/rootfs")
+            .volume("/guest/file.txt", |m| m.bind("/host/file.txt").quota(32u32))
+            .build()
+            .await
+            .unwrap();
+
+        let mut file_mounts = HashMap::new();
+        file_mounts.insert(
+            "/guest/file.txt".to_string(),
+            ("file.txt".to_string(), "fm_11223344".to_string()),
+        );
+        let rendered = render_args_with_file_mounts(&config, &file_mounts);
+
+        assert!(
+            rendered.windows(2).any(|pair| pair[0] == "--file-mount"
+                && pair[1] == "fm_11223344:/host/file.txt:quota=32")
         );
     }
 
@@ -4175,7 +4206,11 @@ mod tests {
         let rendered = render_args_with_file_mounts(&config, &file_mounts);
 
         assert!(rendered.windows(2).any(|pair| pair[0] == "--file-mount"
-            && pair[1] == r"fm_deadbeef:C:\Users\Stephen\config.txt:ro"));
+            && pair[1]
+                == format!(
+                    r"fm_deadbeef:C:\Users\Stephen\config.txt:ro,quota={}",
+                    crate::sandbox::config::DEFAULT_BIND_QUOTA_MIB
+                )));
         assert!(
             rendered.contains(
                 &"MSB_FILE_MOUNTS=fm_deadbeef:config.txt:/guest/config.txt:ro".to_string()


### PR DESCRIPTION
## Summary

- Replace hard-link staging for `--mount-file` with `SingleFileFs`, an isolated one-entry virtiofs backend.
- Keep host and guest changes live while preventing sibling files from entering the guest-visible namespace.
- Preserve open-descriptor semantics across atomic host replacement: existing descriptors stay attached to the old file, while fresh opens see the replacement.
- Revalidate same-length host updates and honor handle-based `setattr` on detached files.
- Support read-only mounts and per-file quotas without counting unrelated sibling files.

This removes the cross-filesystem, link-count, permission, and lifecycle problems of hard-link staging while retaining normal directory mounts through the existing passthrough backend.

## Validation

| Platform | Filesystem suite | Live VM coverage |
|---|---:|---|
| macOS ARM64 | 627 passed | Same-descriptor updates, atomic replacement, detached-handle truncate, quotas, isolation |
| Linux x86-64 | 629 passed | Same-descriptor updates, atomic replacement, detached-handle truncate, quotas, isolation |
| Windows ARM64 / WHP | 47 passed | Same-descriptor updates, atomic replacement, quotas, isolation |
| Windows x86-64 / Prism | 47 passed | Full user-mode filesystem suite; WHP VM execution remains native ARM64 |

All required CI, CodeQL, and Greptile checks pass, and all review threads are resolved.

## Performance

Release builds with warmed image caches. Startup numbers are means over 7 runs; I/O numbers are median guest throughput over 5 runs with a 64 MiB file.

| Platform | 1-file startup overhead | 16-file startup overhead | Read | Write + `fsync` |
|---|---:|---:|---:|---:|
| macOS ARM64 | +1.7 ms | +19.4 ms | 3.4 GB/s | 2.4 GB/s |
| Linux x86-64 | +3.1 ms | +53.4 ms | 865.3 MB/s | 500.4 MB/s |
| Windows ARM64 | +32.1 ms | +137.7 ms | 139.4 MB/s | 124.2 MB/s |

Closes #1357
