### PR TITLE
feat(cloud): add request compatibility and release smoke gate

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,8 @@ on:
       - scripts/ci/publish-crates.py
       - scripts/ci/validate-release-artifacts.py
       - scripts/ci/test_validate_release_artifacts.py
+      - sdk/node-ts/scripts/cloud-release-smoke.mts
+      - sdk/node-ts/scripts/cloud-release-smoke.test.mts
       - scripts/ci/validate_linux_glibc.py
       - scripts/ci/test_validate_linux_glibc.py
       - scripts/ci/wait-for-npm-packages.mjs
@@ -969,6 +971,71 @@ jobs:
 
       - name: Validate crates.io publication graph and package manifests
         run: python3 scripts/ci/publish-crates.py --validate-only
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22
+
+      # Exercise the same packaging path as npm-publish, including the candidate
+      # native binding. No already-published microsandbox package is installed.
+      - name: Build and check TypeScript smoke test
+        working-directory: sdk/node-ts
+        run: |
+          npm ci --omit=optional
+          npm run build:ts
+          npx --no-install tsc --noEmit --strict --skipLibCheck --target ES2023 --module nodenext --allowImportingTsExtensions scripts/cloud-release-smoke.mts scripts/cloud-release-smoke.test.mts
+          node --experimental-strip-types --test scripts/cloud-release-smoke.test.mts
+
+      # Never expose production credentials to PR code. Manual dry-runs run the
+      # live gate only on main; every publishing tag must pass it.
+      - name: Install candidate SDK for production smoke test
+        id: smoke-install
+        if: >-
+          (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) ||
+          (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main')
+        run: |
+          platform=sdk/node-ts/npm/linux-x64-gnu
+          artifact=node-artifacts/node-sdk-linux-x64-gnu
+          mkdir -p "$platform/bin" "$platform/lib"
+          cp "$artifact/npm/linux-x64-gnu/"*.node "$platform/"
+          cp "$artifact/npm/linux-x64-gnu/bin/"* "$platform/bin/"
+          cp "$artifact/npm/linux-x64-gnu/lib/"* "$platform/lib/"
+          chmod +x "$platform/bin/msb"
+          cp "$artifact/native/index.cjs" sdk/node-ts/native/index.cjs
+          cp "$artifact/native/index.d.ts" sdk/node-ts/native/index.d.cts
+          pack_dir="$RUNNER_TEMP/cloud-smoke-packs"
+          consumer_dir="$RUNNER_TEMP/cloud-smoke-consumer"
+          mkdir -p "$pack_dir" "$consumer_dir"
+          main_tarball=$(cd sdk/node-ts && npm pack --silent --pack-destination "$pack_dir")
+          platform_tarball=$(cd "$platform" && npm pack --silent --pack-destination "$pack_dir")
+          cp sdk/node-ts/scripts/cloud-release-smoke.mts "$consumer_dir/"
+          cd "$consumer_dir"
+          npm init --yes >/dev/null
+          npm install --ignore-scripts --omit=optional "$pack_dir/$main_tarball" "$pack_dir/$platform_tarball"
+          node --input-type=module -e 'await import("microsandbox")'
+
+      - name: Smoke test candidate SDK against production
+        id: cloud-smoke
+        if: steps.smoke-install.outcome == 'success'
+        timeout-minutes: 6
+        env:
+          MSB_API_KEY: ${{ secrets.MSB_API_KEY }}
+          MSB_BACKEND: cloud
+          MSB_API_URL: https://api.microsandbox.dev
+          MSB_HOME: ${{ runner.temp }}/cloud-smoke-home
+          MSB_SMOKE_SANDBOX_NAME: release-smoke-${{ github.run_id }}-${{ github.run_attempt }}
+        run: node --experimental-strip-types "$RUNNER_TEMP/cloud-smoke-consumer/cloud-release-smoke.mts" run
+
+      - name: Clean up production smoke sandbox
+        if: ${{ always() && steps.cloud-smoke.outcome != 'skipped' && steps.smoke-install.outcome == 'success' }}
+        timeout-minutes: 4
+        env:
+          MSB_API_KEY: ${{ secrets.MSB_API_KEY }}
+          MSB_BACKEND: cloud
+          MSB_API_URL: https://api.microsandbox.dev
+          MSB_HOME: ${{ runner.temp }}/cloud-smoke-home
+          MSB_SMOKE_SANDBOX_NAME: release-smoke-${{ github.run_id }}-${{ github.run_attempt }}
+        run: node --experimental-strip-types "$RUNNER_TEMP/cloud-smoke-consumer/cloud-release-smoke.mts" cleanup
 
       - name: Upload validation manifest
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -264,6 +264,29 @@ The release workflow (`.github/workflows/release.yml`) will:
 10. Update the Homebrew tap and winget manifests
 11. Sync docs to Mintlify and refresh the npm lockfile on `main`
 
+### Production SDK smoke gate
+
+Add the repository Actions secret `MSB_API_KEY` in
+`superradcompany/microsandbox`. Its value must be a production Microsandbox API
+key for a dedicated test organization with permission and quota to create, run,
+stop, and delete a sandbox. CI sets `MSB_API_KEY`, `MSB_BACKEND=cloud`, and
+`MSB_API_URL=https://api.microsandbox.dev` so the SDK uses its normal environment
+configuration to select production.
+
+Before any publisher runs, `release-ready` installs the candidate TypeScript SDK and Linux x86_64 native
+npm tarballs built from that same workflow, creates a 1-vCPU/512-MiB Alpine sandbox, checks exact
+command output, and confirms removal. The sandbox name includes the run ID and
+attempt. Cleanup runs even when the smoke step fails; an ephemeral lifecycle,
+10-minute maximum duration, and 2-minute idle timeout bound running resources if
+the runner disappears. Missing credentials or smoke/cleanup failure blocks
+publishing. Production outages can therefore block a release.
+
+The live gate runs on release tag pushes and manual Release runs on `main`.
+Pull requests and manual runs on other branches run the credential-free checks
+without accessing production. No published microsandbox package is fetched from npm in place of the
+candidate tarballs. This is a shared SDK-to-Cloud path check, not exhaustive testing
+of every language binding or new Cloud feature.
+
 ## Additional Resources
 
 - [CONTRIBUTING.md](./CONTRIBUTING.md) — How to contribute

--- a/packages/microsandbox-types/README.md
+++ b/packages/microsandbox-types/README.md
@@ -47,3 +47,11 @@ cargo run -p microsandbox-types --features ts --bin microsandbox-types-generate 
 - Validation helpers: sandbox-name and hostname rules shared across SDK, CLI, and cloud.
 
 Backend-private materialized state (registry credentials, local cache paths, DB rows, resolved manifest digests, process handles) deliberately stays out of these packages. See each language's README for details.
+
+## Cloud Request Compatibility
+
+Cloud request objects ignore unknown fields, including fields inside network and runtime options. This allows newer SDKs to send additive options before the receiving Cloud release understands them. Unknown settings have no effect until that server supports them; request success does not confirm that every supplied setting was applied.
+
+Missing fields retain their documented defaults. Required fields, recognized field types and values, and enum variants still undergo validation. Ignoring unknown object keys does not make new enum variants, renamed fields, or changed field types compatible.
+
+This policy applies to public Cloud wire types, not host or operator configuration. SDK checks for runtime-only options remain separate from the server's treatment of future Cloud fields.

--- a/packages/microsandbox-types/rust/lib/cloud.rs
+++ b/packages/microsandbox-types/rust/lib/cloud.rs
@@ -4,6 +4,11 @@
 //! user-facing intent, so disk sizing sits beside CPU and memory; conversion
 //! into the domain spec moves that value onto the OCI rootfs where the runtime
 //! realizes it.
+//!
+//! Cloud request objects ignore unknown fields so SDK and server releases can
+//! evolve independently. Missing fields keep their documented defaults; known
+//! fields and enum variants are still validated. Acceptance of a request does
+//! not imply support for settings unknown to the receiving server.
 
 use std::collections::BTreeMap;
 use std::path::PathBuf;
@@ -730,12 +735,12 @@ impl From<VolumeMount> for CloudVolumeMount {
 
 /// Cloud network specification: a subset of the domain [`NetworkSpec`].
 /// Interface overrides, host port mapping, DNS, TLS interception, rate limits,
-/// and host-CA trust are not part of this type. `deny_unknown_fields` — posting
-/// an omitted field is an error, not a silent drop.
+/// and host-CA trust are not part of this type. Unknown fields are ignored for
+/// compatibility with newer clients; accepting them does not enable their behavior.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[cfg_attr(feature = "ts", derive(ts_rs::TS))]
-#[serde(default, deny_unknown_fields)]
+#[serde(default)]
 pub struct CloudNetworkSpec {
     /// Whether networking is enabled for this sandbox.
     pub enabled: bool,
@@ -770,11 +775,11 @@ impl Default for CloudNetworkSpec {
 
 /// Cloud guest runtime options: a subset of [`SandboxRuntimeOptions`]. The
 /// hostname and the metrics-sampling knobs are not part of this type.
-/// `deny_unknown_fields`.
+/// Unknown fields are ignored for compatibility with newer clients.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[cfg_attr(feature = "ts", derive(ts_rs::TS))]
-#[serde(default, deny_unknown_fields)]
+#[serde(default)]
 pub struct CloudSandboxRuntimeOptions {
     /// Working directory for guest commands.
     pub workdir: Option<String>,
@@ -1411,17 +1416,114 @@ mod tests {
     }
 
     #[test]
-    fn cloud_network_rejects_rate_limit_configuration() {
-        let error = serde_json::from_value::<CloudNetworkSpec>(serde_json::json!({
+    fn cloud_network_ignores_unsupported_options() {
+        let network: CloudNetworkSpec = serde_json::from_value(serde_json::json!({
+            "enabled": false,
+            "max_connections": 64,
             "rate_limiter": {
                 "egress": {
                     "bandwidth": {"size": 1024, "refill_time_ms": 1000}
                 }
             }
         }))
-        .unwrap_err();
+        .unwrap();
 
-        assert!(error.to_string().contains("unknown field `rate_limiter`"));
+        assert!(!network.enabled);
+        assert_eq!(network.max_connections, Some(64));
+        assert!(
+            serde_json::to_value(network)
+                .unwrap()
+                .get("rate_limiter")
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn create_request_ignores_future_fields_at_nested_boundaries() {
+        let baseline = serde_json::json!({
+            "name": "agent-1",
+            "image": {"type": "oci", "reference": "alpine"},
+            "resources": {"vcpus": 2},
+            "network": {
+                "enabled": false,
+                "max_connections": 64,
+                "secrets": {"entries": [], "on_violation": {"type": "block"}}
+            },
+            "runtime": {"workdir": "/app"},
+            "mounts": [{"type": "tmpfs", "guest": "/tmp", "options": {}}],
+            "patches": [{"type": "text", "path": "/hello", "content": "world", "replace": false}],
+            "rlimits": [{"resource": "nofile", "soft": 64, "hard": 128}],
+            "lifecycle": {}
+        });
+        let expected: CloudCreateSandboxRequest = serde_json::from_value(baseline.clone()).unwrap();
+        let expected = serde_json::to_value(expected).unwrap();
+        for pointer in [
+            "",
+            "/image",
+            "/resources",
+            "/network",
+            "/network/secrets",
+            "/network/secrets/on_violation",
+            "/runtime",
+            "/mounts/0",
+            "/mounts/0/options",
+            "/patches/0",
+            "/rlimits/0",
+            "/lifecycle",
+        ] {
+            let mut future = baseline.clone();
+            future
+                .pointer_mut(pointer)
+                .unwrap()
+                .as_object_mut()
+                .unwrap()
+                .insert(
+                    "future_option".into(),
+                    serde_json::json!({"nested": [true, null, "future"]}),
+                );
+            let request: CloudCreateSandboxRequest = serde_json::from_value(future)
+                .unwrap_or_else(|error| panic!("future field at {pointer}: {error}"));
+            assert_eq!(
+                serde_json::to_value(request).unwrap(),
+                expected,
+                "{pointer}"
+            );
+        }
+    }
+
+    #[test]
+    fn create_request_defaults_fields_missing_from_older_clients() {
+        let request: CloudCreateSandboxRequest = serde_json::from_value(serde_json::json!({
+            "name": "older-client",
+            "image": {"type": "oci", "reference": "alpine"},
+            "network": {"enabled": true}
+        }))
+        .unwrap();
+
+        assert!(request.spec.network.enabled);
+        assert!(!request.spec.network.strict);
+        assert_eq!(request.spec.network.max_connections, None);
+        assert_eq!(request.spec.runtime.workdir, None);
+    }
+
+    #[test]
+    fn create_request_still_validates_known_fields_and_variants() {
+        for invalid in [
+            serde_json::json!({"network": {"enabled": "yes"}}),
+            serde_json::json!({"network": {"strict": "yes"}}),
+            serde_json::json!({"network": {"max_connections": -1}}),
+            serde_json::json!({"runtime": {"workdir": 42}}),
+            serde_json::json!({"resources": {"vcpus": 256}}),
+            serde_json::json!({"image": {"type": "oci"}}),
+            serde_json::json!({"image": {"type": "future_source"}}),
+            serde_json::json!({"pull_policy": "future_policy"}),
+            serde_json::json!({"rlimits": [{"resource": "nofile", "soft": 64}]}),
+        ] {
+            assert!(
+                serde_json::from_value::<CloudCreateSandboxRequest>(invalid.clone()).is_err(),
+                "invalid known configuration was accepted: {invalid}"
+            );
+        }
     }
 
     #[test]

--- a/sdk/node-ts/scripts/cloud-release-smoke.mts
+++ b/sdk/node-ts/scripts/cloud-release-smoke.mts
@@ -1,0 +1,84 @@
+/** Exercise the candidate npm packages against production before publishing. */
+import { setTimeout as sleep } from "node:timers/promises";
+import { pathToFileURL } from "node:url";
+
+export type SmokeSdk = Pick<typeof import("microsandbox"), "Sandbox" | "SandboxNotFoundError">;
+export const MARKER = "microsandbox-release-smoke-ok";
+
+export async function exercise(sdk: SmokeSdk, name: string): Promise<void> {
+  const sandbox = await sdk.Sandbox.builder(name)
+    .image("mirror.gcr.io/library/alpine:3.20")
+    .cpus(1)
+    .memory(512)
+    .ephemeral(true)
+    .maxDuration(600)
+    .idleTimeout(120)
+    .create();
+  const output = await sandbox.shell(`printf '${MARKER}\\n'`);
+  if (output.code !== 0 || output.stdout() !== `${MARKER}\n`) {
+    throw new Error("Candidate SDK command returned unexpected exit status or output");
+  }
+  console.log("Production create and command execution passed");
+}
+
+export async function cleanup(
+  sdk: SmokeSdk,
+  name: string,
+  pause: (ms: number) => Promise<void> = sleep,
+): Promise<void> {
+  try {
+    const handle = await sdk.Sandbox.get(name);
+    await handle.destroy({ timeoutMs: 120_000 });
+  } catch (error) {
+    // Ephemeral stop may already have removed the sandbox.
+    if (!(error instanceof sdk.SandboxNotFoundError)) throw error;
+  }
+  // A successful delete response alone is not proof of removal.
+  for (let attempt = 0; attempt < 15; attempt++) {
+    try {
+      await sdk.Sandbox.get(name);
+    } catch (error) {
+      if (!(error instanceof sdk.SandboxNotFoundError)) throw error;
+      console.log("Production sandbox cleanup confirmed");
+      return;
+    }
+    await pause(2_000);
+  }
+  throw new Error(`Smoke sandbox still exists after cleanup: ${name}`);
+}
+
+async function main(): Promise<void> {
+  const action = process.argv[2];
+  if (action !== "run" && action !== "cleanup") throw new Error("Expected run or cleanup");
+  const apiKey = process.env.MSB_API_KEY;
+  if (!apiKey?.trim()) throw new Error("Set the GitHub repository secret MSB_API_KEY");
+  if (process.env.MSB_BACKEND !== "cloud" || process.env.MSB_API_URL !== "https://api.microsandbox.dev") {
+    throw new Error("Smoke test requires MSB_BACKEND=cloud and MSB_API_URL=https://api.microsandbox.dev");
+  }
+  const name = process.env.MSB_SMOKE_SANDBOX_NAME ?? "";
+  if (!/^release-smoke-[0-9]+-[0-9]+$/.test(name)) {
+    throw new Error("MSB_SMOKE_SANDBOX_NAME must be release-smoke-<run-id>-<attempt>");
+  }
+  // Hard deadline also stops hung native operations. The workflow runs cleanup
+  // in a separate process even when this process fails or times out.
+  const deadline = setTimeout(() => {
+    console.error(`Production smoke ${action} timed out`);
+    process.exit(1);
+  }, action === "run" ? 300_000 : 180_000);
+  try {
+    // Resolve the installed candidate package, never a source-tree native override.
+    const sdk = await import("microsandbox");
+    console.log(`Production sandbox ${name}; action ${action}`);
+    if (action === "run") await exercise(sdk, name);
+    else await cleanup(sdk, name);
+  } finally {
+    clearTimeout(deadline);
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().then(() => process.exit(0), (error: unknown) => {
+    console.error(error);
+    process.exit(1);
+  });
+}

--- a/sdk/node-ts/scripts/cloud-release-smoke.test.mts
+++ b/sdk/node-ts/scripts/cloud-release-smoke.test.mts
@@ -1,0 +1,74 @@
+/** Credential-free checks for the release probe and cleanup failure paths. */
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { cleanup, exercise, MARKER, type SmokeSdk } from "./cloud-release-smoke.mts";
+
+class NotFound extends Error {}
+const pause = async () => {};
+
+function fakeSdk(options: {
+  code?: number;
+  stdout?: string;
+  createError?: Error;
+  get?: () => Promise<unknown>;
+} = {}) {
+  const calls: Array<[string, unknown]> = [];
+  const builder: Record<string, unknown> = {};
+  for (const method of ["image", "cpus", "memory", "ephemeral", "maxDuration", "idleTimeout"]) {
+    builder[method] = (value: unknown) => { calls.push([method, value]); return builder; };
+  }
+  builder.create = async () => {
+    if (options.createError) throw options.createError;
+    return { shell: async () => ({ code: options.code ?? 0, stdout: () => options.stdout ?? `${MARKER}\n` }) };
+  };
+  const sdk = {
+    Sandbox: { builder: () => builder, get: options.get },
+    SandboxNotFoundError: NotFound,
+  } as unknown as SmokeSdk;
+  return { sdk, calls };
+}
+
+test("candidate creates a bounded ephemeral sandbox and executes a command", async () => {
+  const { sdk, calls } = fakeSdk();
+  await exercise(sdk, "release-smoke-1-1");
+  assert.ok(calls.some(([key, value]) => key === "ephemeral" && value === true));
+  assert.ok(calls.some(([key, value]) => key === "maxDuration" && value === 600));
+});
+
+test("create rejection blocks release", async () => {
+  const { sdk } = fakeSdk({ createError: new Error("API rejected request") });
+  await assert.rejects(exercise(sdk, "release-smoke-1-1"), /API rejected/);
+});
+
+test("command failure and incorrect output block release", async () => {
+  for (const options of [{ code: 1 }, { stdout: "unexpected" }]) {
+    await assert.rejects(exercise(fakeSdk(options).sdk, "release-smoke-1-1"), /unexpected/);
+  }
+});
+
+test("cleanup confirms absence after destroy", async () => {
+  let gets = 0;
+  let destroyed = false;
+  const { sdk } = fakeSdk({ get: async () => {
+    if (++gets === 3) throw new NotFound();
+    return { destroy: async () => { destroyed = true; } };
+  } });
+  await cleanup(sdk, "release-smoke-1-1", pause);
+  assert.equal(destroyed, true);
+  assert.equal(gets, 3);
+});
+
+test("cleanup accepts an already removed sandbox", async () => {
+  const { sdk } = fakeSdk({ get: async () => { throw new NotFound(); } });
+  await cleanup(sdk, "release-smoke-1-1", pause);
+});
+
+test("cleanup does not treat server errors as absence", async () => {
+  const { sdk } = fakeSdk({ get: async () => { throw new Error("server unavailable"); } });
+  await assert.rejects(cleanup(sdk, "release-smoke-1-1", pause), /server unavailable/);
+});
+
+test("cleanup failure blocks release", async () => {
+  const { sdk } = fakeSdk({ get: async () => ({ destroy: async () => {} }) });
+  await assert.rejects(cleanup(sdk, "release-smoke-1-1", pause), /still exists/);
+});


### PR DESCRIPTION
## TL;DR

Allow additive Cloud request fields across independent SDK and server releases, and gate publication on a production smoke test using the candidate TypeScript SDK packages.

## Description

- Ignore unknown Cloud network and runtime fields while preserving existing defaults, required-field checks, and validation of recognized values and enum variants. Unknown settings have no effect until the receiving server supports them.
- Install locally packed candidate TypeScript and Linux x86_64 native npm packages in an isolated consumer before any publisher runs.
- Create a bounded ephemeral production sandbox, verify command output, and confirm removal. Cleanup runs after probe failures, and smoke or cleanup failure blocks publication.
- Run the live check on release tags and manual Release runs on `main`; keep PR checks credential-free.
- Configure the repository Actions secret `MSB_API_KEY`. The workflow explicitly sets `MSB_BACKEND=cloud` and `MSB_API_URL=https://api.microsandbox.dev`.

## Test Plan

- Shared-types tests passed with `ts,utoipa`; generated TypeScript bindings are unchanged.
- TypeScript SDK build and smoke-script type-check passed; all 7 credential-free smoke tests passed.
- Formatting and diff checks passed; actionlint reports no new diagnostics relative to the base workflow.
- Library Clippy passed. All-target Clippy encounters an existing unrelated needless-borrow warning in a shared-types test.
- Live production smoke has not been run; it requires the repository secret and candidate Linux release artifacts.


<!-- greptile_comment -->

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge; the compatibility behavior is intentional and covered, while the release gate blocks publication on probe or cleanup failure.

No actionable failure remains after checking Cloud request construction, native package selection, lifecycle cleanup semantics, workflow conditions, and timeout bounds.
</details>

<sub>Reviews (1): Last reviewed commit: ["feat(ci): gate releases on a production ..."](https://github.com/superradcompany/microsandbox/commit/77fdfca31548383b861952df51c65cb957db6082) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=62801305)</sub>

**Context used:**

- Knowledge Base — [SDKs and language bindings](https://app.greptile.com/microsandbox/-/custom-context/knowledge-base/superradcompany/microsandbox/-/docs/sdk-bindings.md)
- Knowledge Base — [Language binding adapters](https://app.greptile.com/microsandbox/-/custom-context/knowledge-base/superradcompany/microsandbox/-/docs/language-binding-adapters.md)

<!-- /greptile_comment -->