### PR TITLE
feat: add cloud TCP forwarding and resumable logs

### DIFF
--- a/crates/migration/lib/lib.rs
+++ b/crates/migration/lib/lib.rs
@@ -73,8 +73,11 @@ impl MigratorTrait for Migrator {
             Box::new(m20260808_000001_create_memory_allocation_nodes::Migration),
             Box::new(m20260810_000001_rebuild_sandbox_labels::Migration),
             Box::new(m20260813_000001_share_cpu_allocations::Migration),
-            Box::new(m20260818_000001_sandbox_network_slot::Migration),
             Box::new(m20260824_000001_mount_owner_config::Migration),
+            // This migration was published after mount_owner_config despite
+            // its earlier date. Migration order is an append-only release
+            // contract; never insert it before an already released entry.
+            Box::new(m20260818_000001_sandbox_network_slot::Migration),
         ]
     }
 }

--- a/crates/migration/lib/schema_metadata.rs
+++ b/crates/migration/lib/schema_metadata.rs
@@ -237,6 +237,13 @@ pub const MIGRATION_METADATA: &[MigrationMetadata] = &[
         summary: "restore exclusive logical CPU allocation rows",
     },
     MigrationMetadata {
+        id: MOUNT_OWNER_CONFIG_MIGRATION_ID,
+        reversible: true,
+        affects_cache: false,
+        affects_user_data: false,
+        summary: "remove the compatibility marker after confirming no persisted mount ownership",
+    },
+    MigrationMetadata {
         id: SANDBOX_NETWORK_SLOT_MIGRATION_ID,
         // The column is deliberately left in place on rollback (SQLite has
         // no DROP COLUMN on every supported version); `up` probes for it so a
@@ -245,13 +252,6 @@ pub const MIGRATION_METADATA: &[MigrationMetadata] = &[
         affects_cache: false,
         affects_user_data: false,
         summary: "retain the compatible sandbox network slot column",
-    },
-    MigrationMetadata {
-        id: MOUNT_OWNER_CONFIG_MIGRATION_ID,
-        reversible: true,
-        affects_cache: false,
-        affects_user_data: false,
-        summary: "remove the compatibility marker after confirming no persisted mount ownership",
     },
 ];
 
@@ -357,6 +357,26 @@ mod tests {
 
         let prefix = canonical_applied_prefix(all_applied).expect("valid unordered prefix");
         assert_eq!(prefix, MIGRATION_METADATA);
+    }
+
+    #[test]
+    fn released_mount_owner_schema_remains_a_valid_prefix() {
+        let through_mount_owner = MIGRATION_METADATA
+            .iter()
+            .take_while(|metadata| metadata.id != MOUNT_OWNER_CONFIG_MIGRATION_ID)
+            .chain(
+                MIGRATION_METADATA
+                    .iter()
+                    .find(|metadata| metadata.id == MOUNT_OWNER_CONFIG_MIGRATION_ID),
+            )
+            .map(|metadata| metadata.id);
+
+        let prefix = canonical_applied_prefix(through_mount_owner)
+            .expect("the released pre-network-slot schema must remain compatible");
+        assert_eq!(
+            prefix.last().map(|metadata| metadata.id),
+            Some(MOUNT_OWNER_CONFIG_MIGRATION_ID)
+        );
     }
 
     #[test]

--- a/packages/microsandbox-types/rust/lib/cloud.rs
+++ b/packages/microsandbox-types/rust/lib/cloud.rs
@@ -15,11 +15,11 @@ use zeroize::Zeroizing;
 
 use crate::domain::{
     CpuPlacement, DeploymentProfile, DiskImageFormat, EnvVar, HandoffInit, HostPattern,
-    HostPermissions, MountOptions, NetworkPolicy, NetworkSpec, OciRootfsSource, Patch, PullPolicy,
-    Rlimit, RlimitResource, RootDisk, RootfsSource, SandboxLogLevel, SandboxPolicy,
-    SandboxResources, SandboxRuntimeOptions, SandboxSpec, SecretEntry, SecretInjection,
-    SecretsConfig, SecurityProfile, StatVirtualization, TransparentHugePagePolicy, ViolationAction,
-    VolumeMount, VsockSpec, default_private, default_strict,
+    HostPermissions, MountOptions, NetworkPolicy, NetworkSpec, OciRootfsSource, Patch,
+    PublishedPortSpec, PullPolicy, Rlimit, RlimitResource, RootDisk, RootfsSource, SandboxLogLevel,
+    SandboxPolicy, SandboxResources, SandboxRuntimeOptions, SandboxSpec, SecretEntry,
+    SecretInjection, SecretsConfig, SecurityProfile, StatVirtualization, TransparentHugePagePolicy,
+    ViolationAction, VolumeMount, VsockSpec, default_private, default_strict,
 };
 use crate::modify::SecretSource;
 use crate::{TypesError, TypesResult};
@@ -729,8 +729,8 @@ impl From<VolumeMount> for CloudVolumeMount {
 }
 
 /// Cloud network specification: a subset of the domain [`NetworkSpec`].
-/// Interface overrides, host port mapping, DNS, TLS interception, rate limits,
-/// and host-CA trust are not part of this type. `deny_unknown_fields` — posting
+/// Interface overrides, DNS, TLS interception, rate limits, and host-CA trust
+/// are not part of this type. `deny_unknown_fields` — posting
 /// an omitted field is an error, not a silent drop.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
@@ -743,6 +743,10 @@ pub struct CloudNetworkSpec {
     /// Egress/ingress policy.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub policy: Option<NetworkPolicy>,
+
+    /// TCP listeners the SDK exposes locally and relays to guest ports.
+    #[serde(default)]
+    pub ports: Vec<PublishedPortSpec>,
 
     /// Secret-injection config.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -758,6 +762,7 @@ impl Default for CloudNetworkSpec {
         Self {
             enabled: true,
             policy: None,
+            ports: Vec::new(),
             secrets: None,
             max_connections: None,
         }
@@ -993,7 +998,7 @@ impl TryFrom<CloudSandboxSpec> for SandboxSpec {
         let network = NetworkSpec {
             enabled: spec.network.enabled,
             interface: None,
-            ports: Vec::new(),
+            ports: spec.network.ports,
             policy: spec.network.policy,
             dns: None,
             tls: None,
@@ -1097,6 +1102,7 @@ impl From<SandboxSpec> for CloudSandboxSpec {
             network: CloudNetworkSpec {
                 enabled: spec.network.enabled,
                 policy: spec.network.policy,
+                ports: spec.network.ports,
                 secrets: spec.network.secrets.map(Into::into),
                 max_connections: spec.network.max_connections,
             },

--- a/sdk/rust/lib/backend/cloud/http.rs
+++ b/sdk/rust/lib/backend/cloud/http.rs
@@ -60,6 +60,13 @@ enum CloudSseItem {
     Ignore,
 }
 
+enum CloudLogReadOutcome {
+    Terminal,
+    Retry(String),
+    Fatal(MicrosandboxError),
+    Cancelled,
+}
+
 #[derive(Serialize)]
 struct CloudSandboxListQuery<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -77,6 +84,12 @@ struct CloudSandboxWaitQuery {
     wait_timeout: u64,
 }
 
+#[derive(Debug, Deserialize)]
+struct CloudCapabilities {
+    #[serde(default)]
+    cloud_tcp_ports: bool,
+}
+
 //--------------------------------------------------------------------------------------------------
 // Methods: Sandbox lifecycle
 //
@@ -85,6 +98,31 @@ struct CloudSandboxWaitQuery {
 //--------------------------------------------------------------------------------------------------
 
 impl CloudBackend {
+    pub(in crate::backend) async fn require_cloud_tcp_ports(&self) -> MicrosandboxResult<()> {
+        let url = format!("{}/v1/capabilities", self.url);
+        let response = self
+            .http
+            .get(&url)
+            .send()
+            .await
+            .map_err(|error| cloud_io_error("GET /v1/capabilities", error))?;
+        if response.status() == reqwest::StatusCode::NOT_FOUND {
+            return Err(MicrosandboxError::unsupported(
+                Operation::SandboxCreate,
+                UnsupportedReason::ConfigField("cloud TCP port mappings"),
+            ));
+        }
+        let capabilities: CloudCapabilities = decode_json(response, "GET /v1/capabilities").await?;
+        if capabilities.cloud_tcp_ports {
+            Ok(())
+        } else {
+            Err(MicrosandboxError::unsupported(
+                Operation::SandboxCreate,
+                UnsupportedReason::ConfigField("cloud TCP port mappings"),
+            ))
+        }
+    }
+
     /// `POST /v1/sandboxes` (optionally create, start, and wait for readiness).
     ///
     /// Pass `start=true` to atomically create-and-start in a single round-trip
@@ -335,7 +373,7 @@ impl CloudBackend {
             .await
             .map_err(|e| cloud_io_error("GET /v1/sandboxes/:id/logs", e))?;
         let status = resp.status();
-        if !status.is_success() {
+        if !status.is_success() && !matches!(status.as_u16(), 502..=504) {
             let body_text = resp.text().await.unwrap_or_default();
             let typed: Option<CloudErrorBody> = serde_json::from_str(&body_text).ok();
             return Err(cloud_http_error(
@@ -348,8 +386,99 @@ impl CloudBackend {
 
         let (tx, rx) = mpsc::unbounded_channel();
         let opts = opts.clone();
+        let http = self.http.clone();
         tokio::spawn(async move {
-            parse_cloud_log_sse(Box::pin(resp.bytes_stream()), opts, tx).await;
+            let deadline = tokio::time::Instant::now() + Duration::from_secs(120);
+            let mut backoff = Duration::from_millis(100);
+            let mut response = Some(resp);
+            let mut last_cursor = match &opts.start {
+                LogStreamStart::From(cursor) => Some(cursor.clone()),
+                _ => None,
+            };
+
+            loop {
+                match parse_cloud_log_sse(
+                    Box::pin(
+                        response
+                            .take()
+                            .expect("log response is installed before every read")
+                            .bytes_stream(),
+                    ),
+                    &opts,
+                    &tx,
+                    &mut last_cursor,
+                )
+                .await
+                {
+                    CloudLogReadOutcome::Terminal | CloudLogReadOutcome::Cancelled => return,
+                    CloudLogReadOutcome::Fatal(error) => {
+                        let _ = tx.send(Err(error));
+                        return;
+                    }
+                    CloudLogReadOutcome::Retry(reason) => {
+                        if tokio::time::Instant::now() >= deadline {
+                            let _ = tx.send(Err(MicrosandboxError::Runtime(format!(
+                                "cloud log reconnect deadline exceeded: {reason}"
+                            ))));
+                            return;
+                        }
+                    }
+                }
+
+                tokio::select! {
+                    () = tokio::time::sleep(backoff) => {}
+                    () = tx.closed() => return,
+                }
+                backoff = (backoff * 2).min(Duration::from_secs(5));
+
+                let mut request = http
+                    .get(&url)
+                    .header(ACCEPT, HeaderValue::from_static("text/event-stream"));
+                if let Some(cursor) = &last_cursor {
+                    request = request
+                        .header(HeaderName::from_static("last-event-id"), cursor.to_string());
+                }
+                loop {
+                    match request
+                        .try_clone()
+                        .expect("log request is cloneable")
+                        .send()
+                        .await
+                    {
+                        Ok(next) if matches!(next.status().as_u16(), 502..=504) => {}
+                        Ok(next) if next.status().is_success() => {
+                            response = Some(next);
+                            break;
+                        }
+                        Ok(next) => {
+                            let status = next.status();
+                            let body_text = next.text().await.unwrap_or_default();
+                            let typed: Option<CloudErrorBody> =
+                                serde_json::from_str(&body_text).ok();
+                            let _ = tx.send(Err(cloud_http_error(
+                                status.as_u16(),
+                                typed.as_ref(),
+                                &body_text,
+                                "GET /v1/sandboxes/:id/logs",
+                            )));
+                            return;
+                        }
+                        Err(_) => {}
+                    }
+                    if tokio::time::Instant::now() >= deadline {
+                        let _ = tx.send(Err(MicrosandboxError::Runtime(
+                            "cloud log reconnect deadline exceeded".to_string(),
+                        )));
+                        return;
+                    }
+                    tokio::select! {
+                        () = tokio::time::sleep(backoff) => {}
+                        () = tx.closed() => return,
+                    }
+                    backoff = (backoff * 2).min(Duration::from_secs(5));
+                }
+                backoff = Duration::from_millis(100);
+            }
         });
 
         Ok(Box::pin(stream::unfold(rx, |mut rx| async {
@@ -568,37 +697,44 @@ fn cloud_http_error(
 
 async fn parse_cloud_log_sse(
     mut chunks: Pin<Box<dyn futures::Stream<Item = Result<Bytes, reqwest::Error>> + Send>>,
-    opts: LogStreamOptions,
-    tx: mpsc::UnboundedSender<MicrosandboxResult<LogEntry>>,
-) {
+    opts: &LogStreamOptions,
+    tx: &mpsc::UnboundedSender<MicrosandboxResult<LogEntry>>,
+    last_cursor: &mut Option<LogCursor>,
+) -> CloudLogReadOutcome {
     let mut buffer = Vec::new();
 
     while let Some(chunk) = chunks.next().await {
         match chunk {
             Ok(bytes) => buffer.extend_from_slice(&bytes),
             Err(error) => {
-                let _ = tx.send(Err(MicrosandboxError::Http(error)));
-                return;
+                return CloudLogReadOutcome::Retry(error.to_string());
             }
         }
 
         while let Some((block, consumed)) = take_sse_block(&buffer) {
             buffer.drain(..consumed);
-            match parse_cloud_sse_item(&block, &opts) {
+            match parse_cloud_sse_item(&block, opts) {
                 Ok(CloudSseItem::Entry(entry)) => {
+                    let resumable = entry.cursor != LogCursor::empty();
+                    if resumable && last_cursor.as_ref() == Some(&entry.cursor) {
+                        continue;
+                    }
+                    if resumable {
+                        *last_cursor = Some(entry.cursor.clone());
+                    }
                     if tx.send(Ok(entry)).is_err() {
-                        return;
+                        return CloudLogReadOutcome::Cancelled;
                     }
                 }
-                Ok(CloudSseItem::End) => return,
+                Ok(CloudSseItem::End) => return CloudLogReadOutcome::Terminal,
                 Ok(CloudSseItem::Ignore) => {}
                 Err(error) => {
-                    let _ = tx.send(Err(error));
-                    return;
+                    return CloudLogReadOutcome::Fatal(error);
                 }
             }
         }
     }
+    CloudLogReadOutcome::Retry("cloud log stream reached EOF".to_string())
 }
 
 fn take_sse_block(buffer: &[u8]) -> Option<(Vec<u8>, usize)> {
@@ -754,7 +890,79 @@ pub(super) fn urlencoding(s: &str) -> String {
 
 #[cfg(test)]
 mod tests {
+    use base64::Engine;
+    use futures::StreamExt;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
+
     use super::*;
+
+    fn test_cursor(offset: u64) -> String {
+        let mut bytes = vec![1_u8];
+        bytes.extend_from_slice(&1_u64.to_le_bytes());
+        bytes.extend_from_slice(&offset.to_le_bytes());
+        base64::engine::general_purpose::STANDARD.encode(bytes)
+    }
+
+    #[tokio::test]
+    async fn cloud_log_stream_resumes_with_last_event_id_and_deduplicates_cursor() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let cursor_one = test_cursor(1);
+        let cursor_two = test_cursor(2);
+        let server_cursor_one = cursor_one.clone();
+        let server_cursor_two = cursor_two.clone();
+        let server = tokio::spawn(async move {
+            for attempt in 0..2 {
+                let (mut socket, _) = listener.accept().await.unwrap();
+                let mut request = Vec::new();
+                let mut chunk = [0_u8; 1024];
+                while !request.windows(4).any(|window| window == b"\r\n\r\n") {
+                    let count = socket.read(&mut chunk).await.unwrap();
+                    assert_ne!(count, 0);
+                    request.extend_from_slice(&chunk[..count]);
+                }
+                let request = String::from_utf8(request).unwrap();
+                if attempt == 1 {
+                    assert!(request.to_ascii_lowercase().contains(&format!(
+                        "last-event-id: {}",
+                        server_cursor_one.to_ascii_lowercase()
+                    )));
+                }
+                let body = if attempt == 0 {
+                    format!(
+                        "id: {}\nevent: log\ndata: {{\"source\":\"stdout\",\"ts\":\"2026-05-31T10:00:00Z\",\"text\":\"one\"}}\n\n",
+                        server_cursor_one
+                    )
+                } else {
+                    format!(
+                        "id: {}\nevent: log\ndata: {{\"source\":\"stdout\",\"ts\":\"2026-05-31T10:00:00Z\",\"text\":\"duplicate\"}}\n\nid: {}\nevent: log\ndata: {{\"source\":\"stdout\",\"ts\":\"2026-05-31T10:00:01Z\",\"text\":\"two\"}}\n\nevent: end\ndata: {{}}\n\n",
+                        server_cursor_one, server_cursor_two
+                    )
+                };
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\ncontent-type: text/event-stream\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+                    body.len(),
+                    body
+                );
+                socket.write_all(response.as_bytes()).await.unwrap();
+            }
+        });
+
+        let backend = CloudBackend::new(format!("http://{address}"), "test-key").unwrap();
+        let mut stream = backend
+            .open_log_stream_by_id("sandbox", &LogStreamOptions::default())
+            .await
+            .unwrap();
+        let first = stream.next().await.unwrap().unwrap();
+        let second = stream.next().await.unwrap().unwrap();
+        assert_eq!(first.data, Bytes::from_static(b"one"));
+        assert_eq!(second.data, Bytes::from_static(b"two"));
+        assert_eq!(first.cursor.to_string(), cursor_one);
+        assert_eq!(second.cursor.to_string(), cursor_two);
+        assert!(stream.next().await.is_none());
+        server.await.unwrap();
+    }
 
     #[test]
     fn cloud_http_error_uses_nested_error_body() {

--- a/sdk/rust/lib/backend/cloud/mod.rs
+++ b/sdk/rust/lib/backend/cloud/mod.rs
@@ -359,6 +359,10 @@ impl Backend for CloudBackend {
         self
     }
 
+    fn as_cloud(&self) -> Option<&CloudBackend> {
+        Some(self)
+    }
+
     /// Open an agent connection over `GET /v1/sandboxes/:id/agent`.
     ///
     /// The route upgrades to a WebSocket that pipes bytes to and from the

--- a/sdk/rust/lib/backend/cloud/sandbox.rs
+++ b/sdk/rust/lib/backend/cloud/sandbox.rs
@@ -6,6 +6,12 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use futures::future::BoxFuture;
+use microsandbox_protocol::{
+    message::MessageType,
+    tcp::{TcpClose, TcpClosed, TcpConnect, TcpConnected, TcpData, TcpEof, TcpFailed},
+};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
 
 use super::CloudBackend;
 use crate::backend::{
@@ -66,6 +72,25 @@ pub(in crate::backend) enum CloudRegistrySelection {
     },
 }
 
+/// Owns SDK-local listeners for a running cloud sandbox. Clones of `Sandbox`
+/// share this value; dropping the final handle aborts only the local listener
+/// tasks and deliberately leaves the remote sandbox running.
+pub(crate) struct CloudPortBindings {
+    tasks: Vec<tokio::task::JoinHandle<()>>,
+}
+
+struct PreparedCloudPortBindings {
+    listeners: Vec<(TcpListener, u16)>,
+}
+
+impl Drop for CloudPortBindings {
+    fn drop(&mut self) {
+        for task in &self.tasks {
+            task.abort();
+        }
+    }
+}
+
 //--------------------------------------------------------------------------------------------------
 // Trait Implementations
 //--------------------------------------------------------------------------------------------------
@@ -79,11 +104,14 @@ impl SandboxBackend for CloudBackend {
     ) -> BoxFuture<'a, MicrosandboxResult<Sandbox>> {
         Box::pin(async move {
             let (req, config) = cloud_create_body_and_config(config)?;
+            let bindings = prepare_cloud_port_bindings(self, &config).await?;
             let cloud = CloudBackend::create_sandbox(self, &req, start).await?;
             if start {
                 ensure_cloud_sandbox_ready(&cloud)?;
             }
-            Ok(Sandbox::from_cloud(backend, cloud, config))
+            let name = cloud.name.clone();
+            Ok(Sandbox::from_cloud(backend.clone(), cloud, config)
+                .with_cloud_port_bindings(bindings.activate(backend, name)))
         })
     }
 
@@ -96,6 +124,12 @@ impl SandboxBackend for CloudBackend {
         // by msb-cloud, not by this process. Reuse the eager-start path.
         Box::pin(async move {
             let (req, config) = cloud_create_body_and_config(config)?;
+            if !config.spec.network.ports.is_empty() {
+                return Err(MicrosandboxError::unsupported(
+                    Operation::SandboxCreate,
+                    UnsupportedReason::ConfigField("detached cloud sandbox port mappings"),
+                ));
+            }
             let cloud = CloudBackend::create_sandbox(self, &req, true).await?;
             ensure_cloud_sandbox_ready(&cloud)?;
             Ok(Sandbox::from_cloud(backend, cloud, config))
@@ -110,9 +144,12 @@ impl SandboxBackend for CloudBackend {
         Box::pin(async move {
             let current = CloudBackend::get_sandbox(self, name).await?;
             let config = sandbox_config_from_cloud(&current);
+            let bindings = prepare_cloud_port_bindings(self, &config).await?;
             let cloud = CloudBackend::start_sandbox(self, name).await?;
             ensure_cloud_sandbox_ready(&cloud)?;
-            Ok(Sandbox::from_cloud(backend, cloud, config))
+            let name = cloud.name.clone();
+            Ok(Sandbox::from_cloud(backend.clone(), cloud, config)
+                .with_cloud_port_bindings(bindings.activate(backend, name)))
         })
     }
 
@@ -126,6 +163,12 @@ impl SandboxBackend for CloudBackend {
         Box::pin(async move {
             let current = CloudBackend::get_sandbox(self, name).await?;
             let config = sandbox_config_from_cloud(&current);
+            if !config.spec.network.ports.is_empty() {
+                return Err(MicrosandboxError::unsupported(
+                    Operation::SandboxStart,
+                    UnsupportedReason::ConfigField("detached cloud sandbox port mappings"),
+                ));
+            }
             let cloud = CloudBackend::start_sandbox(self, name).await?;
             ensure_cloud_sandbox_ready(&cloud)?;
             Ok(Sandbox::from_cloud(backend, cloud, config))
@@ -142,9 +185,12 @@ impl SandboxBackend for CloudBackend {
             let id = cloud_identity(identity)?;
             let current = CloudBackend::get_sandbox_by_id(self, &id).await?;
             let config = sandbox_config_from_cloud(&current);
+            let bindings = prepare_cloud_port_bindings(self, &config).await?;
             let cloud = CloudBackend::start_sandbox_by_id(self, &id).await?;
             ensure_cloud_sandbox_ready(&cloud)?;
-            Ok(Sandbox::from_cloud(backend, cloud, config))
+            let name = cloud.name.clone();
+            Ok(Sandbox::from_cloud(backend.clone(), cloud, config)
+                .with_cloud_port_bindings(bindings.activate(backend, name)))
         })
     }
 
@@ -363,15 +409,25 @@ impl TryFrom<SandboxConfig> for CloudCreateBody {
         #[cfg(feature = "net")]
         {
             // Only flag user-set opt-in fields the cloud's create contract does
-            // not accept (published ports, custom DNS resolvers, host-CA trust).
+            // not accept (UDP ports, custom DNS resolvers, host-CA trust).
             // Policy and secrets ride in the request's network section, and the
             // default `NetworkConfig` ships with a baseline policy plus built-in
             // DNS settings, so comparing those would always trigger.
             let net = config.local_network_config()?;
-            if !net.ports.is_empty() || !net.dns.nameservers.is_empty() || net.trust_host_cas {
+            if !net.dns.nameservers.is_empty() || net.trust_host_cas {
                 return Err(MicrosandboxError::unsupported(
                     Operation::SandboxCreate,
-                    UnsupportedReason::ConfigField("network ports / custom DNS / host-CA trust"),
+                    UnsupportedReason::ConfigField("custom DNS / host-CA trust"),
+                ));
+            }
+            if net
+                .ports
+                .iter()
+                .any(|port| port.protocol != microsandbox_network::config::PortProtocol::Tcp)
+            {
+                return Err(MicrosandboxError::unsupported(
+                    Operation::SandboxCreate,
+                    UnsupportedReason::ConfigField("UDP port mappings"),
                 ));
             }
         }
@@ -618,6 +674,197 @@ fn ensure_cloud_sandbox_ready(cloud: &CloudCreateSandboxResponse) -> Microsandbo
     }
 }
 
+async fn prepare_cloud_port_bindings(
+    cloud: &CloudBackend,
+    config: &SandboxConfig,
+) -> MicrosandboxResult<PreparedCloudPortBindings> {
+    let ports = &config.spec.network.ports;
+    if ports.is_empty() {
+        return Ok(PreparedCloudPortBindings {
+            listeners: Vec::new(),
+        });
+    }
+    cloud.require_cloud_tcp_ports().await?;
+
+    let mut listeners = Vec::with_capacity(ports.len());
+    for port in ports {
+        if port.protocol != microsandbox_types::PortProtocol::Tcp {
+            return Err(MicrosandboxError::unsupported(
+                Operation::SandboxCreate,
+                UnsupportedReason::ConfigField("UDP port mappings"),
+            ));
+        }
+        if port.host_port == 0 || port.guest_port == 0 {
+            return Err(MicrosandboxError::InvalidConfig(
+                "cloud TCP port mappings require non-zero host and guest ports".to_string(),
+            ));
+        }
+        let bind_ip = port
+            .host_bind
+            .parse::<std::net::IpAddr>()
+            .map_err(|error| {
+                MicrosandboxError::InvalidConfig(format!(
+                    "invalid cloud TCP bind address {:?}: {error}",
+                    port.host_bind
+                ))
+            })?;
+        let listener = TcpListener::bind((bind_ip, port.host_port))
+            .await
+            .map_err(|error| {
+                MicrosandboxError::Runtime(format!(
+                    "failed to bind cloud TCP listener {}:{}: {error}",
+                    bind_ip, port.host_port
+                ))
+            })?;
+        listeners.push((listener, port.guest_port));
+    }
+    Ok(PreparedCloudPortBindings { listeners })
+}
+
+impl PreparedCloudPortBindings {
+    fn activate(
+        self,
+        backend: Arc<dyn Backend>,
+        sandbox_name: String,
+    ) -> Option<Arc<CloudPortBindings>> {
+        if self.listeners.is_empty() {
+            return None;
+        }
+        let tasks = self
+            .listeners
+            .into_iter()
+            .map(|(listener, guest_port)| {
+                let backend = backend.clone();
+                let sandbox_name = sandbox_name.clone();
+                tokio::spawn(async move {
+                    loop {
+                        let Ok((stream, _peer)) = listener.accept().await else {
+                            break;
+                        };
+                        let backend = backend.clone();
+                        let sandbox_name = sandbox_name.clone();
+                        tokio::spawn(async move {
+                            if let Err(error) =
+                                relay_cloud_tcp(backend, &sandbox_name, stream, guest_port).await
+                            {
+                                tracing::debug!(guest_port, %error, "cloud TCP relay closed");
+                            }
+                        });
+                    }
+                })
+            })
+            .collect();
+        Some(Arc::new(CloudPortBindings { tasks }))
+    }
+}
+
+pub(crate) async fn activate_cloud_port_bindings(
+    cloud: &CloudBackend,
+    backend: Arc<dyn Backend>,
+    sandbox_name: String,
+    config: &SandboxConfig,
+) -> MicrosandboxResult<Option<Arc<CloudPortBindings>>> {
+    Ok(prepare_cloud_port_bindings(cloud, config)
+        .await?
+        .activate(backend, sandbox_name))
+}
+
+async fn relay_cloud_tcp(
+    backend: Arc<dyn Backend>,
+    sandbox_name: &str,
+    mut socket: TcpStream,
+    guest_port: u16,
+) -> MicrosandboxResult<()> {
+    let client = Arc::new(
+        backend
+            .dial_agent(sandbox_name, Duration::from_secs(10))
+            .await?,
+    );
+    if !client.supports(MessageType::TcpConnect) {
+        return Err(MicrosandboxError::Runtime(
+            "sandbox runtime does not support TCP relay".to_string(),
+        ));
+    }
+    let (id, mut inbound) = client
+        .stream(
+            MessageType::TcpConnect,
+            &TcpConnect {
+                host: "127.0.0.1".to_string(),
+                port: guest_port,
+            },
+        )
+        .await?;
+    let first = inbound.recv().await.ok_or_else(|| {
+        MicrosandboxError::Runtime("sandbox TCP relay closed during connect".to_string())
+    })?;
+    match first.t {
+        MessageType::TcpConnected => {
+            let _: TcpConnected = first.payload()?;
+        }
+        MessageType::TcpFailed => {
+            let failed: TcpFailed = first.payload()?;
+            return Err(MicrosandboxError::Runtime(format!(
+                "sandbox TCP connect failed: {}",
+                failed.error
+            )));
+        }
+        other => {
+            return Err(MicrosandboxError::Runtime(format!(
+                "sandbox TCP relay returned unexpected {}",
+                other.as_str()
+            )));
+        }
+    }
+
+    let mut buffer = vec![0_u8; 64 * 1024];
+    let mut local_eof = false;
+    loop {
+        tokio::select! {
+            read = socket.read(&mut buffer), if !local_eof => {
+                match read {
+                    Ok(0) => {
+                        client.send(id, MessageType::TcpEof, &TcpEof {}).await?;
+                        local_eof = true;
+                    }
+                    Ok(count) => client.send(
+                        id,
+                        MessageType::TcpData,
+                        &TcpData { data: buffer[..count].to_vec() },
+                    ).await?,
+                    Err(error) => return Err(error.into()),
+                }
+            }
+            message = inbound.recv() => {
+                let Some(message) = message else { break };
+                match message.t {
+                    MessageType::TcpData => {
+                        let data: TcpData = message.payload()?;
+                        socket.write_all(&data.data).await?;
+                    }
+                    MessageType::TcpEof => {
+                        let _: TcpEof = message.payload()?;
+                        socket.shutdown().await?;
+                    }
+                    MessageType::TcpClosed => {
+                        let _: TcpClosed = message.payload()?;
+                        break;
+                    }
+                    MessageType::TcpFailed => {
+                        let failed: TcpFailed = message.payload()?;
+                        return Err(MicrosandboxError::Runtime(format!(
+                            "sandbox TCP relay failed: {}",
+                            failed.error
+                        )));
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+    let _ = client.send(id, MessageType::TcpClose, &TcpClose {}).await;
+    Ok(())
+}
+
 /// Build the best available runtime config for a sandbox the SDK did not
 /// create itself.
 ///
@@ -671,6 +918,68 @@ mod tests {
     use super::*;
     use crate::backend::{Backend, SandboxBackend};
     use crate::sandbox::{EnvVar, OciRootfsSource, RootDisk, SandboxBuilder, SandboxSpec};
+
+    #[tokio::test]
+    async fn cloud_bind_conflict_fails_before_remote_create() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        let occupied = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let occupied_port = occupied.local_addr().unwrap().port();
+        let api = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let api_address = api.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (mut socket, _) = api.accept().await.unwrap();
+            let mut request = Vec::new();
+            let mut chunk = [0_u8; 1024];
+            while !request.windows(4).any(|window| window == b"\r\n\r\n") {
+                let count = socket.read(&mut chunk).await.unwrap();
+                request.extend_from_slice(&chunk[..count]);
+            }
+            assert!(
+                String::from_utf8(request)
+                    .unwrap()
+                    .starts_with("GET /v1/capabilities ")
+            );
+            let body = r#"{"billing_enabled":false,"cloud_tcp_ports":true}"#;
+            socket
+                .write_all(
+                    format!(
+                        "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+                        body.len(), body
+                    )
+                    .as_bytes(),
+                )
+                .await
+                .unwrap();
+            assert!(
+                tokio::time::timeout(Duration::from_millis(200), api.accept())
+                    .await
+                    .is_err(),
+                "bind failure must prevent POST /v1/sandboxes"
+            );
+        });
+
+        let backend =
+            Arc::new(CloudBackend::new(format!("http://{api_address}"), "test-key").unwrap());
+        let backend_dyn: Arc<dyn Backend> = backend.clone();
+        let mut config = base_cloud_config();
+        config
+            .spec
+            .network
+            .ports
+            .push(microsandbox_types::PublishedPortSpec {
+                host_port: occupied_port,
+                guest_port: 8080,
+                protocol: microsandbox_types::PortProtocol::Tcp,
+                host_bind: "127.0.0.1".to_string(),
+            });
+        let error = match backend.create(backend_dyn, config, true).await {
+            Ok(_) => panic!("occupied listener must fail cloud create"),
+            Err(error) => error,
+        };
+        assert!(matches!(error, MicrosandboxError::Runtime(_)));
+        server.await.unwrap();
+    }
 
     #[tokio::test]
     async fn cloud_boot_error_is_absent_until_the_api_exposes_diagnostics() {
@@ -1150,7 +1459,7 @@ mod tests {
 
     #[cfg(feature = "net")]
     #[test]
-    fn cloud_create_request_rejects_published_ports() {
+    fn cloud_create_request_accepts_tcp_ports_and_rejects_udp() {
         let mut config = base_cloud_config();
         config
             .spec
@@ -1162,6 +1471,9 @@ mod tests {
                 protocol: microsandbox_types::PortProtocol::Tcp,
                 host_bind: std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST).to_string(),
             });
+        let req = CloudCreateBody::try_from(config.clone()).unwrap();
+        assert_eq!(req.envelope.spec.network.ports.len(), 1);
+        config.spec.network.ports[0].protocol = microsandbox_types::PortProtocol::Udp;
         let err = CloudCreateBody::try_from(config).unwrap_err();
         assert!(matches!(err, MicrosandboxError::Unsupported { .. }));
     }

--- a/sdk/rust/lib/backend/cloud/sandbox.rs
+++ b/sdk/rust/lib/backend/cloud/sandbox.rs
@@ -12,6 +12,7 @@ use microsandbox_protocol::{
 };
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
+use tokio::sync::watch;
 
 use super::CloudBackend;
 use crate::backend::{
@@ -77,6 +78,7 @@ pub(in crate::backend) enum CloudRegistrySelection {
 /// tasks and deliberately leaves the remote sandbox running.
 pub(crate) struct CloudPortBindings {
     tasks: Vec<tokio::task::JoinHandle<()>>,
+    cancellation: watch::Sender<bool>,
 }
 
 struct PreparedCloudPortBindings {
@@ -85,6 +87,7 @@ struct PreparedCloudPortBindings {
 
 impl Drop for CloudPortBindings {
     fn drop(&mut self) {
+        let _ = self.cancellation.send(true);
         for task in &self.tasks {
             task.abort();
         }
@@ -730,31 +733,42 @@ impl PreparedCloudPortBindings {
         if self.listeners.is_empty() {
             return None;
         }
+        let (cancellation, _) = watch::channel(false);
         let tasks = self
             .listeners
             .into_iter()
             .map(|(listener, guest_port)| {
                 let backend = backend.clone();
                 let sandbox_name = sandbox_name.clone();
+                let mut listener_cancellation = cancellation.subscribe();
                 tokio::spawn(async move {
                     loop {
-                        let Ok((stream, _peer)) = listener.accept().await else {
-                            break;
+                        let accepted = tokio::select! {
+                            accepted = listener.accept() => accepted,
+                            _ = listener_cancellation.changed() => break,
                         };
+                        let Ok((stream, _peer)) = accepted else { break };
                         let backend = backend.clone();
                         let sandbox_name = sandbox_name.clone();
+                        let mut relay_cancellation = listener_cancellation.clone();
                         tokio::spawn(async move {
-                            if let Err(error) =
-                                relay_cloud_tcp(backend, &sandbox_name, stream, guest_port).await
-                            {
-                                tracing::debug!(guest_port, %error, "cloud TCP relay closed");
+                            tokio::select! {
+                                result = relay_cloud_tcp(backend, &sandbox_name, stream, guest_port) => {
+                                    if let Err(error) = result {
+                                        tracing::debug!(guest_port, %error, "cloud TCP relay closed");
+                                    }
+                                }
+                                _ = relay_cancellation.changed() => {}
                             }
                         });
                     }
                 })
             })
             .collect();
-        Some(Arc::new(CloudPortBindings { tasks }))
+        Some(Arc::new(CloudPortBindings {
+            tasks,
+            cancellation,
+        }))
     }
 }
 
@@ -818,6 +832,7 @@ async fn relay_cloud_tcp(
 
     let mut buffer = vec![0_u8; 64 * 1024];
     let mut local_eof = false;
+    let mut remote_eof = false;
     loop {
         tokio::select! {
             read = socket.read(&mut buffer), if !local_eof => {
@@ -825,6 +840,9 @@ async fn relay_cloud_tcp(
                     Ok(0) => {
                         client.send(id, MessageType::TcpEof, &TcpEof {}).await?;
                         local_eof = true;
+                        if remote_eof {
+                            break;
+                        }
                     }
                     Ok(count) => client.send(
                         id,
@@ -844,6 +862,10 @@ async fn relay_cloud_tcp(
                     MessageType::TcpEof => {
                         let _: TcpEof = message.payload()?;
                         socket.shutdown().await?;
+                        remote_eof = true;
+                        if local_eof {
+                            break;
+                        }
                     }
                     MessageType::TcpClosed => {
                         let _: TcpClosed = message.payload()?;

--- a/sdk/rust/lib/backend/cloud/sandbox.rs
+++ b/sdk/rust/lib/backend/cloud/sandbox.rs
@@ -745,7 +745,7 @@ impl PreparedCloudPortBindings {
                     loop {
                         let accepted = tokio::select! {
                             accepted = listener.accept() => accepted,
-                            _ = listener_cancellation.changed() => break,
+                            _ = listener_cancellation.wait_for(|cancelled| *cancelled) => break,
                         };
                         let Ok((stream, _peer)) = accepted else { break };
                         let backend = backend.clone();
@@ -758,7 +758,7 @@ impl PreparedCloudPortBindings {
                                         tracing::debug!(guest_port, %error, "cloud TCP relay closed");
                                     }
                                 }
-                                _ = relay_cancellation.changed() => {}
+                                _ = relay_cancellation.wait_for(|cancelled| *cancelled) => {}
                             }
                         });
                     }

--- a/sdk/rust/lib/backend/mod.rs
+++ b/sdk/rust/lib/backend/mod.rs
@@ -27,6 +27,7 @@ mod profile;
 pub(crate) mod sandbox;
 pub(crate) mod volume;
 
+pub(crate) use cloud::sandbox::{CloudPortBindings, activate_cloud_port_bindings};
 pub use cloud::{CloudBackend, CloudBackendBuilder, DEFAULT_CLOUD_API_URL};
 use futures::future::BoxFuture;
 pub use local::{LocalBackend, LocalBackendBuilder};
@@ -177,6 +178,12 @@ pub trait Backend: Send + Sync + 'static {
     /// paths) without keeping a separate `Arc<LocalBackend>` alongside the
     /// `Arc<dyn Backend>`. Returns `None` for cloud backends.
     fn as_local(&self) -> Option<&LocalBackend> {
+        None
+    }
+
+    /// Try downcast to the built-in cloud backend for cloud-only transport
+    /// setup such as SDK-owned TCP listeners.
+    fn as_cloud(&self) -> Option<&CloudBackend> {
         None
     }
 

--- a/sdk/rust/lib/sandbox/handle.rs
+++ b/sdk/rust/lib/sandbox/handle.rs
@@ -578,6 +578,18 @@ impl SandboxHandle {
                     ))
                 })?;
 
+                let bindings = crate::backend::activate_cloud_port_bindings(
+                    self.backend.as_cloud().ok_or_else(|| {
+                        MicrosandboxError::Runtime(
+                            "cloud handle has a non-cloud backend".to_string(),
+                        )
+                    })?,
+                    self.backend.clone(),
+                    self.name.clone(),
+                    &config,
+                )
+                .await?;
+
                 Ok(Sandbox::from_cloud_state(
                     self.backend.clone(),
                     SandboxCloudState {
@@ -587,7 +599,8 @@ impl SandboxHandle {
                     },
                     self.name.clone(),
                     config,
-                ))
+                )
+                .with_cloud_port_bindings(bindings))
             }
         }
     }

--- a/sdk/rust/lib/sandbox/mod.rs
+++ b/sdk/rust/lib/sandbox/mod.rs
@@ -208,6 +208,7 @@ pub struct Sandbox {
     inner: Arc<crate::backend::SandboxInner>,
     name: String,
     config: SandboxConfig,
+    _cloud_port_bindings: Option<Arc<crate::backend::CloudPortBindings>>,
 }
 
 /// Result of observing a sandbox in a terminal non-running state.
@@ -476,6 +477,7 @@ impl Sandbox {
             inner: Arc::new(crate::backend::SandboxInner::Local(local)),
             name: config.spec.name.clone(),
             config,
+            _cloud_port_bindings: None,
         }
     }
 
@@ -509,7 +511,16 @@ impl Sandbox {
             inner: Arc::new(crate::backend::SandboxInner::Cloud(state)),
             name,
             config,
+            _cloud_port_bindings: None,
         }
+    }
+
+    pub(crate) fn with_cloud_port_bindings(
+        mut self,
+        bindings: Option<Arc<crate::backend::CloudPortBindings>>,
+    ) -> Self {
+        self._cloud_port_bindings = bindings;
+        self
     }
 }
 


### PR DESCRIPTION
## Summary

- add TCP port declarations to the cloud sandbox contract
- bind SDK listeners before remote lifecycle mutations and relay connections through the authenticated sandbox agent
- restore declared listeners on start and reconnect while keeping them scoped to the SDK handle lifetime
- resume cloud log streams from the last cursor after retriable disconnects and deduplicate replayed events

UDP and detached cloud sandboxes with port mappings return typed unsupported errors. Older cloud deployments remain compatible through capability negotiation.