### PR TITLE
fix(deps): update msb-imago to 0.1.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4303,9 +4303,9 @@ dependencies = [
 
 [[package]]
 name = "msb-imago"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8563624d245da0b51b13959708758f06d1412cacdd17000b001f5ccae80cf6af"
+checksum = "4490214cfae885924274e430222370769e14c2b7f1b985251c7757fb276c2c4a"
 dependencies = [
  "async-trait",
  "cfg-if",

--- a/sdk/ruby/ext/microsandbox/Cargo.lock
+++ b/sdk/ruby/ext/microsandbox/Cargo.lock
@@ -3314,9 +3314,9 @@ dependencies = [
 
 [[package]]
 name = "msb-imago"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8563624d245da0b51b13959708758f06d1412cacdd17000b001f5ccae80cf6af"
+checksum = "4490214cfae885924274e430222370769e14c2b7f1b985251c7757fb276c2c4a"
 dependencies = [
  "async-trait",
  "cfg-if",


### PR DESCRIPTION
## TL;DR

Update `msb-imago` to `0.1.6` on `releases/v0.7.0` so locked builds include the tail-discard fix for [#1472](https://github.com/superradcompany/microsandbox/issues/1472).

## Description

- Select published `msb-imago 0.1.6`, which restores the original raw image length after discarding its tail and prevents the resulting restart mount failure.
- Update the version and crates.io checksum in both the workspace and standalone Ruby SDK lockfiles.
- Preserve all other dependency records, including the existing libkrun versions.
- Pick up the fix and regression coverage from [superradcompany/imago#7](https://github.com/superradcompany/imago/pull/7), with no public API or disk-format changes.

The standalone Ruby graph cannot currently resolve against published `microsandbox =0.6.15`: its existing manifest requests the `cloud` feature, which that published version does not expose. Its lockfile entry was updated using the same registry-verified version and checksum as the workspace. A standalone Ruby build was not validated in this PR.

## Test Plan

- [x] `cargo check -p microsandbox-runtime --no-default-features --features runner,net --locked --offline` passes on macOS arm64.
- [x] `cargo tree --locked --offline -i msb-imago` resolves `msb-imago 0.1.6` through `msb_krun_devices 0.1.32`.
- [x] Run the downloaded `msb-imago 0.1.6` crate's tests with `--all-features --locked --offline`: 37 unit tests and 4 doctests pass, including tail discard and reopen capacity checks; 2 existing doctests are ignored.
- [x] Compare both parsed lockfiles with `origin/releases/v0.7.0` and verify that only the imago version and checksum changed.
- [x] `git diff --check` passes.
- [x] Live test on macOS arm64 using commit `7241f310`, a freshly built matching guest agent, and the same checksum-verified firmware as the earlier failing reproduction: create a 2 GiB ext4 volume, write sentinel data, run guest `fstrim`, stop/start the sandbox, and verify mount, capacity, preserved data, and new writes.

Live test results: `fstrim` reported `2,040,336,384` bytes trimmed. The host raw image and ext4 filesystem remained `2,147,483,648` bytes before trim, after trim, after stop, and after restart. The guest also reported 2 GiB. Restart exited 0, `/dev/vdc` mounted as ext4, the original sentinel matched, and a new file could be written and read. The earlier v0.6.17 reproduction shrank the host image to `2,015,371,264` bytes and failed to restart. The PR build still prints `msb 0.6.15` because that is the release branch's package version; its dependency graph was verified to use `msb-imago 0.1.6`.

Closes #1472.
