### PR TITLE
fix(build): detect native Linux musl target

### DIFF
--- a/justfile
+++ b/justfile
@@ -87,11 +87,29 @@ build-deps: build-agentd build-libkrunfw
 # Build agentd as a static Linux/musl binary. Requires: musl-tools (apt) or musl-dev (apk).
 [linux]
 build-agentd:
-    @command -v musl-gcc >/dev/null || { echo "error: musl-gcc not found. Install your distro's musl toolchain."; exit 1; }
-    rustup target add x86_64-unknown-linux-musl 2>/dev/null || true
-    cargo build --release --manifest-path crates/agentd/Cargo.toml --target-dir target --target x86_64-unknown-linux-musl
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    command -v musl-gcc >/dev/null || {
+        echo "error: musl-gcc not found. Install your distro's musl toolchain."
+        exit 1
+    }
+
+    # Derive the musl target from Rust's host triple instead of maintaining an
+    # architecture allowlist. This keeps local builds aligned with every
+    # Linux target supported by the installed Rust toolchain (x86_64, ARM64,
+    # riscv64, and future targets), while still using the native compiler.
+    host="$(rustc -vV | sed -n 's/^host: //p')"
+    target="${host/-unknown-linux-gnu/-unknown-linux-musl}"
+    if [ "$target" = "$host" ]; then
+        echo "error: cannot derive a Linux musl target from Rust host '$host'"
+        exit 1
+    fi
+
+    rustup target add "$target"
+    cargo build --release --manifest-path crates/agentd/Cargo.toml --target-dir target --target "$target"
     mkdir -p build
-    cp target/x86_64-unknown-linux-musl/release/agentd build/agentd
+    cp "target/$target/release/agentd" build/agentd
     touch build/agentd
 
 # Build agentd as a static Linux/musl binary via Docker cross-compilation. Requires: docker.

--- a/justfile
+++ b/justfile
@@ -100,11 +100,18 @@ build-agentd:
     # Linux target supported by the installed Rust toolchain (x86_64, ARM64,
     # riscv64, and future targets), while still using the native compiler.
     host="$(rustc -vV | sed -n 's/^host: //p')"
-    target="${host/-unknown-linux-gnu/-unknown-linux-musl}"
-    if [ "$target" = "$host" ]; then
-        echo "error: cannot derive a Linux musl target from Rust host '$host'"
-        exit 1
-    fi
+    case "$host" in
+        *-unknown-linux-gnu)
+            target="${host/-unknown-linux-gnu/-unknown-linux-musl}"
+            ;;
+        *-unknown-linux-musl)
+            target="$host"
+            ;;
+        *)
+            echo "error: cannot derive a Linux musl target from Rust host '$host'"
+            exit 1
+            ;;
+    esac
 
     rustup target add "$target"
     cargo build --release --manifest-path crates/agentd/Cargo.toml --target-dir target --target "$target"

--- a/justfile
+++ b/justfile
@@ -90,11 +90,6 @@ build-agentd:
     #!/usr/bin/env bash
     set -euo pipefail
 
-    command -v musl-gcc >/dev/null || {
-        echo "error: musl-gcc not found. Install your distro's musl toolchain."
-        exit 1
-    }
-
     # Derive the musl target from Rust's host triple instead of maintaining an
     # architecture allowlist. This keeps local builds aligned with every
     # Linux target supported by the installed Rust toolchain (x86_64, ARM64,
@@ -112,6 +107,13 @@ build-agentd:
             exit 1
             ;;
     esac
+
+    # Native musl hosts already have a suitable system compiler. GNU hosts
+    # need the musl wrapper to link the cross-libc target.
+    if [ "$target" != "$host" ] && ! command -v musl-gcc >/dev/null; then
+        echo "error: musl-gcc not found. Install your distro's musl toolchain."
+        exit 1
+    fi
 
     rustup target add "$target"
     cargo build --release --manifest-path crates/agentd/Cargo.toml --target-dir target --target "$target"


### PR DESCRIPTION
## Summary

The Linux `just build-agentd` recipe hard-coded `x86_64-unknown-linux-musl`. On ARM64 Linux hosts such as Kunpeng 920, Cargo invoked the native AArch64 compiler with `-m64`, causing linking to fail.

Derive the musl target from Rust's host triple so native Linux builds select the matching architecture without a fixed allowlist. Unknown host triples fail with a clear diagnostic.

## Test plan

- `just --dry-run build-agentd`
- `just build-agentd` on `aarch64-unknown-linux-gnu` (passes)
- `git diff --check`

The local commit could not be GPG-signed because the configured signing key is unavailable in this environment.