### PR TITLE
docs(readme): expand community ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,10 +415,11 @@ Practical ways to put microsandbox to work:
 
 <br />
 
-## <a href="./#gh-dark-mode-only" target="_blank"><img height="18" src="https://octicons-col.vercel.app/people/ffffff" alt="people-dark"></a><a href="./#gh-light-mode-only" target="_blank"><img height="18" src="https://octicons-col.vercel.app/people/000000" alt="people"></a>&nbsp;&nbsp;Projects using microsandbox
+## <a href="./#gh-dark-mode-only" target="_blank"><img height="18" src="https://octicons-col.vercel.app/people/ffffff" alt="people-dark"></a><a href="./#gh-light-mode-only" target="_blank"><img height="18" src="https://octicons-col.vercel.app/people/000000" alt="people"></a>&nbsp;&nbsp;Community ecosystem
 
 > ⏵ **[Eve by Vercel](https://eve.dev/docs/sandbox#microsandbox)**<br />
-> ⏵ **[GSA TTS Agentic Coding Quickstart](https://github.com/GSA-TTS/agentic-coding-quickstart)**<br />
+> ⏵ **[Awesome Microsandbox](https://github.com/ya-luotao/awesome-microsandbox)**<br />
+> ⏵ **[U.S. GSA — Agentic Coding Quickstart](https://github.com/GSA-TTS/agentic-coding-quickstart)**<br />
 > ⏵ **[agent-compose by Chaitin](https://github.com/chaitin/agent-compose)**<br />
 > ⏵ **[Condukt](https://github.com/tuist/condukt) and [Once](https://github.com/tuist/once) by Tuist**<br />
 > ⏵ **[h5i](https://github.com/h5i-dev/h5i)**<br />
@@ -426,9 +427,10 @@ Practical ways to put microsandbox to work:
 > ⏵ **[sandboxed-lit by LlamaIndex](https://github.com/run-llama/sandboxed-lit)**<br />
 > ⏵ **[Agentic Usability by PSPDFKit Labs](https://github.com/PSPDFKit-labs/agentic-usability)**<br />
 > ⏵ **[Agent VM by Wiren Board](https://github.com/wirenboard/agent-vm)**<br />
-> ⏵ **[Devsy](https://github.com/devsy-org/devsy)**
+> ⏵ **[Devsy](https://github.com/devsy-org/devsy)**<br />
+> ⏵ **[msb-omarchy](https://github.com/ya-luotao/msb-omarchy)**
 
-> Built something with microsandbox? [Share it with us on Discord](https://discord.gg/T95Y3XnEAK). We’d love to feature it here.
+<a href="https://discord.gg/T95Y3XnEAK"><img src="https://img.shields.io/badge/Share_a_Project-%E2%86%92-A770EF?style=flat-square&labelColor=2b2b2b" alt="Share a Project"></a>
 
 <br />
 


### PR DESCRIPTION
## TL;DR
Broaden the README community section with two community resources, clearer GSA attribution, and a compact project submission link.

## Description
- Rename the projects section to Community ecosystem to reflect its broader scope.
- Add Awesome Microsandbox and msb-omarchy to the existing community list.
- Identify the Agentic Coding Quickstart as a U.S. GSA resource.
- Replace the Discord sentence with a compact Share a Project badge.

## Test Plan
- [x] `git diff --check origin/main..HEAD` passes
- [x] `gh api repos/ya-luotao/awesome-microsandbox --jq .html_url` resolves the community index
- [x] `gh api repos/ya-luotao/msb-omarchy --jq .html_url` resolves the project
- [x] `gh api repos/GSA-TTS/agentic-coding-quickstart --jq .html_url` resolves the government guide


<!-- greptile_comment -->

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The documentation-only change appears safe to merge.

The updated README markup follows existing badge and list conventions, and the PR test plan confirms the newly added external resources resolve.
</details>

<sub>Reviews (1): Last reviewed commit: ["docs(readme): expand community ecosystem"](https://github.com/superradcompany/microsandbox/commit/feefa76030348e1177599eb741e4b1b85279ab57) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59723835)</sub>

<!-- /greptile_comment -->