### PR TITLE
fix(release): isolate Mintlify sync checks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,8 @@ on:
   push:
     tags: ["v*"]
   pull_request:
+    branches-ignore:
+      - mintlify
     paths:
       - .github/workflows/release.yml
       - .github/workflows/release-linux.yml
@@ -1075,7 +1077,9 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           branch="mintlify-sync-${{ github.ref_name }}"
-          git push --force origin ${{ github.sha }}:refs/heads/"$branch"
+          git switch --detach "${{ github.sha }}"
+          git commit --allow-empty -m "chore(docs): sync mintlify to ${{ github.ref_name }}"
+          git push --force origin HEAD:refs/heads/"$branch"
           if [ "${{ steps.merge.outputs.result }}" = "clean" ]; then
             body="Syncs mintlify to ${{ github.ref_name }}. The release commit merges cleanly, so this PR was enqueued automatically; the merge queue lands it as a merge commit."
           else


### PR DESCRIPTION
## TL;DR

Prevent generated Mintlify sync PRs from launching the full release workflow or inheriting checks from the release tag commit.

## Description

- Exclude pull requests targeting `mintlify` from the Release workflow.
- Add a unique empty commit to each generated sync branch before opening its PR.
- Keep the tagged release commit as the sync commit’s parent so shared history is preserved.

## Test Plan

- `git diff --check`
- `actionlint .github/workflows/release.yml`
- repository pre-commit hooks, including YAML validation

<!-- greptile_comment -->

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no concrete changed-code defect identified.

The new sync commit preserves release ancestry and content, while another pull-request workflow continues to run for the Mintlify branch.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(release): isolate Mintlify sync chec..."](https://github.com/superradcompany/microsandbox/commit/fdca4cbd2acdb859f4ee3db757b5c868437285dc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60488675)</sub>

<!-- /greptile_comment -->