### PR TITLE
fix(release): allow npm-only recovery

### DIFF
--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -1,0 +1,289 @@
+name: Release npm packages
+
+on:
+  workflow_call:
+    inputs:
+      artifact_run_id:
+        description: Workflow run containing the Node SDK artifacts
+        required: true
+        type: string
+      confirm_publish:
+        description: Confirm that npm packages should be published
+        required: true
+        type: boolean
+      release_tag:
+        description: Release tag whose npm packages should be published
+        required: true
+        type: string
+    secrets:
+      NPM_TOKEN:
+        required: true
+  workflow_dispatch:
+    inputs:
+      artifact_run_id:
+        description: Workflow run containing the Node SDK artifacts
+        required: true
+        type: string
+      confirm_publish:
+        description: Publish only the npm release flow
+        required: true
+        default: false
+        type: boolean
+      release_tag:
+        description: Release tag whose npm packages should be published
+        required: true
+        type: string
+
+concurrency:
+  group: release-npm-${{ inputs.release_tag }}
+  cancel-in-progress: false
+
+permissions:
+  actions: read
+  contents: read
+
+jobs:
+  npm-publish:
+    name: Publish npm packages
+    if: inputs.confirm_publish
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ inputs.release_tag }}
+          submodules: true
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22
+          registry-url: https://registry.npmjs.org
+
+      - name: Verify release source
+        env:
+          ARTIFACT_RUN_ID: ${{ inputs.artifact_run_id }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
+        run: |
+          case "$RELEASE_TAG" in
+            v[0-9]*.[0-9]*.[0-9]*) ;;
+            *) echo "Invalid release tag: $RELEASE_TAG" >&2; exit 1 ;;
+          esac
+
+          release_sha=$(git rev-parse HEAD)
+          IFS=$'\t' read -r run_sha run_event run_ref run_status <<EOF
+          $(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${ARTIFACT_RUN_ID}" \
+            --jq '[.head_sha, .event, .head_branch, .status] | @tsv')
+          EOF
+          if [ "$release_sha" != "$run_sha" ]; then
+            echo "Artifact run $ARTIFACT_RUN_ID belongs to $run_sha, not $release_sha ($RELEASE_TAG)" >&2
+            exit 1
+          fi
+          if [ "$run_event" != push ] || [ "$run_ref" != "$RELEASE_TAG" ] || [ "$run_status" != completed ]; then
+            echo "Artifact run $ARTIFACT_RUN_ID is not a completed push run for $RELEASE_TAG" >&2
+            exit 1
+          fi
+
+          version="${RELEASE_TAG#v}"
+          node - "$version" <<'NODE'
+          const fs = require("node:fs");
+
+          const expected = process.argv[2];
+          const manifests = [
+            "sdk/node-ts/package.json",
+            "packages/agent-client/typescript/package.json",
+            "packages/microsandbox-types/typescript/package.json",
+            "mcp/package.json",
+            ...fs.readdirSync("sdk/node-ts/npm").map((dir) => `sdk/node-ts/npm/${dir}/package.json`),
+          ];
+          const mismatched = manifests.filter((path) => {
+            const pkg = JSON.parse(fs.readFileSync(path, "utf8"));
+            return pkg.version !== expected;
+          });
+          if (mismatched.length > 0) {
+            console.error(`Expected npm version ${expected} in: ${mismatched.join(", ")}`);
+            process.exit(1);
+          }
+          NODE
+
+      - name: Download Node SDK artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path: node-artifacts
+          pattern: node-sdk-*
+          repository: ${{ github.repository }}
+          run-id: ${{ inputs.artifact_run_id }}
+
+      - name: Place binaries and update generated files
+        run: |
+          # Copy prepared platform package payloads.
+          for dir in darwin-arm64 linux-x64-gnu linux-arm64-gnu win32-x64-msvc win32-arm64-msvc; do
+            mkdir -p "sdk/node-ts/npm/$dir/bin" "sdk/node-ts/npm/$dir/lib"
+            cp "node-artifacts/node-sdk-$dir/npm/$dir"/microsandbox.*.node "sdk/node-ts/npm/$dir/"
+            cp "node-artifacts/node-sdk-$dir/npm/$dir/bin/"* "sdk/node-ts/npm/$dir/bin/"
+            cp "node-artifacts/node-sdk-$dir/npm/$dir/lib/"* "sdk/node-ts/npm/$dir/lib/"
+            # GitHub Actions artifacts strip Unix exec bits; restore before publish
+            # so the published tarball carries 0755 on the binary.
+            if [ -f "sdk/node-ts/npm/$dir/bin/msb" ]; then
+              chmod +x "sdk/node-ts/npm/$dir/bin/msb"
+            fi
+          done
+
+          # Copy napi-generated bindings into the root package's native/ dir
+          # (use darwin-arm64; all platforms emit identical JS and types).
+          # napi build emits index.d.ts; rename to index.d.cts so nodenext
+          # resolution finds it next to the .cjs binding.
+          cp node-artifacts/node-sdk-darwin-arm64/native/index.cjs sdk/node-ts/native/index.cjs
+          cp node-artifacts/node-sdk-darwin-arm64/native/index.d.ts sdk/node-ts/native/index.d.cts
+
+      - name: Build TypeScript output (root package dist/)
+        working-directory: sdk/node-ts
+        run: |
+          npm ci --omit=optional
+          npm run build:ts
+
+      - name: Build and publish agent client package
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        working-directory: packages/agent-client/typescript
+        run: |
+          npm ci
+          npm run build
+          npm publish --access public
+
+      - name: Build and publish microsandbox types package
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        working-directory: packages/microsandbox-types/typescript
+        run: |
+          npm ci
+          npm run build
+          npm publish --access public
+
+      - name: Publish platform packages
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          for dir in darwin-arm64 linux-x64-gnu linux-arm64-gnu win32-x64-msvc win32-arm64-msvc; do
+            echo "Publishing @superradcompany/microsandbox-$dir..."
+            cd "sdk/node-ts/npm/$dir"
+            npm publish --access public
+            cd ../../../..
+          done
+
+      - name: Wait for npm to index platform packages
+        env:
+          RELEASE_TAG: ${{ inputs.release_tag }}
+        run: |
+          VERSION="${RELEASE_TAG#v}"
+          node scripts/ci/wait-for-npm-packages.mjs "$VERSION" \
+            @superradcompany/microsandbox-darwin-arm64 \
+            @superradcompany/microsandbox-linux-arm64-gnu \
+            @superradcompany/microsandbox-linux-x64-gnu \
+            @superradcompany/microsandbox-win32-arm64-msvc \
+            @superradcompany/microsandbox-win32-x64-msvc
+
+      - name: Verify root package platform dependencies
+        working-directory: sdk/node-ts
+        run: |
+          node - <<'NODE'
+          const fs = require("node:fs");
+
+          const pkg = JSON.parse(fs.readFileSync("package.json", "utf8"));
+          const optionalDependencies = pkg.optionalDependencies ?? {};
+          const required = [
+            "@superradcompany/microsandbox-darwin-arm64",
+            "@superradcompany/microsandbox-linux-arm64-gnu",
+            "@superradcompany/microsandbox-linux-x64-gnu",
+            "@superradcompany/microsandbox-win32-arm64-msvc",
+            "@superradcompany/microsandbox-win32-x64-msvc",
+          ];
+
+          const missing = required.filter((name) => optionalDependencies[name] !== pkg.version);
+
+          if (missing.length > 0) {
+            console.error(`Missing or mismatched platform optional dependencies: ${missing.join(", ")}`);
+            process.exit(1);
+          }
+          NODE
+
+      - name: Publish root package
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        working-directory: sdk/node-ts
+        run: npm publish --access public
+
+  mcp-publish:
+    name: Publish MCP server
+    needs: npm-publish
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ inputs.release_tag }}
+          submodules: true
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22
+          registry-url: https://registry.npmjs.org
+
+      - name: Wait for the root SDK package
+        env:
+          RELEASE_TAG: ${{ inputs.release_tag }}
+        run: |
+          VERSION="${RELEASE_TAG#v}"
+          node scripts/ci/wait-for-npm-packages.mjs "$VERSION" microsandbox
+
+      - name: Build and publish MCP server
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        working-directory: mcp
+        run: |
+          rm -f package-lock.json
+          npm install
+          npm run build
+          npm publish --access public
+
+  refresh-lockfile:
+    name: Refresh npm lockfile
+    needs: npm-publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: main
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22
+
+      - name: Wait for npm to index platform packages
+        env:
+          RELEASE_TAG: ${{ inputs.release_tag }}
+        run: |
+          VERSION="${RELEASE_TAG#v}"
+          node scripts/ci/wait-for-npm-packages.mjs "$VERSION" \
+            @superradcompany/microsandbox-darwin-arm64 \
+            @superradcompany/microsandbox-linux-arm64-gnu \
+            @superradcompany/microsandbox-linux-x64-gnu \
+            @superradcompany/microsandbox-win32-arm64-msvc \
+            @superradcompany/microsandbox-win32-x64-msvc
+
+      - name: Regenerate lockfile
+        working-directory: sdk/node-ts
+        run: npm install --package-lock-only --ignore-scripts
+
+      - uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+        with:
+          title: "chore: refresh npm lockfile after ${{ inputs.release_tag }}"
+          body: |
+            Regenerates `sdk/node-ts/package-lock.json` against the platform packages published for ${{ inputs.release_tag }}, so `npm ci` keeps working on main.
+          branch: refresh-lockfile-${{ inputs.release_tag }}
+          commit-message: "chore: refresh npm lockfile after ${{ inputs.release_tag }}"
+          base: main
+          add-paths: sdk/node-ts/package-lock.json
+          delete-branch: true

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -25,7 +25,7 @@ on:
         required: true
         type: string
       confirm_publish:
-        description: Publish only the npm release flow
+        description: Publish an npm flow that failed before any npm package was published
         required: true
         default: false
         type: boolean
@@ -104,6 +104,34 @@ jobs:
             process.exit(1);
           }
           NODE
+
+      - name: Verify npm versions are unpublished
+        env:
+          RELEASE_TAG: ${{ inputs.release_tag }}
+        run: |
+          version="${RELEASE_TAG#v}"
+          packages=(
+            microsandbox
+            @microsandbox/agent-client
+            @microsandbox/types
+            microsandbox-mcp
+            @superradcompany/microsandbox-darwin-arm64
+            @superradcompany/microsandbox-linux-arm64-gnu
+            @superradcompany/microsandbox-linux-x64-gnu
+            @superradcompany/microsandbox-win32-arm64-msvc
+            @superradcompany/microsandbox-win32-x64-msvc
+          )
+          published=()
+          for package in "${packages[@]}"; do
+            if npm view "$package@$version" version --json >/dev/null 2>&1; then
+              published+=("$package@$version")
+            fi
+          done
+          if [ "${#published[@]}" -ne 0 ]; then
+            echo "Refusing npm recovery because these versions already exist:" >&2
+            printf '  %s\n' "${published[@]}" >&2
+            exit 1
+          fi
 
       - name: Download Node SDK artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -25,7 +25,7 @@ on:
         required: true
         type: string
       confirm_publish:
-        description: Publish an npm flow that failed before any npm package was published
+        description: Publish only the npm release flow
         required: true
         default: false
         type: boolean
@@ -57,6 +57,15 @@ jobs:
         with:
           node-version: 22
           registry-url: https://registry.npmjs.org
+
+      # Manual recovery can target a tag created before this helper existed,
+      # so load release tooling from the commit running this workflow.
+      - name: Checkout release tooling
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          path: .release-workflow
+          sparse-checkout: scripts/ci/publish_npm_package.py
+          sparse-checkout-cone-mode: false
 
       - name: Verify release source
         env:
@@ -105,34 +114,6 @@ jobs:
           }
           NODE
 
-      - name: Verify npm versions are unpublished
-        env:
-          RELEASE_TAG: ${{ inputs.release_tag }}
-        run: |
-          version="${RELEASE_TAG#v}"
-          packages=(
-            microsandbox
-            @microsandbox/agent-client
-            @microsandbox/types
-            microsandbox-mcp
-            @superradcompany/microsandbox-darwin-arm64
-            @superradcompany/microsandbox-linux-arm64-gnu
-            @superradcompany/microsandbox-linux-x64-gnu
-            @superradcompany/microsandbox-win32-arm64-msvc
-            @superradcompany/microsandbox-win32-x64-msvc
-          )
-          published=()
-          for package in "${packages[@]}"; do
-            if npm view "$package@$version" version --json >/dev/null 2>&1; then
-              published+=("$package@$version")
-            fi
-          done
-          if [ "${#published[@]}" -ne 0 ]; then
-            echo "Refusing npm recovery because these versions already exist:" >&2
-            printf '  %s\n' "${published[@]}" >&2
-            exit 1
-          fi
-
       - name: Download Node SDK artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -177,7 +158,7 @@ jobs:
         run: |
           npm ci
           npm run build
-          npm publish --access public
+          python3 ../../../.release-workflow/scripts/ci/publish_npm_package.py .
 
       - name: Build and publish microsandbox types package
         env:
@@ -186,18 +167,18 @@ jobs:
         run: |
           npm ci
           npm run build
-          npm publish --access public
+          python3 ../../../.release-workflow/scripts/ci/publish_npm_package.py .
 
       - name: Publish platform packages
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
-          for dir in darwin-arm64 linux-x64-gnu linux-arm64-gnu win32-x64-msvc win32-arm64-msvc; do
-            echo "Publishing @superradcompany/microsandbox-$dir..."
-            cd "sdk/node-ts/npm/$dir"
-            npm publish --access public
-            cd ../../../..
-          done
+          python3 .release-workflow/scripts/ci/publish_npm_package.py \
+            sdk/node-ts/npm/darwin-arm64 \
+            sdk/node-ts/npm/linux-x64-gnu \
+            sdk/node-ts/npm/linux-arm64-gnu \
+            sdk/node-ts/npm/win32-x64-msvc \
+            sdk/node-ts/npm/win32-arm64-msvc
 
       - name: Wait for npm to index platform packages
         env:
@@ -239,7 +220,7 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         working-directory: sdk/node-ts
-        run: npm publish --access public
+        run: python3 ../../.release-workflow/scripts/ci/publish_npm_package.py .
 
   mcp-publish:
     name: Publish MCP server
@@ -256,6 +237,15 @@ jobs:
           node-version: 22
           registry-url: https://registry.npmjs.org
 
+      # Manual recovery can target a tag created before this helper existed,
+      # so load release tooling from the commit running this workflow.
+      - name: Checkout release tooling
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          path: .release-workflow
+          sparse-checkout: scripts/ci/publish_npm_package.py
+          sparse-checkout-cone-mode: false
+
       - name: Wait for the root SDK package
         env:
           RELEASE_TAG: ${{ inputs.release_tag }}
@@ -271,7 +261,7 @@ jobs:
           rm -f package-lock.json
           npm install
           npm run build
-          npm publish --access public
+          python3 ../.release-workflow/scripts/ci/publish_npm_package.py .
 
   refresh-lockfile:
     name: Refresh npm lockfile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1182,7 +1182,8 @@ jobs:
       artifact_run_id: ${{ github.run_id }}
       confirm_publish: true
       release_tag: ${{ github.ref_name }}
-    secrets: inherit
+    secrets:
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   # ---------------------------------------------------------------------------
   # Publish Rust crates to crates.io

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,8 @@ on:
       - .github/workflows/release-windows.yml
       - .github/actions/cache-libkrunfw-kernel/action.yml
       - scripts/ci/publish-crates.py
+      - scripts/ci/publish_npm_package.py
+      - scripts/ci/test_publish_npm_package.py
       - scripts/ci/validate-release-artifacts.py
       - scripts/ci/test_validate_release_artifacts.py
       - scripts/ci/validate_linux_glibc.py

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@ on:
       - .github/workflows/release.yml
       - .github/workflows/release-linux.yml
       - .github/workflows/release-macos.yml
+      - .github/workflows/release-npm.yml
       - .github/workflows/release-windows.yml
       - .github/actions/cache-libkrunfw-kernel/action.yml
       - scripts/ci/publish-crates.py
@@ -1164,203 +1165,24 @@ jobs:
           token: ${{ secrets.WINGET_TOKEN }}
 
   # ---------------------------------------------------------------------------
-  # Publish Node SDK to npm
+  # Publish the Node SDK and MCP server to npm, then refresh the Node lockfile.
+  # The reusable workflow can also recover this flow independently without
+  # rerunning publishers for the other ecosystems.
   # ---------------------------------------------------------------------------
-  npm-publish:
-    name: Publish npm packages
+  npm-release:
+    name: Publish npm release
     needs: release-ready
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: 22
-          registry-url: https://registry.npmjs.org
-
-      - name: Download Node SDK artifacts
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          path: node-artifacts
-          pattern: node-sdk-*
-
-      - name: Place binaries and update generated files
-        run: |
-          # Copy prepared platform package payloads.
-          for dir in darwin-arm64 linux-x64-gnu linux-arm64-gnu win32-x64-msvc win32-arm64-msvc; do
-            mkdir -p "sdk/node-ts/npm/$dir/bin" "sdk/node-ts/npm/$dir/lib"
-            cp "node-artifacts/node-sdk-$dir/npm/$dir"/microsandbox.*.node "sdk/node-ts/npm/$dir/"
-            cp "node-artifacts/node-sdk-$dir/npm/$dir/bin/"* "sdk/node-ts/npm/$dir/bin/"
-            cp "node-artifacts/node-sdk-$dir/npm/$dir/lib/"* "sdk/node-ts/npm/$dir/lib/"
-            # GitHub Actions artifacts strip Unix exec bits; restore before publish
-            # so the published tarball carries 0755 on the binary.
-            if [ -f "sdk/node-ts/npm/$dir/bin/msb" ]; then
-              chmod +x "sdk/node-ts/npm/$dir/bin/msb"
-            fi
-          done
-
-          # Copy napi-generated bindings into the root package's native/ dir
-          # (use darwin-arm64; all platforms emit identical JS and types).
-          # napi build emits index.d.ts; rename to index.d.cts so nodenext
-          # resolution finds it next to the .cjs binding.
-          cp node-artifacts/node-sdk-darwin-arm64/native/index.cjs sdk/node-ts/native/index.cjs
-          cp node-artifacts/node-sdk-darwin-arm64/native/index.d.ts sdk/node-ts/native/index.d.cts
-
-      - name: Build TypeScript output (root package dist/)
-        working-directory: sdk/node-ts
-        run: |
-          npm install --omit=optional --package-lock=false
-          npm run build:ts
-
-      - name: Build and publish agent client package
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        working-directory: packages/agent-client/typescript
-        run: |
-          npm ci
-          npm run build
-          npm publish --access public
-
-      - name: Build and publish microsandbox types package
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        working-directory: packages/microsandbox-types/typescript
-        run: |
-          npm ci
-          npm run build
-          npm publish --access public
-
-      - name: Publish platform packages
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: |
-          for dir in darwin-arm64 linux-x64-gnu linux-arm64-gnu win32-x64-msvc win32-arm64-msvc; do
-            echo "Publishing @superradcompany/microsandbox-$dir..."
-            cd sdk/node-ts/npm/$dir
-            npm publish --access public
-            cd ../../../..
-          done
-
-      - name: Wait for npm to index platform packages
-        run: |
-          VERSION="${GITHUB_REF_NAME#v}"
-          node scripts/ci/wait-for-npm-packages.mjs "$VERSION" \
-            @superradcompany/microsandbox-darwin-arm64 \
-            @superradcompany/microsandbox-linux-arm64-gnu \
-            @superradcompany/microsandbox-linux-x64-gnu \
-            @superradcompany/microsandbox-win32-arm64-msvc \
-            @superradcompany/microsandbox-win32-x64-msvc
-
-      - name: Verify root package platform dependencies
-        working-directory: sdk/node-ts
-        run: |
-          node - <<'NODE'
-          const fs = require("node:fs");
-
-          const pkg = JSON.parse(fs.readFileSync("package.json", "utf8"));
-          const optionalDependencies = pkg.optionalDependencies ?? {};
-          const required = [
-            "@superradcompany/microsandbox-darwin-arm64",
-            "@superradcompany/microsandbox-linux-arm64-gnu",
-            "@superradcompany/microsandbox-linux-x64-gnu",
-            "@superradcompany/microsandbox-win32-arm64-msvc",
-            "@superradcompany/microsandbox-win32-x64-msvc",
-          ];
-
-          const missing = required.filter((name) => optionalDependencies[name] !== pkg.version);
-
-          if (missing.length > 0) {
-            console.error(`Missing or mismatched platform optional dependencies: ${missing.join(", ")}`);
-            process.exit(1);
-          }
-          NODE
-
-      - name: Publish root package
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        working-directory: sdk/node-ts
-        run: npm publish --access public
-
-  # ---------------------------------------------------------------------------
-  # Refresh sdk/node-ts/package-lock.json against the just-published platform
-  # packages, so main always has lockfile integrity hashes that satisfy
-  # `npm ci`. Opens a PR that the maintainer merges manually.
-  # ---------------------------------------------------------------------------
-  refresh-lockfile:
-    name: Refresh npm lockfile
-    needs: npm-publish
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
-    runs-on: ubuntu-latest
     permissions:
+      actions: read
       contents: write
       pull-requests: write
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          ref: main
-
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: 22
-
-      - name: Wait for npm to index platform packages
-        run: |
-          VERSION="${GITHUB_REF_NAME#v}"
-          node scripts/ci/wait-for-npm-packages.mjs "$VERSION" \
-            @superradcompany/microsandbox-darwin-arm64 \
-            @superradcompany/microsandbox-linux-arm64-gnu \
-            @superradcompany/microsandbox-linux-x64-gnu \
-            @superradcompany/microsandbox-win32-arm64-msvc \
-            @superradcompany/microsandbox-win32-x64-msvc
-
-      - name: Regenerate lockfile
-        working-directory: sdk/node-ts
-        run: npm install --package-lock-only --ignore-scripts
-
-      - uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
-        with:
-          title: "chore: refresh npm lockfile after ${{ github.ref_name }}"
-          body: |
-            Regenerates `sdk/node-ts/package-lock.json` against the platform packages published for ${{ github.ref_name }}, so `npm ci` keeps working on main.
-          branch: refresh-lockfile-${{ github.ref_name }}
-          commit-message: "chore: refresh npm lockfile after ${{ github.ref_name }}"
-          base: main
-          add-paths: sdk/node-ts/package-lock.json
-          delete-branch: true
-
-  # ---------------------------------------------------------------------------
-  # Publish MCP server to npm
-  # ---------------------------------------------------------------------------
-  mcp-publish:
-    name: Publish MCP server
-    needs: npm-publish
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          submodules: true
-
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: 22
-          registry-url: https://registry.npmjs.org
-
-      - name: Wait for the root SDK package
-        run: |
-          VERSION="${GITHUB_REF_NAME#v}"
-          node scripts/ci/wait-for-npm-packages.mjs "$VERSION" microsandbox
-
-      - name: Build and publish MCP server
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        working-directory: mcp
-        run: |
-          rm -f package-lock.json
-          npm install
-          npm run build
-          npm publish --access public
+    uses: ./.github/workflows/release-npm.yml
+    with:
+      artifact_run_id: ${{ github.run_id }}
+      confirm_publish: true
+      release_tag: ${{ github.ref_name }}
+    secrets: inherit
 
   # ---------------------------------------------------------------------------
   # Publish Rust crates to crates.io

--- a/scripts/ci/publish_npm_package.py
+++ b/scripts/ci/publish_npm_package.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Publish npm packages idempotently after verifying immutable contents."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+
+
+NPM_REGISTRY = "https://registry.npmjs.org"
+USER_AGENT = "microsandbox-release-ci (https://github.com/superradcompany/microsandbox)"
+
+
+@dataclass(frozen=True)
+class Package:
+    """An npm package directory and its immutable registry identity."""
+
+    directory: Path
+    name: str
+    version: str
+
+    @property
+    def spec(self) -> str:
+        """Return the registry package and version selector."""
+        return f"{self.name}@{self.version}"
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse package directories from the command line."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "packages", type=Path, nargs="+", help="npm package directories"
+    )
+    return parser.parse_args()
+
+
+def load_package(directory: Path) -> Package:
+    """Load an npm package identity from a package directory."""
+    manifest_path = directory / "package.json"
+    manifest = json.loads(manifest_path.read_text())
+    try:
+        name = manifest["name"]
+        version = manifest["version"]
+    except KeyError as error:
+        raise SystemExit(f"missing {error.args[0]} in {manifest_path}") from error
+    if not isinstance(name, str) or not isinstance(version, str):
+        raise SystemExit(f"invalid npm package identity in {manifest_path}")
+    return Package(directory, name, version)
+
+
+def request_json(url: str) -> dict[str, object] | None:
+    """Fetch registry JSON, returning None only for an absent version."""
+    request = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            return json.load(response)
+    except urllib.error.HTTPError as error:
+        if error.code == 404:
+            return None
+        raise
+
+
+def registry_integrity(package: Package) -> str | None:
+    """Return the published tarball integrity for a package version."""
+    encoded_name = urllib.parse.quote(package.name, safe="@")
+    encoded_version = urllib.parse.quote(package.version, safe="")
+    metadata = request_json(f"{NPM_REGISTRY}/{encoded_name}/{encoded_version}")
+    if metadata is None:
+        return None
+    dist = metadata.get("dist")
+    integrity = dist.get("integrity") if isinstance(dist, dict) else None
+    if not isinstance(integrity, str):
+        raise SystemExit(f"npm registry omitted dist.integrity for {package.spec}")
+    return integrity
+
+
+def pack_integrity(package: Package) -> str:
+    """Build the local npm tarball manifest and return its integrity."""
+    result = subprocess.run(
+        ["npm", "pack", "--dry-run", "--json"],
+        cwd=package.directory,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    payload = json.loads(result.stdout)
+    if not isinstance(payload, list) or len(payload) != 1:
+        raise SystemExit(f"unexpected npm pack output for {package.spec}")
+    packed = payload[0]
+    if packed.get("name") != package.name or packed.get("version") != package.version:
+        raise SystemExit(f"npm pack identity mismatch for {package.spec}")
+    integrity = packed.get("integrity")
+    if not isinstance(integrity, str):
+        raise SystemExit(f"npm pack omitted integrity for {package.spec}")
+    return integrity
+
+
+def publish_package(package: Package) -> None:
+    """Publish a missing version or verify an identical existing version."""
+    local_integrity = pack_integrity(package)
+    remote_integrity = registry_integrity(package)
+    if remote_integrity is not None:
+        if remote_integrity != local_integrity:
+            raise SystemExit(f"{package.spec} exists with different contents")
+        print(f"{package.spec} already published; integrity matches", flush=True)
+        return
+
+    print(f"publishing {package.spec}", flush=True)
+    subprocess.run(
+        ["npm", "publish", "--access", "public"],
+        cwd=package.directory,
+        check=True,
+    )
+
+
+def main() -> None:
+    """Publish each requested npm package in command-line order."""
+    args = parse_args()
+    for directory in args.packages:
+        publish_package(load_package(directory))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/ci/test_publish_npm_package.py
+++ b/scripts/ci/test_publish_npm_package.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Tests for idempotent npm package publication."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from scripts.ci import publish_npm_package
+
+
+class PublishNpmPackageTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary_directory = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temporary_directory.cleanup)
+        self.directory = Path(self.temporary_directory.name)
+        (self.directory / "package.json").write_text(
+            json.dumps({"name": "@example/package", "version": "1.2.3"})
+        )
+        self.package = publish_npm_package.load_package(self.directory)
+
+    def test_load_package_reads_identity(self) -> None:
+        self.assertEqual(self.package.name, "@example/package")
+        self.assertEqual(self.package.version, "1.2.3")
+        self.assertEqual(self.package.spec, "@example/package@1.2.3")
+
+    @mock.patch.object(publish_npm_package.subprocess, "run")
+    @mock.patch.object(publish_npm_package, "registry_integrity", return_value=None)
+    @mock.patch.object(
+        publish_npm_package, "pack_integrity", return_value="sha512-local"
+    )
+    def test_missing_package_is_published(
+        self,
+        _pack_integrity: mock.Mock,
+        _registry_integrity: mock.Mock,
+        run: mock.Mock,
+    ) -> None:
+        publish_npm_package.publish_package(self.package)
+
+        run.assert_called_once_with(
+            ["npm", "publish", "--access", "public"],
+            cwd=self.directory,
+            check=True,
+        )
+
+    @mock.patch.object(publish_npm_package.subprocess, "run")
+    @mock.patch.object(
+        publish_npm_package,
+        "registry_integrity",
+        return_value="sha512-matching",
+    )
+    @mock.patch.object(
+        publish_npm_package,
+        "pack_integrity",
+        return_value="sha512-matching",
+    )
+    def test_matching_package_is_skipped(
+        self,
+        _pack_integrity: mock.Mock,
+        _registry_integrity: mock.Mock,
+        run: mock.Mock,
+    ) -> None:
+        publish_npm_package.publish_package(self.package)
+
+        run.assert_not_called()
+
+    @mock.patch.object(
+        publish_npm_package,
+        "registry_integrity",
+        return_value="sha512-remote",
+    )
+    @mock.patch.object(
+        publish_npm_package,
+        "pack_integrity",
+        return_value="sha512-local",
+    )
+    def test_mismatched_package_fails(
+        self,
+        _pack_integrity: mock.Mock,
+        _registry_integrity: mock.Mock,
+    ) -> None:
+        with self.assertRaisesRegex(
+            SystemExit,
+            "@example/package@1.2.3 exists with different contents",
+        ):
+            publish_npm_package.publish_package(self.package)
+
+    @mock.patch.object(publish_npm_package.subprocess, "run")
+    def test_pack_integrity_validates_identity(self, run: mock.Mock) -> None:
+        run.return_value = subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout=json.dumps(
+                [
+                    {
+                        "name": "another-package",
+                        "version": "1.2.3",
+                        "integrity": "sha512-local",
+                    }
+                ]
+            ),
+        )
+
+        with self.assertRaisesRegex(SystemExit, "npm pack identity mismatch"):
+            publish_npm_package.pack_integrity(self.package)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/ci/test_publish_npm_package.py
+++ b/scripts/ci/test_publish_npm_package.py
@@ -6,14 +6,13 @@ from __future__ import annotations
 import json
 import subprocess
 import tempfile
-import unittest
 from pathlib import Path
-from unittest import mock
+from unittest import TestCase, main, mock
 
 from scripts.ci import publish_npm_package
 
 
-class PublishNpmPackageTests(unittest.TestCase):
+class PublishNpmPackageTests(TestCase):
     def setUp(self) -> None:
         self.temporary_directory = tempfile.TemporaryDirectory()
         self.addCleanup(self.temporary_directory.cleanup)
@@ -110,4 +109,4 @@ class PublishNpmPackageTests(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    unittest.main()
+    main()


### PR DESCRIPTION
## TL;DR

Extract the npm publication flow into a reusable workflow that can recover v0.6.17 without rerunning any other ecosystem publisher. The publish-stage Node install now uses the tested lockfile.

## Description

- replace the floating publish-stage install with `npm ci --omit=optional`
- let normal tagged releases call the same reusable npm workflow
- allow an explicitly confirmed manual run to publish only Node packages, MCP, and the npm lockfile refresh
- require the selected release tag and artifact run to resolve to the same commit and a completed tag-push run
- safely resume partial npm publication by skipping existing versions only when their packed integrity matches exactly
- abort if an existing immutable npm version differs from the release contents
- pass only `NPM_TOKEN` to the reusable publisher
- reuse the already validated platform artifacts from the selected release run

## Test Plan

- `actionlint .github/workflows/release-npm.yml`
- `python3 -m unittest scripts.ci.test_publish_npm_package`
- `uv run --project sdk/python ruff check scripts/ci/publish_npm_package.py scripts/ci/test_publish_npm_package.py`
- `uv run --project sdk/python ruff format --check scripts/ci/publish_npm_package.py scripts/ci/test_publish_npm_package.py`
- verify the helper recognizes an identical published `@microsandbox/types@0.6.16` tarball by its registry integrity
- `npx --yes npm@10.9.8 ci --omit=optional && npm run build:ts` in `sdk/node-ts`
- `npx --yes npm@10.9.8 ci && npm run build` in both shared TypeScript packages
- verify `v0.6.17` and release run `33873257618` resolve to the same commit and completed tag-push metadata
- verify all nine npm package manifests report version `0.6.17`
- `git diff --check`



<!-- greptile_comment -->

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR is not yet safe to merge because an immediate recovery can still stop on a duplicate npm publication while registry metadata is being indexed.

A single transient 404 causes the helper to publish an already-existing immutable version, and that failure aborts the serial package loop before remaining packages are recovered.

**Files Needing Attention:** scripts/ci/publish_npm_package.py, .github/workflows/release-npm.yml
</details>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22superradcompany%2Fmicrosandbox%22%20on%20the%20existing%20branch%20%22toks%2Frecover-0.6.17-npm%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22toks%2Frecover-0.6.17-npm%22.%0A%0AGreploop%20superradcompany%2Fmicrosandbox%20PR%20%231521%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AAFTER%20THE%20LOOP%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%20%20%20%20%20%20%20%20%20%20%7C%0A%2B------------------------------------------------------%2B&repo=superradcompany%2Fmicrosandbox&pr=1521&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22superradcompany%2Fmicrosandbox%22%20on%20the%20existing%20branch%20%22toks%2Frecover-0.6.17-npm%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22toks%2Frecover-0.6.17-npm%22.%0A%0A%23%23%23%20Issue%201%0Ascripts%2Fci%2Fpublish_npm_package.py%3A107-114%0A**Transient%20404%20breaks%20recovery**%0A%0AWhen%20npm-only%20recovery%20starts%20while%20an%20already-published%20version%20is%20still%20being%20indexed%2C%20a%20single%20404%20makes%20this%20helper%20attempt%20to%20publish%20that%20immutable%20version%20again.%20npm%20rejects%20the%20duplicate%2C%20%60check%3DTrue%60%20terminates%20the%20serial%20package%20loop%2C%20and%20the%20remaining%20packages%20stay%20unpublished.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=superradcompany%2Fmicrosandbox&pr=1521&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Ascripts%2Fci%2Fpublish_npm_package.py%3A107-114%0A**Transient%20404%20breaks%20recovery**%0A%0AWhen%20npm-only%20recovery%20starts%20while%20an%20already-published%20version%20is%20still%20being%20indexed%2C%20a%20single%20404%20makes%20this%20helper%20attempt%20to%20publish%20that%20immutable%20version%20again.%20npm%20rejects%20the%20duplicate%2C%20%60check%3DTrue%60%20terminates%20the%20serial%20package%20loop%2C%20and%20the%20remaining%20packages%20stay%20unpublished.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=superradcompany%2Fmicrosandbox&pr=1521&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
scripts/ci/publish_npm_package.py:107-114
**Transient 404 breaks recovery**

When npm-only recovery starts while an already-published version is still being indexed, a single 404 makes this helper attempt to publish that immutable version again. npm rejects the duplicate, `check=True` terminates the serial package loop, and the remaining packages stay unpublished.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (4): Last reviewed commit: ["style(release): normalize unittest impor..."](https://github.com/superradcompany/microsandbox/commit/c58722b12b66d9d1891e6762dee76323d2128aed) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60406725)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Restore post-publish npm lockfile refresh](https://app.greptile.com/microsandbox/-/custom-context/knowledge-base/superradcompany/microsandbox/-/reverts/rollback_717-20260513-stale-npm-lockfile-01f154d.md)
- Knowledge Base — [Restore executable bits in Unix release artifacts](https://app.greptile.com/microsandbox/-/custom-context/knowledge-base/superradcompany/microsandbox/-/reverts/rollback_1413-20260819-non-executable-unix-artifacts-d1b0140.md)

<!-- /greptile_comment -->