### PR TITLE
docs: simplify 0.6.16 lifecycle documentation

### DIFF
--- a/docs/changelog/2026-08-26.mdx
+++ b/docs/changelog/2026-08-26.mdx
@@ -1,14 +1,14 @@
 ---
 title: "Week of August 26, 2026"
-description: "Convergent sandbox lifecycle APIs and stable receiver identities across every SDK."
+description: "Reuse named sandboxes safely across every SDK."
 icon: "rotate"
 ---
 
 ## New features
 
-**Convergent named sandboxes**
+**Reuse named sandboxes**
 
-Every SDK now exposes a connect-or-create operation for reusable sandbox names: `connect_or_create` in Rust, Python, and Ruby, `connectOrCreate` in TypeScript, and `ConnectOrCreateSandbox` in Go. It connects to a running persisted sandbox, starts a created, stopped, or crashed sandbox, and creates only when the name is absent. Existing configuration wins, and concurrent callers converge on the same persisted identity.
+Every SDK now has a connect-or-create operation for reusable sandbox names: `connect_or_create` in Rust, Python, and Ruby, `connectOrCreate` in TypeScript, and `ConnectOrCreateSandbox` in Go. It connects when the sandbox is running, starts it when it is stopped or crashed, and creates it only when the name is unused. Existing sandboxes keep their saved configuration.
 
 ```python
 sb = await Sandbox.connect_or_create(
@@ -18,12 +18,12 @@ sb = await Sandbox.connect_or_create(
 )
 ```
 
-Metadata handles also gain `connect_or_start` and language-idiomatic equivalents, plus general wait-for-status, graceful restart, and stop-and-remove destroy operations. See [Reuse or create a named sandbox](/sandboxes/lifecycle#reuse-or-create-a-named-sandbox).
+Metadata handles also gain `connect_or_start` and its language-specific equivalents, along with methods for waiting on a state, restarting, and stopping and removing a sandbox. See [Reuse or create a named sandbox](/sandboxes/lifecycle#reuse-or-create-a-named-sandbox).
 
-The SDK references document the exact method spelling in Rust, TypeScript, Python, Go, and Ruby, while the lifecycle guide explains the shared [name and identity behavior](/sandboxes/lifecycle#names-handles-and-concurrent-callers) exercised by the cross-SDK example.
+The SDK references show the exact method names for Rust, TypeScript, Python, Go, and Ruby.
 
-**Stable identity-safe receivers**
+**Handles stay attached to one sandbox**
 
-Live sandboxes and metadata handles now expose an opaque stable ID backed by the existing local database row ID or cloud sandbox UUID. Receiver lifecycle calls remain bound to that identity, so removing a sandbox and recreating its name cannot redirect an old handle toward the replacement. Rust, TypeScript, Python, and Go expose typed stale-identity errors; Ruby reports the same refusal through `Microsandbox::Error`.
+Live sandboxes and metadata handles now expose a stable ID. Lifecycle calls use that ID, so removing a sandbox and recreating its name cannot redirect an old handle to the replacement. Rust, TypeScript, Python, and Go return typed replacement errors; Ruby reports the same refusal through `Microsandbox::Error`.
 
-This change requires no persistence migration or guest wire-protocol update. See [Names, handles, and concurrent callers](/sandboxes/lifecycle#names-handles-and-concurrent-callers) and [Error handling](/sdk/errors#stale-receiver-identities).
+See [Names, handles, and concurrent callers](/sandboxes/lifecycle#names-handles-and-concurrent-callers) and [Error handling](/sdk/errors#when-a-sandbox-object-is-stale) for details.

--- a/docs/changelog/2026-08-26.mdx
+++ b/docs/changelog/2026-08-26.mdx
@@ -18,12 +18,12 @@ sb = await Sandbox.connect_or_create(
 )
 ```
 
-Metadata handles also gain `connect_or_start` and language-idiomatic equivalents, plus general wait-for-status, graceful restart, and stop-and-remove destroy operations. See [Sandbox lifecycle](/sandboxes/lifecycle#converge-on-a-named-sandbox).
+Metadata handles also gain `connect_or_start` and language-idiomatic equivalents, plus general wait-for-status, graceful restart, and stop-and-remove destroy operations. See [Reuse or create a named sandbox](/sandboxes/lifecycle#reuse-or-create-a-named-sandbox).
 
-The [live-tested SDK surface](/sandboxes/lifecycle#live-tested-sdk-surface) marks the exact method spelling in Rust, TypeScript, Python, Go, and Ruby and records the shared lifecycle invariants exercised by the cross-SDK example.
+The SDK references document the exact method spelling in Rust, TypeScript, Python, Go, and Ruby, while the lifecycle guide explains the shared [name and identity behavior](/sandboxes/lifecycle#names-handles-and-concurrent-callers) exercised by the cross-SDK example.
 
 **Stable identity-safe receivers**
 
 Live sandboxes and metadata handles now expose an opaque stable ID backed by the existing local database row ID or cloud sandbox UUID. Receiver lifecycle calls remain bound to that identity, so removing a sandbox and recreating its name cannot redirect an old handle toward the replacement. Rust, TypeScript, Python, and Go expose typed stale-identity errors; Ruby reports the same refusal through `Microsandbox::Error`.
 
-This change requires no persistence migration or guest wire-protocol update. See [Identity-safe receivers](/sandboxes/lifecycle#identity-safe-receivers) and [Error handling](/sdk/errors#stale-receiver-identities).
+This change requires no persistence migration or guest wire-protocol update. See [Names, handles, and concurrent callers](/sandboxes/lifecycle#names-handles-and-concurrent-callers) and [Error handling](/sdk/errors#stale-receiver-identities).

--- a/docs/cli/configuration.mdx
+++ b/docs/cli/configuration.mdx
@@ -4,11 +4,9 @@ description: Configure sandboxes created by the CLI with root or scoped YAML fil
 icon: "file-code"
 ---
 
-<Tooltip tip="Common image, resource, lifecycle, environment, policy, secret, script, and patch fields work everywhere. Host-integrated networking, local rootfs forms, snapshots, replace behavior, and several runtime fields are unavailable on microsandbox cloud.">
-  <span className="msb-badge-limited">
-    Limited on cloud <Icon icon="circle-info" size={11} />
-  </span>
-</Tooltip>
+<Note>
+Common image, resource, lifecycle, environment, policy, secret, script, and patch fields work everywhere. Host-integrated networking, local rootfs forms, snapshots, replace behavior, and several runtime fields are unavailable on microsandbox cloud.
+</Note>
 
 Sandbox configuration is a reusable, sparse definition for one sandbox. Load it with `msb run`, `msb create`, or `msb install`; explicit CLI arguments are applied on top. The file may have any name when passed with `--conf`.
 
@@ -62,15 +60,15 @@ If neither the files nor the arguments provide an image, the command fails befor
 
 Scoped flags accept the contents of one field or field group without its root wrapper. They are useful for focused policies that should fail on unrelated fields.
 
-| Flag                   | Accepted fields                                                                                  |
-| ---------------------- | ------------------------------------------------------------------------------------------------ |
-| `--conf PATH`          | Any sandbox configuration field                                                                  |
-| `--net-conf PATH`      | `policy`, `allow`, `deny`, `ports`, `dns`, `tls`, `trust_host_cas`, `max_connections`            |
-| `--resource-conf PATH` | `cpus`, `memory`, `max_duration`, `idle_timeout`, `rlimits`                                      |
-| `--runtime-conf PATH`  | `workdir`, `shell`, `user`, `hostname`, `security`, `entrypoint`, `cmd`, `env`, `labels`, `init` |
-| `--fs-conf PATH`       | `mounts`, `patch_files`, `patches`                                                               |
-| `--secret-conf PATH`   | A map of secret names to secret definitions                                                      |
-| `--script-conf PATH`   | A map of script names to shell snippets                                                          |
+| Flag | Accepted fields |
+| --- | --- |
+| `--conf PATH` | Any sandbox configuration field |
+| `--net-conf PATH` | `policy`, `allow`, `deny`, `ports`, `dns`, `tls`, `trust_host_cas`, `max_connections` |
+| `--resource-conf PATH` | `cpus`, `memory`, `max_duration`, `idle_timeout`, `rlimits` |
+| `--runtime-conf PATH` | `workdir`, `shell`, `user`, `hostname`, `security`, `entrypoint`, `cmd`, `env`, `labels`, `init` |
+| `--fs-conf PATH` | `mounts`, `patch_files`, `patches` |
+| `--secret-conf PATH` | A map of secret names to secret definitions |
+| `--script-conf PATH` | A map of script names to shell snippets |
 
 For example, `--net-conf` expects this unwrapped document:
 
@@ -112,38 +110,7 @@ msb run python \
 
 Relative host paths are resolved against the file that contains them. Paths inside a file listed by `patch_files` are resolved against that patch file.
 
-## Rust SDK patches
-
-`SandboxConfigPatch` is the typed sparse representation for per-sandbox configuration. Its nested patch types are generated from the canonical sandbox configuration, compose with right-hand-side precedence, and are applied by `SandboxBuilder::overlay` before later fluent builder calls:
-
-```rust
-use microsandbox::{
-    EnvVar, Sandbox, SandboxConfigPatch, SandboxResourcesPatch,
-};
-
-let resources_patch = SandboxResourcesPatch::new()
-  .max_memory_mib(1024)
-  .memory_mib(1024)
-  .max_cpus(2)
-  .cpus(2);
-
-let patch = SandboxConfigPatch::new()
-    .resources(resources_patch)
-    .env(vec![EnvVar::new("MODE", "production")]);
-
-let sandbox = Sandbox::builder("agent")
-    .image("python:3.12")
-    .overlay(patch)
-    .memory(2048) // Explicit builder calls are higher precedence.
-    .create()
-    .await?;
-```
-
-Every canonical nested struct has a corresponding generated patch type. Adding a field to the source struct adds it to the patch API and its overlay/apply implementations automatically. Patch types do not read YAML, resolve relative paths, expand `${ENV}`, or carry registry credentials and snapshot-selection state; those remain file-adapter or explicit builder responsibilities. `SandboxConfig` remains the complete durable configuration.
-
-Collection fields are atomic unless their canonical field declares a merge strategy. Environment variables merge by variable name, labels and scripts merge by map key, and secret entries merge by environment-variable name; higher values win when keys match. Their normal setters merge, while generated `replace_*` methods replace the complete collection. Calling `clear_*` removes that field from the patch, so applying the patch leaves the lower-layer value unchanged.
-
-The generated model replaces the earlier handwritten patch hierarchy. Use `SandboxResourcesPatch`, `SandboxRuntimeOptionsPatch`, `NetworkSpecPatch`, `SandboxPolicyPatch`, and `SecretsConfigPatch` in place of the former resource, runtime, network, network-policy, and secret patch types. Filesystem, script, image, and init changes are now expressed directly through `SandboxConfigPatch` and its canonical nested patches. The old `LocalConfig` name remains as a deprecated alias of `GlobalConfig`.
+Rust applications can apply the same sparse configuration model without loading YAML. See [`SandboxBuilder::overlay`](/sdk/rust/sandbox#sandbox-overlay) for the typed API, merge behavior, and migration from the earlier patch types.
 
 ## Schema
 
@@ -153,7 +120,7 @@ The common image form is a string. Local paths beginning with `.`, `..`, or `/` 
 
 ```yaml
 image: "python:3.12"
-pull_policy: missing # missing | always | never
+pull_policy: missing       # missing | always | never
 registry:
   username: "deploy"
   password_env: "REGISTRY_TOKEN"
@@ -191,7 +158,7 @@ workdir: "/app"
 shell: "/bin/bash"
 user: "app"
 hostname: "api"
-security: restricted # default | restricted
+security: restricted       # default | restricted
 entrypoint: ["/usr/bin/tini", "--"]
 cmd: ["python", "app.py"]
 env:
@@ -199,7 +166,7 @@ env:
 labels:
   team: "platform"
 init:
-  cmd: auto # auto or an absolute guest path
+  cmd: auto                # auto or an absolute guest path
   args: []
   env: {}
 ```
@@ -250,17 +217,10 @@ Patch files run first in listed order, followed by inline patches:
 patch_files:
   - "./patches/common.yaml"
 patches:
-  - copy_file:
-      {
-        src: "./config.toml",
-        dst: "/etc/app/config.toml",
-        mode: "0644",
-        replace: true,
-      }
+  - copy_file: { src: "./config.toml", dst: "/etc/app/config.toml", mode: "0644", replace: true }
   - copy_dir: { src: "./certs", dst: "/etc/app/certs" }
   - text: { path: "/etc/app/build.txt", content: "release", mode: "0644" }
-  - file:
-      { path: "/etc/app/blob.bin", content_base64: "SGVsbG8=", mode: "0600" }
+  - file: { path: "/etc/app/blob.bin", content_base64: "SGVsbG8=", mode: "0600" }
   - mkdir: { path: "/var/cache/app", mode: "0755" }
   - symlink: { target: "/etc/app/config.toml", link: "/etc/app/active.toml" }
   - append: { path: "/etc/hosts", content: "10.0.0.5 db.internal\n" }
@@ -274,7 +234,7 @@ A patch file has one top-level `patches` list using the same operations. File mo
 Use a preset string for the common cases:
 
 ```yaml
-network: public # none | public | open
+network: public             # none | public | open
 ```
 
 `public`, the default, permits public internet access while blocking private, loopback, link-local, and metadata destinations. `none` denies ingress and egress. `open` is unrestricted.

--- a/docs/configuration.mdx
+++ b/docs/configuration.mdx
@@ -206,7 +206,7 @@ Defaults applied to sandboxes unless overridden per-sandbox.
 
 Explicit CLI or SDK options win over `config.json`, and `config.json` wins over built-in defaults. microsandbox resolves the effective values once when it creates a local sandbox and persists that resolved sandbox configuration; changing the global file affects future creations, not existing sandboxes.
 
-`SandboxBuilder::new()` and `Sandbox::builder()` apply this base automatically. Use `.overlay(SandboxConfigPatch)` to overlay sparse per-sandbox values, giving the precedence order built-in defaults < `config.json` < per-sandbox patch.
+`SandboxBuilder::new()` and `Sandbox::builder()` apply this base automatically. Rust applications can use [`SandboxBuilder::overlay`](/sdk/rust/sandbox#sandbox-overlay) to add sparse per-sandbox values, giving the precedence order built-in defaults < `config.json` < per-sandbox patch.
 
 For workload effects, host requirements, filesystem expectations, and verification steps for these settings, see [Optimization](/sandboxes/optimization).
 

--- a/docs/sandboxes/lifecycle.mdx
+++ b/docs/sandboxes/lifecycle.mdx
@@ -152,7 +152,7 @@ sb = Microsandbox::Sandbox.connect_or_create(
 </CodeGroup>
 
 <Warning>
-Creation options are used only when a new sandbox is created. If `worker` already exists, its saved image, resources, environment, mounts, and other configuration are kept. To apply new configuration, replace the existing sandbox locally. On microsandbox cloud, where replacement is unavailable, remove the existing sandbox and then create it again.
+Creation options are used only when a new sandbox is created. If `worker` already exists, its saved image, resources, environment, mounts, and other configuration are kept. To apply new configuration, use the [local replacement workflow](/sandboxes/overview#naming-conflicts). On microsandbox cloud, where replacement is unavailable, remove the existing sandbox and then create it again.
 </Warning>
 
 If you already have a `SandboxHandle`, use `connect_or_start` to connect to that exact sandbox or start it when needed.

--- a/docs/sandboxes/lifecycle.mdx
+++ b/docs/sandboxes/lifecycle.mdx
@@ -57,16 +57,16 @@ An attached local SDK handle normally stops its sandbox when the client process 
 Stopping gracefully terminates guest processes and shuts down the VM. The sandbox moves to `Stopped`, but its configuration and filesystem remain available for the next start.
 
 <CodeGroup>
-```rust Rust
-sb.stop().await?;
-
-let sb = Sandbox::start("worker").await?;
-```
-
 ```typescript TypeScript
 await sb.stop();
 
 const sb = await Sandbox.start("worker");
+```
+
+```rust Rust
+sb.stop().await?;
+
+let sb = Sandbox::start("worker").await?;
 ```
 
 ```python Python
@@ -233,12 +233,6 @@ You can also detach an existing SDK receiver with `detach()` (`Detach` in Go).
 List sandboxes to discover what exists, or get one by name when you already know which sandbox you need.
 
 <CodeGroup>
-```rust Rust
-for handle in Sandbox::list().await?.sandboxes {
-    println!("{}: {:?}", handle.name(), handle.status_snapshot());
-}
-```
-
 ```typescript TypeScript
 const page = await Sandbox.list();
 for (const handle of page.sandboxes) {
@@ -247,6 +241,12 @@ for (const handle of page.sandboxes) {
 
 const handle = await Sandbox.get("worker");
 console.log(handle.status);
+```
+
+```rust Rust
+for handle in Sandbox::list().await?.sandboxes {
+    println!("{}: {:?}", handle.name(), handle.status_snapshot());
+}
 ```
 
 ```python Python
@@ -278,12 +278,12 @@ msb ps worker
 Use `wait_until_stopped` when another part of your application is responsible for stopping the sandbox and you only need to wait for it to finish.
 
 <CodeGroup>
-```rust Rust
-let result = sb.wait_until_stopped().await?;
-```
-
 ```typescript TypeScript
 const result = await sb.waitUntilStopped();
+```
+
+```rust Rust
+let result = sb.wait_until_stopped().await?;
 ```
 
 ```python Python

--- a/docs/sandboxes/lifecycle.mdx
+++ b/docs/sandboxes/lifecycle.mdx
@@ -152,7 +152,7 @@ sb = Microsandbox::Sandbox.connect_or_create(
 </CodeGroup>
 
 <Warning>
-Creation options are used only when a new sandbox is created. If `worker` already exists, its saved image, resources, environment, mounts, and other configuration are kept. Use `create` or `replace` when the configuration in your code must take precedence.
+Creation options are used only when a new sandbox is created. If `worker` already exists, its saved image, resources, environment, mounts, and other configuration are kept. To apply new configuration, replace the existing sandbox locally. On microsandbox cloud, where replacement is unavailable, remove the existing sandbox and then create it again.
 </Warning>
 
 If you already have a `SandboxHandle`, use `connect_or_start` to connect to that exact sandbox or start it when needed.

--- a/docs/sandboxes/lifecycle.mdx
+++ b/docs/sandboxes/lifecycle.mdx
@@ -4,46 +4,15 @@ description: Create, start, stop, and manage sandbox state
 icon: "rotate"
 ---
 
-Each sandbox runs as a child process of whatever application creates it. `Sandbox.builder(...).create()` boots a microVM, starts the guest agent inside it, and establishes a communication channel back to the host.
-
-Understanding the lifecycle is useful once you start managing long-running sandboxes, graceful shutdown, or resilient agent workflows.
-
-```mermaid
-stateDiagram-v2
-    [*] --> Created: persist configuration
-    Created --> Starting: start()
-    Starting --> Running: boot complete
-    Starting --> Crashed: boot/runtime failure
-    Running --> Draining: request_drain()
-    Running --> Stopped: stop()
-    Running --> Crashed: unexpected exit
-    Running --> Paused: backend-managed pause
-    Paused --> Running: backend-managed resume
-    Draining --> Stopped: drain complete
-    Stopped --> Starting: start()
-    Crashed --> Starting: start()
-    Created --> [*]: remove()
-    Stopped --> [*]: remove()
-    Crashed --> [*]: remove()
-```
-
-## States
-
-| Status | Description |
-|--------|-------------|
-| **Created** | Persisted configuration exists, but no runtime has started yet. |
-| **Starting** | The VM is booting. The kernel is loaded, the filesystem is mounted, and the guest agent is initializing. |
-| **Running** | The guest agent is ready. You can call `exec`, `shell`, and `fs`. |
-| **Draining** | Graceful shutdown in progress. Existing commands run to completion, but new `exec` calls are rejected. Transitions to Stopped when all commands finish. |
-| **Paused** | Runtime execution is suspended by the backend. SDK resume support is not currently exposed, so convergent start calls reject this state. |
-| **Stopped** | The VM has shut down. Sandbox configuration and state are persisted to the database and can be restarted. |
-| **Crashed** | The VM exited unexpectedly (e.g., kernel panic, OOM kill). |
+A sandbox has a simple lifecycle: create it, use it, stop it when it is idle, start it again when you need it, and remove it when you are finished. Stopping preserves the sandbox's configuration and filesystem, while removing deletes its sandbox-owned state.
 
 ## Create a sandbox
 
-<Tooltip tip="Local attached SDK handles stop their sandbox when the client process exits. Cloud sandboxes are service-owned, so stop or remove them explicitly."><span className="msb-badge-limited">Limited on cloud <Icon icon="circle-info" size={11} /></span></Tooltip>
+<Note>
+Locally, an attached SDK handle stops its sandbox when the client process exits. Cloud sandboxes are service-owned, so stop or remove them explicitly.
+</Note>
 
-Creating a sandbox boots the microVM, mounts the filesystem, initializes the guest agent, and waits until it's ready to accept commands. Names must be non-empty and no longer than 128 UTF-8 bytes.
+Creating a sandbox starts the microVM and waits until it is ready to accept commands. Give each sandbox a name so you can find and manage it later. Names must be non-empty and no longer than 128 UTF-8 bytes.
 
 <CodeGroup>
 ```typescript TypeScript
@@ -58,59 +27,89 @@ const detached = await Sandbox.builder("worker")
 ```
 
 ```rust Rust
-// Local attached handle: sandbox stops when your process exits
-let sb = Sandbox::builder("worker").image("python").create().await?;
-
-// Detached: sandbox survives after your process exits
 let sb = Sandbox::builder("worker")
     .image("python")
-    .detached(true)
     .create()
     .await?;
 ```
 
 ```python Python
-# Local attached handle: sandbox stops when your process exits
 sb = await Sandbox.create("worker", image="python")
-
-# Detached: sandbox survives after your process exits
-sb = await Sandbox.create("worker", image="python", detached=True)
-await sb.detach()
 ```
 
 ```go Go
-// Local attached handle: sandbox stops when your process exits
 sb, err := m.CreateSandbox(ctx, "worker", m.WithImage("python"))
-
-// Detached: sandbox survives after your process exits
-detached, err := m.CreateSandbox(ctx, "worker",
-    m.WithImage("python"),
-    m.WithDetached(),
-)
 ```
 
 ```ruby Ruby
-# Local lifecycle-owning handle: sandbox stops when it is collected
 sb = Microsandbox::Sandbox.create("worker", image: "python")
-
-# Detached: sandbox survives after this handle is released
-detached = Microsandbox::Sandbox.create("worker", image: "python", detached: true)
-detached.detach
 ```
 
 ```bash CLI
-# Attached
 msb create python --name worker
-
-# Detached
-msb run -d python --name worker
 ```
-
 </CodeGroup>
 
-## Converge on a named sandbox
+An attached local SDK handle normally stops its sandbox when the client process exits. See [Keep a sandbox running](#keep-a-sandbox-running) when the sandbox should outlive that process.
 
-Use `connect_or_create` when several callers may converge on the same reusable name. It connects if the current persisted sandbox is already running, starts it if it is stopped or crashed, and creates it only when the name is missing. If another caller wins a concurrent create or start, the operation observes the winner and converges on it.
+## Stop and start again
+
+Stopping gracefully terminates guest processes and shuts down the VM. The sandbox moves to `Stopped`, but its configuration and filesystem remain available for the next start.
+
+<CodeGroup>
+```rust Rust
+sb.stop().await?;
+
+let sb = Sandbox::start("worker").await?;
+```
+
+```typescript TypeScript
+await sb.stop();
+
+const sb = await Sandbox.start("worker");
+```
+
+```python Python
+await sb.stop()
+
+sb = await Sandbox.start("worker")
+```
+
+```go Go
+_ = sb.Stop(ctx)
+
+sb, err := m.StartSandbox(ctx, "worker")
+```
+
+```ruby Ruby
+sb.stop
+
+sb = Microsandbox::Sandbox.start("worker")
+```
+
+```bash CLI
+msb stop worker
+msb start worker
+```
+</CodeGroup>
+
+Use `restart` when you want to stop and start the sandbox in one operation. If it is already stopped or crashed, restart starts it directly. SDK receiver methods preserve the sandbox's identity and configuration while replacing only the running VM instance.
+
+```bash CLI
+msb restart worker
+```
+
+On microsandbox cloud, restart and destroy can request a graceful stop, but timeout expiry cannot escalate to a force kill. Force controls are local-only, and detached-start controls affect only local process ownership.
+
+## Reuse or create a named sandbox
+
+Use `connect_or_create` when your application wants a sandbox with a stable name but does not know whether it already exists. This is useful for workers, development environments, and services that reconnect after the client process restarts.
+
+The operation:
+
+- Connects if the sandbox is running
+- Starts it if it is stopped or crashed
+- Creates it if the name does not exist
 
 <CodeGroup>
 ```typescript TypeScript
@@ -152,9 +151,11 @@ sb = Microsandbox::Sandbox.connect_or_create(
 ```
 </CodeGroup>
 
-Builder options apply only when a sandbox is created. An existing sandbox always keeps its persisted image, resources, environment, mounts, and other configuration. `connect_or_create` rejects replace options because replacing and converging express conflicting identity semantics.
+<Warning>
+Creation options are used only when a new sandbox is created. If `worker` already exists, its saved image, resources, environment, mounts, and other configuration are kept. Use `create` or `replace` when the configuration in your code must take precedence.
+</Warning>
 
-If you already hold a metadata handle, use `connect_or_start` instead. It connects without taking lifecycle ownership when the exact sandbox is running, waits through `Starting`, or starts the exact persisted sandbox when it is created, stopped, or crashed.
+If you already have a `SandboxHandle`, use `connect_or_start` to connect to that exact sandbox or start it when needed.
 
 <CodeGroup>
 ```typescript TypeScript
@@ -183,133 +184,126 @@ sb = handle.connect_or_start
 ```
 </CodeGroup>
 
-`Draining` is not reinterpreted as a start request, and `Paused` requires explicit resume support, which is not currently exposed.
+## Keep a sandbox running
 
-## Identity-safe receivers
-
-Sandbox names are reusable lookup keys. Every `Sandbox` and `SandboxHandle` also exposes an opaque stable `id` (`ID()` in Go) for the persisted sandbox it represents. Do not parse this value; use it for logging, correlation, and equality checks.
-
-On the built-in local and cloud backends, receiver-based status and lifecycle operations remain bound to that captured identity. If `worker` is removed and another sandbox is created with the same name, a stale receiver cannot refresh, start, stop, kill, drain, restart, destroy, or remove the replacement. The SDK returns `SandboxReplaced` (or the language's typed equivalent) when it can observe the new identity; ID-addressed cloud operations may instead report that the old resource is gone. Custom Rust backends should override the `*_identified` backend methods to provide the same guarantee.
-
-This closes the check-then-act race that an `exists()` helper would encourage:
-
-```text
-name lookup         stable identity check/action
-    │                           │
-    ├── connect_or_create ─────────┤ selects the current identity
-    │                           │
-    └── SandboxHandle(id=A) ────┤ may act only on A, never replacement B
-```
-
-Identity safety uses the existing local database row ID and cloud sandbox UUID. It requires no persistence migration or wire-protocol change.
-
-## Lifecycle invariants
-
-The convergent APIs preserve the following contracts across all SDKs:
-
-| Invariant | Contract |
-|-----------|----------|
-| Name versus identity | A name selects the current persisted sandbox. An opaque ID identifies one exact persisted sandbox, even if the name is later reused. |
-| Strict creation | Same-name local creators are serialized across processes. `create` remains strict and the loser receives an already-exists error after the winner finishes; `connect_or_create` observes that winner and returns it. |
-| Single start winner | A local start atomically changes the exact persisted identity from `Created`, `Stopped`, or `Crashed` to `Starting`. Concurrent callers cannot both claim the same runtime generation. |
-| Single runtime generation | Local database and host-namespace transitions are serialized per name, while a separate process-held lock remains owned for the runtime's lifetime. A successor cannot reuse that name's sockets, pipes, or storage until the previous runtime has exited. |
-| Existing configuration wins | Creation options are used only when `connect_or_create` creates. Reuse never overwrites the persisted image, resources, environment, mounts, or other configuration. |
-| Readiness is truthful | `Starting` means the VM or guest agent is not ready yet. `Running` is published only after the agent endpoint is connected and commands can be accepted. |
-| Exact-handle convergence | `connect_or_start` remains bound to the handle's captured ID. It connects to `Running`, waits through `Starting`, starts `Created`, `Stopped`, or `Crashed`, and rejects `Draining` or `Paused`. |
-| Restart continuity | `restart` returns the same persisted ID and retains configuration while replacing only the runtime instance. |
-| Destroy finality | `destroy` stops and removes the exact persisted identity. Recreating the same name produces a different ID. |
-| Stale receiver refusal | A receiver captured before same-name recreation cannot inspect or mutate the replacement through identity-safe receiver operations. |
-| Exact-state waits | `wait_for_status` follows the captured identity and has no implicit deadline. Use the language's normal cancellation or timeout primitive. |
-
-The local coordination is per sandbox name. It does not introduce a global lifecycle lock, and it does not keep a database transaction open while an image is prepared or a VM boots:
-
-```text
-same-name callers
-       |
-       v
-per-name transition lock ---> atomic DB claim: terminal -> Starting
-       |                                      |
-       |                                      v
-       +------------------------------> launch and wait for readiness
-                                              |
-                                              v
-runtime-lifetime lock ----------------> Starting -> Running
-       |
-       +-- released automatically when that runtime process exits
-```
-
-## Live-tested SDK surface
-
-Every checked cell below is exercised by the in-tree lifecycle-convergence example against a real microVM. The examples also cover concurrent find/create and connect/start calls, existing-configuration precedence, detached start, force and timeout controls, exec after readiness, restart continuity, same-name recreation, and stale-receiver rejection.
-
-| SDK | Connect or create | Stable ID | Connect or start | Wait for status | Restart | Destroy | Stale identity |
-|-----|----------------|-----------|------------------|-----------------|---------|---------|----------------|
-| Rust | ✅ `connect_or_create()` | ✅ `id()` | ✅ `connect_or_start()` | ✅ `wait_for_status()` | ✅ `restart()` | ✅ `destroy()` | ✅ `SandboxReplaced` |
-| TypeScript | ✅ `connectOrCreate()` | ✅ `id` | ✅ `connectOrStart()` | ✅ `waitForStatus()` | ✅ `restart()` | ✅ `destroy()` | ✅ `SandboxReplacedError` |
-| Python | ✅ `connect_or_create()` | ✅ `id` | ✅ `connect_or_start()` | ✅ `wait_for_status()` | ✅ `restart()` | ✅ `destroy()` | ✅ `SandboxReplacedError` |
-| Go | ✅ `ConnectOrCreateSandbox()` | ✅ `ID()` | ✅ `ConnectOrStart()` | ✅ `WaitForStatus()` | ✅ `Restart()` | ✅ `Destroy()` | ✅ `ErrSandboxReplaced` |
-| Ruby | ✅ `connect_or_create` | ✅ `id` | ✅ `connect_or_start` | ✅ `wait_for_status` | ✅ `restart` | ✅ `destroy` | ✅ refusal via `Microsandbox::Error` |
-
-## Stop and restart
-
-Stopping gracefully terminates guest processes and shuts down the VM. The sandbox moves to `Stopped` and can be restarted later with all its configuration preserved.
+Detach a local sandbox when it should keep running after the client process exits. You can reconnect to it later by name.
 
 <CodeGroup>
 ```typescript TypeScript
-await sb.stop()
-
-// Later, resume where you left off
-const sb = await Sandbox.start("worker")
+const sb = await Sandbox.builder("worker")
+  .image("python")
+  .detached(true)
+  .create();
 ```
 
 ```rust Rust
-sb.stop().await?;
-
-let sb = Sandbox::start("worker").await?;
+let sb = Sandbox::builder("worker")
+    .image("python")
+    .detached(true)
+    .create()
+    .await?;
 ```
 
 ```python Python
-await sb.stop()
-
-# Later, resume where you left off
-sb = await Sandbox.start("worker")
+sb = await Sandbox.create("worker", image="python", detached=True)
+await sb.detach()
 ```
 
 ```go Go
-_ = sb.Stop(ctx)
-
-// Later, resume where you left off
-sb, err := m.StartSandbox(ctx, "worker")
+sb, err := m.CreateSandbox(ctx, "worker",
+    m.WithImage("python"),
+    m.WithDetached(),
+)
 ```
 
 ```ruby Ruby
-sb.stop
-
-# Later, resume where you left off
-sb = Microsandbox::Sandbox.start("worker")
+sb = Microsandbox::Sandbox.create("worker", image: "python", detached: true)
+sb.detach
 ```
 
 ```bash CLI
-msb stop worker
-
-# Later, resume where you left off
-msb start worker
-
-# Or stop and start in one command
-msb restart worker
+msb run -d python --name worker
 ```
-
 </CodeGroup>
 
-`msb restart` follows the same lifecycle semantics as `msb stop` followed by `msb start`. If the sandbox is already stopped or crashed, it starts it directly.
+You can also detach an existing SDK receiver with `detach()` (`Detach` in Go).
 
-SDK receivers also expose a convergent `restart` operation with graceful shutdown by default and options for force, timeout, and detached start where supported.
+## List and inspect
 
-On microsandbox cloud, restart and destroy can request graceful stop, but timeout expiry cannot escalate to force kill. Force controls are local-only, and detached-start controls affect only local process ownership.
+List sandboxes to discover what exists, or get one by name when you already know which sandbox you need.
 
-## Configuration
+<CodeGroup>
+```rust Rust
+for handle in Sandbox::list().await?.sandboxes {
+    println!("{}: {:?}", handle.name(), handle.status_snapshot());
+}
+```
 
-Use `msb modify`, or the SDK `modify()` methods, to change an existing sandbox without recreating it. Some changes apply live, some affect future execs only, and some need a restart or the next start.
+```typescript TypeScript
+const page = await Sandbox.list();
+for (const handle of page.sandboxes) {
+  console.log(`${handle.name}: ${handle.status}`);
+}
+
+const handle = await Sandbox.get("worker");
+console.log(handle.status);
+```
+
+```python Python
+for handle in (await Sandbox.list()).sandboxes:
+    print(f"{handle.name}: {handle.status}")
+
+handle = await Sandbox.get("worker")
+print(handle.status)
+```
+
+```go Go
+page, err := m.ListSandboxes(ctx)
+for _, handle := range page.Sandboxes {
+    fmt.Printf("%s: %s\n", handle.Name(), handle.Status())
+}
+
+handle, err := m.GetSandbox(ctx, "worker")
+fmt.Println(handle.Status())
+```
+
+```bash CLI
+msb ls
+msb ps worker
+```
+</CodeGroup>
+
+## Wait for a state
+
+Use `wait_until_stopped` when another part of your application is responsible for stopping the sandbox and you only need to wait for it to finish.
+
+<CodeGroup>
+```rust Rust
+let result = sb.wait_until_stopped().await?;
+```
+
+```typescript TypeScript
+const result = await sb.waitUntilStopped();
+```
+
+```python Python
+result = await sb.wait_until_stopped()
+```
+
+```go Go
+result, err := sb.WaitUntilStopped(ctx)
+```
+
+```ruby Ruby
+result = sb.wait_until_stopped
+```
+</CodeGroup>
+
+Use `wait_for_status` (`waitForStatus` in TypeScript and `WaitForStatus` in Go) when you need to wait for a specific lifecycle state. It has no built-in timeout, so use the language's normal timeout or cancellation primitive around it.
+
+## Change configuration
+
+Use `msb modify`, or the SDK `modify()` methods, to change an existing sandbox without recreating it. Some changes apply immediately, some affect future commands, and some take effect after a restart.
 
 <CodeGroup>
 ```typescript TypeScript
@@ -339,11 +333,13 @@ msb modify api --cpus 4 --memory 4G
 
 See [Live Modify](/sandboxes/tuning) for the change model, CPU and memory resize, labels, environment variables, secrets, and storage sizing.
 
-## Ping and touch
+## Check health and keep a sandbox active
 
-<Tooltip tip="Not yet available on microsandbox cloud."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
+<Note>
+Ping and touch are currently available only for local sandboxes.
+</Note>
 
-Use `ping` to check that a running sandbox's guest agent is reachable, and `touch` to intentionally refresh its idle timer. Ping is a health check only: it does not count as sandbox activity and will not keep an idle sandbox alive by itself. Touch is the explicit keepalive.
+Use `ping` to check that a running sandbox's guest agent is reachable. A ping is only a health check and does not reset the idle timer. Use `touch` when you intentionally want to keep the sandbox active.
 
 <CodeGroup>
 ```typescript TypeScript
@@ -364,21 +360,48 @@ sb.touch().await?;
 msb ping worker
 msb touch worker
 
-# Health check and then keep alive if reachable
+# Check health, then keep the sandbox active if it is reachable
 msb ping worker --touch
 ```
-
 </CodeGroup>
 
-## Kill immediately
+## Drain before stopping
 
-<Tooltip tip="Not yet available on microsandbox cloud; use a graceful stop instead."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
+<Note>
+Draining is currently available only for local sandboxes. Use a graceful stop on microsandbox cloud.
+</Note>
 
-If a sandbox is unresponsive (e.g., stuck in a tight loop or a panic), force-kill it. microsandbox terminates the sandbox immediately with no graceful shutdown.
+Use a drain when existing commands should finish but new commands should be rejected. The sandbox moves to `Draining`, waits for in-flight commands, and then stops. This is useful when rotating worker sandboxes without interrupting active jobs.
 
 <CodeGroup>
 ```typescript TypeScript
-await sb.kill()
+await sb.requestDrain();
+```
+
+```rust Rust
+sb.request_drain().await?;
+```
+
+```python Python
+await sb.request_drain()
+```
+
+```go Go
+err := sb.RequestDrain(ctx)
+```
+</CodeGroup>
+
+## Stop an unresponsive sandbox
+
+<Note>
+Force kill is currently available only for local sandboxes. Use a graceful stop on microsandbox cloud.
+</Note>
+
+If a sandbox does not respond to a graceful stop, force-kill it. This ends the VM immediately without waiting for guest processes to shut down.
+
+<CodeGroup>
+```typescript TypeScript
+await sb.kill();
 ```
 
 ```rust Rust
@@ -396,89 +419,11 @@ err := sb.Kill(ctx)
 ```bash CLI
 msb stop --force worker
 ```
-
 </CodeGroup>
 
-## Detach
+## Destroy or remove
 
-Keeps a sandbox running after the parent process exits. It becomes a background process that you can reconnect to later with `Sandbox::get("worker")`.
-
-<CodeGroup>
-```typescript TypeScript
-await sb.detach()
-```
-
-```rust Rust
-sb.detach().await;
-```
-
-```python Python
-await sb.detach()
-```
-
-```go Go
-err := sb.Detach(ctx)
-```
-
-</CodeGroup>
-
-## Request drain
-
-<Tooltip tip="Not yet available on microsandbox cloud; use a graceful stop instead."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
-
-Trigger a graceful shutdown that lets existing commands finish but rejects new ones. The sandbox moves to `Draining` and transitions to `Stopped` when all in-flight commands complete. This is useful for zero-downtime rotation of worker sandboxes.
-
-<CodeGroup>
-```typescript TypeScript
-await sb.requestDrain()
-```
-
-```rust Rust
-sb.request_drain().await?;
-```
-
-```python Python
-await sb.request_drain()
-```
-
-```go Go
-err := sb.RequestDrain(ctx)
-```
-
-</CodeGroup>
-
-## Wait until stopped
-
-Block until the sandbox is observed in a terminal non-running state, without triggering a stop or kill request.
-
-<CodeGroup>
-```typescript TypeScript
-const result = await sb.waitUntilStopped()
-```
-
-```rust Rust
-let result = sb.wait_until_stopped().await?;
-```
-
-```python Python
-result = await sb.wait_until_stopped()
-```
-
-```go Go
-result, err := sb.WaitUntilStopped(ctx)
-```
-
-```ruby Ruby
-result = sb.wait_until_stopped
-```
-
-</CodeGroup>
-
-Use `wait_for_status` / `waitForStatus` / `WaitForStatus` when you need any exact lifecycle state rather than only a terminal state. It intentionally has no built-in timeout; compose the language's normal deadline or cancellation primitive around it.
-
-## Destroy
-
-`destroy` combines stop and remove for the exact sandbox identity. It requests a graceful stop by default, escalates after the configured timeout, and refuses to act on a replacement that reused the name.
+Use `destroy` when you have an SDK receiver and want to stop and remove that exact sandbox in one operation. It requests a graceful stop by default, escalates after the configured timeout, and refuses to act on a replacement that reused the name.
 
 <CodeGroup>
 ```typescript TypeScript
@@ -502,13 +447,11 @@ sb.destroy
 ```
 </CodeGroup>
 
-## Remove
-
-Delete a stopped sandbox. Every local SDK entry point and `msb rm` uses the same deletion scope.
+Use `remove` when the sandbox is already stopped and you want to delete it by name.
 
 <CodeGroup>
 ```typescript TypeScript
-await Sandbox.remove("worker")
+await Sandbox.remove("worker");
 ```
 
 ```rust Rust
@@ -530,7 +473,6 @@ Microsandbox::Sandbox.remove("worker")
 ```bash CLI
 msb rm worker
 ```
-
 </CodeGroup>
 
 For a local sandbox, removal deletes sandbox-owned state while leaving independently managed resources intact:
@@ -545,89 +487,9 @@ For a local sandbox, removal deletes sandbox-owned state while leaving independe
 
 Removing a sandbox does not undo writes made to a named volume, bind mount, or user-supplied disk image. On cloud, removal deletes the remote sandbox resource; the local disk details above do not apply.
 
-## List and inspect
+## Automatic lifecycle policies
 
-<CodeGroup>
-```typescript TypeScript
-const page = await Sandbox.list();
-for (const handle of page.sandboxes) {
-    console.log(`${handle.name}: ${handle.status}`);
-}
-
-const handle = await Sandbox.get("worker");
-console.log(handle.status); // "running" | "stopped" | ...
-```
-
-```rust Rust
-for handle in Sandbox::list().await?.sandboxes {
-    println!("{}: {:?}", handle.name(), handle.status_snapshot());
-}
-```
-
-```python Python
-for handle in (await Sandbox.list()).sandboxes:
-    print(f"{handle.name}: {handle.status}")
-
-handle = await Sandbox.get("worker")
-print(handle.status)  # "running" | "stopped" | ...
-```
-
-```go Go
-page, err := m.ListSandboxes(ctx)
-for _, handle := range page.Sandboxes {
-    fmt.Printf("%s: %s\n", handle.Name(), handle.Status())
-}
-
-handle, err := m.GetSandbox(ctx, "worker")
-fmt.Println(handle.Status()) // "running" | "stopped" | ...
-```
-
-```bash CLI
-msb ls
-msb ps worker
-```
-
-</CodeGroup>
-
-## Runtime process architecture
-
-At runtime, your application talks to a host-side sandbox process, and that process relays requests to the guest agent inside the VM.
-
-```mermaid
-graph TD
-    subgraph Host["Host"]
-        A["Your Application<br/><small>microsandbox SDK</small>"]
-        B["Sandbox Process<br/><small>VM + networking + lifecycle</small>"]
-    end
-
-    subgraph Guest["Guest VM"]
-        F["agentd<br/><small>exec, fs</small>"]
-    end
-
-    A -- "spawn" --> B
-    B -- "boot" --> F
-    A -. "commands & responses" .-> F
-
-    style Host fill:#f5f0ff,stroke:#a770ef,color:#333
-    style Guest fill:#fef4e8,stroke:#e8a838,color:#333
-    style A fill:#d4bfff,stroke:#8b5cf6,color:#1a1a1a
-    style B fill:#d4bfff,stroke:#8b5cf6,color:#1a1a1a
-    style F fill:#fdd49e,stroke:#d97706,color:#1a1a1a
-```
-
-The sandbox process also handles:
-
-- Graceful stop and drain signals
-- Cleanup when the sandbox exits
-- Idle detection and maximum lifetime enforcement
-
-## Logs and diagnostics
-
-Use [`msb logs`](/cli/sandbox-commands#msb-logs) or the SDK `logs()` method to read captured output from running, stopped, or crashed sandboxes. For source semantics, boot errors, and diagnostic flows, see [Logs](/sandboxes/logs).
-
-## Sandbox process policies
-
-For production workloads, configure how the sandbox process handles shutdown, idle detection, and maximum lifetime.
+For production workloads, configure a maximum lifetime or idle timeout so sandboxes shut down automatically.
 
 <CodeGroup>
 ```typescript TypeScript
@@ -663,5 +525,31 @@ sb, err := m.CreateSandbox(ctx, "worker",
     m.WithIdleTimeout(5*time.Minute),
 )
 ```
-
 </CodeGroup>
+
+## Lifecycle states
+
+Most applications only need to distinguish between `Running` and `Stopped`. The complete set is useful for status displays and recovery logic.
+
+| Status | Meaning |
+|--------|---------|
+| **Created** | Configuration has been saved, but the sandbox has not started yet. |
+| **Starting** | The VM and guest agent are starting. Commands are not ready yet. |
+| **Running** | The sandbox is ready for `exec`, `shell`, and filesystem operations. |
+| **Draining** | Existing commands may finish, but new commands are rejected. The sandbox stops when the drain completes. |
+| **Stopped** | The VM is off. Configuration and sandbox state are preserved for a later start. |
+| **Crashed** | The VM exited unexpectedly and can be started again. |
+
+Some backends can also report `Paused`. Resume is not currently exposed through the SDKs, so start and connect operations do not treat a paused sandbox as stopped.
+
+## Names, handles, and concurrent callers
+
+A sandbox name finds the current sandbox saved under that name. A `Sandbox` or `SandboxHandle` also carries an opaque stable ID (`ID()` in Go) for one exact saved sandbox. Treat the ID as an opaque value and use it for logging, correlation, and equality checks.
+
+If `worker` is removed and a different sandbox is later created with the same name, an old receiver will not act on the replacement. Lifecycle methods return `SandboxReplaced` or the language's typed equivalent when they can detect this situation; an ID-addressed cloud request may instead report that the old resource no longer exists.
+
+Concurrent callers are safe to use with the named lifecycle APIs. `create` remains strict, so only one same-name creation succeeds. `connect_or_create` may reuse the sandbox created by another caller, and `connect_or_start` remains attached to the exact identity held by its handle. Calls that encounter `Starting` wait for the sandbox to become ready instead of launching a second runtime.
+
+## Logs and diagnostics
+
+Use [`msb logs`](/cli/sandbox-commands#msb-logs) or the SDK `logs()` method to read captured output from running, stopped, or crashed sandboxes. For source semantics, boot errors, and diagnostic flows, see [Logs](/sandboxes/logs).

--- a/docs/sandboxes/overview.mdx
+++ b/docs/sandboxes/overview.mdx
@@ -165,7 +165,7 @@ See [Images](/images/overview) for the full OCI and disk image model.
 
 <Tooltip tip="Replace-on-create is not available on microsandbox cloud; remove the existing sandbox first, then create the replacement."><span className="msb-badge-local">Local-only <Icon icon="circle-info" size={11} /></span></Tooltip>
 
-Creating a sandbox fails if another sandbox already has the same name. Use [`connect_or_create`](/sandboxes/lifecycle#converge-on-a-named-sandbox) when you want to reuse the current persisted identity and its configuration. Use replace when you explicitly want a fresh sandbox with that name:
+Creating a sandbox fails if another sandbox already has the same name. Use [`connect_or_create`](/sandboxes/lifecycle#reuse-or-create-a-named-sandbox) when you want to reuse the current persisted identity and its configuration. Use replace when you explicitly want a fresh sandbox with that name:
 
 <CodeGroup>
 ```typescript TypeScript

--- a/docs/sdk/errors.mdx
+++ b/docs/sdk/errors.mdx
@@ -272,11 +272,11 @@ end
 
 </CodeGroup>
 
-Use `connect_or_create` and its language-idiomatic equivalents to converge on the existing persisted identity without changing its configuration. Pass `replace()` / `replace=True` / `replace: true` / `--replace` / `WithReplace()` only when you intend to stop the existing sandbox and create a new identity. See [Naming conflicts](/sandboxes/overview#naming-conflicts) for the grace-period knob.
+Use `connect_or_create` and its language-specific equivalents to reuse the existing sandbox without changing its configuration. Pass `replace()` / `replace=True` / `replace: true` / `--replace` / `WithReplace()` only when you intend to stop the existing sandbox and create a new one. See [Naming conflicts](/sandboxes/overview#naming-conflicts) for the grace-period setting.
 
-## Stale receiver identities
+## When a sandbox object is stale
 
-Built-in local and cloud lifecycle receivers capture a stable sandbox identity in addition to the reusable name. If the name now points to a replacement, receiver lifecycle operations refuse to act on it and surface a typed stale-identity error.
+A `Sandbox` or `SandboxHandle` keeps the ID of the exact sandbox it represents. If that sandbox is removed and the name is reused, lifecycle methods refuse to act on the replacement and return a typed error.
 
 <CodeGroup>
 ```typescript TypeScript

--- a/docs/sdk/go/sandbox.mdx
+++ b/docs/sdk/go/sandbox.mdx
@@ -6,7 +6,7 @@ keywords: ["Go SDK", "Go sandbox", "microsandbox sandbox"]
 
 Create and control a microVM sandbox: boot it from an image, run commands, stream logs and metrics, then shut it down. See [Overview](/sandboxes/overview) for configuration examples and [Lifecycle](/sandboxes/lifecycle) for state management.
 
-## Lifecycle convergence
+## Reuse and restart sandboxes
 
 ```go
 ConnectOrCreateSandbox(ctx, name, opts...) (*Sandbox, error)
@@ -18,7 +18,9 @@ sandbox.ID() string
 handle.ID() string
 ```
 
-`ConnectOrCreateSandbox` converges on the current persisted sandbox by name and uses options only when it creates. Receiver lifecycle operations are bound to the stable opaque `ID`; a stale receiver returns `ErrSandboxReplaced` instead of acting on a replacement that reused the name. `Sandbox` also exposes `WaitForStatus`, `Restart`, and `Destroy`. See [Reuse or create a named sandbox](/sandboxes/lifecycle#reuse-or-create-a-named-sandbox) for state behavior and examples.
+Use `ConnectOrCreateSandbox` when a named sandbox might already exist. It connects to a running sandbox, starts a stopped or crashed sandbox, and creates one only when the name is unused. Options apply only to a new sandbox.
+
+Lifecycle methods on a `Sandbox` or `SandboxHandle` stay attached to its opaque `ID`. If the name is removed and reused, an old receiver returns `ErrSandboxReplaced` instead of acting on the replacement. See [Reuse or create a named sandbox](/sandboxes/lifecycle#reuse-or-create-a-named-sandbox) for examples.
 
 
 ## Functions
@@ -87,11 +89,11 @@ Create and boot a new sandbox. Pulls the image if needed, boots the VM, starts t
 func ConnectOrCreateSandbox(ctx context.Context, name string, opts ...SandboxOption) (*Sandbox, error)
 ```
 
-Converge on the current persisted sandbox by name. The function connects when it is running, waits through `SandboxStatusStarting`, starts it when it is created, stopped, or crashed, and creates it only when the name is absent. Options apply only to creation; an existing sandbox keeps its persisted configuration. Concurrent callers converge on the winning identity. `WithReplace` and `WithReplaceWithTimeout` are invalid with this function.
+Reuse or create the sandbox with this name. The function connects when it is running, waits while it is starting, starts it when it is created, stopped, or crashed, and creates it only when the name is unused. Options apply only to a new sandbox. Concurrent callers reuse the same sandbox. `WithReplace` and `WithReplaceWithTimeout` are invalid with this function.
 
 <p className="msb-label">Parameters</p>
 
-- `ctx`: controls this convergence operation; cancellation does not stop a sandbox already returned.
+- `ctx`: controls this operation; cancellation does not stop a sandbox already returned.
 - `name`: reusable sandbox name, up to 128 UTF-8 bytes.
 - `opts`: the same creation options accepted by [`CreateSandbox`](#m-createsandbox), used only when creation is necessary.
 
@@ -1893,7 +1895,7 @@ Force-kill instead of requesting graceful shutdown during `Restart`.
 func WithRestartTimeout(timeout time.Duration) RestartOption
 ```
 
-Set the graceful-shutdown convergence window used by `Restart`. The default is ten seconds.
+Set how long `Restart` waits for graceful shutdown before it times out. The default is ten seconds.
 
 #### <span className="msb-recv"></span><span className="msb-hn">WithRestartDetached()</span>
 
@@ -1917,7 +1919,7 @@ Force-kill instead of requesting graceful shutdown during `Destroy`.
 func WithDestroyTimeout(timeout time.Duration) DestroyOption
 ```
 
-Set the graceful-shutdown convergence window used by `Destroy`. The default is ten seconds.
+Set how long `Destroy` waits for graceful shutdown before it times out. The default is ten seconds.
 
 #### <span className="msb-recv"></span><span className="msb-hn">WithKillTimeout()</span>
 

--- a/docs/sdk/go/sandbox.mdx
+++ b/docs/sdk/go/sandbox.mdx
@@ -18,7 +18,7 @@ sandbox.ID() string
 handle.ID() string
 ```
 
-`ConnectOrCreateSandbox` converges on the current persisted sandbox by name and uses options only when it creates. Receiver lifecycle operations are bound to the stable opaque `ID`; a stale receiver returns `ErrSandboxReplaced` instead of acting on a replacement that reused the name. `Sandbox` also exposes `WaitForStatus`, `Restart`, and `Destroy`. See [Lifecycle convergence and identity safety](/sandboxes/lifecycle#converge-on-a-named-sandbox) for state behavior and examples.
+`ConnectOrCreateSandbox` converges on the current persisted sandbox by name and uses options only when it creates. Receiver lifecycle operations are bound to the stable opaque `ID`; a stale receiver returns `ErrSandboxReplaced` instead of acting on a replacement that reused the name. `Sandbox` also exposes `WaitForStatus`, `Restart`, and `Destroy`. See [Reuse or create a named sandbox](/sandboxes/lifecycle#reuse-or-create-a-named-sandbox) for state behavior and examples.
 
 
 ## Functions
@@ -291,7 +291,7 @@ err := m.RemoveSandbox(ctx, "api")
 
 </Accordion>
 
-Delete a stopped sandbox by name. See [Remove](/sandboxes/lifecycle#remove) for the exact local deletion scope and the external resources that are preserved. Fails if the sandbox is still running; stop it first.
+Delete a stopped sandbox by name. See [Destroy or remove](/sandboxes/lifecycle#destroy-or-remove) for the exact local deletion scope and the external resources that are preserved. Fails if the sandbox is still running; stop it first.
 
 <p className="msb-label">Parameters</p>
 

--- a/docs/sdk/python/sandbox.mdx
+++ b/docs/sdk/python/sandbox.mdx
@@ -8,7 +8,7 @@ Create and control a microVM sandbox: boot it from an image, run commands, strea
 
 For local runtime installation and verification, see [Runtime setup](/sdk/setup#install-and-verify).
 
-## Lifecycle convergence
+## Reuse and restart sandboxes
 
 ```python
 await Sandbox.connect_or_create(name, **kwargs) -> Sandbox
@@ -20,7 +20,9 @@ await sandbox.id -> str
 handle.id -> str
 ```
 
-`connect_or_create` converges on the current persisted sandbox by name and uses creation arguments only when it creates. Receiver lifecycle operations are bound to the stable opaque `id`; a stale receiver raises `SandboxReplacedError` instead of acting on a replacement that reused the name. `Sandbox` also exposes `wait_for_status`, `restart`, and `destroy`. See [Reuse or create a named sandbox](/sandboxes/lifecycle#reuse-or-create-a-named-sandbox) for state behavior and examples.
+Use `connect_or_create` when a named sandbox might already exist. It connects to a running sandbox, starts a stopped or crashed sandbox, and creates one only when the name is unused. Creation arguments apply only to a new sandbox.
+
+Lifecycle methods on a `Sandbox` or `SandboxHandle` stay attached to its opaque `id`. If the name is removed and reused, an old receiver raises `SandboxReplacedError` instead of acting on the replacement. See [Reuse or create a named sandbox](/sandboxes/lifecycle#reuse-or-create-a-named-sandbox) for examples.
 
 ## Sandbox
 
@@ -170,7 +172,7 @@ Same parameters as [`create()`](#sandbox-create) but returns a [`PullSession`](#
 async def connect_or_create(name: str, **kwargs) -> Sandbox
 ```
 
-Converge on the current persisted sandbox by name. The method connects when it is running, waits through `SandboxStatus.STARTING`, starts it when it is created, stopped, or crashed, and creates it only when the name is absent. Keyword arguments apply only to creation; an existing sandbox keeps its persisted configuration. Concurrent callers converge on the winning identity. Passing `replace=True` or `replace_with_timeout` raises an invalid-configuration error.
+Reuse or create the sandbox with this name. The method connects when it is running, waits while it is starting, starts it when it is created, stopped, or crashed, and creates it only when the name is unused. Keyword arguments apply only to a new sandbox. Concurrent callers reuse the same sandbox. Passing `replace=True` or `replace_with_timeout` raises an invalid-configuration error.
 
 <p className="msb-label">Parameters</p>
 
@@ -1061,7 +1063,7 @@ async def restart(
 ) -> Sandbox
 ```
 
-Restart this exact sandbox. Defaults to graceful shutdown, the SDK's ten-second timeout, and attached local start. A created, stopped, or crashed sandbox starts directly; a starting sandbox is observed until it settles. Set `force` to kill, `timeout` in seconds to change shutdown convergence, or `detached` for a local background start.
+Restart this exact sandbox. Defaults to graceful shutdown, the SDK's ten-second timeout, and attached local start. A created, stopped, or crashed sandbox starts directly; a starting sandbox is observed until it settles. Set `force` to kill, `timeout` in seconds to change how long shutdown can take, or `detached` for a local background start.
 
 #### <span className="msb-recv">sb.</span><span className="msb-hn">destroy()</span>
 

--- a/docs/sdk/python/sandbox.mdx
+++ b/docs/sdk/python/sandbox.mdx
@@ -20,7 +20,7 @@ await sandbox.id -> str
 handle.id -> str
 ```
 
-`connect_or_create` converges on the current persisted sandbox by name and uses creation arguments only when it creates. Receiver lifecycle operations are bound to the stable opaque `id`; a stale receiver raises `SandboxReplacedError` instead of acting on a replacement that reused the name. `Sandbox` also exposes `wait_for_status`, `restart`, and `destroy`. See [Lifecycle convergence and identity safety](/sandboxes/lifecycle#converge-on-a-named-sandbox) for state behavior and examples.
+`connect_or_create` converges on the current persisted sandbox by name and uses creation arguments only when it creates. Receiver lifecycle operations are bound to the stable opaque `id`; a stale receiver raises `SandboxReplacedError` instead of acting on a replacement that reused the name. `Sandbox` also exposes `wait_for_status`, `restart`, and `destroy`. See [Reuse or create a named sandbox](/sandboxes/lifecycle#reuse-or-create-a-named-sandbox) for state behavior and examples.
 
 ## Sandbox
 
@@ -353,7 +353,7 @@ await Sandbox.remove("api")
 
 </Accordion>
 
-Delete a stopped sandbox by name. See [Remove](/sandboxes/lifecycle#remove) for the exact local deletion scope and the external resources that are preserved. Fails if the sandbox is still running; stop it first.
+Delete a stopped sandbox by name. See [Destroy or remove](/sandboxes/lifecycle#destroy-or-remove) for the exact local deletion scope and the external resources that are preserved. Fails if the sandbox is still running; stop it first.
 
 <p className="msb-label">Parameters</p>
 

--- a/docs/sdk/ruby/sandbox.mdx
+++ b/docs/sdk/ruby/sandbox.mdx
@@ -19,7 +19,7 @@ require "microsandbox"
 Microsandbox.install unless Microsandbox.installed?
 ```
 
-## Convergent creation
+## Reuse or create a sandbox
 
 #### <span className="msb-recv">Microsandbox::Sandbox.</span><span className="msb-hn">connect_or_create()</span>
 
@@ -27,7 +27,7 @@ Microsandbox.install unless Microsandbox.installed?
 Microsandbox::Sandbox.connect_or_create(name, **options) # => Sandbox
 ```
 
-Converge on the current persisted sandbox by name. The method connects when it is running, waits through `starting`, starts it when it is `created`, `stopped`, or `crashed`, and creates it only when the name is absent. Options apply only to creation; an existing sandbox keeps its persisted configuration. Concurrent callers converge on the winning identity. Replace options are rejected because replacement conflicts with convergence.
+Reuse or create the sandbox with this name. The method connects when it is running, waits while it is starting, starts it when it is created, stopped, or crashed, and creates it only when the name is unused. Options apply only to a new sandbox, and concurrent callers reuse the same sandbox. Replace options are rejected because they request a different sandbox.
 
 ```ruby
 sandbox = Microsandbox::Sandbox.connect_or_create(
@@ -48,7 +48,7 @@ Use `Sandbox.create` when name conflicts must remain an error, or explicit repla
 Microsandbox::Sandbox.builder(name).connect_or_create # => Sandbox
 ```
 
-Builder terminal with the same convergence, existing-configuration, concurrency, and replace-option behavior as `Microsandbox::Sandbox.connect_or_create`.
+Builder terminal with the same reuse, creation-option, concurrency, and replace-option behavior as `Microsandbox::Sandbox.connect_or_create`.
 
 ## Sandbox
 
@@ -76,7 +76,7 @@ Wait without a built-in timeout until this exact sandbox reaches one of `created
 sandbox.restart(force: false, timeout: nil, detached: false) # => Sandbox
 ```
 
-Restart this exact sandbox. Defaults to graceful shutdown, the SDK's ten-second timeout, and attached local start. A created, stopped, or crashed sandbox starts directly; a starting sandbox is observed until it settles. Set `force: true` to kill, `timeout:` in seconds to change shutdown convergence, or `detached: true` for a local background start.
+Restart this exact sandbox. Defaults to graceful shutdown, the SDK's ten-second timeout, and attached local start. A created, stopped, or crashed sandbox starts directly; a starting sandbox is observed until it settles. Set `force: true` to kill, `timeout:` in seconds to change how long shutdown can take, or `detached: true` for a local background start.
 
 On microsandbox cloud, graceful restart is supported, but timeout expiry cannot escalate to force kill. `force: true` is local-only, and `detached:` affects only local process ownership.
 
@@ -148,8 +148,8 @@ rescue Microsandbox::Error => error
 end
 ```
 
-See [Stale receiver identities](/sdk/errors#stale-receiver-identities) for the typed equivalents in the other SDKs and [Names, handles, and concurrent callers](/sandboxes/lifecycle#names-handles-and-concurrent-callers) for the race this prevents.
+See [When a sandbox object is stale](/sdk/errors#when-a-sandbox-object-is-stale) for the typed equivalents in the other SDKs and [Names, handles, and concurrent callers](/sandboxes/lifecycle#names-handles-and-concurrent-callers) for the race this prevents.
 
 ## Live lifecycle example
 
-Run `ruby examples/lifecycle_convergence.rb` from `sdk/ruby` to exercise convergent creation and reuse, stable identity, connect, wait, exec, restart, destroy, same-name replacement, and stale-handle rejection against a live microVM.
+Run `ruby examples/lifecycle_convergence.rb` from `sdk/ruby` to exercise sandbox creation and reuse, stable identity, connect, wait, exec, restart, destroy, same-name replacement, and stale-handle rejection against a live microVM.

--- a/docs/sdk/ruby/sandbox.mdx
+++ b/docs/sdk/ruby/sandbox.mdx
@@ -148,7 +148,7 @@ rescue Microsandbox::Error => error
 end
 ```
 
-See [Stale receiver identities](/sdk/errors#stale-receiver-identities) for the typed equivalents in the other SDKs and [Identity-safe receivers](/sandboxes/lifecycle#identity-safe-receivers) for the race this prevents.
+See [Stale receiver identities](/sdk/errors#stale-receiver-identities) for the typed equivalents in the other SDKs and [Names, handles, and concurrent callers](/sandboxes/lifecycle#names-handles-and-concurrent-callers) for the race this prevents.
 
 ## Live lifecycle example
 

--- a/docs/sdk/rust/sandbox.mdx
+++ b/docs/sdk/rust/sandbox.mdx
@@ -20,7 +20,7 @@ Sandbox::id(&self) -> SandboxId
 SandboxHandle::id(&self) -> SandboxId
 ```
 
-`connect_or_create` converges on the current persisted sandbox by name and uses builder configuration only when it creates. On the built-in local and cloud backends, receiver lifecycle operations are bound to the opaque `SandboxId`; a stale receiver returns `MicrosandboxError::SandboxReplaced` instead of acting on a replacement that reused the name. Custom backends should override the `*_identified` methods on `SandboxBackend` to provide the same guarantee. `Sandbox` also exposes `wait_for_status`, `restart`, and `destroy`; use `restart_with(RestartOptions)` and `destroy_with(DestroyOptions)` for force, timeout, and detached-start controls. See [Lifecycle convergence and identity safety](/sandboxes/lifecycle#converge-on-a-named-sandbox) for state behavior and examples.
+`connect_or_create` converges on the current persisted sandbox by name and uses builder configuration only when it creates. On the built-in local and cloud backends, receiver lifecycle operations are bound to the opaque `SandboxId`; a stale receiver returns `MicrosandboxError::SandboxReplaced` instead of acting on a replacement that reused the name. Custom backends should override the `*_identified` methods on `SandboxBackend` to provide the same guarantee. `Sandbox` also exposes `wait_for_status`, `restart`, and `destroy`; use `restart_with(RestartOptions)` and `destroy_with(DestroyOptions)` for force, timeout, and detached-start controls. See [Reuse or create a named sandbox](/sandboxes/lifecycle#reuse-or-create-a-named-sandbox) for state behavior and examples.
 
 ## Sandbox
 
@@ -164,7 +164,7 @@ Sandbox::remove("api").await?;
 
 </Accordion>
 
-Delete a stopped sandbox by name. Locally, this removes the same state as [`sb.remove_persisted()`](#sb-remove_persisted); see [Remove](/sandboxes/lifecycle#remove) for the exact deletion scope. Unlike `remove_persisted()`, this associated function routes through the default backend and also supports cloud sandboxes. Fails if the sandbox is still running. Stop it first.
+Delete a stopped sandbox by name. Locally, this removes the same state as [`sb.remove_persisted()`](#sb-remove_persisted); see [Destroy or remove](/sandboxes/lifecycle#destroy-or-remove) for the exact deletion scope. Unlike `remove_persisted()`, this associated function routes through the default backend and also supports cloud sandboxes. Fails if the sandbox is still running. Stop it first.
 
 <p className="msb-label">Parameters</p>
 
@@ -665,7 +665,7 @@ sb.remove_persisted().await?;
 
 </Accordion>
 
-Delete this stopped sandbox's persisted state. This receiver-based form is useful when you still hold the `Sandbox` instance; it has exactly the same deletion scope as [`Sandbox::remove(name)`](#sandboxremove). It does **not** perform additional cleanup. See [Remove](/sandboxes/lifecycle#remove) for what is deleted and which external resources are preserved.
+Delete this stopped sandbox's persisted state. This receiver-based form is useful when you still hold the `Sandbox` instance; it has exactly the same deletion scope as [`Sandbox::remove(name)`](#sandboxremove). It does **not** perform additional cleanup. See [Destroy or remove](/sandboxes/lifecycle#destroy-or-remove) for what is deleted and which external resources are preserved.
 
 #### <span className="msb-recv">sb.</span><span className="msb-hn">request_stop()</span>
 

--- a/docs/sdk/rust/sandbox.mdx
+++ b/docs/sdk/rust/sandbox.mdx
@@ -8,7 +8,7 @@ Create and control a microVM sandbox: boot it from an image, run commands, strea
 
 For local runtime installation and verification, see [Runtime setup](/sdk/setup#install-and-verify).
 
-## Lifecycle convergence
+## Reuse and restart sandboxes
 
 ```rust
 SandboxBuilder::connect_or_create(self) -> MicrosandboxResult<Sandbox>
@@ -20,7 +20,9 @@ Sandbox::id(&self) -> SandboxId
 SandboxHandle::id(&self) -> SandboxId
 ```
 
-`connect_or_create` converges on the current persisted sandbox by name and uses builder configuration only when it creates. On the built-in local and cloud backends, receiver lifecycle operations are bound to the opaque `SandboxId`; a stale receiver returns `MicrosandboxError::SandboxReplaced` instead of acting on a replacement that reused the name. Custom backends should override the `*_identified` methods on `SandboxBackend` to provide the same guarantee. `Sandbox` also exposes `wait_for_status`, `restart`, and `destroy`; use `restart_with(RestartOptions)` and `destroy_with(DestroyOptions)` for force, timeout, and detached-start controls. See [Reuse or create a named sandbox](/sandboxes/lifecycle#reuse-or-create-a-named-sandbox) for state behavior and examples.
+Use `connect_or_create` when a named sandbox might already exist. It connects to a running sandbox, starts a stopped or crashed sandbox, and creates one only when the name is unused. Builder options apply only to a new sandbox.
+
+Lifecycle methods on a `Sandbox` or `SandboxHandle` stay attached to its opaque `SandboxId`. If the name is removed and reused, an old receiver returns `MicrosandboxError::SandboxReplaced` instead of acting on the replacement. Custom backends provide the same behavior by implementing the `*_identified` methods on `SandboxBackend`. See [Reuse or create a named sandbox](/sandboxes/lifecycle#reuse-or-create-a-named-sandbox) for examples.
 
 ## Sandbox
 
@@ -794,7 +796,7 @@ Gracefully stop and start this exact sandbox using the persisted configuration. 
 async fn restart_with(&self, options: RestartOptions) -> MicrosandboxResult<Sandbox>
 ```
 
-Restart with explicit lifecycle controls. `RestartOptions` defaults to graceful shutdown, a ten-second timeout, and attached local start. Set `force` to kill instead of draining, `timeout` to control shutdown convergence, and `detached` to start a local background sandbox.
+Restart with explicit lifecycle controls. `RestartOptions` defaults to graceful shutdown, a ten-second timeout, and attached local start. Set `force` to kill instead of draining, `timeout` to control how long shutdown can take, and `detached` to start a local background sandbox.
 
 #### <span className="msb-recv">sb.</span><span className="msb-hn">destroy()</span>
 
@@ -802,7 +804,7 @@ Restart with explicit lifecycle controls. `RestartOptions` defaults to graceful 
 async fn destroy(&self) -> MicrosandboxResult<()>
 ```
 
-Gracefully stop and remove this exact sandbox. Unlike [`remove_persisted()`](#remove-persisted), `destroy` accepts a running sandbox and converges it through shutdown before deleting persisted state.
+Gracefully stop and remove this exact sandbox. Unlike [`remove_persisted()`](#remove-persisted), `destroy` accepts a running sandbox, waits for it to shut down, and then deletes its persisted state.
 
 #### <span className="msb-recv">sb.</span><span className="msb-hn">destroy_with()</span>
 
@@ -810,7 +812,7 @@ Gracefully stop and remove this exact sandbox. Unlike [`remove_persisted()`](#re
 async fn destroy_with(&self, options: DestroyOptions) -> MicrosandboxResult<()>
 ```
 
-Destroy with explicit shutdown controls. `DestroyOptions` defaults to graceful shutdown with a ten-second timeout; set `force` to kill immediately or `timeout` to change the convergence window. Identity checks prevent this receiver from deleting a same-name replacement.
+Destroy with explicit shutdown controls. `DestroyOptions` defaults to graceful shutdown with a ten-second timeout; set `force` to kill immediately or `timeout` to change how long shutdown can take. Identity checks prevent this receiver from deleting a same-name replacement.
 
 ## SandboxBuilder
 
@@ -851,6 +853,61 @@ Materialize the [`SandboxConfig`](#sandboxconfig) without booting the sandbox. V
     <div className="msb-param-desc">Validated, ready-to-boot configuration.</div>
   </div>
 </div>
+
+#### <span className="msb-recv">sandbox.</span><span className="msb-hn">overlay()</span>
+
+```rust
+fn overlay(self, patch: SandboxConfigPatch) -> Self
+```
+
+Apply sparse per-sandbox configuration after built-in and global defaults. Builder methods called after `overlay` take precedence over the patch.
+
+<Accordion title="Example">
+
+```rust
+use microsandbox::{
+    EnvVar, Sandbox, SandboxConfigPatch, SandboxResourcesPatch,
+};
+
+let resources = SandboxResourcesPatch::new()
+    .max_memory_mib(1024)
+    .memory_mib(1024)
+    .max_cpus(2)
+    .cpus(2);
+
+let patch = SandboxConfigPatch::new()
+    .resources(resources)
+    .env(vec![EnvVar::new("MODE", "production")]);
+
+let sandbox = Sandbox::builder("agent")
+    .image("python:3.12")
+    .overlay(patch)
+    .memory(2048)
+    .create()
+    .await?;
+```
+
+</Accordion>
+
+Environment variables merge by variable name, while labels and scripts merge by map key. Secret entries merge by environment-variable name. Later values win when keys match. Use the generated `replace_*` methods to replace a complete collection; `clear_*` removes the field from the patch so the lower-precedence value remains unchanged.
+
+`SandboxConfigPatch` contains typed configuration values only. YAML loading, relative-path resolution, `${ENV}` expansion, registry credentials, and snapshot selection remain separate CLI or builder responsibilities.
+
+<Accordion title="Migrating from the earlier patch types">
+
+The generated patch model replaces the handwritten patch hierarchy from microsandbox 0.6.15 and earlier:
+
+| Earlier type | Current type |
+| --- | --- |
+| `ResourceConfigPatch` | `SandboxResourcesPatch` |
+| `RuntimeConfigPatch` | `SandboxRuntimeOptionsPatch` |
+| `NetworkConfigPatch` | `NetworkSpecPatch` |
+| `NetworkPolicyConfigPatch` | `SandboxPolicyPatch` |
+| `SecretConfigPatch` | `SecretsConfigPatch` |
+
+Filesystem, script, image, and init values now use `SandboxConfigPatch` and its nested patch types directly. `LocalConfig` remains available as a deprecated alias of `GlobalConfig`.
+
+</Accordion>
 
 #### <span className="msb-recv">sandbox.</span><span className="msb-hn">cpus()</span>
 
@@ -911,7 +968,7 @@ Boot the sandbox. Local handles use attached mode and stop the sandbox when the 
 async fn connect_or_create(self) -> MicrosandboxResult<Sandbox>
 ```
 
-Converge on the current persisted sandbox by name. The method connects when it is running, waits through `Starting`, starts it when it is `Created`, `Stopped`, or `Crashed`, and creates it only when the name is absent. Builder configuration is used only for creation; an existing sandbox keeps its persisted configuration. Concurrent creators and starters converge on the winning identity. Combining this method with [`replace()`](#replace) returns `InvalidConfig`.
+Reuse or create the sandbox with this name. The method connects when it is running, waits while it is starting, starts it when it is created, stopped, or crashed, and creates it only when the name is unused. Builder configuration applies only to a new sandbox. Concurrent callers reuse the same sandbox. Combining this method with [`replace()`](#replace) returns `InvalidConfig`.
 
 <p className="msb-label">Returns</p>
 
@@ -2295,7 +2352,7 @@ Same as `connect()` with an explicit timeout
 async fn connect_or_start(&self) -> MicrosandboxResult<Sandbox>
 ```
 
-Connect to this exact sandbox when it is running, wait through `Starting`, or start it in attached mode when it is `Created`, `Stopped`, or `Crashed`. `Draining` and `Paused` are rejected. Concurrent starts converge on the winner without following a replacement identity.
+Connect to this exact sandbox when it is running, wait through `Starting`, or start it in attached mode when it is `Created`, `Stopped`, or `Crashed`. `Draining` and `Paused` are rejected. If another caller starts it at the same time, both callers connect to the same sandbox without following a same-name replacement.
 
 #### <span className="msb-recv">h.</span><span className="msb-hn">connect_or_start_detached()</span>
 
@@ -2303,7 +2360,7 @@ Connect to this exact sandbox when it is running, wait through `Starting`, or st
 async fn connect_or_start_detached(&self) -> MicrosandboxResult<Sandbox>
 ```
 
-Use the same state convergence as [`connect_or_start()`](#connect-or-start), but start a local stopped sandbox in detached/background mode. Connecting to an already-running sandbox never changes its ownership.
+Behaves like [`connect_or_start()`](#connect-or-start), but starts a local stopped sandbox in detached/background mode. Connecting to an already-running sandbox never changes its ownership.
 
 #### <span className="msb-recv">h.</span><span className="msb-hn">created_at()</span>
 

--- a/docs/sdk/typescript/sandbox.mdx
+++ b/docs/sdk/typescript/sandbox.mdx
@@ -18,7 +18,7 @@ sandbox.id: string
 handle.id: string
 ```
 
-`connectOrCreate` converges on the current persisted sandbox by name and uses builder configuration only when it creates. Receiver lifecycle operations are bound to the stable opaque `id`; a stale receiver throws `SandboxReplacedError` instead of acting on a replacement that reused the name. `Sandbox` also exposes `waitForStatus`, `restart`, and `destroy`. See [Lifecycle convergence and identity safety](/sandboxes/lifecycle#converge-on-a-named-sandbox) for state behavior and examples.
+`connectOrCreate` converges on the current persisted sandbox by name and uses builder configuration only when it creates. Receiver lifecycle operations are bound to the stable opaque `id`; a stale receiver throws `SandboxReplacedError` instead of acting on a replacement that reused the name. `Sandbox` also exposes `waitForStatus`, `restart`, and `destroy`. See [Reuse or create a named sandbox](/sandboxes/lifecycle#reuse-or-create-a-named-sandbox) for state behavior and examples.
 
 ## Functions
 
@@ -189,7 +189,7 @@ await Sandbox.remove("api");
 
 </Accordion>
 
-Delete a stopped sandbox by name. See [Remove](/sandboxes/lifecycle#remove) for the exact local deletion scope and the external resources that are preserved. Fails if the sandbox is still running. Stop it first.
+Delete a stopped sandbox by name. See [Destroy or remove](/sandboxes/lifecycle#destroy-or-remove) for the exact local deletion scope and the external resources that are preserved. Fails if the sandbox is still running. Stop it first.
 
 <p className="msb-label">Parameters</p>
 

--- a/docs/sdk/typescript/sandbox.mdx
+++ b/docs/sdk/typescript/sandbox.mdx
@@ -6,7 +6,7 @@ keywords: ["TypeScript SDK", "TypeScript sandbox", "microsandbox sandbox"]
 
 Create and control a microVM sandbox: boot it from an image, run commands, stream logs and metrics, then shut it down. See [Overview](/sandboxes/overview) for configuration examples and [Lifecycle](/sandboxes/lifecycle) for state management.
 
-## Lifecycle convergence
+## Reuse and restart sandboxes
 
 ```typescript
 Sandbox.builder(name).connectOrCreate(): Promise<Sandbox>
@@ -18,7 +18,9 @@ sandbox.id: string
 handle.id: string
 ```
 
-`connectOrCreate` converges on the current persisted sandbox by name and uses builder configuration only when it creates. Receiver lifecycle operations are bound to the stable opaque `id`; a stale receiver throws `SandboxReplacedError` instead of acting on a replacement that reused the name. `Sandbox` also exposes `waitForStatus`, `restart`, and `destroy`. See [Reuse or create a named sandbox](/sandboxes/lifecycle#reuse-or-create-a-named-sandbox) for state behavior and examples.
+Use `connectOrCreate` when a named sandbox might already exist. It connects to a running sandbox, starts a stopped or crashed sandbox, and creates one only when the name is unused. Builder options apply only to a new sandbox.
+
+Lifecycle methods on a `Sandbox` or `SandboxHandle` stay attached to its opaque `id`. If the name is removed and reused, an old receiver throws `SandboxReplacedError` instead of acting on the replacement. See [Reuse or create a named sandbox](/sandboxes/lifecycle#reuse-or-create-a-named-sandbox) for examples.
 
 ## Functions
 
@@ -780,7 +782,7 @@ Wait without a built-in timeout until this exact persisted sandbox reaches `stat
 restart(options?: { force?: boolean; timeoutMs?: number; detached?: boolean }): Promise<Sandbox>
 ```
 
-Restart this exact sandbox. Defaults to graceful shutdown, a 10_000 ms timeout, and attached local start. A stopped, crashed, or created sandbox starts directly; `Starting` is observed until it settles. Set `force` to kill, `timeoutMs` to change shutdown convergence, or `detached` for a local background start.
+Restart this exact sandbox. Defaults to graceful shutdown, a 10_000 ms timeout, and attached local start. A stopped, crashed, or created sandbox starts directly; `Starting` is observed until it settles. Set `force` to kill, `timeoutMs` to change how long shutdown can take, or `detached` for a local background start.
 
 #### <span className="msb-recv">sandbox.</span><span className="msb-hn">destroy()</span>
 
@@ -956,7 +958,7 @@ Build and boot the sandbox. By default, a local handle is attached and stops whe
 connectOrCreate(): Promise<Sandbox>
 ```
 
-Converge on the current persisted sandbox by name. The method connects when it is running, waits through `starting`, starts it when it is `created`, `stopped`, or `crashed`, and creates it only when the name is absent. Builder settings apply only when creation is necessary; existing persisted configuration always wins. Concurrent callers converge on the winning identity. Calling [`replace()`](#replace) or [`replaceWithTimeout()`](#replacewithtimeout) on this builder is invalid.
+Reuse or create the sandbox with this name. The method connects when it is running, waits while it is starting, starts it when it is created, stopped, or crashed, and creates it only when the name is unused. Builder settings apply only to a new sandbox. Concurrent callers reuse the same sandbox. Calling [`replace()`](#replace) or [`replaceWithTimeout()`](#replacewithtimeout) on this builder is invalid.
 
 <p className="msb-label">Returns</p>
 


### PR DESCRIPTION
## TL;DR
Refactor the 0.6.16 lifecycle documentation around the workflows readers actually follow, and move detailed SDK migration material into the relevant API reference.

## Description
- Lead the lifecycle guide with create, stop, start, reuse, detach, and remove instead of states and implementation details.
- Explain `connect_or_create`, stable sandbox IDs, and stale objects in plain language.
- Remove the lifecycle ASCII diagrams and emoji compatibility matrix.
- Replace repeated “lifecycle convergence” introductions across the Rust, TypeScript, Python, Go, and Ruby references with task-oriented summaries.
- Keep the CLI configuration guide focused on YAML workflows and move the Rust patch migration mapping beside `SandboxBuilder::overlay`.
- Simplify the 0.6.16 changelog and error guide while preserving behavior, caveats, and language-specific method names.
- Update affected anchors and cross-references.

## Test Plan
- [x] `npx --yes mintlify validate` passes the full-site build.
- [x] `npx --yes mintlify broken-links` reports no broken links.
- [x] Reviewed the lifecycle, CLI configuration, and Rust overlay reference in the local Mintlify preview.
- [x] `git diff --check` reports no whitespace errors.
