### PR TITLE
feat(ruby): add optional runtime binaries companion

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -55,6 +55,9 @@ jobs:
               - 'sdk/rust/**'
             ruby_binaries:
               - '.github/workflows/check.yml'
+              - 'Cargo.toml'
+              - 'scripts/bump-version.sh'
+              - 'sdk/ruby/lib/microsandbox/version.rb'
               - 'sdk/ruby-binaries/**'
             ruby_package:
               - '.github/workflows/check.yml'

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -33,6 +33,7 @@ jobs:
     outputs:
       code: ${{ steps.filter.outputs.code }}
       ruby: ${{ steps.filter.outputs.ruby }}
+      ruby_binaries: ${{ steps.filter.outputs.ruby_binaries }}
       ruby_package: ${{ steps.filter.outputs.ruby_package }}
       ruby_platform: ${{ steps.filter.outputs.ruby_platform }}
     steps:
@@ -52,6 +53,9 @@ jobs:
               - 'scripts/ci/ruby-sdk-checkout.sh'
               - 'sdk/ruby/**'
               - 'sdk/rust/**'
+            ruby_binaries:
+              - '.github/workflows/check.yml'
+              - 'sdk/ruby-binaries/**'
             ruby_package:
               - '.github/workflows/check.yml'
               - 'Cargo.lock'
@@ -941,6 +945,26 @@ jobs:
           # installed wheel instead of the adjacent Python source tree.
           uv run --project sdk/python --no-sync pytest sdk/python/tests
           uv run --project sdk/python --no-sync ruff check sdk/python
+
+  ruby-binaries:
+    name: Ruby binaries gem / fixture suite
+    needs: changes
+    if: needs.changes.outputs.ruby_binaries == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1
+        with:
+          ruby-version: "3.4"
+
+      - name: Install Ruby test dependencies
+        run: gem install rake test-unit --no-document
+
+      - name: Test fixture-only suite
+        working-directory: sdk/ruby-binaries
+        run: rake test
 
   ruby-sdk:
     name: Ruby ${{ matrix.ruby }} / Linux x86_64
@@ -1948,6 +1972,7 @@ jobs:
       - node-sdk-build
       - python-wheel-build
       - python-quality
+      - ruby-binaries
       - ruby-sdk
       - ruby-source-gem
       - ruby-platform-gem

--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,14 @@ sdk/ruby/lib/microsandbox/*.so
 sdk/ruby/lib/microsandbox/*.bundle
 sdk/ruby/lib/microsandbox/[0-9].[0-9]/
 
+# Ruby runtime-data gem build inputs, staging trees, and packaged gems.
+# Release binaries must never be committed; `sdk/ruby-binaries/Rakefile`
+# recreates these from verified GitHub release bundles.
+sdk/ruby-binaries/downloads/
+sdk/ruby-binaries/libexec/
+sdk/ruby-binaries/pkg/
+sdk/ruby-binaries/*.gem
+
 # Python
 __pycache__/
 *.pyc

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -19,6 +19,8 @@
 #   - crates/agentd/Cargo.lock (the agentd sub-workspace ships its own
 #     lockfile that the root `cargo check` won't refresh — targeted sed
 #     against microsandbox-* entries)
+#   - sdk/ruby/lib/microsandbox/version.rb
+#   - sdk/ruby-binaries/lib/microsandbox/binaries/version.rb
 #   - packages/agent-client/typescript/package.json
 #   - packages/microsandbox-types/typescript/package.json
 #   - sdk/node-ts/package.json (top-level + optionalDependencies versions)
@@ -124,6 +126,18 @@ for f in Cargo.lock crates/agentd/Cargo.lock; do
     fi
   done
   [ "$changed" -eq 1 ] && echo "  updated ${f}"
+done
+
+# --- Ruby: SDK and companion gem version constants ----------------------
+for f in \
+  sdk/ruby/lib/microsandbox/version.rb \
+  sdk/ruby-binaries/lib/microsandbox/binaries/version.rb; do
+  if grep -q "VERSION = \"${OLD}\"" "$f"; then
+    inplace "s/VERSION = \"${OLD}\"/VERSION = \"${NEW}\"/" "$f"
+    echo "  updated ${f}"
+  else
+    echo "warning: ${f} does not contain VERSION = \"${OLD}\"" >&2
+  fi
 done
 
 # --- Node: package.json files --------------------------------------------

--- a/sdk/ruby-binaries/LICENSE
+++ b/sdk/ruby-binaries/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/sdk/ruby-binaries/README.md
+++ b/sdk/ruby-binaries/README.md
@@ -10,6 +10,9 @@ support is needed:
 gem install microsandbox-binaries
 ```
 
+For Bundler applications, add `gem "microsandbox-binaries"` to the Gemfile
+alongside `microsandbox`, then run `bundle install`.
+
 The main gem discovers this gem opportunistically and has no dependency on it,
 so cloud-only installations do not download runtime binaries. Explicit
 `MSB_PATH` and `MSB_LIBKRUNFW_PATH` environment variables retain precedence
@@ -19,3 +22,20 @@ over the bundled files. Keep this gem on the same minor series as
 Runtime files are downloaded from the matching Microsandbox GitHub release and
 packaged as pure data for `arm64-darwin`, `x86_64-linux-gnu`, and
 `aarch64-linux-gnu`. There is no generic `ruby`-platform fallback gem.
+RubyGems 3.3.11 or newer is required to select these platform gems correctly.
+
+## Building from a checkout
+
+Run from `sdk/ruby-binaries`:
+
+```sh
+rake test
+rake package
+```
+
+Both commands check that the companion version matches the Ruby SDK and
+workspace version. `rake package` downloads that release's bundles, verifies
+their SHA-256 checksums, and writes the three verified gems to `pkg/`.
+An explicit release, such as `rake 'package[0.6.17]'`, must match the version
+in `lib/microsandbox/binaries/version.rb`. Run `rake clobber` to remove cached
+downloads and packaged gems before a fresh build.

--- a/sdk/ruby-binaries/README.md
+++ b/sdk/ruby-binaries/README.md
@@ -1,0 +1,20 @@
+# microsandbox-binaries
+
+`microsandbox-binaries` is the optional runtime companion for the
+[`microsandbox`](../ruby) Ruby SDK. Its platform gems contain the `msb`
+executable and libkrunfw firmware library used by local sandboxes. Most users
+should install `microsandbox`; install this companion only when local runtime
+support is needed:
+
+```sh
+gem install microsandbox-binaries
+```
+
+The main gem discovers this gem opportunistically and has no dependency on it,
+so cloud-only installations do not download runtime binaries. Explicit
+`MSB_PATH` and `MSB_LIBKRUNFW_PATH` environment variables retain precedence
+over the bundled files.
+
+Runtime files are downloaded from the matching Microsandbox GitHub release and
+packaged as pure data for `arm64-darwin`, `x86_64-linux-gnu`, and
+`aarch64-linux-gnu`. There is no generic `ruby`-platform fallback gem.

--- a/sdk/ruby-binaries/README.md
+++ b/sdk/ruby-binaries/README.md
@@ -13,7 +13,8 @@ gem install microsandbox-binaries
 The main gem discovers this gem opportunistically and has no dependency on it,
 so cloud-only installations do not download runtime binaries. Explicit
 `MSB_PATH` and `MSB_LIBKRUNFW_PATH` environment variables retain precedence
-over the bundled files.
+over the bundled files. Keep this gem on the same minor series as
+`microsandbox`: the SDK warns and ignores a companion from another series.
 
 Runtime files are downloaded from the matching Microsandbox GitHub release and
 packaged as pure data for `arm64-darwin`, `x86_64-linux-gnu`, and

--- a/sdk/ruby-binaries/Rakefile
+++ b/sdk/ruby-binaries/Rakefile
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "rake/clean"
+require "rake/testtask"
+
+require_relative "tasks/package"
+
+CLEAN.include("libexec")
+CLOBBER.include("downloads", "pkg")
+
+Rake::TestTask.new do |test|
+  test.libs << "lib"
+  test.pattern = "test/**/*_test.rb"
+  test.verbose = true
+end
+
+desc "Download, verify, and build all platform gems for the lockstep runtime version"
+task :package, [:version] do |_task, args|
+  Microsandbox::Binaries::Package.package_all!(args[:version] || Microsandbox::Binaries::VERSION)
+end
+
+namespace :package do
+  Microsandbox::Binaries::Package::PLATFORMS.each_key do |platform|
+    task_name = platform.tr("-", "_")
+    desc "Download, verify, and build the #{platform} platform gem"
+    task task_name, [:version] do |_task, args|
+      Microsandbox::Binaries::Package.package_platform!(
+        platform,
+        args[:version] || Microsandbox::Binaries::VERSION
+      )
+    end
+  end
+end
+
+task default: :test

--- a/sdk/ruby-binaries/Rakefile
+++ b/sdk/ruby-binaries/Rakefile
@@ -8,14 +8,30 @@ require_relative "tasks/package"
 CLEAN.include("libexec")
 CLOBBER.include("downloads", "pkg")
 
+desc "Verify the companion, Ruby SDK, and workspace versions remain in lockstep"
+task :version_check do
+  {
+    "../ruby/lib/microsandbox/version.rb" => /^\s*VERSION = "([^"]+)"$/,
+    "../../Cargo.toml" => /^version = "([^"]+)"$/
+  }.each do |relative_path, pattern|
+    version = File.read(File.expand_path(relative_path, __dir__))[pattern, 1]
+    next if version == Microsandbox::Binaries::VERSION
+
+    abort "microsandbox-binaries version mismatch: #{Microsandbox::Binaries::VERSION} " \
+          "does not match #{relative_path} (#{version || "missing version"}); " \
+          "update the companion version with the release manifests"
+  end
+end
+
 Rake::TestTask.new do |test|
   test.libs << "lib"
   test.pattern = "test/**/*_test.rb"
   test.verbose = true
+  test.deps << :version_check
 end
 
 desc "Download, verify, and build all platform gems for the lockstep runtime version"
-task :package, [:version] do |_task, args|
+task :package, [:version] => :version_check do |_task, args|
   Microsandbox::Binaries::Package.package_all!(args[:version] || Microsandbox::Binaries::VERSION)
 end
 
@@ -23,7 +39,7 @@ namespace :package do
   Microsandbox::Binaries::Package::PLATFORMS.each_key do |platform|
     task_name = platform.tr("-", "_")
     desc "Download, verify, and build the #{platform} platform gem"
-    task task_name, [:version] do |_task, args|
+    task task_name, [:version] => :version_check do |_task, args|
       Microsandbox::Binaries::Package.package_platform!(
         platform,
         args[:version] || Microsandbox::Binaries::VERSION

--- a/sdk/ruby-binaries/lib/microsandbox/binaries.rb
+++ b/sdk/ruby-binaries/lib/microsandbox/binaries.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require "rubygems"
+
+require_relative "binaries/version"
+
+module Microsandbox
+  # Paths to the runtime files carried by the platform-specific companion gem.
+  module Binaries
+    GEM_NAME = "microsandbox-binaries"
+
+    # Raised when the activated gem does not carry a usable payload for the
+    # current host platform.
+    class PlatformError < StandardError; end
+
+    class << self
+      # Returns the absolute path to the bundled `msb` executable.
+      def msb_path
+        ensure_matching_platform!
+        path = File.join(package_root, "libexec", "msb")
+
+        unless File.file?(path)
+          raise PlatformError,
+                "#{GEM_NAME} for #{current_platform} is missing its bundled msb executable"
+        end
+
+        path
+      end
+
+      # Returns the absolute path to the bundled, versioned libkrunfw library.
+      def libkrunfw_path
+        ensure_matching_platform!
+        matches = Dir.glob(File.join(package_root, "libexec", libkrunfw_pattern)).select { |path| File.file?(path) }
+
+        unless matches.one?
+          raise PlatformError,
+                "#{GEM_NAME} for #{current_platform} must contain exactly one versioned libkrunfw library"
+        end
+
+        matches.first
+      end
+
+      private
+
+      def current_platform
+        Gem::Platform.local
+      end
+
+      def ensure_matching_platform!
+        loaded_spec = Gem.loaded_specs[GEM_NAME]
+        unless loaded_spec
+          raise PlatformError,
+                "#{GEM_NAME} is not activated through RubyGems; " \
+                "install the matching platform gem before requiring microsandbox/binaries"
+        end
+
+        gem_platform = loaded_spec.platform
+        return if gem_platform === current_platform
+
+        raise PlatformError,
+              "#{GEM_NAME} platform #{gem_platform} does not match current platform #{current_platform}"
+      end
+
+      def libkrunfw_pattern
+        case current_platform.os
+        when "darwin" then "libkrunfw.*.dylib"
+        when "linux" then "libkrunfw.so.*.*.*"
+        else
+          raise PlatformError,
+                "#{GEM_NAME} does not support current platform #{current_platform}"
+        end
+      end
+
+      # Every path is built from this absolute root, so callers never need to
+      # expand what they receive.
+      def package_root
+        File.expand_path("../..", __dir__)
+      end
+    end
+  end
+end

--- a/sdk/ruby-binaries/lib/microsandbox/binaries/version.rb
+++ b/sdk/ruby-binaries/lib/microsandbox/binaries/version.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module Microsandbox
+  module Binaries
+    VERSION = "0.6.16"
+  end
+end

--- a/sdk/ruby-binaries/lib/microsandbox/binaries/version.rb
+++ b/sdk/ruby-binaries/lib/microsandbox/binaries/version.rb
@@ -2,6 +2,6 @@
 
 module Microsandbox
   module Binaries
-    VERSION = "0.6.16"
+    VERSION = "0.6.17"
   end
 end

--- a/sdk/ruby-binaries/microsandbox-binaries.gemspec
+++ b/sdk/ruby-binaries/microsandbox-binaries.gemspec
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require_relative "lib/microsandbox/binaries/version"
+
+platform_name = ENV.fetch("GEM_PLATFORM", nil)
+supported_platforms = %w[arm64-darwin x86_64-linux-gnu aarch64-linux-gnu].freeze
+unless supported_platforms.include?(platform_name)
+  raise Gem::InvalidSpecificationException,
+        "microsandbox-binaries.gemspec is build-time-only; GEM_PLATFORM must name a supported " \
+        "binaries platform (#{supported_platforms.join(", ")}). Build with " \
+        "`rake package[#{Microsandbox::Binaries::VERSION}]`; Gemfile path checkouts do not " \
+        "contain a staged runtime payload"
+end
+
+Gem::Specification.new do |spec|
+  spec.name = "microsandbox-binaries"
+  spec.version = Microsandbox::Binaries::VERSION
+  spec.authors = ["Super Rad Company"]
+  spec.email = ["development@superrad.company"]
+  spec.summary = "Platform runtime binaries for the microsandbox Ruby SDK"
+  spec.description = "Pure-data platform gem containing the msb runtime and libkrunfw firmware library."
+  spec.homepage = "https://github.com/superradcompany/microsandbox"
+  spec.license = "Apache-2.0"
+  spec.required_ruby_version = ">= 3.1"
+  # RubyGems only matches the -gnu platform gems on glibc hosts from 3.3.11 onwards.
+  spec.required_rubygems_version = Gem::Requirement.new(">= 3.3.11")
+  spec.platform = Gem::Platform.new(platform_name)
+  spec.metadata = {
+    "source_code_uri" => "#{spec.homepage}/tree/main/sdk/ruby-binaries",
+    "bug_tracker_uri" => "#{spec.homepage}/issues",
+    "changelog_uri" => "#{spec.homepage}/releases",
+    "rubygems_mfa_required" => "true"
+  }
+
+  runtime_files = Dir.chdir(__dir__) do
+    Dir["libexec/*"].select { |path| File.file?(path) }
+  end
+  msb_files = runtime_files.select { |path| path == "libexec/msb" }
+  firmware_files = runtime_files.select { |path| File.basename(path).start_with?("libkrunfw") }
+  unless msb_files.one? && firmware_files.one? && runtime_files.length == 2
+    raise Gem::InvalidSpecificationException,
+          "staged payload must contain exactly libexec/msb and one versioned libkrunfw library; " \
+          "build with the Rake packaging task"
+  end
+
+  spec.files = Dir.chdir(__dir__) do
+    Dir["lib/**/*.rb", "README.md", "LICENSE"] + runtime_files
+  end
+  spec.require_paths = ["lib"]
+end

--- a/sdk/ruby-binaries/tasks/package.rb
+++ b/sdk/ruby-binaries/tasks/package.rb
@@ -1,0 +1,214 @@
+# frozen_string_literal: true
+
+require "digest"
+require "fileutils"
+require "open-uri"
+require "tmpdir"
+require "zlib"
+require "rubygems/package"
+
+require_relative "../lib/microsandbox/binaries/version"
+
+module Microsandbox
+  module Binaries
+    # Build-time support for producing the pure-data platform gems.
+    module Package
+      ROOT = File.expand_path("..", __dir__)
+      DOWNLOADS_DIR = File.join(ROOT, "downloads")
+      LIBEXEC_DIR = File.join(ROOT, "libexec")
+      PKG_DIR = File.join(ROOT, "pkg")
+
+      REPOSITORY = "superradcompany/microsandbox"
+      CHECKSUMS_ASSET = "checksums.sha256"
+      PLATFORMS = {
+        "arm64-darwin" => {
+          target: "darwin-aarch64",
+          firmware: /\Alibkrunfw\.\d+\.dylib\z/
+        },
+        "x86_64-linux-gnu" => {
+          target: "linux-x86_64",
+          firmware: /\Alibkrunfw\.so\.\d+\.\d+\.\d+\z/
+        },
+        "aarch64-linux-gnu" => {
+          target: "linux-aarch64",
+          firmware: /\Alibkrunfw\.so\.\d+\.\d+\.\d+\z/
+        }
+      }.freeze
+
+      module_function
+
+      def package_all!(version = VERSION)
+        PLATFORMS.each_key { |platform| package_platform!(platform, version) }
+      end
+
+      def package_platform!(platform, version = VERSION)
+        version = validate_version!(version)
+        config = PLATFORMS.fetch(platform) do
+          raise ArgumentError, "unsupported gem platform: #{platform}"
+        end
+
+        release_dir = File.join(DOWNLOADS_DIR, "v#{version}")
+        checksums_path = File.join(release_dir, CHECKSUMS_ASSET)
+        bundle_name = "microsandbox-#{config.fetch(:target)}.tar.gz"
+        bundle_path = File.join(release_dir, bundle_name)
+        base_url = "https://github.com/#{REPOSITORY}/releases/download/v#{version}"
+
+        FileUtils.mkdir_p(release_dir)
+        download!("#{base_url}/#{CHECKSUMS_ASSET}", checksums_path)
+        download!("#{base_url}/#{bundle_name}", bundle_path)
+
+        expected = expected_sha256!(File.read(checksums_path), bundle_name)
+        verify_sha256!(bundle_path, expected)
+
+        FileUtils.rm_rf(LIBEXEC_DIR)
+        stage_bundle!(bundle_path, config.fetch(:firmware), LIBEXEC_DIR)
+        build_gem!(platform, version)
+      ensure
+        FileUtils.rm_rf(LIBEXEC_DIR)
+      end
+
+      def expected_sha256!(checksums, asset)
+        matches = checksums.lines.filter_map do |line|
+          match = line.chomp.match(/\A([0-9a-fA-F]{64}) [ *](.+)\z/)
+          match[1] if match && match[2] == asset
+        end
+        unless matches.one?
+          raise "#{CHECKSUMS_ASSET} must contain exactly one valid entry for #{asset}"
+        end
+
+        matches.first.downcase
+      end
+
+      def verify_sha256!(path, expected)
+        actual = Digest::SHA256.file(path).hexdigest
+        return actual if actual == expected
+
+        raise "sha256 mismatch for #{File.basename(path)}: expected #{expected}, got #{actual}; " \
+              "run `rake clobber` and retry"
+      end
+
+      def stage_bundle!(bundle_path, firmware_pattern, destination)
+        payload = {}
+        Zlib::GzipReader.open(bundle_path) do |gzip|
+          Gem::Package::TarReader.new(gzip) do |tar|
+            tar.each do |entry|
+              next unless entry.file?
+
+              basename = File.basename(entry.full_name)
+              key = if basename == "msb"
+                      :msb
+                    elsif firmware_pattern.match?(basename)
+                      :firmware
+                    end
+              next unless key
+              raise "release bundle contains more than one #{key} artifact" if payload.key?(key)
+
+              payload[key] = [basename, entry.read]
+            end
+          end
+        end
+
+        raise "release bundle is missing msb" unless payload.key?(:msb)
+        raise "release bundle must contain exactly one versioned libkrunfw library" unless payload.key?(:firmware)
+
+        FileUtils.mkdir_p(destination)
+        write_payload!(File.join(destination, "msb"), payload.fetch(:msb).last, 0o755)
+        firmware_name, firmware_data = payload.fetch(:firmware)
+        write_payload!(File.join(destination, firmware_name), firmware_data, 0o644)
+      end
+
+      def verify_built_gem!(gem_path, platform, version)
+        package = Gem::Package.new(gem_path)
+        spec = package.spec
+        unless spec.name == "microsandbox-binaries" && spec.version.to_s == version && spec.platform.to_s == platform
+          raise "built gem identity does not match microsandbox-binaries #{version} #{platform}"
+        end
+
+        expected_files = %w[
+          LICENSE
+          README.md
+          lib/microsandbox/binaries.rb
+          lib/microsandbox/binaries/version.rb
+          libexec/msb
+        ]
+        firmware_pattern = PLATFORMS.fetch(platform).fetch(:firmware)
+        firmware_files = spec.files.select do |path|
+          path.start_with?("libexec/libkrunfw") && firmware_pattern.match?(File.basename(path))
+        end
+        unless firmware_files.one? && spec.files.sort == (expected_files + firmware_files).sort
+          raise "built gem contains an unexpected payload: #{spec.files.sort.inspect}"
+        end
+
+        Dir.mktmpdir("microsandbox-binaries-gem") do |directory|
+          package.extract_files(directory)
+          msb = File.join(directory, "libexec", "msb")
+          unless File.file?(msb) && File.stat(msb).mode.anybits?(0o111)
+            raise "built gem did not preserve the executable bit on libexec/msb"
+          end
+          firmware = File.join(directory, firmware_files.first)
+          raise "built gem is missing #{firmware_files.first}" unless File.file?(firmware)
+        end
+      end
+
+      def download!(url, destination)
+        return destination if File.file?(destination) && File.size(destination).positive?
+
+        temporary = "#{destination}.part-#{Process.pid}"
+        URI.open(url, "rb") do |input|
+          File.open(temporary, "wb") { |output| IO.copy_stream(input, output) }
+        end
+        File.rename(temporary, destination)
+        destination
+      ensure
+        FileUtils.rm_f(temporary) if temporary
+      end
+
+      def build_gem!(platform, version)
+        previous_platform = ENV["GEM_PLATFORM"]
+        ENV["GEM_PLATFORM"] = platform
+        FileUtils.mkdir_p(PKG_DIR)
+
+        destination = Dir.chdir(ROOT) do
+          gemspec_path = File.join(ROOT, "microsandbox-binaries.gemspec")
+          # Gem::Specification.load caches by path. A single `rake package`
+          # process builds three payloads in sequence, so that cache would
+          # reuse the first platform's file list for the later gems.
+          spec = eval(File.read(gemspec_path, encoding: "UTF-8"), binding, gemspec_path)
+          raise "failed to load microsandbox-binaries.gemspec" unless spec
+
+          destination = File.join(PKG_DIR, spec.file_name)
+          FileUtils.rm_f(destination)
+          Gem::Package.build(spec, false, true, destination)
+          destination
+        end
+        verify_built_gem!(destination, platform, version)
+        puts "built and verified #{destination}"
+        destination
+      rescue
+        FileUtils.rm_f(destination) if destination
+        raise
+      ensure
+        if previous_platform
+          ENV["GEM_PLATFORM"] = previous_platform
+        else
+          ENV.delete("GEM_PLATFORM")
+        end
+      end
+
+      def validate_version!(version)
+        normalized = version.to_s.delete_prefix("v")
+        unless normalized == VERSION
+          raise ArgumentError, "requested release #{version.inspect} does not match gem version #{VERSION}"
+        end
+
+        normalized
+      end
+
+      def write_payload!(path, data, mode)
+        File.binwrite(path, data)
+        FileUtils.chmod(mode, path)
+      end
+      private_class_method :build_gem!, :download!, :validate_version!, :write_payload!
+    end
+  end
+end

--- a/sdk/ruby-binaries/test/binaries_test.rb
+++ b/sdk/ruby-binaries/test/binaries_test.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require "fileutils"
+require "test/unit"
+
+require "microsandbox/binaries"
+
+class MicrosandboxBinariesTest < Test::Unit::TestCase
+  def setup
+    @libexec = File.expand_path("../libexec", __dir__)
+    @original_spec = Gem.loaded_specs[Microsandbox::Binaries::GEM_NAME]
+    FileUtils.mkdir_p(@libexec)
+    File.write(File.join(@libexec, "msb"), "fixture")
+    File.write(File.join(@libexec, firmware_name), "fixture")
+    activate_for(Gem::Platform.local)
+  end
+
+  def teardown
+    FileUtils.rm_rf(@libexec)
+    if @original_spec
+      Gem.loaded_specs[Microsandbox::Binaries::GEM_NAME] = @original_spec
+    else
+      Gem.loaded_specs.delete(Microsandbox::Binaries::GEM_NAME)
+    end
+  end
+
+  def test_resolves_absolute_runtime_paths
+    assert_equal File.join(@libexec, "msb"), Microsandbox::Binaries.msb_path
+    assert_equal File.join(@libexec, firmware_name), Microsandbox::Binaries.libkrunfw_path
+    assert_true File.absolute_path?(Microsandbox::Binaries.msb_path)
+    assert_true File.absolute_path?(Microsandbox::Binaries.libkrunfw_path)
+  end
+
+  def test_rejects_a_gem_for_another_platform
+    other = %w[arm64-darwin x86_64-linux-gnu aarch64-linux-gnu]
+            .map { |name| Gem::Platform.new(name) }
+            .find { |platform| !(platform === Gem::Platform.local) }
+    activate_for(other)
+
+    error = assert_raise(Microsandbox::Binaries::PlatformError) do
+      Microsandbox::Binaries.msb_path
+    end
+
+    assert_include error.message, Gem::Platform.local.to_s
+  end
+
+  def test_requires_rubygems_activation
+    Gem.loaded_specs.delete(Microsandbox::Binaries::GEM_NAME)
+
+    error = assert_raise(Microsandbox::Binaries::PlatformError) do
+      Microsandbox::Binaries.msb_path
+    end
+
+    assert_include error.message, "not activated through RubyGems"
+  end
+
+  def test_requires_exactly_one_versioned_firmware_library
+    File.write(File.join(@libexec, second_firmware_name), "fixture")
+
+    error = assert_raise(Microsandbox::Binaries::PlatformError) do
+      Microsandbox::Binaries.libkrunfw_path
+    end
+
+    assert_include error.message, Gem::Platform.local.to_s
+  end
+
+  private
+
+  def activate_for(platform)
+    spec = Gem::Specification.new do |candidate|
+      candidate.name = Microsandbox::Binaries::GEM_NAME
+      candidate.version = Microsandbox::Binaries::VERSION
+      candidate.platform = platform
+    end
+    Gem.loaded_specs[Microsandbox::Binaries::GEM_NAME] = spec
+  end
+
+  def firmware_name
+    Gem::Platform.local.os == "darwin" ? "libkrunfw.4.dylib" : "libkrunfw.so.4.1.0"
+  end
+
+  def second_firmware_name
+    Gem::Platform.local.os == "darwin" ? "libkrunfw.5.dylib" : "libkrunfw.so.5.1.0"
+  end
+end

--- a/sdk/ruby-binaries/test/fixtures/checksums.sha256
+++ b/sdk/ruby-binaries/test/fixtures/checksums.sha256
@@ -1,0 +1,1 @@
+b209b9f8e2fa71ff82e24cead7790a631bd9dd4f67a86f0893ec997fc44223cc  payload.txt

--- a/sdk/ruby-binaries/test/fixtures/payload.txt
+++ b/sdk/ruby-binaries/test/fixtures/payload.txt
@@ -1,0 +1,1 @@
+microsandbox checksum fixture

--- a/sdk/ruby-binaries/test/package_test.rb
+++ b/sdk/ruby-binaries/test/package_test.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+require "fileutils"
+require "test/unit"
+require "tmpdir"
+
+require_relative "../tasks/package"
+
+class MicrosandboxBinariesPackageTest < Test::Unit::TestCase
+  FIXTURES = File.expand_path("fixtures", __dir__)
+
+  def test_verifies_checksum_against_fixture
+    asset = "payload.txt"
+    checksums = File.read(File.join(FIXTURES, "checksums.sha256"))
+    expected = Microsandbox::Binaries::Package.expected_sha256!(checksums, asset)
+
+    assert_equal expected,
+                 Microsandbox::Binaries::Package.verify_sha256!(File.join(FIXTURES, asset), expected)
+  end
+
+  def test_checksum_mismatch_fails_hard
+    checksums = File.read(File.join(FIXTURES, "checksums.sha256"))
+    expected = Microsandbox::Binaries::Package.expected_sha256!(checksums, "payload.txt")
+
+    Dir.mktmpdir do |directory|
+      path = File.join(directory, "payload.txt")
+      File.write(path, "tampered")
+
+      error = assert_raise(RuntimeError) do
+        Microsandbox::Binaries::Package.verify_sha256!(path, expected)
+      end
+
+      assert_include error.message, "rake clobber"
+    end
+  end
+
+  def test_missing_checksum_entry_fails_hard
+    error = assert_raise(RuntimeError) do
+      Microsandbox::Binaries::Package.expected_sha256!("", "missing.tar.gz")
+    end
+
+    assert_include error.message, "exactly one valid entry"
+  end
+
+  def test_version_must_match_the_gem
+    error = assert_raise(ArgumentError) do
+      Microsandbox::Binaries::Package.package_all!("999.0.0")
+    end
+
+    assert_include error.message, Microsandbox::Binaries::VERSION
+  end
+
+  def test_gemspec_refuses_generic_path_builds_with_actionable_context
+    gemspec = File.expand_path("../microsandbox-binaries.gemspec", __dir__)
+    previous_platform = ENV.delete("GEM_PLATFORM")
+
+    error = assert_raise(Gem::InvalidSpecificationException) do
+      eval(File.read(gemspec, encoding: "UTF-8"), binding, gemspec)
+    end
+
+    assert_include error.message, "build-time-only"
+    assert_include error.message, "Gemfile path checkouts"
+  ensure
+    ENV["GEM_PLATFORM"] = previous_platform if previous_platform
+  end
+
+  def test_built_gem_verification_rejects_the_wrong_firmware_flavor
+    Dir.mktmpdir do |directory|
+      files = %w[
+        LICENSE
+        README.md
+        lib/microsandbox/binaries.rb
+        lib/microsandbox/binaries/version.rb
+        libexec/msb
+        libexec/libkrunfw.4.dylib
+      ]
+      files.each do |path|
+        absolute_path = File.join(directory, path)
+        FileUtils.mkdir_p(File.dirname(absolute_path))
+        File.write(absolute_path, "fixture")
+      end
+      FileUtils.chmod(0o755, File.join(directory, "libexec/msb"))
+
+      spec = Gem::Specification.new do |candidate|
+        candidate.name = "microsandbox-binaries"
+        candidate.version = Microsandbox::Binaries::VERSION
+        candidate.platform = Gem::Platform.new("x86_64-linux-gnu")
+        candidate.summary = "fixture"
+        candidate.authors = ["fixture"]
+        candidate.files = files
+      end
+      gem_path = File.join(directory, spec.file_name)
+      Dir.chdir(directory) { Gem::Package.build(spec, true, false, gem_path) }
+
+      error = assert_raise(RuntimeError) do
+        Microsandbox::Binaries::Package.verify_built_gem!(
+          gem_path,
+          "x86_64-linux-gnu",
+          Microsandbox::Binaries::VERSION
+        )
+      end
+
+      assert_include error.message, "unexpected payload"
+    end
+  end
+end

--- a/sdk/ruby-binaries/test/version_test.rb
+++ b/sdk/ruby-binaries/test/version_test.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require "fileutils"
+require "open3"
+require "rbconfig"
+require "test/unit"
+require "tmpdir"
+
+require_relative "../lib/microsandbox/binaries/version"
+
+class MicrosandboxBinariesVersionTest < Test::Unit::TestCase
+  REPOSITORY = File.expand_path("../../..", __dir__)
+  VERSION_FILES = %w[
+    sdk/ruby/lib/microsandbox/version.rb
+    Cargo.toml
+  ].freeze
+
+  def test_version_drift_refuses_all_packaging_entrypoints_before_staging
+    VERSION_FILES.each do |version_file|
+      with_release_tree do |directory|
+        path = File.join(directory, version_file)
+        File.write(path, File.read(path).sub(Microsandbox::Binaries::VERSION, "999.0.0"))
+        staged = File.join(directory, "sdk/ruby-binaries/libexec/msb")
+        FileUtils.mkdir_p(File.dirname(staged))
+        File.write(staged, "existing payload")
+
+        %w[test package package:arm64_darwin package:x86_64_linux_gnu package:aarch64_linux_gnu].each do |task|
+          _stdout, stderr, status = run_rake(directory, task)
+
+          assert_false status.success?, "#{task} accepted drift in #{version_file}"
+          assert_include stderr, "version mismatch"
+          assert_equal "existing payload", File.read(staged)
+        end
+      end
+    end
+  end
+
+  def test_release_bump_keeps_the_companion_in_lockstep
+    with_release_tree do |directory|
+      parts = Microsandbox::Binaries::VERSION.split(".")
+      parts[-1] = (parts.last.to_i + 1).to_s
+      next_version = parts.join(".")
+      stdout, stderr, status = Open3.capture3(
+        "bash", "scripts/bump-version.sh", next_version, chdir: directory
+      )
+
+      assert_predicate status, :success?, "#{stdout}\n#{stderr}"
+      assert_equal "", stderr
+      version_file = File.join(directory, "sdk/ruby-binaries/lib/microsandbox/binaries/version.rb")
+      assert_include File.read(version_file), "VERSION = \"#{next_version}\""
+      stdout, stderr, status = run_rake(directory, "version_check")
+      assert_predicate status, :success?, "#{stdout}\n#{stderr}"
+    end
+  end
+
+  private
+
+  def run_rake(directory, task)
+    Open3.capture3(
+      { "RUBYOPT" => nil, "RUBYLIB" => nil },
+      RbConfig.ruby, "-S", "rake", task,
+      chdir: File.join(directory, "sdk/ruby-binaries")
+    )
+  end
+
+  def with_release_tree
+    Dir.mktmpdir("microsandbox-release") do |directory|
+      %w[crates packages].each { |name| FileUtils.mkdir_p(File.join(directory, name)) }
+      (VERSION_FILES + %w[
+        scripts/bump-version.sh
+        sdk/ruby-binaries/Rakefile
+        sdk/ruby-binaries/tasks/package.rb
+        sdk/ruby-binaries/lib/microsandbox/binaries/version.rb
+      ]).each do |relative_path|
+        destination = File.join(directory, relative_path)
+        FileUtils.mkdir_p(File.dirname(destination))
+        FileUtils.cp(File.join(REPOSITORY, relative_path), destination)
+      end
+      yield directory
+    end
+  end
+end

--- a/sdk/ruby/README.md
+++ b/sdk/ruby/README.md
@@ -94,7 +94,10 @@ Microsandbox.install unless Microsandbox.installed?
 ```
 
 Explicit `MSB_PATH` and `MSB_LIBKRUNFW_PATH` environment variables override
-the companion gem paths.
+the companion gem paths. The SDK only uses a companion from its own minor
+series (for example `0.6.x` with `0.6.x`); a `microsandbox-binaries` from
+another series is skipped with a warning and resolution falls through to
+the SDK's remaining runtime tiers, such as the SDK-installed runtime.
 
 Local sandboxes require Apple Silicon virtualization on macOS or KVM on Linux. On Windows, use Windows 11 on x64 or ARM64 and enable WHP. Ruby CI currently covers Linux x86_64.
 

--- a/sdk/ruby/README.md
+++ b/sdk/ruby/README.md
@@ -85,6 +85,9 @@ it, so cloud-only users can omit it:
 gem install microsandbox-binaries
 ```
 
+With Bundler, also add `gem "microsandbox-binaries"` to your Gemfile and run
+`bundle install`; installing it globally does not make it available to a bundle.
+
 Alternatively, install the microsandbox runtime and firmware through the SDK:
 
 ```ruby

--- a/sdk/ruby/README.md
+++ b/sdk/ruby/README.md
@@ -77,13 +77,24 @@ resolve against the patched path. When you are done, run
 would otherwise keep later local builds silently resolving against the in-tree
 SDK) and restores the lockfile.
 
-To use the local backend, install the microsandbox runtime and firmware once:
+To use the local backend without a separate runtime download, install the
+optional platform companion. The main gem deliberately has no dependency on
+it, so cloud-only users can omit it:
+
+```sh
+gem install microsandbox-binaries
+```
+
+Alternatively, install the microsandbox runtime and firmware through the SDK:
 
 ```ruby
 require "microsandbox"
 
 Microsandbox.install unless Microsandbox.installed?
 ```
+
+Explicit `MSB_PATH` and `MSB_LIBKRUNFW_PATH` environment variables override
+the companion gem paths.
 
 Local sandboxes require Apple Silicon virtualization on macOS or KVM on Linux. On Windows, use Windows 11 on x64 or ARM64 and enable WHP. Ruby CI currently covers Linux x86_64.
 

--- a/sdk/ruby/lib/microsandbox.rb
+++ b/sdk/ruby/lib/microsandbox.rb
@@ -17,6 +17,18 @@ rescue LoadError => abi_error
   end
 end
 
+begin
+  require "microsandbox/binaries"
+rescue LoadError => error
+  raise if defined?(Gem) && Gem.loaded_specs.key?("microsandbox-binaries")
+  raise unless error.path == "microsandbox/binaries"
+else
+  msb_path = Microsandbox::Binaries.msb_path
+  libkrunfw_path = Microsandbox::Binaries.libkrunfw_path
+  Microsandbox.set_runtime_msb_path(msb_path)
+  Microsandbox.set_runtime_libkrunfw_path(libkrunfw_path)
+end
+
 module Microsandbox
   class SandboxBuilder
     %i[

--- a/sdk/ruby/lib/microsandbox.rb
+++ b/sdk/ruby/lib/microsandbox.rb
@@ -23,10 +23,23 @@ rescue LoadError => error
   raise if defined?(Gem) && Gem.loaded_specs.key?("microsandbox-binaries")
   raise unless error.path == "microsandbox/binaries"
 else
-  msb_path = Microsandbox::Binaries.msb_path
-  libkrunfw_path = Microsandbox::Binaries.libkrunfw_path
-  Microsandbox.set_runtime_msb_path(msb_path)
-  Microsandbox.set_runtime_libkrunfw_path(libkrunfw_path)
+  # The SDK and runtime are only guaranteed compatible within one minor
+  # series, and the companion is not a gemspec dependency, so an installed
+  # microsandbox-binaries from another series is skipped rather than used.
+  # Resolution then falls through to the SDK's remaining runtime tiers.
+  sdk_series = Microsandbox::VERSION.split(".").first(2)
+  companion_series = Microsandbox::Binaries::VERSION.split(".").first(2)
+  if sdk_series == companion_series
+    msb_path = Microsandbox::Binaries.msb_path
+    libkrunfw_path = Microsandbox::Binaries.libkrunfw_path
+    Microsandbox.set_runtime_msb_path(msb_path)
+    Microsandbox.set_runtime_libkrunfw_path(libkrunfw_path)
+  else
+    warn "microsandbox #{Microsandbox::VERSION} is ignoring microsandbox-binaries " \
+         "#{Microsandbox::Binaries::VERSION}: the runtime companion must come from the " \
+         "#{sdk_series.join(".")}.x series; install a matching microsandbox-binaries " \
+         "or set MSB_PATH and MSB_LIBKRUNFW_PATH to a compatible runtime"
+  end
 end
 
 module Microsandbox

--- a/sdk/ruby/test/binaries_hookup_test.rb
+++ b/sdk/ruby/test/binaries_hookup_test.rb
@@ -1,0 +1,190 @@
+# frozen_string_literal: true
+
+require "fileutils"
+require "open3"
+require "rbconfig"
+require "test/unit"
+require "tmpdir"
+
+class MicrosandboxBinariesHookupTest < Test::Unit::TestCase
+  SDK_LIB = File.expand_path("../lib", __dir__)
+
+  def test_require_is_silent_when_companion_gem_is_absent
+    Dir.mktmpdir do |directory|
+      write_native_stub(directory)
+
+      stdout, stderr, status = run_ruby(
+        "--disable-gems",
+        "-I", File.join(directory, "lib"),
+        "-I", SDK_LIB,
+        "-e", 'require "microsandbox"; puts "ready"'
+      )
+
+      assert_predicate status, :success?
+      assert_equal "ready\n", stdout
+      assert_equal "", stderr
+    end
+  end
+
+  def test_present_companion_sets_both_runtime_paths
+    Dir.mktmpdir do |directory|
+      calls = File.join(directory, "calls")
+      write_native_stub(directory, record_calls: true)
+      write_companion_stub(directory)
+
+      stdout, stderr, status = run_ruby(
+        "-I", File.join(directory, "lib"),
+        "-I", SDK_LIB,
+        "-e", 'require "microsandbox"; puts "ready"',
+        env: { "MSB_HOOK_CALLS" => calls }
+      )
+
+      assert_predicate status, :success?
+      assert_equal "ready\n", stdout
+      assert_equal "", stderr
+      assert_equal "msb=/bundled/msb\nlibkrunfw=/bundled/libkrunfw.4.dylib\n", File.read(calls)
+    end
+  end
+
+  def test_companion_paths_are_resolved_before_either_setter
+    Dir.mktmpdir do |directory|
+      calls = File.join(directory, "calls")
+      write_native_stub(directory, record_calls: true)
+      write_companion_stub(directory, broken_firmware: true)
+
+      _stdout, stderr, status = run_ruby(
+        "-I", File.join(directory, "lib"),
+        "-I", SDK_LIB,
+        "-e", 'require "microsandbox"',
+        env: { "MSB_HOOK_CALLS" => calls }
+      )
+
+      assert_false status.success?
+      assert_include stderr, "broken firmware payload"
+      assert_false File.exist?(calls)
+    end
+  end
+
+  def test_load_error_inside_present_companion_is_not_swallowed
+    Dir.mktmpdir do |directory|
+      write_native_stub(directory)
+      companion = File.join(directory, "lib", "microsandbox", "binaries.rb")
+      FileUtils.mkdir_p(File.dirname(companion))
+      File.write(companion, 'require "missing_microsandbox_binaries_dependency"')
+
+      _stdout, stderr, status = run_ruby(
+        "-I", File.join(directory, "lib"),
+        "-I", SDK_LIB,
+        "-e", 'require "microsandbox"'
+      )
+
+      assert_false status.success?
+      assert_include stderr, "missing_microsandbox_binaries_dependency"
+    end
+  end
+
+  def test_missing_entry_file_is_not_swallowed_for_an_activated_companion
+    Dir.mktmpdir do |directory|
+      write_native_stub(directory)
+
+      _stdout, stderr, status = run_ruby(
+        "--disable-gems",
+        "-I", File.join(directory, "lib"),
+        "-I", SDK_LIB,
+        "-e", <<~'RUBY',
+          require "rubygems"
+          spec = Gem::Specification.new do |candidate|
+            candidate.name = "microsandbox-binaries"
+            candidate.version = "0.0.0"
+          end
+          Gem.loaded_specs["microsandbox-binaries"] = spec
+          require "microsandbox"
+        RUBY
+        env: {
+          "GEM_HOME" => File.join(directory, "gems"),
+          "GEM_PATH" => File.join(directory, "gems")
+        }
+      )
+
+      assert_false status.success?
+      assert_include stderr, "microsandbox/binaries"
+    end
+  end
+
+  def test_environment_override_remains_above_companion_sdk_tier
+    Dir.mktmpdir do |directory|
+      calls = File.join(directory, "calls")
+      write_native_stub(directory, record_calls: true)
+      write_companion_stub(directory)
+
+      stdout, stderr, status = run_ruby(
+        "-I", File.join(directory, "lib"),
+        "-I", SDK_LIB,
+        "-e", 'require "microsandbox"; puts ENV.fetch("MSB_PATH")',
+        env: { "MSB_HOOK_CALLS" => calls, "MSB_PATH" => "/explicit/msb" }
+      )
+
+      assert_predicate status, :success?, stderr
+      assert_equal "/explicit/msb\n", stdout
+      assert_equal "msb=/bundled/msb\nlibkrunfw=/bundled/libkrunfw.4.dylib\n", File.read(calls)
+    end
+  end
+
+  private
+
+  def run_ruby(*arguments, env: {})
+    Open3.capture3(
+      { "RUBYLIB" => nil, "RUBYOPT" => nil }.merge(env),
+      RbConfig.ruby,
+      *arguments
+    )
+  end
+
+  def write_native_stub(directory, record_calls: false)
+    abi = RUBY_VERSION[/\d+\.\d+/]
+    path = File.join(directory, "lib", "microsandbox", abi, "microsandbox.rb")
+    FileUtils.mkdir_p(File.dirname(path))
+    recorder = if record_calls
+                 <<~'RUBY'
+                   def self.record_runtime_path(name, path)
+                     File.open(ENV.fetch("MSB_HOOK_CALLS"), "a") { |file| file.puts("#{name}=#{path}") }
+                   end
+                 RUBY
+               else
+                 ""
+               end
+    setters = if record_calls
+                <<~RUBY
+                  def self.set_runtime_msb_path(path) = record_runtime_path("msb", path)
+                  def self.set_runtime_libkrunfw_path(path) = record_runtime_path("libkrunfw", path)
+                RUBY
+              else
+                <<~RUBY
+                  def self.set_runtime_msb_path(_path); end
+                  def self.set_runtime_libkrunfw_path(_path); end
+                RUBY
+              end
+    File.write(path, <<~RUBY)
+      module Microsandbox
+        class SandboxBuilder; end
+        class Sandbox; end
+        #{recorder}
+        #{setters}
+      end
+    RUBY
+  end
+
+  def write_companion_stub(directory, msb: "/bundled/msb", firmware: "/bundled/libkrunfw.4.dylib", broken_firmware: false)
+    path = File.join(directory, "lib", "microsandbox", "binaries.rb")
+    FileUtils.mkdir_p(File.dirname(path))
+    firmware_method = broken_firmware ? 'raise "broken firmware payload"' : firmware.inspect
+    File.write(path, <<~RUBY)
+      module Microsandbox
+        module Binaries
+          def self.msb_path = #{msb.inspect}
+          def self.libkrunfw_path = #{firmware_method}
+        end
+      end
+    RUBY
+  end
+end

--- a/sdk/ruby/test/binaries_hookup_test.rb
+++ b/sdk/ruby/test/binaries_hookup_test.rb
@@ -6,6 +6,8 @@ require "rbconfig"
 require "test/unit"
 require "tmpdir"
 
+require_relative "../lib/microsandbox/version"
+
 class MicrosandboxBinariesHookupTest < Test::Unit::TestCase
   SDK_LIB = File.expand_path("../lib", __dir__)
 
@@ -26,21 +28,24 @@ class MicrosandboxBinariesHookupTest < Test::Unit::TestCase
     end
   end
 
-  def test_present_companion_sets_both_runtime_paths
+  def test_same_series_companion_sets_both_paths_and_leaves_env_alone
     Dir.mktmpdir do |directory|
       calls = File.join(directory, "calls")
-      write_native_stub(directory, record_calls: true)
-      write_companion_stub(directory)
+      write_native_stub(directory)
+      # Patch-level difference on purpose: the same-minor rule accepts it, the
+      # hookup publishes both bundled paths in order, and it must not touch an
+      # explicit MSB_PATH while doing so.
+      write_companion_stub(directory, version: other_patch_version)
 
       stdout, stderr, status = run_ruby(
         "-I", File.join(directory, "lib"),
         "-I", SDK_LIB,
-        "-e", 'require "microsandbox"; puts "ready"',
-        env: { "MSB_HOOK_CALLS" => calls }
+        "-e", 'require "microsandbox"; puts ENV.fetch("MSB_PATH")',
+        env: { "MSB_HOOK_CALLS" => calls, "MSB_PATH" => "/explicit/msb" }
       )
 
-      assert_predicate status, :success?
-      assert_equal "ready\n", stdout
+      assert_predicate status, :success?, stderr
+      assert_equal "/explicit/msb\n", stdout
       assert_equal "", stderr
       assert_equal "msb=/bundled/msb\nlibkrunfw=/bundled/libkrunfw.4.dylib\n", File.read(calls)
     end
@@ -49,7 +54,7 @@ class MicrosandboxBinariesHookupTest < Test::Unit::TestCase
   def test_companion_paths_are_resolved_before_either_setter
     Dir.mktmpdir do |directory|
       calls = File.join(directory, "calls")
-      write_native_stub(directory, record_calls: true)
+      write_native_stub(directory)
       write_companion_stub(directory, broken_firmware: true)
 
       _stdout, stderr, status = run_ruby(
@@ -111,26 +116,39 @@ class MicrosandboxBinariesHookupTest < Test::Unit::TestCase
     end
   end
 
-  def test_environment_override_remains_above_companion_sdk_tier
+  def test_companion_from_another_minor_series_is_skipped_with_a_warning
     Dir.mktmpdir do |directory|
       calls = File.join(directory, "calls")
-      write_native_stub(directory, record_calls: true)
-      write_companion_stub(directory)
+      write_native_stub(directory)
+      write_companion_stub(directory, version: other_series_version)
 
       stdout, stderr, status = run_ruby(
         "-I", File.join(directory, "lib"),
         "-I", SDK_LIB,
-        "-e", 'require "microsandbox"; puts ENV.fetch("MSB_PATH")',
-        env: { "MSB_HOOK_CALLS" => calls, "MSB_PATH" => "/explicit/msb" }
+        "-e", 'require "microsandbox"; puts "ready"',
+        env: { "MSB_HOOK_CALLS" => calls }
       )
 
       assert_predicate status, :success?, stderr
-      assert_equal "/explicit/msb\n", stdout
-      assert_equal "msb=/bundled/msb\nlibkrunfw=/bundled/libkrunfw.4.dylib\n", File.read(calls)
+      assert_equal "ready\n", stdout
+      assert_include stderr, "ignoring microsandbox-binaries #{other_series_version}"
+      assert_include stderr, "microsandbox #{Microsandbox::VERSION}"
+      assert_include stderr, "MSB_PATH"
+      assert_false File.exist?(calls), "a companion from another minor series must not set the SDK tier"
     end
   end
 
   private
+
+  def other_series_version
+    major, minor, = Microsandbox::VERSION.split(".")
+    "#{major}.#{minor.to_i + 1}.0"
+  end
+
+  def other_patch_version
+    major, minor, patch = Microsandbox::VERSION.split(".")
+    "#{major}.#{minor}.#{patch.to_i + 1}"
+  end
 
   def run_ruby(*arguments, env: {})
     Open3.capture3(
@@ -140,48 +158,37 @@ class MicrosandboxBinariesHookupTest < Test::Unit::TestCase
     )
   end
 
-  def write_native_stub(directory, record_calls: false)
+  # The setters always record: reaching one without MSB_HOOK_CALLS raises
+  # KeyError, which fails louder than a silently ignored path would.
+  def write_native_stub(directory)
     abi = RUBY_VERSION[/\d+\.\d+/]
     path = File.join(directory, "lib", "microsandbox", abi, "microsandbox.rb")
     FileUtils.mkdir_p(File.dirname(path))
-    recorder = if record_calls
-                 <<~'RUBY'
-                   def self.record_runtime_path(name, path)
-                     File.open(ENV.fetch("MSB_HOOK_CALLS"), "a") { |file| file.puts("#{name}=#{path}") }
-                   end
-                 RUBY
-               else
-                 ""
-               end
-    setters = if record_calls
-                <<~RUBY
-                  def self.set_runtime_msb_path(path) = record_runtime_path("msb", path)
-                  def self.set_runtime_libkrunfw_path(path) = record_runtime_path("libkrunfw", path)
-                RUBY
-              else
-                <<~RUBY
-                  def self.set_runtime_msb_path(_path); end
-                  def self.set_runtime_libkrunfw_path(_path); end
-                RUBY
-              end
-    File.write(path, <<~RUBY)
+    File.write(path, <<~'RUBY')
       module Microsandbox
         class SandboxBuilder; end
         class Sandbox; end
-        #{recorder}
-        #{setters}
+
+        def self.record_runtime_path(name, path)
+          File.open(ENV.fetch("MSB_HOOK_CALLS"), "a") { |file| file.puts("#{name}=#{path}") }
+        end
+
+        def self.set_runtime_msb_path(path) = record_runtime_path("msb", path)
+        def self.set_runtime_libkrunfw_path(path) = record_runtime_path("libkrunfw", path)
       end
     RUBY
   end
 
-  def write_companion_stub(directory, msb: "/bundled/msb", firmware: "/bundled/libkrunfw.4.dylib", broken_firmware: false)
+  def write_companion_stub(directory, broken_firmware: false, version: Microsandbox::VERSION)
     path = File.join(directory, "lib", "microsandbox", "binaries.rb")
     FileUtils.mkdir_p(File.dirname(path))
-    firmware_method = broken_firmware ? 'raise "broken firmware payload"' : firmware.inspect
+    firmware_method = broken_firmware ? 'raise "broken firmware payload"' : '"/bundled/libkrunfw.4.dylib"'
     File.write(path, <<~RUBY)
       module Microsandbox
         module Binaries
-          def self.msb_path = #{msb.inspect}
+          VERSION = #{version.inspect}
+
+          def self.msb_path = "/bundled/msb"
           def self.libkrunfw_path = #{firmware_method}
         end
       end

--- a/sdk/ruby/test/binaries_integration_test.rb
+++ b/sdk/ruby/test/binaries_integration_test.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require "securerandom"
+require "test/unit"
+
+require_relative "../lib/microsandbox"
+
+class MicrosandboxBinariesIntegrationTest < Test::Unit::TestCase
+  IMAGE = ENV.fetch("MSB_RUBY_TEST_IMAGE", "alpine")
+
+  def setup
+    @names = []
+    omit("set MSB_RUBY_BINARIES_INTEGRATION=1 to run the companion-gem boot smoke") unless ENV["MSB_RUBY_BINARIES_INTEGRATION"] == "1"
+  end
+
+  def teardown
+    @names.each do |name|
+      sandbox = Microsandbox::Sandbox.get(name)
+      sandbox.stop if sandbox.status == "running"
+      sandbox.remove
+    rescue Microsandbox::Error
+      nil
+    end
+  end
+
+  def test_bundled_runtime_boots_and_environment_override_still_fails_fast
+    assert defined?(Microsandbox::Binaries), "microsandbox-binaries was not activated"
+    assert_nil ENV["MSB_PATH"], "MSB_PATH must be unset for the bundled-runtime boot assertion"
+    assert_nil ENV["MSB_LIBKRUNFW_PATH"],
+               "MSB_LIBKRUNFW_PATH must be unset for the bundled-runtime boot assertion"
+    assert_false path_contains_msb?, "PATH must be scrubbed of msb for this acceptance test"
+    msb_home = ENV["MSB_HOME"]
+    assert_not_nil msb_home, "MSB_HOME must point to the isolated integration-test home"
+    assert_false File.exist?(File.join(msb_home, "bin", "msb"))
+
+    name = sandbox_name("boot")
+    sandbox = Microsandbox::Sandbox.create(
+      name,
+      image: IMAGE,
+      cpus: 1,
+      memory: 256,
+      replace: true
+    )
+    output = sandbox.shell("printf binaries-gem-ok")
+
+    assert_true output.success?
+    assert_equal "binaries-gem-ok", output.stdout
+    sandbox.stop
+
+    ENV["MSB_PATH"] = "/nonexistent/msb"
+    started_at = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    error = assert_raise(Microsandbox::Error) do
+      Microsandbox::Sandbox.create(
+        sandbox_name("override"),
+        image: IMAGE,
+        cpus: 1,
+        memory: 256,
+        replace: true
+      )
+    end
+    elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - started_at
+
+    assert_include error.message, "No such file or directory"
+    assert_operator elapsed, :<, 10.0, "explicit MSB_PATH should fail before runtime boot"
+  ensure
+    ENV.delete("MSB_PATH")
+  end
+
+  private
+
+  def path_contains_msb?
+    ENV.fetch("PATH", "").split(File::PATH_SEPARATOR).any? do |directory|
+      File.file?(File.join(directory, "msb"))
+    end
+  end
+
+  def sandbox_name(label)
+    name = "ruby-bin-#{label}-#{Process.pid}-#{SecureRandom.hex(3)}"
+    @names << name
+    name
+  end
+end


### PR DESCRIPTION
## TL;DR

Local Ruby sandboxes currently need a separate runtime installation. Add an optional `microsandbox-binaries` platform gem supplying `msb` and `libkrunfw`, so applications can install their runtime through RubyGems while cloud-only users keep the main SDK alone.

## Description

- Add pure-data companion gems for `arm64-darwin`, `x86_64-linux-gnu`, and `aarch64-linux-gnu`, without a per-Ruby-ABI dimension or generic fallback gem.
- Build from matching release bundles, verify SHA-256 before extraction, and validate the finished gem's identity, exact payload, and executable mode. The companion version is aligned with release `0.6.17`.
- Discover the companion after loading the native extension and resolve both runtime paths before calling either existing SDK setter. Environment overrides retain precedence; absent companions are optional, activated-but-broken companions raise, and companions from another minor series are skipped with a warning.
- Extend the version bump script to both Ruby gems. Guard tests and packaging against workspace/SDK version drift, with fixture tests included in the aggregate CI gate.
- Document Bundler activation, supported platforms, and local packaging. The main gem has no dependency on the companion.

Refs #1305. Windows companion gems and automated release publication remain follow-ups.

## Test Plan

Local validation completed on September 6 with Ruby 3.4.5:

- `cd sdk/ruby-binaries && rake test`: 12 tests / 56 assertions passed on macOS and actual Linux aarch64, including version-drift refusal and a release-script bump to the next patch version.
- `cd sdk/ruby && ruby -Ilib -Itest test/binaries_hookup_test.rb`: 6 tests / 20 assertions passed.
- `cd sdk/ruby-binaries && rake 'package[0.6.17]'`: all three platform gems built and verified. The Linux aarch64 gem also installed and its executable reported `msb 0.6.17`.
- Installed-gem macOS VM smoke: Alpine boot with scrubbed PATH and an empty `MSB_HOME`, followed by an invalid `MSB_PATH` override that fails fast. Passed with SDK 0.6.17 and companions 0.6.17 and 0.6.16 (11 assertions each).
- Isolated `bundle install --local` and `bundle exec` probes passed for SDK-only and SDK-plus-companion Gemfiles.
- Full native rebuild and `sdk/ruby` `rake test`: 30 tests / 45 assertions, 1 failure, 8 omissions. The sole failure, `test_native_runtime_rebuilds_after_fork`, reads an empty child pipe. The same failure reproduces on unmodified main `e25cae31` with the same native extension and isolated environment (23 tests / 25 assertions, 1 failure, 7 omissions). The test is unchanged by this PR.
- Workflow YAML and aggregate-gate checks passed; `git diff --check` is clean.

Linux KVM VM boot, the full Ruby ABI matrix, and the seven unrelated opt-in VM/network/SSH integration tests were not run locally.


<!-- greptile_comment -->

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The CI aggregation issue should be fixed before merging so failures in the new Ruby companion validation actually block pull requests.

The companion implementation and packaging checks are internally consistent, but the workflow's sole branch-protected aggregate can pass even when the newly added ruby-binaries job fails.

**Files Needing Attention:** .github/workflows/check.yml
</details>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22superradcompany%2Fmicrosandbox%22%20on%20the%20existing%20branch%20%22feature%2Fruby-binaries-gem%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feature%2Fruby-binaries-gem%22.%0A%0AGreploop%20superradcompany%2Fmicrosandbox%20PR%20%231536%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AAFTER%20THE%20LOOP%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%20%20%20%20%20%20%20%20%20%20%7C%0A%2B------------------------------------------------------%2B&repo=superradcompany%2Fmicrosandbox&pr=1536&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22superradcompany%2Fmicrosandbox%22%20on%20the%20existing%20branch%20%22feature%2Fruby-binaries-gem%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feature%2Fruby-binaries-gem%22.%0A%0A%23%23%23%20Issue%201%0A.github%2Fworkflows%2Fcheck.yml%3A1978%0AWhen%20the%20new%20%60ruby-binaries%60%20job%20fails%2C%20only%20%60Check%20Summary%60%20consumes%20its%20result%3B%20the%20branch-protected%20%60Test%20Summary%60%20omits%20it%20and%20can%20remain%20successful%2C%20allowing%20companion%20version%20drift%20or%20broken%20packaging%20code%20to%20merge%20despite%20the%20failed%20validation.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=superradcompany%2Fmicrosandbox&pr=1536&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0A.github%2Fworkflows%2Fcheck.yml%3A1978%0AWhen%20the%20new%20%60ruby-binaries%60%20job%20fails%2C%20only%20%60Check%20Summary%60%20consumes%20its%20result%3B%20the%20branch-protected%20%60Test%20Summary%60%20omits%20it%20and%20can%20remain%20successful%2C%20allowing%20companion%20version%20drift%20or%20broken%20packaging%20code%20to%20merge%20despite%20the%20failed%20validation.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=superradcompany%2Fmicrosandbox&pr=1536&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
.github/workflows/check.yml:1978
When the new `ruby-binaries` job fails, only `Check Summary` consumes its result; the branch-protected `Test Summary` omits it and can remain successful, allowing companion version drift or broken packaging code to merge despite the failed validation.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ruby): keep binaries packaging in re..."](https://github.com/superradcompany/microsandbox/commit/451eae22b78df70ebfadfe90abf44e0430278fd1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61124527)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->