### PR TITLE
fix(release): install locked Node dependencies

### DIFF
--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -251,7 +251,7 @@ jobs:
         working-directory: sdk/node-ts
         run: |
           node scripts/prune-platform-optional-deps.mjs
-          npm install --package-lock=false
+          npm ci
           npm run build:native -- --target ${{ inputs.napi_target }}
           node -e 'require("./native/index.cjs")'
 

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -241,7 +241,7 @@ jobs:
         working-directory: sdk/node-ts
         run: |
           node scripts/prune-platform-optional-deps.mjs
-          npm install --package-lock=false
+          npm ci
           npm run build:native -- --target ${{ inputs.napi_target }}
           node -e 'require("./native/index.cjs")'
 

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -270,7 +270,7 @@ jobs:
           . "$env:GITHUB_WORKSPACE\vendor\libkrunfw\scripts\msvc-env.ps1"
           Set-MsvcEnvironment -Architecture ${{ inputs.vs_arch }} -HostArchitecture ${{ inputs.vs_host_arch }}
           node scripts/prune-platform-optional-deps.mjs
-          npm install --package-lock=false
+          npm ci
           npm run build:native -- --target ${{ inputs.napi_target }}
           node -e "require('./native/index.cjs')"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -610,7 +610,7 @@ jobs:
         working-directory: sdk/node-ts
         run: |
           node scripts/prune-platform-optional-deps.mjs
-          npm install --package-lock=false
+          npm ci
           npm run build:native -- --target ${{ matrix.napi_target }}
           npm run build:ts
 
@@ -832,7 +832,7 @@ jobs:
           . "$env:GITHUB_WORKSPACE\vendor\libkrunfw\scripts\msvc-env.ps1"
           Set-MsvcEnvironment -Architecture ${{ matrix.vs_arch }} -HostArchitecture ${{ matrix.vs_host_arch }}
           node scripts/prune-platform-optional-deps.mjs
-          npm install --package-lock=false
+          npm ci
           npm run build:native -- --target ${{ matrix.napi_target }}
           npm run build:ts
 


### PR DESCRIPTION
## TL;DR

Use the tested Node lockfile during release builds. This fixes the npm resolver crash that blocked the v0.6.17 release before publication.

## Description

- Replace the floating Node dependency install with npm ci after platform optional dependencies are pruned.
- Apply the fix to Linux, macOS, Windows, and the disabled legacy release fallback.
- Keep all package versions and release artifacts unchanged.

Failed release run: https://github.com/superradcompany/microsandbox/actions/runs/33839055683

## Test Plan

- Reproduced the npm 10.9.8 edgesOut crash from the v0.6.17 tagged tree.
- Verified npm ci installs the pruned locked graph and TypeScript compiles.
- Verified a clean macOS release-profile native build and generated binding load.
- Ran actionlint on the four changed workflow files, excluding existing intentional legacy and shellcheck warnings.
- Ran git diff --check.

<!-- greptile_comment -->

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete changed-code-triggered failures identified.

The changed release steps use an installation sequence already exercised by repository CI, and the investigated manifest/lockfile shape is accepted by npm without preventing the native builds.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(release): install locked Node depend..."](https://github.com/superradcompany/microsandbox/commit/723043bb117bef33e8f9b151646e3712bc9db1e4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60361530)</sub>

<!-- /greptile_comment -->