### PR TITLE
chore: release v0.6.18

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1059,7 +1059,7 @@ jobs:
         run: |
           gem build microsandbox.gemspec
           mold -run gem install --local microsandbox-*.gem --no-document
-          ruby --disable-gems -e 'require "rubygems"; require "microsandbox"; abort unless Microsandbox.version == "0.6.17"'
+          ruby --disable-gems -e 'require "rubygems"; require "microsandbox"; abort unless Microsandbox.version == "0.6.18"'
 
       - name: Restore standalone Ruby lockfile
         if: always()

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3799,7 +3799,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox"
-version = "0.6.17"
+version = "0.6.18"
 dependencies = [
  "anyhow",
  "astral-tokio-tar",
@@ -3864,7 +3864,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-agent-client"
-version = "0.6.17"
+version = "0.6.18"
 dependencies = [
  "ciborium",
  "microsandbox-protocol",
@@ -3877,7 +3877,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-agentd"
-version = "0.6.17"
+version = "0.6.18"
 dependencies = [
  "base64 0.23.1",
  "chrono",
@@ -3894,7 +3894,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-cli"
-version = "0.6.17"
+version = "0.6.18"
 dependencies = [
  "anyhow",
  "base64 0.23.1",
@@ -3939,7 +3939,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-db"
-version = "0.6.17"
+version = "0.6.18"
 dependencies = [
  "async-trait",
  "sea-orm",
@@ -3951,7 +3951,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-filesystem"
-version = "0.6.17"
+version = "0.6.18"
 dependencies = [
  "libc",
  "microsandbox-utils",
@@ -3964,7 +3964,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-go"
-version = "0.6.17"
+version = "0.6.18"
 dependencies = [
  "base64 0.23.1",
  "cbindgen",
@@ -3982,7 +3982,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-image"
-version = "0.6.17"
+version = "0.6.18"
 dependencies = [
  "astral-tokio-tar",
  "async-compression",
@@ -4010,7 +4010,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-metrics"
-version = "0.6.17"
+version = "0.6.18"
 dependencies = [
  "chrono",
  "libc",
@@ -4022,7 +4022,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-metrics-collector"
-version = "0.6.17"
+version = "0.6.18"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4050,7 +4050,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-migration"
-version = "0.6.17"
+version = "0.6.18"
 dependencies = [
  "sea-orm-migration",
  "serde_json",
@@ -4059,7 +4059,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-network"
-version = "0.6.17"
+version = "0.6.18"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -4104,7 +4104,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-node"
-version = "0.6.17"
+version = "0.6.18"
 dependencies = [
  "bytes",
  "chrono",
@@ -4121,7 +4121,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-protocol"
-version = "0.6.17"
+version = "0.6.18"
 dependencies = [
  "chrono",
  "ciborium",
@@ -4136,7 +4136,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-py"
-version = "0.6.17"
+version = "0.6.18"
 dependencies = [
  "chrono",
  "futures",
@@ -4153,7 +4153,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-runtime"
-version = "0.6.17"
+version = "0.6.18"
 dependencies = [
  "bytes",
  "chrono",
@@ -4188,7 +4188,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-types"
-version = "0.6.17"
+version = "0.6.18"
 dependencies = [
  "chrono",
  "dprint-plugin-typescript",
@@ -4206,7 +4206,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-types-macros"
-version = "0.6.17"
+version = "0.6.18"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4215,7 +4215,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-utils"
-version = "0.6.17"
+version = "0.6.18"
 dependencies = [
  "dirs",
  "libc",
@@ -4228,7 +4228,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-vsock"
-version = "0.6.17"
+version = "0.6.18"
 dependencies = [
  "libc",
  "msb_krun",
@@ -7661,14 +7661,14 @@ dependencies = [
 
 [[package]]
 name = "test-init"
-version = "0.6.17"
+version = "0.6.18"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "test-macros"
-version = "0.6.17"
+version = "0.6.18"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7677,7 +7677,7 @@ dependencies = [
 
 [[package]]
 name = "test-utils"
-version = "0.6.17"
+version = "0.6.18"
 dependencies = [
  "tempfile",
  "test-macros",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ members = [
 [workspace.package]
 authors = ["Super Rad Company <development@superrad.company>"]
 repository = "https://github.com/superradcompany/microsandbox"
-version = "0.6.17"
+version = "0.6.18"
 license = "Apache-2.0"
 edition = "2024"
 
@@ -77,20 +77,20 @@ strip = false
 # Exact (`=`) pins: these crates share private, unstable APIs across patch
 # releases, so every published version must resolve its siblings to the same
 # version. Caret would let an older release pull newer siblings and break.
-microsandbox = { version = "=0.6.17", path = "sdk/rust", default-features = false }
-microsandbox-agent-client = { version = "=0.6.17", path = "packages/agent-client/rust" }
-microsandbox-db = { version = "=0.6.17", path = "crates/db" }
-microsandbox-filesystem = { version = "=0.6.17", path = "crates/filesystem", default-features = false }
-microsandbox-image = { version = "=0.6.17", path = "crates/image" }
-microsandbox-metrics = { version = "=0.6.17", path = "crates/metrics" }
-microsandbox-types-macros = { version = "=0.6.17", path = "packages/microsandbox-types/macros" }
-microsandbox-types = { version = "=0.6.17", path = "packages/microsandbox-types/rust" }
-microsandbox-migration = { version = "=0.6.17", path = "crates/migration" }
-microsandbox-network = { version = "=0.6.17", path = "crates/network" }
-microsandbox-protocol = { version = "=0.6.17", path = "crates/protocol" }
-microsandbox-runtime = { version = "=0.6.17", path = "crates/runtime", default-features = false }
-microsandbox-utils = { version = "=0.6.17", path = "crates/utils" }
-microsandbox-vsock = { version = "=0.6.17", path = "crates/vsock" }
+microsandbox = { version = "=0.6.18", path = "sdk/rust", default-features = false }
+microsandbox-agent-client = { version = "=0.6.18", path = "packages/agent-client/rust" }
+microsandbox-db = { version = "=0.6.18", path = "crates/db" }
+microsandbox-filesystem = { version = "=0.6.18", path = "crates/filesystem", default-features = false }
+microsandbox-image = { version = "=0.6.18", path = "crates/image" }
+microsandbox-metrics = { version = "=0.6.18", path = "crates/metrics" }
+microsandbox-types-macros = { version = "=0.6.18", path = "packages/microsandbox-types/macros" }
+microsandbox-types = { version = "=0.6.18", path = "packages/microsandbox-types/rust" }
+microsandbox-migration = { version = "=0.6.18", path = "crates/migration" }
+microsandbox-network = { version = "=0.6.18", path = "crates/network" }
+microsandbox-protocol = { version = "=0.6.18", path = "crates/protocol" }
+microsandbox-runtime = { version = "=0.6.18", path = "crates/runtime", default-features = false }
+microsandbox-utils = { version = "=0.6.18", path = "crates/utils" }
+microsandbox-vsock = { version = "=0.6.18", path = "crates/vsock" }
 msb_krun = "=0.1.32"
 msb_krun_utils = "=0.1.32"
 test-macros = { path = "crates/testing/macros" }

--- a/examples/typescript/cloud-backend/package.json
+++ b/examples/typescript/cloud-backend/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.6.17"
+    "microsandbox": "0.6.18"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/fs-read-stream/package.json
+++ b/examples/typescript/fs-read-stream/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.6.17"
+    "microsandbox": "0.6.18"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/init-handoff/package.json
+++ b/examples/typescript/init-handoff/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.6.17"
+    "microsandbox": "0.6.18"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/net-basic/package.json
+++ b/examples/typescript/net-basic/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.6.17"
+    "microsandbox": "0.6.18"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/net-dns/package.json
+++ b/examples/typescript/net-dns/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.6.17"
+    "microsandbox": "0.6.18"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/net-policy/package.json
+++ b/examples/typescript/net-policy/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.6.17"
+    "microsandbox": "0.6.18"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/net-ports/package.json
+++ b/examples/typescript/net-ports/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.6.17"
+    "microsandbox": "0.6.18"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/net-secrets/package.json
+++ b/examples/typescript/net-secrets/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.6.17"
+    "microsandbox": "0.6.18"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/net-tls/package.json
+++ b/examples/typescript/net-tls/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.6.17"
+    "microsandbox": "0.6.18"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/root-bind/package.json
+++ b/examples/typescript/root-bind/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.6.17"
+    "microsandbox": "0.6.18"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/root-block/package.json
+++ b/examples/typescript/root-block/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.6.17"
+    "microsandbox": "0.6.18"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/root-oci/package.json
+++ b/examples/typescript/root-oci/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.6.17"
+    "microsandbox": "0.6.18"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/rootfs-patch/package.json
+++ b/examples/typescript/rootfs-patch/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.6.17"
+    "microsandbox": "0.6.18"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/snapshot-fork/package.json
+++ b/examples/typescript/snapshot-fork/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.6.17"
+    "microsandbox": "0.6.18"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/volume-disk/package.json
+++ b/examples/typescript/volume-disk/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.6.17"
+    "microsandbox": "0.6.18"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/examples/typescript/volume-named/package.json
+++ b/examples/typescript/volume-named/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "microsandbox": "0.6.17"
+    "microsandbox": "0.6.18"
   },
   "devDependencies": {
     "tsx": "^4"

--- a/packages/agent-client/rust/README.md
+++ b/packages/agent-client/rust/README.md
@@ -10,19 +10,19 @@ Use this crate when you already have an agent relay endpoint and want direct pro
 
 ```toml
 [dependencies]
-microsandbox-agent-client = "0.6.17"
-microsandbox-protocol = "0.6.17"
+microsandbox-agent-client = "0.6.18"
+microsandbox-protocol = "0.6.18"
 ```
 
 The crate is transport-agnostic by default. Enable exactly the transport adapter you need:
 
 ```toml
 # Local microsandbox relay sockets.
-microsandbox-agent-client = { version = "0.6.17", features = ["uds"] }
+microsandbox-agent-client = { version = "0.6.18", features = ["uds"] }
 
 # Any caller-owned byte-stream transport (e.g. a pre-authenticated WebSocket
 # adapted to bytes).
-microsandbox-agent-client = { version = "0.6.17", features = ["stream"] }
+microsandbox-agent-client = { version = "0.6.18", features = ["stream"] }
 ```
 
 The high-level `microsandbox` SDK enables `uds` explicitly because local sandboxes are reached through Unix domain sockets.
@@ -99,7 +99,7 @@ async fn example() -> Result<(), Box<dyn std::error::Error>> {
 Enable the `stream` feature:
 
 ```toml
-microsandbox-agent-client = { version = "0.6.17", features = ["stream"] }
+microsandbox-agent-client = { version = "0.6.18", features = ["stream"] }
 ```
 
 Drive the client over any `AsyncRead + AsyncWrite` — the caller owns the dial and any authentication, then hands over the connected stream:

--- a/packages/agent-client/typescript/package-lock.json
+++ b/packages/agent-client/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@microsandbox/agent-client",
-  "version": "0.6.17",
+  "version": "0.6.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@microsandbox/agent-client",
-      "version": "0.6.17",
+      "version": "0.6.18",
       "license": "Apache-2.0",
       "dependencies": {
         "cbor-x": "^1.6.0"

--- a/packages/agent-client/typescript/package.json
+++ b/packages/agent-client/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsandbox/agent-client",
-  "version": "0.6.17",
+  "version": "0.6.18",
   "type": "module",
   "license": "Apache-2.0",
   "engines": {

--- a/packages/microsandbox-types/rust/README.md
+++ b/packages/microsandbox-types/rust/README.md
@@ -25,7 +25,7 @@ Backend-private materialized state stays out: registry credentials, local CA pat
 
 ```toml
 [dependencies]
-microsandbox-types = "0.6.17"
+microsandbox-types = "0.6.18"
 ```
 
 ```rust

--- a/packages/microsandbox-types/typescript/package-lock.json
+++ b/packages/microsandbox-types/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@microsandbox/types",
-  "version": "0.6.17",
+  "version": "0.6.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@microsandbox/types",
-      "version": "0.6.17",
+      "version": "0.6.18",
       "license": "Apache-2.0",
       "devDependencies": {
         "typescript": "^5.6"

--- a/packages/microsandbox-types/typescript/package.json
+++ b/packages/microsandbox-types/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsandbox/types",
-  "version": "0.6.17",
+  "version": "0.6.18",
   "type": "module",
   "main": "./dist/cloud.js",
   "types": "./dist/cloud.d.ts",

--- a/sdk/go/setup.go
+++ b/sdk/go/setup.go
@@ -24,7 +24,7 @@ import (
 // embedded FFI library and the downloaded msb+libkrunfw artefacts are
 // both pinned to this version. Bump when cutting a new SDK release so
 // it matches published binaries.
-const sdkVersion = "0.6.17"
+const sdkVersion = "0.6.18"
 
 // libkrunfwABI is the major SONAME version of libkrunfw that msb links
 // against.

--- a/sdk/node-ts/native/index.cjs
+++ b/sdk/node-ts/native/index.cjs
@@ -77,8 +77,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-android-arm64')
         const bindingPackageVersion = require('@superradcompany/microsandbox-android-arm64/package.json').version
-        if (bindingPackageVersion !== '0.6.17' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.6.17 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.6.18' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.6.18 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -93,8 +93,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-android-arm-eabi')
         const bindingPackageVersion = require('@superradcompany/microsandbox-android-arm-eabi/package.json').version
-        if (bindingPackageVersion !== '0.6.17' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.6.17 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.6.18' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.6.18 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -114,8 +114,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-win32-x64-gnu')
         const bindingPackageVersion = require('@superradcompany/microsandbox-win32-x64-gnu/package.json').version
-        if (bindingPackageVersion !== '0.6.17' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.6.17 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.6.18' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.6.18 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -130,8 +130,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-win32-x64-msvc')
         const bindingPackageVersion = require('@superradcompany/microsandbox-win32-x64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.6.17' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.6.17 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.6.18' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.6.18 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -147,8 +147,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-win32-ia32-msvc')
         const bindingPackageVersion = require('@superradcompany/microsandbox-win32-ia32-msvc/package.json').version
-        if (bindingPackageVersion !== '0.6.17' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.6.17 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.6.18' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.6.18 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -163,8 +163,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-win32-arm64-msvc')
         const bindingPackageVersion = require('@superradcompany/microsandbox-win32-arm64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.6.17' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.6.17 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.6.18' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.6.18 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -182,8 +182,8 @@ function requireNative() {
     try {
       const binding = require('@superradcompany/microsandbox-darwin-universal')
       const bindingPackageVersion = require('@superradcompany/microsandbox-darwin-universal/package.json').version
-      if (bindingPackageVersion !== '0.6.17' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-        throw new Error(`Native binding package version mismatch, expected 0.6.17 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+      if (bindingPackageVersion !== '0.6.18' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+        throw new Error(`Native binding package version mismatch, expected 0.6.18 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
       }
       return binding
     } catch (e) {
@@ -198,8 +198,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-darwin-x64')
         const bindingPackageVersion = require('@superradcompany/microsandbox-darwin-x64/package.json').version
-        if (bindingPackageVersion !== '0.6.17' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.6.17 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.6.18' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.6.18 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -214,8 +214,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-darwin-arm64')
         const bindingPackageVersion = require('@superradcompany/microsandbox-darwin-arm64/package.json').version
-        if (bindingPackageVersion !== '0.6.17' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.6.17 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.6.18' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.6.18 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -234,8 +234,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-freebsd-x64')
         const bindingPackageVersion = require('@superradcompany/microsandbox-freebsd-x64/package.json').version
-        if (bindingPackageVersion !== '0.6.17' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.6.17 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.6.18' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.6.18 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -250,8 +250,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-freebsd-arm64')
         const bindingPackageVersion = require('@superradcompany/microsandbox-freebsd-arm64/package.json').version
-        if (bindingPackageVersion !== '0.6.17' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.6.17 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.6.18' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.6.18 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -271,8 +271,8 @@ function requireNative() {
         try {
           const binding = require('@superradcompany/microsandbox-linux-x64-musl')
           const bindingPackageVersion = require('@superradcompany/microsandbox-linux-x64-musl/package.json').version
-          if (bindingPackageVersion !== '0.6.17' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.6.17 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.6.18' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.6.18 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -287,8 +287,8 @@ function requireNative() {
         try {
           const binding = require('@superradcompany/microsandbox-linux-x64-gnu')
           const bindingPackageVersion = require('@superradcompany/microsandbox-linux-x64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.6.17' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.6.17 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.6.18' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.6.18 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -305,8 +305,8 @@ function requireNative() {
         try {
           const binding = require('@superradcompany/microsandbox-linux-arm64-musl')
           const bindingPackageVersion = require('@superradcompany/microsandbox-linux-arm64-musl/package.json').version
-          if (bindingPackageVersion !== '0.6.17' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.6.17 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.6.18' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.6.18 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -321,8 +321,8 @@ function requireNative() {
         try {
           const binding = require('@superradcompany/microsandbox-linux-arm64-gnu')
           const bindingPackageVersion = require('@superradcompany/microsandbox-linux-arm64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.6.17' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.6.17 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.6.18' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.6.18 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -339,8 +339,8 @@ function requireNative() {
         try {
           const binding = require('@superradcompany/microsandbox-linux-arm-musleabihf')
           const bindingPackageVersion = require('@superradcompany/microsandbox-linux-arm-musleabihf/package.json').version
-          if (bindingPackageVersion !== '0.6.17' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.6.17 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.6.18' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.6.18 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -355,8 +355,8 @@ function requireNative() {
         try {
           const binding = require('@superradcompany/microsandbox-linux-arm-gnueabihf')
           const bindingPackageVersion = require('@superradcompany/microsandbox-linux-arm-gnueabihf/package.json').version
-          if (bindingPackageVersion !== '0.6.17' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.6.17 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.6.18' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.6.18 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -373,8 +373,8 @@ function requireNative() {
         try {
           const binding = require('@superradcompany/microsandbox-linux-loong64-musl')
           const bindingPackageVersion = require('@superradcompany/microsandbox-linux-loong64-musl/package.json').version
-          if (bindingPackageVersion !== '0.6.17' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.6.17 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.6.18' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.6.18 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -389,8 +389,8 @@ function requireNative() {
         try {
           const binding = require('@superradcompany/microsandbox-linux-loong64-gnu')
           const bindingPackageVersion = require('@superradcompany/microsandbox-linux-loong64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.6.17' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.6.17 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.6.18' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.6.18 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -407,8 +407,8 @@ function requireNative() {
         try {
           const binding = require('@superradcompany/microsandbox-linux-riscv64-musl')
           const bindingPackageVersion = require('@superradcompany/microsandbox-linux-riscv64-musl/package.json').version
-          if (bindingPackageVersion !== '0.6.17' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.6.17 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.6.18' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.6.18 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -423,8 +423,8 @@ function requireNative() {
         try {
           const binding = require('@superradcompany/microsandbox-linux-riscv64-gnu')
           const bindingPackageVersion = require('@superradcompany/microsandbox-linux-riscv64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.6.17' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.6.17 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.6.18' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.6.18 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -440,8 +440,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-linux-ppc64-gnu')
         const bindingPackageVersion = require('@superradcompany/microsandbox-linux-ppc64-gnu/package.json').version
-        if (bindingPackageVersion !== '0.6.17' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.6.17 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.6.18' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.6.18 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -456,8 +456,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-linux-s390x-gnu')
         const bindingPackageVersion = require('@superradcompany/microsandbox-linux-s390x-gnu/package.json').version
-        if (bindingPackageVersion !== '0.6.17' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.6.17 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.6.18' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.6.18 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -476,8 +476,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-openharmony-arm64')
         const bindingPackageVersion = require('@superradcompany/microsandbox-openharmony-arm64/package.json').version
-        if (bindingPackageVersion !== '0.6.17' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.6.17 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.6.18' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.6.18 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -492,8 +492,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-openharmony-x64')
         const bindingPackageVersion = require('@superradcompany/microsandbox-openharmony-x64/package.json').version
-        if (bindingPackageVersion !== '0.6.17' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.6.17 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.6.18' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.6.18 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -508,8 +508,8 @@ function requireNative() {
       try {
         const binding = require('@superradcompany/microsandbox-openharmony-arm')
         const bindingPackageVersion = require('@superradcompany/microsandbox-openharmony-arm/package.json').version
-        if (bindingPackageVersion !== '0.6.17' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.6.17 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.6.18' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.6.18 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {

--- a/sdk/node-ts/npm/darwin-arm64/package.json
+++ b/sdk/node-ts/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superradcompany/microsandbox-darwin-arm64",
-  "version": "0.6.17",
+  "version": "0.6.18",
   "description": "Bundled msb + libkrunfw + napi binding for microsandbox on macOS arm64.",
   "os": ["darwin"],
   "cpu": ["arm64"],

--- a/sdk/node-ts/npm/linux-arm64-gnu/package.json
+++ b/sdk/node-ts/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superradcompany/microsandbox-linux-arm64-gnu",
-  "version": "0.6.17",
+  "version": "0.6.18",
   "description": "Bundled msb + libkrunfw + napi binding for microsandbox on Linux arm64 (glibc).",
   "os": ["linux"],
   "cpu": ["arm64"],

--- a/sdk/node-ts/npm/linux-x64-gnu/package.json
+++ b/sdk/node-ts/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superradcompany/microsandbox-linux-x64-gnu",
-  "version": "0.6.17",
+  "version": "0.6.18",
   "description": "Bundled msb + libkrunfw + napi binding for microsandbox on Linux x86_64 (glibc).",
   "os": ["linux"],
   "cpu": ["x64"],

--- a/sdk/node-ts/npm/win32-arm64-msvc/package.json
+++ b/sdk/node-ts/npm/win32-arm64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superradcompany/microsandbox-win32-arm64-msvc",
-  "version": "0.6.17",
+  "version": "0.6.18",
   "description": "Bundled msb + libkrunfw + napi binding for microsandbox on Windows arm64.",
   "os": ["win32"],
   "cpu": ["arm64"],

--- a/sdk/node-ts/npm/win32-x64-msvc/package.json
+++ b/sdk/node-ts/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superradcompany/microsandbox-win32-x64-msvc",
-  "version": "0.6.17",
+  "version": "0.6.18",
   "description": "Bundled msb + libkrunfw + napi binding for microsandbox on Windows x64.",
   "os": ["win32"],
   "cpu": ["x64"],

--- a/sdk/node-ts/package-lock.json
+++ b/sdk/node-ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "microsandbox",
-  "version": "0.6.17",
+  "version": "0.6.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "microsandbox",
-      "version": "0.6.17",
+      "version": "0.6.18",
       "license": "Apache-2.0",
       "bin": {
         "microsandbox": "bin/microsandbox.cjs",
@@ -22,11 +22,11 @@
         "node": ">= 22"
       },
       "optionalDependencies": {
-        "@superradcompany/microsandbox-darwin-arm64": "0.6.17",
-        "@superradcompany/microsandbox-linux-arm64-gnu": "0.6.17",
-        "@superradcompany/microsandbox-linux-x64-gnu": "0.6.17",
-        "@superradcompany/microsandbox-win32-arm64-msvc": "0.6.17",
-        "@superradcompany/microsandbox-win32-x64-msvc": "0.6.17"
+        "@superradcompany/microsandbox-darwin-arm64": "0.6.18",
+        "@superradcompany/microsandbox-linux-arm64-gnu": "0.6.18",
+        "@superradcompany/microsandbox-linux-x64-gnu": "0.6.18",
+        "@superradcompany/microsandbox-win32-arm64-msvc": "0.6.18",
+        "@superradcompany/microsandbox-win32-x64-msvc": "0.6.18"
       }
     },
     "node_modules/@emnapi/core": {
@@ -1849,86 +1849,6 @@
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@superradcompany/microsandbox-darwin-arm64": {
-      "version": "0.6.17",
-      "resolved": "https://registry.npmjs.org/@superradcompany/microsandbox-darwin-arm64/-/microsandbox-darwin-arm64-0.6.17.tgz",
-      "integrity": "sha512-H+h+lNGlPWpt9qQ9k/MOFAApLFloA22zJAzormM1CSISkyaLBromH4bt9XlCP3nhG3/oHuYnO7FqhKZN+klVgA==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 22"
-      }
-    },
-    "node_modules/@superradcompany/microsandbox-linux-arm64-gnu": {
-      "version": "0.6.17",
-      "resolved": "https://registry.npmjs.org/@superradcompany/microsandbox-linux-arm64-gnu/-/microsandbox-linux-arm64-gnu-0.6.17.tgz",
-      "integrity": "sha512-j7YfBbVKDpF1fC38FPI0Ut1iThpUf0U4+I4IA+lBTyxo3ptux0b2ouY0CDSB+okrWTCe/kxgxUhgOKc9V3gOPA==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 22"
-      }
-    },
-    "node_modules/@superradcompany/microsandbox-linux-x64-gnu": {
-      "version": "0.6.17",
-      "resolved": "https://registry.npmjs.org/@superradcompany/microsandbox-linux-x64-gnu/-/microsandbox-linux-x64-gnu-0.6.17.tgz",
-      "integrity": "sha512-o9IXJNWi1Ml9VMD0IAbLdUTeujbmY39z5reuez03Svxrqy8AlGGJoNR6Nh+oAm5p0Ytke8BChI9OlYcSFFCPHw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 22"
-      }
-    },
-    "node_modules/@superradcompany/microsandbox-win32-arm64-msvc": {
-      "version": "0.6.17",
-      "resolved": "https://registry.npmjs.org/@superradcompany/microsandbox-win32-arm64-msvc/-/microsandbox-win32-arm64-msvc-0.6.17.tgz",
-      "integrity": "sha512-M2wdSTTEBRKJXpYX3P0+5tQJep17HY1p7UTFLxFsiWH+xEJ6z5RvYb1U2i5BvNVvyymkfBbh5rnyBSv8vnyDcg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 22"
-      }
-    },
-    "node_modules/@superradcompany/microsandbox-win32-x64-msvc": {
-      "version": "0.6.17",
-      "resolved": "https://registry.npmjs.org/@superradcompany/microsandbox-win32-x64-msvc/-/microsandbox-win32-x64-msvc-0.6.17.tgz",
-      "integrity": "sha512-1Acpg7zb7o+R1BRV2pWFyMAKTqm7YvMJFPMjAA6H69jAyPTVBdJw3TVCLiN2RR5lHLvV2EdHmx/awl9X5Oj8/g==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 22"
-      }
     },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.2",

--- a/sdk/node-ts/package.json
+++ b/sdk/node-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "microsandbox",
-  "version": "0.6.17",
+  "version": "0.6.18",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -53,11 +53,11 @@
     "vitest": "^4.1"
   },
   "optionalDependencies": {
-    "@superradcompany/microsandbox-darwin-arm64": "0.6.17",
-    "@superradcompany/microsandbox-linux-arm64-gnu": "0.6.17",
-    "@superradcompany/microsandbox-linux-x64-gnu": "0.6.17",
-    "@superradcompany/microsandbox-win32-arm64-msvc": "0.6.17",
-    "@superradcompany/microsandbox-win32-x64-msvc": "0.6.17"
+    "@superradcompany/microsandbox-darwin-arm64": "0.6.18",
+    "@superradcompany/microsandbox-linux-arm64-gnu": "0.6.18",
+    "@superradcompany/microsandbox-linux-x64-gnu": "0.6.18",
+    "@superradcompany/microsandbox-win32-arm64-msvc": "0.6.18",
+    "@superradcompany/microsandbox-win32-x64-msvc": "0.6.18"
   },
   "files": [
     "dist",

--- a/sdk/ruby/ext/microsandbox/Cargo.toml
+++ b/sdk/ruby/ext/microsandbox/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "microsandbox-ruby"
-version = "0.6.17"
+version = "0.6.18"
 edition = "2024"
 rust-version = "1.85"
 description = "Ruby bindings for the microsandbox Rust SDK."
@@ -22,5 +22,5 @@ strip = false
 
 [dependencies]
 magnus = "0.8.2"
-microsandbox_core = { package = "microsandbox", version = "=0.6.17", default-features = false, features = ["net", "ssh"] }
+microsandbox_core = { package = "microsandbox", version = "=0.6.18", default-features = false, features = ["net", "ssh"] }
 tokio = { version = "1.52", features = ["rt-multi-thread", "time"] }

--- a/sdk/ruby/lib/microsandbox/version.rb
+++ b/sdk/ruby/lib/microsandbox/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Microsandbox
-  VERSION = "0.6.17"
+  VERSION = "0.6.18"
 end


### PR DESCRIPTION
## TL;DR
Prepare the 0.6.18 release across Rust, Python (inherited Cargo version), Node, Go, Ruby, and shared packages. Includes the MCP and skills release-preparation commits through updated submodule pointers.

## Description
- Bump the workspace version and exact internal dependency pins, Node platform packages and binding-loader checks, Go runtime download version, Ruby package/native references, and current README/example dependency references.
- Regenerate Cargo.lock and the shared TypeScript and Node SDK lockfiles without unrelated dependency upgrades. The Node lockfile drops old native tarballs because 0.6.18 is unpublished; CI supplies fresh native artifacts, and release.yml refreshes resolved tarballs after publishing. Example lockfiles retain their existing resolved artifacts.
- Changes since v0.6.17 already on main: align HTTP host-policy checks; add opt-in strict hostname policy with pre-connect enforcement; fix Node publishing to use npm ci; isolate Mintlify sync checks.
- Compatibility: this PR changes release metadata only. Strict policy is opt-in; release notes should describe its inspectable-authority requirement and behavior for non-intercepted HTTPS. Cross-release runtime compatibility has not been exercised locally.
- Advance MCP to `1dd1eac1` (package, SDK dependency, and server versions) and skills to `21b17d55` (Rust SDK reference). Companion PRs: https://github.com/superradcompany/microsandbox-mcp/pull/36 and https://github.com/superradcompany/skills/pull/37. Both commits are pushed and included in this PR. libkrun and libkrunfw remain unchanged.

## Test Plan
- Passed: cargo metadata --offline --format-version 1; verified all 20 local microsandbox-prefixed workspace packages report 0.6.18.
- Passed: cargo fmt --all -- --check; cargo clippy --manifest-path crates/agentd/Cargo.toml -- -D warnings; git diff --check.
- Passed: python3 scripts/ci/publish-crates.py --validate-only after committing (registry-independent package validation).
- Passed: agent-client npm build, typecheck, and all 7 tests; shared types npm build and typecheck.
- Passed: Node SDK npm 10 ci --ignore-scripts, build:ts, typecheck, and npm pack --dry-run --ignore-scripts. The local newer npm rejects missing unpublished optional entries; npm 10, matching Node 22 CI, installs successfully.
- Passed: prepared MCP TypeScript build in a temporary copy using the local Node SDK dependency, following CI's approach.
- Blocked locally: cargo check --workspace --locked; cargo test --workspace --locked; cargo clippy --workspace --locked -- -D warnings; cargo doc --workspace --no-deps; cargo build -p microsandbox-cli. Missing local runtime/agentd artifacts cause downloads of unpublished v0.6.18 assets to return HTTP 404. The corresponding three failing commit hooks were skipped after observing the same failures; CI builds artifacts from source.
- Blocked locally: Node test:unit requires the unbuilt native binding. Python/Go/Ruby native builds and VM smoke tests were not run because matching runtime/native artifacts are unavailable in this checkout.







<!-- greptile_comment -->

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because the previously reported Ruby version mismatch has been corrected and no blocking failure remains.

No blocking failure remains.
</details>

<sub>Reviews (3): Last reviewed commit: ["chore(release): align mcp and skills wit..."](https://github.com/superradcompany/microsandbox/commit/573050f7e360dd110ead513fb930f3a86d060271) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=62210934)</sub>

<!-- /greptile_comment -->