### PR TITLE
docs: mention optional coding-agent host-shell hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@
 - <img height="14" src="https://octicons-col.vercel.app/plug/A770EF"> **Embeddable**: Spawn VMs right within your code. No setup server. No long-running daemon.
 - <img height="14" src="https://octicons-col.vercel.app/lock/A770EF"> **Secrets That Can't Leak**: Unexploitable secret keys that never enter the VM.
 - <img height="14" src="https://octicons-col.vercel.app/database/A770EF"> **Long-Running**: Sandboxes can run in detached mode. Great for long-lived sessions.
-- <img height="14" src="https://octicons-col.vercel.app/terminal/A770EF"> **Agent-Ready**: Your agents can create their own sandboxes with our [Agent Skills](https://github.com/superradcompany/skills) and [MCP server](https://github.com/superradcompany/microsandbox-mcp).
+- <img height="14" src="https://octicons-col.vercel.app/terminal/A770EF"> **Agent-Ready**: Your agents can create their own sandboxes with our [Agent Skills](https://github.com/superradcompany/skills), [MCP server](https://github.com/superradcompany/microsandbox-mcp), and optional host-shell hooks (skills repo; not auto-installed).
 
 <br />
 
@@ -412,6 +412,12 @@ Practical ways to put microsandbox to work:
 > # Claude Code
 > claude mcp add --transport stdio microsandbox -- npx -y microsandbox-mcp
 > ```
+
+#### <img height="14" src="https://octicons-col.vercel.app/shield-lock/A770EF">&nbsp;&nbsp;Optional host-shell hooks
+
+> MCP-only clients do not need this. Coding agents that still have a **host shell** can attach an optional PreToolUse-style hook so `apt` / `brew` / `npm -g` on the workstation is denied unless wrapped in `msb run` / `msb exec`.
+>
+> The hook pack lives in the [skills](https://github.com/superradcompany/skills) repo and is **not** auto-installed. Guest bootstrap / `--init` stays a separate mechanism.
 
 <br />
 

--- a/README.md
+++ b/README.md
@@ -444,7 +444,7 @@ Practical ways to put microsandbox to work:
 
 #### <img height="14" src="https://octicons-col.vercel.app/shield-lock/A770EF">&nbsp;&nbsp;Optional host-shell hooks
 
-> MCP-only clients do not need this. Coding agents that still have a **host shell** can attach an optional PreToolUse-style hook so `apt` / `brew` / `npm -g` on the workstation is denied unless wrapped in `msb run` / `msb exec`.
+> MCP-only clients do not need this. Coding agents that still have a **host shell** can attach an optional PreToolUse-style hook so `apt install` / `brew install` / `npm install -g` on the workstation is denied unless wrapped in `msb run` / `msb exec`.
 >
 > The hook pack lives in the [skills](https://github.com/superradcompany/skills) repo and is **not** auto-installed. Guest bootstrap / `--init` stays a separate mechanism.
 


### PR DESCRIPTION
Fixes #1419. Optional PreToolUse-style hooks next to Skills and MCP. Not auto-installed.











<!-- greptile_comment -->

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<sub>Reviews (6): Last reviewed commit: ["Merge branch &#39;main&#39; into docs/agent-hook..."](https://github.com/superradcompany/microsandbox/commit/ab3ac9b141c4034284ec3d02aa15ded191ff2004) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59460078)</sub>

<!-- /greptile_comment -->