### PR TITLE
docs(readme): organize community showcase

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,12 +398,12 @@ Practical ways to put microsandbox to work:
 
 #### <img height="14" src="https://octicons-col.vercel.app/hubot/A770EF">&nbsp;&nbsp;Agent frameworks & runtimes
 
-> • <img height="14" src="https://octicons-col.vercel.app/workflow/A770EF"> **[Eve by Vercel](https://eve.dev/docs/sandbox#microsandbox)**: Agent framework that ships microsandbox as a sandbox backend.<br />
+> • <img height="14" src="https://octicons-col.vercel.app/workflow/A770EF"> **[Eve](https://eve.dev/docs/sandbox#microsandbox) by Vercel**: Agent framework that ships microsandbox as a sandbox backend.<br />
 > • <img height="14" src="https://octicons-col.vercel.app/package/A770EF"> **[Condukt](https://github.com/tuist/condukt) and [Once](https://github.com/tuist/once) by Tuist**: Elixir agentic engine, and cacheable actions that run in fresh sandboxes.<br />
 > • <img height="14" src="https://octicons-col.vercel.app/stack/A770EF"> **[agent-compose by Chaitin](https://github.com/chaitin/agent-compose)**: docker-compose-style daemon for orchestrating agents.<br />
 > • <img height="14" src="https://octicons-col.vercel.app/history/A770EF"> **[Smithers](https://github.com/smithersai/smithers)**: Agent workflows with full observability, rewind, fork, and replay.<br />
 > • <img height="14" src="https://octicons-col.vercel.app/terminal/A770EF"> **[wrap](https://github.com/tobi/wrap) by Tobi Lütke**: Run coding agents and project commands in isolated Arch Linux microVMs.<br />
-> • <img height="14" src="https://octicons-col.vercel.app/shield-lock/A770EF"> **[Agent VM by Wiren Board](https://github.com/wirenboard/agent-vm)**: Run AI agents in safe VMs scoped to a local folder.
+> • <img height="14" src="https://octicons-col.vercel.app/shield-lock/A770EF"> **[Agent VM](https://github.com/wirenboard/agent-vm) by Wiren Board**: Run AI agents in safe VMs scoped to a local folder.
 
 #### <img height="14" src="https://octicons-col.vercel.app/cpu/A770EF">&nbsp;&nbsp;Tools & infrastructure
 

--- a/README.md
+++ b/README.md
@@ -400,7 +400,7 @@ Practical ways to put microsandbox to work:
 
 > • <img height="14" src="https://octicons-col.vercel.app/workflow/A770EF"> **[Eve](https://eve.dev/docs/sandbox#microsandbox) by Vercel**: Agent framework that ships microsandbox as a sandbox backend.<br />
 > • <img height="14" src="https://octicons-col.vercel.app/package/A770EF"> **[Condukt](https://github.com/tuist/condukt) and [Once](https://github.com/tuist/once) by Tuist**: Elixir agentic engine, and cacheable actions that run in fresh sandboxes.<br />
-> • <img height="14" src="https://octicons-col.vercel.app/stack/A770EF"> **[agent-compose](https://github.com/chaitin/agent-compose) by Chaitin**: docker-compose-style daemon for orchestrating agents.<br />
+> • <img height="14" src="https://octicons-col.vercel.app/link/A770EF"> **[langchain-microsandbox](https://github.com/kenwoodjw/langchain-microsandbox) by kenwoodjw**: Microsandbox integration for LangChain Deep Agents.<br />
 > • <img height="14" src="https://octicons-col.vercel.app/history/A770EF"> **[Smithers](https://github.com/smithersai/smithers) by Smithers**: Agent workflows with full observability, rewind, fork, and replay.<br />
 > • <img height="14" src="https://octicons-col.vercel.app/terminal/A770EF"> **[wrap](https://github.com/tobi/wrap) by Tobi Lütke**: Run coding agents and project commands in isolated Arch Linux microVMs.<br />
 > • <img height="14" src="https://octicons-col.vercel.app/shield-lock/A770EF"> **[Agent VM](https://github.com/wirenboard/agent-vm) by Wiren Board**: Run AI agents in safe VMs scoped to a local folder.

--- a/README.md
+++ b/README.md
@@ -394,7 +394,7 @@ Practical ways to put microsandbox to work:
 
 <br />
 
-## <a href="./#gh-dark-mode-only" target="_blank"><img height="18" src="https://octicons-col.vercel.app/people/ffffff" alt="people-dark"></a><a href="./#gh-light-mode-only" target="_blank"><img height="18" src="https://octicons-col.vercel.app/people/000000" alt="people"></a>&nbsp;&nbsp;Community ecosystem
+## <a href="./#gh-dark-mode-only" target="_blank"><img height="18" src="https://octicons-col.vercel.app/people/ffffff" alt="people-dark"></a><a href="./#gh-light-mode-only" target="_blank"><img height="18" src="https://octicons-col.vercel.app/people/000000" alt="people"></a>&nbsp;&nbsp;Community Showcase
 
 #### <img height="14" src="https://octicons-col.vercel.app/hubot/A770EF">&nbsp;&nbsp;Agent frameworks & runtimes
 

--- a/README.md
+++ b/README.md
@@ -401,6 +401,7 @@ Practical ways to put microsandbox to work:
 > • <img height="14" src="https://octicons-col.vercel.app/workflow/A770EF"> **[Eve](https://eve.dev/docs/sandbox#microsandbox) by Vercel**: Agent framework that ships microsandbox as a sandbox backend.<br />
 > • <img height="14" src="https://octicons-col.vercel.app/package/A770EF"> **[Condukt](https://github.com/tuist/condukt) and [Once](https://github.com/tuist/once) by Tuist**: Elixir agentic engine, and cacheable actions that run in fresh sandboxes.<br />
 > • <img height="14" src="https://octicons-col.vercel.app/link/A770EF"> **[langchain-microsandbox](https://github.com/kenwoodjw/langchain-microsandbox) by kenwoodjw**: Microsandbox integration for LangChain Deep Agents.<br />
+> • <img height="14" src="https://octicons-col.vercel.app/organization/A770EF"> **[Agentic Coding Quickstart](https://github.com/GSA-TTS/agentic-coding-quickstart) by U.S. GSA**: From zero to a running AI coding agent with USAi in minutes.<br />
 > • <img height="14" src="https://octicons-col.vercel.app/history/A770EF"> **[Smithers](https://github.com/smithersai/smithers) by Smithers**: Agent workflows with full observability, rewind, fork, and replay.<br />
 > • <img height="14" src="https://octicons-col.vercel.app/terminal/A770EF"> **[wrap](https://github.com/tobi/wrap) by Tobi Lütke**: Run coding agents and project commands in isolated Arch Linux microVMs.<br />
 > • <img height="14" src="https://octicons-col.vercel.app/shield-lock/A770EF"> **[Agent VM](https://github.com/wirenboard/agent-vm) by Wiren Board**: Run AI agents in safe VMs scoped to a local folder.
@@ -414,7 +415,6 @@ Practical ways to put microsandbox to work:
 #### <img height="14" src="https://octicons-col.vercel.app/list-unordered/A770EF">&nbsp;&nbsp;Guides & showcases
 
 > • <img height="14" src="https://octicons-col.vercel.app/list-unordered/A770EF"> **[Awesome Microsandbox](https://github.com/ya-luotao/awesome-microsandbox) by luotao**: Curated list of SDKs, integrations, tools, and resources.<br />
-> • <img height="14" src="https://octicons-col.vercel.app/organization/A770EF"> **[Agentic Coding Quickstart](https://github.com/GSA-TTS/agentic-coding-quickstart) by U.S. GSA**: From zero to a running AI coding agent with USAi in minutes.<br />
 > • <img height="14" src="https://octicons-col.vercel.app/device-desktop/A770EF"> **[msb-omarchy](https://github.com/ya-luotao/msb-omarchy) by luotao**: Omarchy desktop with graphics inside a microVM on Apple Silicon.
 
 <br />

--- a/README.md
+++ b/README.md
@@ -399,9 +399,9 @@ Practical ways to put microsandbox to work:
 #### <img height="14" src="https://octicons-col.vercel.app/hubot/A770EF">&nbsp;&nbsp;Agent frameworks & runtimes
 
 > • <img height="14" src="https://octicons-col.vercel.app/workflow/A770EF"> **[Eve](https://eve.dev/docs/sandbox#microsandbox) by Vercel**: Agent framework that ships microsandbox as a sandbox backend.<br />
+> • <img height="14" src="https://octicons-col.vercel.app/organization/A770EF"> **[Agentic Coding Quickstart](https://github.com/GSA-TTS/agentic-coding-quickstart) by U.S. GSA**: From zero to a running AI coding agent with USAi in minutes.<br />
 > • <img height="14" src="https://octicons-col.vercel.app/package/A770EF"> **[Condukt](https://github.com/tuist/condukt) and [Once](https://github.com/tuist/once) by Tuist**: Elixir agentic engine, and cacheable actions that run in fresh sandboxes.<br />
 > • <img height="14" src="https://octicons-col.vercel.app/link/A770EF"> **[langchain-microsandbox](https://github.com/kenwoodjw/langchain-microsandbox) by kenwoodjw**: Microsandbox integration for LangChain Deep Agents.<br />
-> • <img height="14" src="https://octicons-col.vercel.app/organization/A770EF"> **[Agentic Coding Quickstart](https://github.com/GSA-TTS/agentic-coding-quickstart) by U.S. GSA**: From zero to a running AI coding agent with USAi in minutes.<br />
 > • <img height="14" src="https://octicons-col.vercel.app/history/A770EF"> **[Smithers](https://github.com/smithersai/smithers) by Smithers**: Agent workflows with full observability, rewind, fork, and replay.<br />
 > • <img height="14" src="https://octicons-col.vercel.app/terminal/A770EF"> **[wrap](https://github.com/tobi/wrap) by Tobi Lütke**: Run coding agents and project commands in isolated Arch Linux microVMs.<br />
 > • <img height="14" src="https://octicons-col.vercel.app/shield-lock/A770EF"> **[Agent VM](https://github.com/wirenboard/agent-vm) by Wiren Board**: Run AI agents in safe VMs scoped to a local folder.
@@ -410,7 +410,7 @@ Practical ways to put microsandbox to work:
 
 > • <img height="14" src="https://octicons-col.vercel.app/browser/A770EF"> **[h5i](https://github.com/h5i-dev/h5i) by h5i**: Secure, auditable browser for AI agents, written in pure Rust.<br />
 > • <img height="14" src="https://octicons-col.vercel.app/cloud/A770EF"> **[Devsy](https://github.com/devsy-org/devsy) by Devsy**: Deploy devcontainers onto any cloud, Kubernetes cluster, or Docker host.<br />
-> • <img height="14" src="https://octicons-col.vercel.app/briefcase/A770EF"> **[OpenWork](https://github.com/different-ai/openwork) by Different AI**: Open-source alternative to Claude Cowork, with a ready-made microsandbox image.
+> • <img height="14" src="https://octicons-col.vercel.app/briefcase/A770EF"> **[OpenWork](https://github.com/different-ai/openwork) by Different AI**: Open-source Claude Cowork alternative with a microsandbox image.
 
 #### <img height="14" src="https://octicons-col.vercel.app/list-unordered/A770EF">&nbsp;&nbsp;Guides & showcases
 

--- a/README.md
+++ b/README.md
@@ -400,22 +400,22 @@ Practical ways to put microsandbox to work:
 
 > • <img height="14" src="https://octicons-col.vercel.app/workflow/A770EF"> **[Eve](https://eve.dev/docs/sandbox#microsandbox) by Vercel**: Agent framework that ships microsandbox as a sandbox backend.<br />
 > • <img height="14" src="https://octicons-col.vercel.app/package/A770EF"> **[Condukt](https://github.com/tuist/condukt) and [Once](https://github.com/tuist/once) by Tuist**: Elixir agentic engine, and cacheable actions that run in fresh sandboxes.<br />
-> • <img height="14" src="https://octicons-col.vercel.app/stack/A770EF"> **[agent-compose by Chaitin](https://github.com/chaitin/agent-compose)**: docker-compose-style daemon for orchestrating agents.<br />
-> • <img height="14" src="https://octicons-col.vercel.app/history/A770EF"> **[Smithers](https://github.com/smithersai/smithers)**: Agent workflows with full observability, rewind, fork, and replay.<br />
+> • <img height="14" src="https://octicons-col.vercel.app/stack/A770EF"> **[agent-compose](https://github.com/chaitin/agent-compose) by Chaitin**: docker-compose-style daemon for orchestrating agents.<br />
+> • <img height="14" src="https://octicons-col.vercel.app/history/A770EF"> **[Smithers](https://github.com/smithersai/smithers) by Smithers**: Agent workflows with full observability, rewind, fork, and replay.<br />
 > • <img height="14" src="https://octicons-col.vercel.app/terminal/A770EF"> **[wrap](https://github.com/tobi/wrap) by Tobi Lütke**: Run coding agents and project commands in isolated Arch Linux microVMs.<br />
 > • <img height="14" src="https://octicons-col.vercel.app/shield-lock/A770EF"> **[Agent VM](https://github.com/wirenboard/agent-vm) by Wiren Board**: Run AI agents in safe VMs scoped to a local folder.
 
 #### <img height="14" src="https://octicons-col.vercel.app/cpu/A770EF">&nbsp;&nbsp;Tools & infrastructure
 
-> • <img height="14" src="https://octicons-col.vercel.app/browser/A770EF"> **[h5i](https://github.com/h5i-dev/h5i)**: Secure, auditable browser for AI agents, written in pure Rust.<br />
-> • <img height="14" src="https://octicons-col.vercel.app/cloud/A770EF"> **[Devsy](https://github.com/devsy-org/devsy)**: Deploy devcontainers onto any cloud, Kubernetes cluster, or Docker host.<br />
-> • <img height="14" src="https://octicons-col.vercel.app/briefcase/A770EF"> **[OpenWork](https://github.com/different-ai/openwork)**: Open-source alternative to Claude Cowork, with a ready-made microsandbox image.
+> • <img height="14" src="https://octicons-col.vercel.app/browser/A770EF"> **[h5i](https://github.com/h5i-dev/h5i) by h5i**: Secure, auditable browser for AI agents, written in pure Rust.<br />
+> • <img height="14" src="https://octicons-col.vercel.app/cloud/A770EF"> **[Devsy](https://github.com/devsy-org/devsy) by Devsy**: Deploy devcontainers onto any cloud, Kubernetes cluster, or Docker host.<br />
+> • <img height="14" src="https://octicons-col.vercel.app/briefcase/A770EF"> **[OpenWork](https://github.com/different-ai/openwork) by Different AI**: Open-source alternative to Claude Cowork, with a ready-made microsandbox image.
 
 #### <img height="14" src="https://octicons-col.vercel.app/list-unordered/A770EF">&nbsp;&nbsp;Guides & showcases
 
-> • <img height="14" src="https://octicons-col.vercel.app/list-unordered/A770EF"> **[Awesome Microsandbox](https://github.com/ya-luotao/awesome-microsandbox)**: Curated list of SDKs, integrations, tools, and resources.<br />
-> • <img height="14" src="https://octicons-col.vercel.app/organization/A770EF"> **[U.S. GSA — Agentic Coding Quickstart](https://github.com/GSA-TTS/agentic-coding-quickstart)**: From zero to a running AI coding agent with USAi in minutes.<br />
-> • <img height="14" src="https://octicons-col.vercel.app/device-desktop/A770EF"> **[msb-omarchy](https://github.com/ya-luotao/msb-omarchy)**: Omarchy desktop with graphics inside a microVM on Apple Silicon.
+> • <img height="14" src="https://octicons-col.vercel.app/list-unordered/A770EF"> **[Awesome Microsandbox](https://github.com/ya-luotao/awesome-microsandbox) by luotao**: Curated list of SDKs, integrations, tools, and resources.<br />
+> • <img height="14" src="https://octicons-col.vercel.app/organization/A770EF"> **[Agentic Coding Quickstart](https://github.com/GSA-TTS/agentic-coding-quickstart) by U.S. GSA**: From zero to a running AI coding agent with USAi in minutes.<br />
+> • <img height="14" src="https://octicons-col.vercel.app/device-desktop/A770EF"> **[msb-omarchy](https://github.com/ya-luotao/msb-omarchy) by luotao**: Omarchy desktop with graphics inside a microVM on Apple Silicon.
 
 <br />
 

--- a/README.md
+++ b/README.md
@@ -417,18 +417,30 @@ Practical ways to put microsandbox to work:
 
 ## <a href="./#gh-dark-mode-only" target="_blank"><img height="18" src="https://octicons-col.vercel.app/people/ffffff" alt="people-dark"></a><a href="./#gh-light-mode-only" target="_blank"><img height="18" src="https://octicons-col.vercel.app/people/000000" alt="people"></a>&nbsp;&nbsp;Community ecosystem
 
-> ⏵ **[Eve by Vercel](https://eve.dev/docs/sandbox#microsandbox)**<br />
-> ⏵ **[Awesome Microsandbox](https://github.com/ya-luotao/awesome-microsandbox)**<br />
-> ⏵ **[U.S. GSA — Agentic Coding Quickstart](https://github.com/GSA-TTS/agentic-coding-quickstart)**<br />
-> ⏵ **[agent-compose by Chaitin](https://github.com/chaitin/agent-compose)**<br />
-> ⏵ **[Condukt](https://github.com/tuist/condukt) and [Once](https://github.com/tuist/once) by Tuist**<br />
-> ⏵ **[h5i](https://github.com/h5i-dev/h5i)**<br />
-> ⏵ **[Smithers](https://github.com/smithersai/smithers)**<br />
-> ⏵ **[sandboxed-lit by LlamaIndex](https://github.com/run-llama/sandboxed-lit)**<br />
-> ⏵ **[Agentic Usability by PSPDFKit Labs](https://github.com/PSPDFKit-labs/agentic-usability)**<br />
-> ⏵ **[Agent VM by Wiren Board](https://github.com/wirenboard/agent-vm)**<br />
-> ⏵ **[Devsy](https://github.com/devsy-org/devsy)**<br />
-> ⏵ **[msb-omarchy](https://github.com/ya-luotao/msb-omarchy)**
+Projects and platforms built on top of microsandbox, or built to run inside it:
+
+#### <img height="14" src="https://octicons-col.vercel.app/hubot/A770EF">&nbsp;&nbsp;Agent frameworks & runtimes
+
+> • <img height="14" src="https://octicons-col.vercel.app/workflow/A770EF"> **[Eve by Vercel](https://eve.dev/docs/sandbox#microsandbox)**: Agent framework that ships microsandbox as a sandbox backend.<br />
+> • <img height="14" src="https://octicons-col.vercel.app/package/A770EF"> **[Condukt](https://github.com/tuist/condukt) and [Once](https://github.com/tuist/once) by Tuist**: Elixir agentic engine, and cacheable actions that run in fresh sandboxes.<br />
+> • <img height="14" src="https://octicons-col.vercel.app/stack/A770EF"> **[agent-compose by Chaitin](https://github.com/chaitin/agent-compose)**: docker-compose-style daemon for orchestrating agents.<br />
+> • <img height="14" src="https://octicons-col.vercel.app/history/A770EF"> **[Smithers](https://github.com/smithersai/smithers)**: Agent workflows with full observability, rewind, fork, and replay.<br />
+> • <img height="14" src="https://octicons-col.vercel.app/terminal/A770EF"> **[wrap](https://github.com/tobi/wrap) by Tobi Lütke**: Run coding agents and project commands in isolated Arch Linux microVMs.<br />
+> • <img height="14" src="https://octicons-col.vercel.app/shield-lock/A770EF"> **[Agent VM by Wiren Board](https://github.com/wirenboard/agent-vm)**: Run AI agents in safe VMs scoped to a local folder.
+
+#### <img height="14" src="https://octicons-col.vercel.app/cpu/A770EF">&nbsp;&nbsp;Tools & infrastructure
+
+> • <img height="14" src="https://octicons-col.vercel.app/browser/A770EF"> **[h5i](https://github.com/h5i-dev/h5i)**: Secure, auditable browser for AI agents, written in pure Rust.<br />
+> • <img height="14" src="https://octicons-col.vercel.app/cloud/A770EF"> **[Devsy](https://github.com/devsy-org/devsy)**: Deploy devcontainers onto any cloud, Kubernetes cluster, or Docker host.<br />
+> • <img height="14" src="https://octicons-col.vercel.app/briefcase/A770EF"> **[OpenWork](https://github.com/different-ai/openwork)**: Open-source alternative to Claude Cowork, with a ready-made microsandbox image.
+
+#### <img height="14" src="https://octicons-col.vercel.app/list-unordered/A770EF">&nbsp;&nbsp;Guides & showcases
+
+> • <img height="14" src="https://octicons-col.vercel.app/list-unordered/A770EF"> **[Awesome Microsandbox](https://github.com/ya-luotao/awesome-microsandbox)**: Curated list of SDKs, integrations, tools, and resources.<br />
+> • <img height="14" src="https://octicons-col.vercel.app/organization/A770EF"> **[U.S. GSA — Agentic Coding Quickstart](https://github.com/GSA-TTS/agentic-coding-quickstart)**: From zero to a running AI coding agent with USAi in minutes.<br />
+> • <img height="14" src="https://octicons-col.vercel.app/device-desktop/A770EF"> **[msb-omarchy](https://github.com/ya-luotao/msb-omarchy)**: Omarchy desktop with graphics inside a microVM on Apple Silicon.
+
+<br />
 
 <a href="https://discord.gg/T95Y3XnEAK"><img src="https://img.shields.io/badge/Share_a_Project-%E2%86%92-A770EF?style=flat-square&labelColor=2b2b2b" alt="Share a Project"></a>
 

--- a/README.md
+++ b/README.md
@@ -394,27 +394,6 @@ Practical ways to put microsandbox to work:
 
 <br />
 
-## <a href="./#gh-dark-mode-only" target="_blank"><img height="18" src="https://octicons-col.vercel.app/dependabot/ffffff" alt="agents-dark"></a><a href="./#gh-light-mode-only" target="_blank"><img height="18" src="https://octicons-col.vercel.app/dependabot/000000" alt="agents"></a>&nbsp;&nbsp;AI Agents
-
-#### <img height="14" src="https://octicons-col.vercel.app/book/A770EF">&nbsp;&nbsp;Agent Skills
-
-> Teach any AI coding agent how to use microsandbox by installing the [Agent Skills](https://github.com/superradcompany/skills). Works with Claude Code, Cursor, Codex, Gemini CLI, GitHub Copilot, and more.
->
-> ```sh
-> npx skills add superradcompany/skills
-> ```
-
-#### <img height="14" src="https://octicons-col.vercel.app/plug/A770EF">&nbsp;&nbsp;MCP Server
-
-> Connect any MCP-compatible agent to microsandbox with the [MCP server](https://github.com/superradcompany/microsandbox-mcp). Provides structured tool calls for sandbox lifecycle, command execution, filesystem access, volumes, and monitoring.
->
-> ```sh
-> # Claude Code
-> claude mcp add --transport stdio microsandbox -- npx -y microsandbox-mcp
-> ```
-
-<br />
-
 ## <a href="./#gh-dark-mode-only" target="_blank"><img height="18" src="https://octicons-col.vercel.app/people/ffffff" alt="people-dark"></a><a href="./#gh-light-mode-only" target="_blank"><img height="18" src="https://octicons-col.vercel.app/people/000000" alt="people"></a>&nbsp;&nbsp;Community ecosystem
 
 #### <img height="14" src="https://octicons-col.vercel.app/hubot/A770EF">&nbsp;&nbsp;Agent frameworks & runtimes
@@ -441,6 +420,27 @@ Practical ways to put microsandbox to work:
 <br />
 
 <a href="https://discord.gg/T95Y3XnEAK"><img src="https://img.shields.io/badge/Share_a_Project-%E2%86%92-A770EF?style=flat-square&labelColor=2b2b2b" alt="Share a Project"></a>
+
+<br />
+
+## <a href="./#gh-dark-mode-only" target="_blank"><img height="18" src="https://octicons-col.vercel.app/dependabot/ffffff" alt="agents-dark"></a><a href="./#gh-light-mode-only" target="_blank"><img height="18" src="https://octicons-col.vercel.app/dependabot/000000" alt="agents"></a>&nbsp;&nbsp;AI Agents
+
+#### <img height="14" src="https://octicons-col.vercel.app/book/A770EF">&nbsp;&nbsp;Agent Skills
+
+> Teach any AI coding agent how to use microsandbox by installing the [Agent Skills](https://github.com/superradcompany/skills). Works with Claude Code, Cursor, Codex, Gemini CLI, GitHub Copilot, and more.
+>
+> ```sh
+> npx skills add superradcompany/skills
+> ```
+
+#### <img height="14" src="https://octicons-col.vercel.app/plug/A770EF">&nbsp;&nbsp;MCP Server
+
+> Connect any MCP-compatible agent to microsandbox with the [MCP server](https://github.com/superradcompany/microsandbox-mcp). Provides structured tool calls for sandbox lifecycle, command execution, filesystem access, volumes, and monitoring.
+>
+> ```sh
+> # Claude Code
+> claude mcp add --transport stdio microsandbox -- npx -y microsandbox-mcp
+> ```
 
 <br />
 

--- a/README.md
+++ b/README.md
@@ -417,8 +417,6 @@ Practical ways to put microsandbox to work:
 
 ## <a href="./#gh-dark-mode-only" target="_blank"><img height="18" src="https://octicons-col.vercel.app/people/ffffff" alt="people-dark"></a><a href="./#gh-light-mode-only" target="_blank"><img height="18" src="https://octicons-col.vercel.app/people/000000" alt="people"></a>&nbsp;&nbsp;Community ecosystem
 
-Projects and platforms built on top of microsandbox, or built to run inside it:
-
 #### <img height="14" src="https://octicons-col.vercel.app/hubot/A770EF">&nbsp;&nbsp;Agent frameworks & runtimes
 
 > • <img height="14" src="https://octicons-col.vercel.app/workflow/A770EF"> **[Eve by Vercel](https://eve.dev/docs/sandbox#microsandbox)**: Agent framework that ships microsandbox as a sandbox backend.<br />


### PR DESCRIPTION
## TL;DR
Organize the README community showcase into clear categories with project icons and short descriptions so readers can scan it more easily.

## Description
- Place the Community Showcase section above AI Agents so the project showcase appears earlier in the README.
- Group featured projects under Agent frameworks and runtimes, Tools and infrastructure, and Guides and showcases.
- Add a short description and matching icon to every featured entry.
- Show each project owner as an unlinked attribution after the linked project name.
- Add wrap and OpenWork to the showcase.
- Feature langchain-microsandbox as the LangChain Deep Agents integration.
- Keep broader project discovery through Awesome Microsandbox while removing sandboxed-lit and Agentic Usability from the featured list.
- Place the U.S. GSA quickstart under Agent frameworks and runtimes, with Awesome Microsandbox and msb-omarchy under Guides and showcases.

## Test Plan
- [x] `git diff --check origin/main..HEAD` passes
- [x] GitHub API checks resolve all 12 GitHub project links in the categorized section
- [x] The Eve documentation link and all community section icon assets return successful responses
- [x] GitHub's Markdown API renders the Agent frameworks and runtimes heading




<!-- greptile_comment -->

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<sub>Reviews (6): Last reviewed commit: ["docs(readme): refine community showcase ..."](https://github.com/superradcompany/microsandbox/commit/ecd077a77ba3d2c5b1a166913b7d51841298a5c4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59774059)</sub>

<!-- /greptile_comment -->