### PR TITLE
ci(docs): automate production API reference sync

### DIFF
--- a/.github/workflows/sync-docs-openapi.yml
+++ b/.github/workflows/sync-docs-openapi.yml
@@ -1,0 +1,65 @@
+name: Sync docs OpenAPI
+
+# Refresh the staging API reference without making unrelated pull requests
+# depend on the live API. Scheduled workflows run from the default branch,
+# while the generated docs are proposed against the Mintlify deploy branch.
+
+on:
+  schedule:
+    - cron: "23 6 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: sync-docs-openapi
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    name: Refresh staging API reference
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: mintlify
+
+      - name: Generate reference
+        run: python3 scripts/sync-docs-openapi.py --environment staging --audience all
+
+      - name: Validate reference
+        run: |
+          python3 scripts/sync-docs-openapi.py --environment staging --audience all --check
+          jq empty \
+            docs/api-reference/openapi.staging.json \
+            docs/api-reference/openapi.personal.staging.json
+
+      - name: Open update PR
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+        with:
+          title: "docs(api): refresh staging reference"
+          body: |
+            ## TL;DR
+
+            Refreshes the checked-in API reference from the staging OpenAPI contract.
+
+            ## Description
+
+            - updates API-key endpoints
+            - updates personal-token endpoints
+            - excludes unauthenticated, `x-hidden`, and `x-excluded` operations
+
+            ## Test Plan
+
+            - `python3 scripts/sync-docs-openapi.py --environment staging --audience all --check`
+            - validate both generated files with `jq`
+          branch: automation/sync-docs-openapi
+          base: mintlify
+          commit-message: "docs(api): refresh staging reference"
+          add-paths: |
+            docs/api-reference/openapi.staging.json
+            docs/api-reference/openapi.personal.staging.json
+          delete-branch: true

--- a/.github/workflows/sync-docs-openapi.yml
+++ b/.github/workflows/sync-docs-openapi.yml
@@ -1,6 +1,6 @@
 name: Sync docs OpenAPI
 
-# Refresh the staging API reference without making unrelated pull requests
+# Refresh the production API reference without making unrelated pull requests
 # depend on the live API. Scheduled workflows run from the default branch,
 # while the generated docs are proposed against the Mintlify deploy branch.
 
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   sync:
-    name: Refresh staging API reference
+    name: Refresh production API reference
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -28,23 +28,23 @@ jobs:
           ref: mintlify
 
       - name: Generate reference
-        run: python3 scripts/sync-docs-openapi.py --environment staging --audience all
+        run: python3 scripts/sync-docs-openapi.py --environment production --audience all
 
       - name: Validate reference
         run: |
-          python3 scripts/sync-docs-openapi.py --environment staging --audience all --check
+          python3 scripts/sync-docs-openapi.py --environment production --audience all --check
           jq empty \
-            docs/api-reference/openapi.staging.json \
-            docs/api-reference/openapi.personal.staging.json
+            docs/api-reference/openapi.json \
+            docs/api-reference/openapi.personal.json
 
       - name: Open update PR
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
-          title: "docs(api): refresh staging reference"
+          title: "docs(api): refresh production reference"
           body: |
             ## TL;DR
 
-            Refreshes the checked-in API reference from the staging OpenAPI contract.
+            Refreshes the checked-in API reference from the production OpenAPI contract.
 
             ## Description
 
@@ -54,12 +54,12 @@ jobs:
 
             ## Test Plan
 
-            - `python3 scripts/sync-docs-openapi.py --environment staging --audience all --check`
+            - `python3 scripts/sync-docs-openapi.py --environment production --audience all --check`
             - validate both generated files with `jq`
           branch: automation/sync-docs-openapi
           base: mintlify
-          commit-message: "docs(api): refresh staging reference"
+          commit-message: "docs(api): refresh production reference"
           add-paths: |
-            docs/api-reference/openapi.staging.json
-            docs/api-reference/openapi.personal.staging.json
+            docs/api-reference/openapi.json
+            docs/api-reference/openapi.personal.json
           delete-branch: true


### PR DESCRIPTION
## TL;DR

Adds a daily and manually triggerable updater for the production API reference. It opens a focused PR against `mintlify` only when production-generated files change.

Depends on #1531 and should merge after it so the generator and personal-token production artifact are available on `mintlify`.

## Description

- runs once daily and supports manual dispatch
- regenerates production API-key and personal-token references
- validates both generated JSON files
- opens or updates a single automation branch against `mintlify`
- keeps live API availability out of ordinary builds and pull-request checks
- leaves staging artifacts independent from the production deployment

## Test Plan

- `actionlint .github/workflows/sync-docs-openapi.yml`
- inspect the workflow permissions, target branch, generated paths, and pinned action revisions
- manually dispatch once after #1531 merges and confirm it creates no PR when the production reference is current


<!-- greptile_comment -->

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because no eligible blocking failure or outstanding prior finding remains in this follow-up review.

No blocking failure remains within the supplied follow-up-review scope.
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(ci): sync production API docs to Min..."](https://github.com/superradcompany/microsandbox/commit/d4bdca4be0a4bec65de1f0aed0bda76f205f524e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60795601)</sub>

<!-- /greptile_comment -->