### PR TITLE
fix(sdk): treat empty MSB_HOME as unset

### DIFF
--- a/crates/utils/lib/lib.rs
+++ b/crates/utils/lib/lib.rs
@@ -156,15 +156,18 @@ pub fn metrics_registry_shm_name(home: &std::path::Path, registry_abi_version: u
 /// Resolve the microsandbox home directory.
 ///
 /// Order of resolution:
-/// 1. `MSB_HOME` env var (used as-is, no `.microsandbox` suffix appended)
+/// 1. Non-empty `MSB_HOME` env var (used as-is, no `.microsandbox` suffix appended)
 /// 2. `~/.microsandbox/` (i.e. `dirs::home_dir().join(BASE_DIR_NAME)`)
 /// 3. `./.microsandbox/` if no home is available
+///
+/// An empty `MSB_HOME` is treated as unset, matching common shell and SDK
+/// configuration conventions and avoiding an accidental current-directory root.
 ///
 /// `MSB_HOME` lets CI and integration tests isolate microsandbox state
 /// (db, sandboxes, cache, logs) per process without disturbing other
 /// `$HOME`-rooted tooling.
 pub fn resolve_home() -> std::path::PathBuf {
-    if let Some(path) = std::env::var_os("MSB_HOME") {
+    if let Some(path) = std::env::var_os("MSB_HOME").filter(|path| !path.is_empty()) {
         return std::path::PathBuf::from(path);
     }
     dirs::home_dir()
@@ -288,22 +291,31 @@ pub fn is_windows_drive_separator_at(s: &str, index: usize) -> bool {
 mod tests {
     use super::*;
 
-    /// `MSB_HOME` is honoured verbatim (no `.microsandbox` suffix appended)
-    /// so callers can isolate state per process without disturbing tooling
-    /// that reads `$HOME` (npm cache, ssh keys, etc.).
-    ///
-    /// Uses a unique env var per test process to avoid clashing with other
-    /// parallel tests that read `MSB_HOME`.
+    /// Non-empty `MSB_HOME` is honoured verbatim (no `.microsandbox` suffix
+    /// appended), while an empty value falls back to the default home.
     #[test]
-    fn test_resolve_home_respects_env_override() {
+    fn test_resolve_home_env_contract() {
         // SAFETY: This test sets a process-global env var. Vitest-style
         // single-test isolation isn't available; rely on the test being
         // the sole reader of `MSB_HOME` in this binary.
+        let original = std::env::var_os("MSB_HOME");
         let custom = std::path::PathBuf::from("/tmp/msb-home-resolve-test-12345");
         unsafe { std::env::set_var("MSB_HOME", &custom) };
-        let resolved = resolve_home();
+        let overridden = resolve_home();
+
+        unsafe { std::env::set_var("MSB_HOME", "") };
+        let empty = resolve_home();
+
         unsafe { std::env::remove_var("MSB_HOME") };
-        assert_eq!(resolved, custom);
+        let unset = resolve_home();
+
+        match original {
+            Some(value) => unsafe { std::env::set_var("MSB_HOME", value) },
+            None => unsafe { std::env::remove_var("MSB_HOME") },
+        }
+
+        assert_eq!(overridden, custom);
+        assert_eq!(empty, unset);
     }
 
     #[test]

--- a/docs/cli/ssh-commands.mdx
+++ b/docs/cli/ssh-commands.mdx
@@ -41,7 +41,7 @@ cat ~/.ssh/id_ed25519.pub | msb ssh authorize --stdin
 | `--key KEY` | Read one public key from the flag value |
 | `--stdin` | Read one public key from stdin |
 
-The default authorization file is `<MSB_HOME>/ssh/authorized_keys`, or `~/.microsandbox/ssh/authorized_keys` when `MSB_HOME` is unset. The file is created with private permissions.
+The default authorization file is `<MSB_HOME>/ssh/authorized_keys`, or `~/.microsandbox/ssh/authorized_keys` when `MSB_HOME` is unset or empty. The file is created with private permissions.
 
 ## msb ssh serve
 
@@ -108,4 +108,4 @@ All SSH commands inherit `ssh.inactivity_timeout_secs` from the global configura
 | `<sandbox-dir>/ssh/host_ed25519` | Per-sandbox SSH host private key, created on first serve |
 | `<MSB_HOME>/ssh/authorized_keys` | Public keys allowed to connect |
 
-When `MSB_HOME` is unset, `<MSB_HOME>` is `~/.microsandbox`.
+When `MSB_HOME` is unset or empty, `<MSB_HOME>` is `~/.microsandbox`.

--- a/docs/observability/deep-dive.mdx
+++ b/docs/observability/deep-dive.mdx
@@ -25,7 +25,7 @@ The shm object is mode `0600` (owner read/write only). Running
 
 The shm name is derived from `stable_hash($MSB_HOME)`, so both
 processes must agree on it. Pass `--msb-home` explicitly if your
-environment doesn't set `$MSB_HOME`; the default is `~/.microsandbox`.
+environment leaves `$MSB_HOME` unset or empty; the default is `~/.microsandbox`.
 
 ### Per-host
 

--- a/sdk/node-ts/native/setup.rs
+++ b/sdk/node-ts/native/setup.rs
@@ -109,7 +109,8 @@ pub fn is_installed() -> bool {
     microsandbox::setup::is_installed()
 }
 
-/// Download and install msb + libkrunfw to ~/.microsandbox/.
+/// Download and install msb + libkrunfw under non-empty $MSB_HOME, or
+/// ~/.microsandbox/ when the override is unset or empty.
 #[napi]
 pub async fn install() -> Result<()> {
     microsandbox::setup::install().await.map_err(to_napi_error)

--- a/sdk/node-ts/src/setup.ts
+++ b/sdk/node-ts/src/setup.ts
@@ -38,7 +38,8 @@ export function setup(): Setup {
   return new Setup();
 }
 
-/** Download and install msb + libkrunfw to `~/.microsandbox/`. */
+/** Download and install msb + libkrunfw under non-empty `$MSB_HOME`,
+ * or `~/.microsandbox/` when the override is unset or empty. */
 export async function install(): Promise<void> {
   await withMappedErrors(() => napi.install());
 }

--- a/sdk/python/src/setup.rs
+++ b/sdk/python/src/setup.rs
@@ -6,7 +6,8 @@ use crate::error::to_py_err;
 // Functions
 //--------------------------------------------------------------------------------------------------
 
-/// Download and install msb + libkrunfw to ~/.microsandbox/.
+/// Download and install msb + libkrunfw under non-empty $MSB_HOME, or
+/// ~/.microsandbox/ when the override is unset or empty.
 #[pyfunction]
 pub fn install<'py>(py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
     pyo3_async_runtimes::tokio::future_into_py(py, async move {

--- a/sdk/rust/lib/config/mod.rs
+++ b/sdk/rust/lib/config/mod.rs
@@ -1202,7 +1202,7 @@ fn read_config_from(path: &Path) -> MicrosandboxResult<GlobalConfig> {
     })
 }
 
-/// Resolve the default home directory (`~/.microsandbox`, or `$MSB_HOME` if set).
+/// Resolve the default home directory (`~/.microsandbox`, or non-empty `$MSB_HOME`).
 fn resolve_default_home() -> PathBuf {
     microsandbox_utils::resolve_home()
 }

--- a/sdk/rust/lib/setup/download.rs
+++ b/sdk/rust/lib/setup/download.rs
@@ -22,7 +22,8 @@ use super::verify::verify_installation;
 /// Builder for configuring and running the microsandbox setup process.
 #[derive(Debug, typed_builder::TypedBuilder)]
 pub struct Setup {
-    /// Base directory for microsandbox files. Defaults to `~/.microsandbox`.
+    /// Base directory for microsandbox files. Defaults to non-empty
+    /// `$MSB_HOME`, then `~/.microsandbox`.
     #[builder(default, setter(strip_option, into))]
     base_dir: Option<PathBuf>,
 
@@ -150,7 +151,8 @@ impl Setup {
 /// Install microsandbox runtime dependencies with default settings.
 ///
 /// This downloads the microsandbox bundle tarball and extracts `msb`
-/// and `libkrunfw` to `~/.microsandbox/{bin,lib}/`.
+/// and `libkrunfw` under non-empty `$MSB_HOME`, or
+/// `~/.microsandbox/{bin,lib}/` when the override is unset or empty.
 pub async fn install() -> MicrosandboxResult<()> {
     Setup::builder().build().install().await
 }


### PR DESCRIPTION
## TL;DR

Treat an empty `MSB_HOME` like an unset override so SDKs fall back to `~/.microsandbox` instead of accidentally using the current working directory.

## Description

- Ignore empty `MSB_HOME` values in the shared Rust home resolver used by the Rust SDK, Python binding, Node native binding, and CLI.
- Preserve verbatim handling for every non-empty override.
- Cover non-empty, empty, and unset environment states in the resolver contract test.
- Update SDK and user documentation to describe the empty-value fallback.
- Compatibility note: callers that intentionally relied on `MSB_HOME=""` resolving relative to the current directory must use an explicit path instead.

## Test Plan

- `cargo fmt --all -- --check`
- `cargo test -p microsandbox-utils`
- `cargo test -p microsandbox --lib setup::`
- `cargo check -p microsandbox -p microsandbox-py -p microsandbox-node`
- `cargo clippy -p microsandbox-utils -p microsandbox -p microsandbox-py -p microsandbox-node -- -D warnings`
- `npm run format:check --if-present` from `sdk/node-ts`