### PR TITLE
fix(migration): preserve released upgrade order

### DIFF
--- a/.github/workflows/check-platform.yml
+++ b/.github/workflows/check-platform.yml
@@ -201,7 +201,7 @@ jobs:
         working-directory: sdk/node-ts
         run: |
           node scripts/prune-platform-optional-deps.mjs
-          npm install --package-lock=false
+          npm ci --ignore-scripts
           npm run build:ci
 
   python-build:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1365,6 +1365,35 @@ jobs:
           go test -tags "smoke microsandbox_ffi_path" -count=1 -timeout 2m .
 
   # ---------------------------------------------------------------------------
+  # Previous-release upgrade smoke test
+  #
+  # Creates databases with the two latest released CLIs, then opens them with
+  # the candidate binary. This catches migration-order and compatibility gaps
+  # without requiring KVM.
+  # ---------------------------------------------------------------------------
+  previous-release-upgrade-smoke:
+    name: Previous Release Upgrade Smoke
+    needs: [build-linux-x86_64, changes]
+    if: needs.changes.outputs.code == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Download candidate runtime
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: msb-linux-x86_64
+          path: build/
+
+      - name: Test released database upgrades
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          chmod +x build/msb
+          python3 scripts/smoke/cli/previous_release_upgrade.py
+
+  # ---------------------------------------------------------------------------
   # CLI smoke tests (requires KVM)
   #
   # Runs black-box CLI user flows against the freshly-built msb artifact.
@@ -1925,6 +1954,7 @@ jobs:
       - ruby-platform-smoke
       - ruby-platform-smoke-clean
       - go-quality
+      - previous-release-upgrade-smoke
       - cli-smoke-test
       - integration-test
       - node-sdk-test

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -815,7 +815,7 @@ jobs:
         working-directory: sdk/node-ts
         run: |
           node scripts/prune-platform-optional-deps.mjs
-          npm install --package-lock=false
+          npm ci --ignore-scripts
           npm run build:ci
 
       - name: Build MCP server
@@ -1587,7 +1587,7 @@ jobs:
         working-directory: sdk/node-ts
         run: |
           node scripts/prune-platform-optional-deps.mjs
-          npm install --package-lock=false --ignore-scripts
+          npm ci --ignore-scripts
 
       # The published platform-pkg msb may lag the SDK; replace it with the
       # freshly-built binaries so the smoke test runs against current code.

--- a/crates/cli/lib/commands/self_cmd.rs
+++ b/crates/cli/lib/commands/self_cmd.rs
@@ -3479,23 +3479,10 @@ mod tests {
         .unwrap();
         Migrator::up(db.inner(), None).await.unwrap();
 
-        // The newest owner-compatibility marker has no schema objects of its
-        // own. With no persisted sandboxes, its preflight permits rollback and
-        // removes only the migration record.
-        rollback_schema(db.inner(), 1).await.unwrap();
-
-        let rows = db
-            .query_all_raw(Statement::from_sql_and_values(
-                DatabaseBackend::Sqlite,
-                "SELECT version FROM seaql_migrations WHERE version = ?",
-                [schema_metadata::MOUNT_OWNER_CONFIG_MIGRATION_ID.into()],
-            ))
-            .await
-            .unwrap();
-        assert!(rows.is_empty(), "mount owner marker should be rolled back");
-
-        // The network-slot migration leaves its compatible SQLite column and
-        // constraints in place, but removes the migration record.
+        // The backdated network-slot migration was released after the
+        // owner-compatibility marker, so it is the first migration rolled back.
+        // It leaves its compatible SQLite column and constraints in place, but
+        // removes the migration record.
         rollback_schema(db.inner(), 1).await.unwrap();
 
         let rows = db
@@ -3524,6 +3511,21 @@ mod tests {
                 .any(|row| row.try_get_by_index::<String>(1).unwrap() == "network_slot"),
             "network slot column should remain compatible after rollback"
         );
+
+        // The owner-compatibility marker has no schema objects of its own. With
+        // no persisted sandboxes, its preflight permits rollback and removes
+        // only the migration record.
+        rollback_schema(db.inner(), 1).await.unwrap();
+
+        let rows = db
+            .query_all_raw(Statement::from_sql_and_values(
+                DatabaseBackend::Sqlite,
+                "SELECT version FROM seaql_migrations WHERE version = ?",
+                [schema_metadata::MOUNT_OWNER_CONFIG_MIGRATION_ID.into()],
+            ))
+            .await
+            .unwrap();
+        assert!(rows.is_empty(), "mount owner marker should be rolled back");
 
         // Shared CPU assignment rows downgrade first. Active sandboxes are
         // prohibited during schema rollback, so the allocation table is empty

--- a/crates/migration/lib/lib.rs
+++ b/crates/migration/lib/lib.rs
@@ -73,8 +73,11 @@ impl MigratorTrait for Migrator {
             Box::new(m20260808_000001_create_memory_allocation_nodes::Migration),
             Box::new(m20260810_000001_rebuild_sandbox_labels::Migration),
             Box::new(m20260813_000001_share_cpu_allocations::Migration),
-            Box::new(m20260818_000001_sandbox_network_slot::Migration),
             Box::new(m20260824_000001_mount_owner_config::Migration),
+            // This backdated migration first shipped in v0.6.16, after the
+            // v0.6.15 mount-owner marker. Keep release order here even though
+            // the identifiers sort differently.
+            Box::new(m20260818_000001_sandbox_network_slot::Migration),
         ]
     }
 }

--- a/crates/migration/lib/schema_metadata.rs
+++ b/crates/migration/lib/schema_metadata.rs
@@ -237,6 +237,15 @@ pub const MIGRATION_METADATA: &[MigrationMetadata] = &[
         summary: "restore exclusive logical CPU allocation rows",
     },
     MigrationMetadata {
+        id: MOUNT_OWNER_CONFIG_MIGRATION_ID,
+        reversible: true,
+        affects_cache: false,
+        affects_user_data: false,
+        summary: "remove the compatibility marker after confirming no persisted mount ownership",
+    },
+    MigrationMetadata {
+        // This backdated migration first shipped in v0.6.16. Keep it after
+        // the v0.6.15 mount-owner marker so released databases stay prefixes.
         id: SANDBOX_NETWORK_SLOT_MIGRATION_ID,
         // The column is deliberately left in place on rollback (SQLite has
         // no DROP COLUMN on every supported version); `up` probes for it so a
@@ -245,13 +254,6 @@ pub const MIGRATION_METADATA: &[MigrationMetadata] = &[
         affects_cache: false,
         affects_user_data: false,
         summary: "retain the compatible sandbox network slot column",
-    },
-    MigrationMetadata {
-        id: MOUNT_OWNER_CONFIG_MIGRATION_ID,
-        reversible: true,
-        affects_cache: false,
-        affects_user_data: false,
-        summary: "remove the compatibility marker after confirming no persisted mount ownership",
     },
 ];
 
@@ -372,6 +374,16 @@ mod tests {
             .map(|metadata| metadata.id)
             .chain(["m20990101_000001_future"]);
         assert!(canonical_applied_prefix(with_unknown).is_none());
+    }
+
+    #[test]
+    fn released_v0_6_15_migrations_remain_a_prefix() {
+        let applied: Vec<_> = migration_ids()
+            .take_while(|id| *id != SANDBOX_NETWORK_SLOT_MIGRATION_ID)
+            .collect();
+
+        assert_eq!(applied.last(), Some(&MOUNT_OWNER_CONFIG_MIGRATION_ID));
+        assert!(canonical_applied_prefix(applied).is_some());
     }
 
     #[test]

--- a/scripts/smoke/cli/previous_release_upgrade.py
+++ b/scripts/smoke/cli/previous_release_upgrade.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+
+"""Smoke-test local database upgrades from recent microsandbox releases."""
+
+from __future__ import annotations
+
+import json
+import os
+import platform
+import shutil
+import sqlite3
+import stat
+import subprocess
+import sys
+import tempfile
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+
+ROOT_DIR = Path(__file__).resolve().parents[3]
+DEFAULT_REPOSITORY = "superradcompany/microsandbox"
+
+
+class SmokeError(Exception):
+    """An expected smoke-test failure with a concise user-facing message."""
+
+
+def github_request(url: str) -> urllib.request.Request:
+    """Build an authenticated GitHub request when CI provides a token."""
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "User-Agent": "microsandbox-upgrade-smoke",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    if token := os.environ.get("GH_TOKEN"):
+        headers["Authorization"] = f"Bearer {token}"
+    return urllib.request.Request(url, headers=headers)
+
+
+def load_json(url: str) -> Any:
+    """Load JSON from the GitHub API."""
+    with urllib.request.urlopen(github_request(url), timeout=30) as response:
+        return json.load(response)
+
+
+def released_versions(repository: str) -> list[str]:
+    """Return the two latest stable release tags, or an explicit override."""
+    if override := os.environ.get("MSB_UPGRADE_FROM_VERSIONS"):
+        return override.split()
+
+    releases = load_json(f"https://api.github.com/repos/{repository}/releases?per_page=10")
+    return [
+        release["tag_name"]
+        for release in releases
+        if not release["draft"] and not release["prerelease"]
+    ][:2]
+
+
+def platform_asset() -> str:
+    """Return the release asset name for the current host."""
+    systems = {"Darwin": "darwin", "Linux": "linux"}
+    machines = {
+        "arm64": "aarch64",
+        "aarch64": "aarch64",
+        "x86_64": "x86_64",
+        "amd64": "x86_64",
+    }
+    try:
+        system = systems[platform.system()]
+        machine = machines[platform.machine().lower()]
+    except KeyError as error:
+        raise SmokeError(
+            f"unsupported smoke-test platform: {platform.system()} {platform.machine()}"
+        ) from error
+    return f"msb-{system}-{machine}"
+
+
+def download_release_binary(repository: str, version: str, destination: Path) -> None:
+    """Download one released msb binary for this host."""
+    release = load_json(
+        f"https://api.github.com/repos/{repository}/releases/tags/{version}"
+    )
+    asset_name = platform_asset()
+    asset = next(
+        (candidate for candidate in release["assets"] if candidate["name"] == asset_name),
+        None,
+    )
+    if asset is None:
+        raise SmokeError(f"release {version} has no {asset_name} asset")
+
+    with urllib.request.urlopen(
+        github_request(asset["browser_download_url"]), timeout=30
+    ) as response, destination.open("wb") as output:
+        shutil.copyfileobj(response, output)
+    destination.chmod(
+        destination.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH
+    )
+
+
+def run_msb(binary: Path, *arguments: str, home: Path | None = None) -> None:
+    """Run msb with output hidden unless the command fails."""
+    environment = os.environ.copy()
+    if home is not None:
+        environment["MSB_HOME"] = str(home)
+    result = subprocess.run(
+        [str(binary), *arguments],
+        env=environment,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        sys.stdout.write(result.stdout)
+        sys.stderr.write(result.stderr)
+        raise SmokeError(f"{binary} {' '.join(arguments)} exited with {result.returncode}")
+
+
+def schema_baseline(binary: Path) -> dict[str, Any]:
+    """Read the hidden schema compatibility metadata from an msb binary."""
+    result = subprocess.run(
+        [str(binary), "__schema-baseline", "--json"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        sys.stderr.write(result.stderr)
+        raise SmokeError(f"failed to read schema baseline from {binary}")
+    return json.loads(result.stdout)
+
+
+def verify_migration_set(
+    version: str,
+    old_baseline: dict[str, Any],
+    candidate_baseline: dict[str, Any],
+    database_path: Path,
+) -> None:
+    """Verify released identifiers survive and the candidate fully migrates."""
+    old_migrations = old_baseline["migrations"]
+    candidate_migrations = candidate_baseline["migrations"]
+    if len(old_migrations) != len(set(old_migrations)):
+        raise SmokeError(f"{version} reports duplicate migration identifiers")
+    if len(candidate_migrations) != len(set(candidate_migrations)):
+        raise SmokeError("candidate reports duplicate migration identifiers")
+
+    missing = sorted(set(old_migrations) - set(candidate_migrations))
+    if missing:
+        raise SmokeError(
+            f"candidate removed migrations shipped by {version}: {', '.join(missing)}"
+        )
+
+    with sqlite3.connect(database_path) as database:
+        applied = {
+            row[0] for row in database.execute("SELECT version FROM seaql_migrations")
+        }
+    expected = set(candidate_migrations)
+    if applied != expected:
+        raise SmokeError(
+            "candidate database migration set does not match its schema baseline; "
+            f"missing={sorted(expected - applied)}, "
+            f"unexpected={sorted(applied - expected)}"
+        )
+
+
+def verify_upgrade(
+    repository: str,
+    version: str,
+    candidate: Path,
+    candidate_baseline: dict[str, Any],
+    smoke_root: Path,
+) -> None:
+    """Create a released database and open it twice with the candidate."""
+    release_dir = smoke_root / version
+    release_dir.mkdir(parents=True)
+    old_msb = release_dir / "msb"
+    old_home = release_dir / "home"
+
+    download_release_binary(repository, version, old_msb)
+    old_baseline = schema_baseline(old_msb)
+    run_msb(old_msb, "list", home=old_home)
+
+    # Opening twice verifies both the upgrade and its steady-state/idempotent path.
+    run_msb(candidate, "list", home=old_home)
+    run_msb(candidate, "list", home=old_home)
+    verify_migration_set(
+        version,
+        old_baseline,
+        candidate_baseline,
+        old_home / "db" / "msb.db",
+    )
+    print(f"upgrade smoke passed: {version} -> candidate")
+
+
+def main() -> int:
+    """Run the previous-release upgrade smoke test."""
+    candidate = Path(os.environ.get("MSB_BIN", ROOT_DIR / "build" / "msb"))
+    repository = os.environ.get("MSB_UPGRADE_SMOKE_REPO", DEFAULT_REPOSITORY)
+    if not candidate.is_file() or not os.access(candidate, os.X_OK):
+        raise SmokeError(f"msb binary is not executable: {candidate}")
+
+    versions = released_versions(repository)
+    if not versions:
+        raise SmokeError("no released versions found for upgrade smoke test")
+
+    candidate_baseline = schema_baseline(candidate)
+    with tempfile.TemporaryDirectory(prefix="msb-upgrade-smoke-") as temp_dir:
+        smoke_root = Path(temp_dir)
+        for version in versions:
+            verify_upgrade(
+                repository,
+                version,
+                candidate,
+                candidate_baseline,
+                smoke_root,
+            )
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except (OSError, KeyError, ValueError, SmokeError) as error:
+        raise SystemExit(f"error: {error}") from error

--- a/sdk/ruby/Rakefile
+++ b/sdk/ruby/Rakefile
@@ -129,6 +129,12 @@ namespace :cargo do
       microsandbox = { path = "../rust" }
     TOML
     File.write(PATCH_STATE, patch_config_digest)
+
+    # tinyvec 1.13.0 does not import the vec! macro for alloc-only builds.
+    # Keep the temporary patched graph on the version already proven by the
+    # standalone lockfile until an upstream fix supersedes the broken release.
+    sh "cargo", "update", "--manifest-path", "ext/microsandbox/Cargo.toml",
+       "-p", "tinyvec", "--precise", "1.12.0"
   end
 
   desc "Undo cargo:patch_workspace: drop the patch config, restore the lockfile"

--- a/sdk/rust/lib/backend/local/mod.rs
+++ b/sdk/rust/lib/backend/local/mod.rs
@@ -1127,6 +1127,73 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_connect_and_migrate_upgrades_v0_6_15_prefix() {
+        let tmp = tempfile::tempdir().unwrap();
+        let db_dir = tmp.path().join("db");
+        let db_path = db_dir.join(microsandbox_utils::DB_FILENAME);
+        std::fs::create_dir_all(&db_dir).unwrap();
+
+        let db = microsandbox_db::connection::DbWriteConnection::open(
+            &db_path,
+            Duration::from_secs(5),
+            Duration::from_secs(5),
+        )
+        .await
+        .unwrap();
+        let released_prefix_len = schema_metadata::migration_ids()
+            .position(|id| id == schema_metadata::SHARED_CPU_ALLOCATION_MIGRATION_ID)
+            .unwrap()
+            + 1;
+        Migrator::up(db.inner(), Some(released_prefix_len as u32))
+            .await
+            .unwrap();
+
+        // v0.6.15 ended with this schema-free compatibility marker. Insert
+        // its migration row to reproduce a database last opened by v0.6.15.
+        db.inner()
+            .execute_raw(Statement::from_sql_and_values(
+                DatabaseBackend::Sqlite,
+                "INSERT INTO seaql_migrations (version, applied_at) VALUES (?, ?)",
+                [
+                    schema_metadata::MOUNT_OWNER_CONFIG_MIGRATION_ID.into(),
+                    1_i64.into(),
+                ],
+            ))
+            .await
+            .unwrap();
+        drop(db);
+
+        let pools = connect_and_migrate(
+            &db_dir,
+            &DatabaseConfig::default(),
+            &tmp.path().join("snapshots"),
+        )
+        .await
+        .unwrap();
+        let network_slot_migration = pools
+            .read()
+            .query_one_raw(Statement::from_sql_and_values(
+                DatabaseBackend::Sqlite,
+                "SELECT version FROM seaql_migrations WHERE version = ?",
+                [schema_metadata::SANDBOX_NETWORK_SLOT_MIGRATION_ID.into()],
+            ))
+            .await
+            .unwrap();
+        let network_slot_column = pools
+            .read()
+            .query_one_raw(Statement::from_string(
+                DatabaseBackend::Sqlite,
+                "SELECT name FROM pragma_table_info('sandbox') WHERE name = 'network_slot'"
+                    .to_owned(),
+            ))
+            .await
+            .unwrap();
+
+        assert!(network_slot_migration.is_some());
+        assert!(network_slot_column.is_some());
+    }
+
+    #[tokio::test]
     async fn test_connect_and_migrate_accepts_equal_migration_timestamps() {
         let tmp = tempfile::tempdir().unwrap();
         let db_dir = tmp.path().join("db");


### PR DESCRIPTION
## TL;DR

Restore the released v0.6.15 migration prefix so existing installations can upgrade normally. Add regression and black-box release-upgrade coverage to prevent the same class of breakage.

Closes #1502.

## Description

- Keep the v0.6.15 mount ownership marker before the backdated network slot migration in executable and downgrade metadata order.
- Reproduce a v0.6.15 database in the local backend test and verify the candidate applies the network slot migration.
- Add a standard-library Python smoke test that upgrades databases created by the two latest stable release binaries.
- Verify released migration identifiers remain present and the upgraded database exactly matches the candidate schema baseline.
- Run the release-upgrade smoke on a hosted Linux runner without requiring KVM.
- Install Node SDK dependencies from the checked-in lockfile so npm 10 does not re-resolve and crash after platform-package pruning.
- Keep temporary in-tree Ruby platform builds on the known-good `tinyvec` 1.12.0 after the newly published 1.13.0 broke alloc-only compilation.

## Test Plan

- `cargo test -p microsandbox-migration`
- `cargo test -p microsandbox --lib backend::local::tests`
- `cargo test -p microsandbox-cli --lib`
- `cargo clippy -p microsandbox-migration --all-targets -- -D warnings`
- `cargo clippy -p microsandbox --lib -- -D warnings`
- `MSB_BIN=target/debug/msb python3 scripts/smoke/cli/previous_release_upgrade.py`
- Reproduced the npm failure with npm 10.9.8 and verified `npm ci --ignore-scripts` plus the TypeScript build in a clean SDK copy.
- Verified the Ruby patch/unpatch task pins the temporary graph to `tinyvec` 1.12.0 and restores the standalone lockfile cleanly.
- Confirmed the candidate upgrades databases created by v0.6.15 and v0.6.16.
- Confirmed the released v0.6.16 binary fails the v0.6.15 negative control with the error reported in #1502.
- Confirmed the final CI run passes the release-upgrade smoke, Rust tests, Node builds, and Ruby platform builds on all configured platforms.

<!-- greptile_comment -->

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because no eligible blocking failure remains.

No blocking failure remains.
</details>

<sub>Reviews (4): Last reviewed commit: ["ci(ruby): pin patched builds to working ..."](https://github.com/superradcompany/microsandbox/commit/a5c27c30a8ef7ce5ddef4f3c6328329bfa0af3d8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60147677)</sub>

<!-- /greptile_comment -->
