### PR TITLE
refactor(agent): trim transport API surface

### DIFF
--- a/crates/cli/lib/sandbox_cmd.rs
+++ b/crates/cli/lib/sandbox_cmd.rs
@@ -40,7 +40,7 @@ pub struct SandboxArgs {
         default_value = "auto",
         value_parser = parse_agent_transport_profile
     )]
-    pub agent_transport: AgentTransportProfile,
+    pub(crate) agent_transport: AgentTransportProfile,
 
     /// Name of the sandbox.
     #[arg(long = "name")]

--- a/crates/protocol/lib/lib.rs
+++ b/crates/protocol/lib/lib.rs
@@ -79,9 +79,11 @@ const _: () = assert!(
 pub const AGENT_PORT_NAME: &str = "agent";
 
 /// Virtio-console port name for the optional generation-8 bulk lane.
+#[doc(hidden)]
 pub const AGENT_BULK_PORT_NAME: &str = "agent-bulk";
 
 /// Internal kernel command-line selector for the first dual-port transport profile.
+#[doc(hidden)]
 pub const AGENT_TRANSPORT_DUAL_PORT_CMDLINE: &str = "microsandbox.agent_transport=dual-port-v1";
 
 /// Virtiofs tag for the runtime filesystem (scripts, heartbeat).
@@ -446,6 +448,7 @@ pub mod fs;
 pub mod heartbeat;
 pub mod message;
 pub mod tcp;
+#[doc(hidden)]
 pub mod transport;
 
 pub use error::*;

--- a/crates/runtime/lib/runner/vm.rs
+++ b/crates/runtime/lib/runner/vm.rs
@@ -84,6 +84,8 @@ const AGENT_BULK_QUEUE_SIZE: u16 = 256;
 
 /// Internal host/guest topology for the agent data plane.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+#[doc(hidden)]
+#[non_exhaustive]
 pub enum AgentTransportProfile {
     /// Offer the dedicated bulk port and retain combined mode when agentd does not select it.
     #[default]
@@ -109,6 +111,7 @@ struct AgentConsoleBackends {
 #[derive(Debug)]
 pub struct Config {
     /// Internal per-boot agent transport policy.
+    #[doc(hidden)]
     pub agent_transport: AgentTransportProfile,
 
     /// Name of the sandbox.

--- a/packages/agent-client/rust/README.md
+++ b/packages/agent-client/rust/README.md
@@ -27,6 +27,8 @@ microsandbox-agent-client = { version = "0.6.15", features = ["stream"] }
 
 The high-level `microsandbox` SDK enables `uds` explicitly because local sandboxes are reached through Unix domain sockets.
 
+The `uds` adapter negotiates local shared-memory payload transport automatically when the runtime supports it. Callers continue to use `AgentClient`; arena descriptors, mappings, and releases are an internal connection detail.
+
 ## Protocol Model
 
 The agent protocol uses a stable length-prefixed binary frame header:

--- a/packages/agent-client/rust/lib/lib.rs
+++ b/packages/agent-client/rust/lib/lib.rs
@@ -13,8 +13,11 @@
 
 pub mod client;
 pub mod error;
-/// Unix-local shared-memory bulk transport primitives.
+/// Internal Unix-local shared-memory transport used by the UDS adapter and runtime relay.
+///
+/// Callers connect through [`AgentClient`]; arena negotiation and lifecycle are automatic.
 #[cfg(all(feature = "uds", unix))]
+#[doc(hidden)]
 pub mod local_shm;
 pub mod message;
 pub mod stream;

--- a/sdk/rust/lib/backend/sandbox.rs
+++ b/sdk/rust/lib/backend/sandbox.rs
@@ -24,7 +24,7 @@ use crate::logs::{BootError, LogEntry, LogOptions, LogStreamOptions};
 #[cfg(feature = "local")]
 use crate::runtime::ProcessHandle;
 use crate::sandbox::exec::{ExecHandle, ExecOptions, ExecOutput};
-use crate::sandbox::fs::{FsEntry, FsMetadata, FsReadStream, FsWriteSink, HostCopyOptions};
+use crate::sandbox::fs::{FsEntry, FsMetadata, FsReadStream, FsWriteSink};
 use crate::sandbox::metrics::SandboxMetrics;
 use crate::sandbox::{
     Sandbox, SandboxConfig, SandboxHandle, SandboxListBuilder, SandboxPage, SandboxStatus,
@@ -475,7 +475,7 @@ pub trait SandboxBackend: Send + Sync {
         })
     }
 
-    /// Copy a guest file out to the host.
+    /// Copy a guest file out to the host with buffered atomic publication.
     fn fs_copy_to_host<'a>(
         &'a self,
         backend: Arc<dyn Backend>,
@@ -485,27 +485,6 @@ pub trait SandboxBackend: Send + Sync {
     ) -> BoxFuture<'a, MicrosandboxResult<()>> {
         Box::pin(async move {
             crate::sandbox::fs::agent::copy_to_host(backend.as_ref(), name, guest, host).await
-        })
-    }
-
-    /// Copy a guest file out to the host with explicit publication durability.
-    fn fs_copy_to_host_with_options<'a>(
-        &'a self,
-        backend: Arc<dyn Backend>,
-        name: &'a str,
-        guest: &'a str,
-        host: &'a Path,
-        options: HostCopyOptions,
-    ) -> BoxFuture<'a, MicrosandboxResult<()>> {
-        Box::pin(async move {
-            crate::sandbox::fs::agent::copy_to_host_with_options(
-                backend.as_ref(),
-                name,
-                guest,
-                host,
-                options,
-            )
-            .await
         })
     }
 }

--- a/sdk/rust/lib/sandbox/fs.rs
+++ b/sdk/rust/lib/sandbox/fs.rs
@@ -158,26 +158,6 @@ pub struct FsWriteSink {
     bulk_active: bool,
 }
 
-/// Host-side durability requested when publishing a copied guest file.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
-pub enum HostCopyDurability {
-    /// Atomically replace the destination after buffered writes complete, without forcing the
-    /// temporary file to stable storage.
-    #[default]
-    Buffered,
-
-    /// Call `sync_all` on the completed temporary file before atomically replacing the destination.
-    /// This does not by itself guarantee that the containing directory entry survives a crash.
-    File,
-}
-
-/// Options controlling a guest-to-host file copy.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
-pub struct HostCopyOptions {
-    /// Durability applied before the temporary file is published.
-    pub durability: HostCopyDurability,
-}
-
 enum FsWriteProtocol {
     Legacy {
         rx: mpsc::Receiver<AgentFrame>,
@@ -532,6 +512,10 @@ impl<'a> SandboxFsOps<'a> {
     }
 
     /// Copy a file from the sandbox to the host.
+    ///
+    /// The destination is published with an atomic rename after the complete file has been
+    /// received. An interrupted copy leaves an existing destination unchanged. Publication uses
+    /// buffered host I/O and does not force file or directory metadata to stable storage.
     pub async fn copy_to_host(
         &self,
         guest_path: &str,
@@ -544,25 +528,6 @@ impl<'a> SandboxFsOps<'a> {
                 self.name,
                 guest_path,
                 host_path.as_ref(),
-            )
-            .await
-    }
-
-    /// Copy a file from the sandbox to the host with explicit publication durability.
-    pub async fn copy_to_host_with_options(
-        &self,
-        guest_path: &str,
-        host_path: impl AsRef<Path>,
-        options: HostCopyOptions,
-    ) -> MicrosandboxResult<()> {
-        self.backend
-            .sandboxes()
-            .fs_copy_to_host_with_options(
-                self.backend.clone(),
-                self.name,
-                guest_path,
-                host_path.as_ref(),
-                options,
             )
             .await
     }
@@ -1133,9 +1098,9 @@ pub(crate) mod agent {
     use crate::{MicrosandboxError, MicrosandboxResult, agent::AgentClient, backend::Backend};
 
     use super::{
-        FsEntry, FsHandle, FsMetadata, FsReadStream, FsWriteSink, HostCopyDurability,
-        HostCopyOptions, check_response, entry_info_to_fs_entry, entry_info_to_metadata,
-        receive_fs_bulk_acceptance, should_offer_fs_write_bulk,
+        FsEntry, FsHandle, FsMetadata, FsReadStream, FsWriteSink, check_response,
+        entry_info_to_fs_entry, entry_info_to_metadata, receive_fs_bulk_acceptance,
+        should_offer_fs_write_bulk,
     };
 
     /// Open a fresh agent connection for the named sandbox.
@@ -1789,23 +1754,6 @@ pub(crate) mod agent {
         guest_path: &str,
         host_path: &Path,
     ) -> MicrosandboxResult<()> {
-        copy_to_host_with_options(
-            backend,
-            name,
-            guest_path,
-            host_path,
-            HostCopyOptions::default(),
-        )
-        .await
-    }
-
-    pub(crate) async fn copy_to_host_with_options(
-        backend: &dyn Backend,
-        name: &str,
-        guest_path: &str,
-        host_path: &Path,
-        options: HostCopyOptions,
-    ) -> MicrosandboxResult<()> {
         let (std_file, temp_path) = prepare_host_copy_target(host_path).await?;
         let mut file = tokio::fs::File::from_std(std_file);
         let mut stream = read_stream(backend, name, guest_path).await?;
@@ -1828,9 +1776,6 @@ pub(crate) mod agent {
                 format!("host copy byte-count mismatch: received {received}, wrote {written}"),
             )
             .into());
-        }
-        if options.durability == HostCopyDurability::File {
-            file.sync_all().await?;
         }
         drop(file);
 
@@ -1935,14 +1880,6 @@ pub(crate) mod agent {
         use std::os::unix::fs::{PermissionsExt, symlink};
 
         use super::*;
-
-        #[test]
-        fn host_copy_defaults_to_buffered_atomic_publication() {
-            assert_eq!(
-                HostCopyOptions::default().durability,
-                HostCopyDurability::Buffered
-            );
-        }
 
         #[tokio::test]
         async fn host_copy_target_atomically_replaces_existing_file() {

--- a/sdk/rust/lib/sandbox/mod.rs
+++ b/sdk/rust/lib/sandbox/mod.rs
@@ -126,7 +126,7 @@ pub use config_patch::{
 pub use exec::{ExecOptionsBuilder, ExecOutput, Rlimit, RlimitResource};
 pub use fs::{
     FsEntry, FsEntryKind, FsHandle, FsMetadata, FsOpenOptions, FsReadStream, FsSetAttrs,
-    FsWriteSink, HostCopyDurability, HostCopyOptions, SandboxFsOps,
+    FsWriteSink, SandboxFsOps,
 };
 pub use handle::{DEFAULT_KILL_TIMEOUT, DEFAULT_STOP_TIMEOUT, SandboxHandle};
 pub use init::{HandoffInit, InitOptionsBuilder};


### PR DESCRIPTION
## TL;DR
Remove the unreleased host-copy durability API and keep the optimized transport machinery out of the documented product surface before v0.7.0 ships.

## Description
- Keep `SandboxFsOps::copy_to_host` as the single guest-to-host copy API, with the same buffered atomic publication behavior used by the merged stack.
- Remove `HostCopyDurability`, `HostCopyOptions`, `copy_to_host_with_options`, and the matching backend hook because the transport work does not need a new product option.
- Hide local shared-arena and physical transport-binding modules from generated Rust documentation while retaining the cross-crate visibility required by the runtime.
- Hide and make `AgentTransportProfile` non-exhaustive, and keep the diagnostic `agent_transport` CLI field crate-private.
- Preserve generation-8 negotiation, dual-port selection, local shared memory, compatibility fallback, and the measured transfer paths without wire changes.

```rust
sandbox
    .fs()
    .copy_to_host("/output/model.bin", "./model.bin")
    .await?;
```

## Test Plan
- [x] `cargo fmt --all -- --check` exits 0
- [x] `cargo test -p microsandbox --lib --no-default-features --features local,net,ssh` passes 576 tests with 2 platform-specific tests ignored
- [x] `cargo test -p microsandbox-protocol -p microsandbox-agent-client --all-features` passes 81 unit, schema, and doc tests
- [x] `cargo test -p microsandbox-cli --lib --no-default-features --features net,ssh` passes 315 tests
- [x] `cargo clippy -p microsandbox --lib --no-default-features --features local,net,ssh -- -D warnings` exits 0
- [x] `cargo clippy -p microsandbox-cli --lib --no-default-features --features net,ssh -- -D warnings` exits 0

<!-- greptile_comment -->

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the intended API-surface reductions preserving current transport and buffered atomic copy behavior.

The hidden modules and constants remain accessible to dependent crates, repository callers do not use the removed durability API, and the remaining copy path retains its prior default publication semantics.
</details>

<sub>Reviews (1): Last reviewed commit: ["refactor(agent): trim transport API surf..."](https://github.com/superradcompany/microsandbox/commit/dfbd11bcb26a2f3c305bff2658e61164a138f46e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61097889)</sub>

<!-- /greptile_comment -->