### PR TITLE
fix(release): use npm ci when publishing Node package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1210,7 +1210,7 @@ jobs:
       - name: Build TypeScript output (root package dist/)
         working-directory: sdk/node-ts
         run: |
-          npm install --omit=optional --package-lock=false
+          npm ci --omit=optional
           npm run build:ts
 
       - name: Build and publish agent client package


### PR DESCRIPTION
## TL;DR

Use the lockfile when assembling the root Node package during release, avoiding the npm 10 dependency-graph failure seen while publishing v0.6.17.

## Description

- Replace the publish-stage npm install command with npm ci --omit=optional.
- Keep the release fix limited to the failing command.

## Test Plan

- The exact command completed successfully under Node 22.23.2 and npm 10.9.8 in the npm-only v0.6.17 recovery run.
- Repository pre-commit YAML validation passes.

<!-- greptile_comment -->

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable issues identified.

The release workflow now performs a lockfile-enforced clean install while continuing to omit platform-specific optional dependencies before building the TypeScript output.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(release): use locked npm install whe..."](https://github.com/superradcompany/microsandbox/commit/a099f7ebf624507dea94d12f1a55845d4401e49a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60434188)</sub>

<!-- /greptile_comment -->