### PR TITLE
fix(snapshot): preserve restore intent and Windows startup locking

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1458,7 +1458,9 @@ jobs:
           scripts/smoke/cli/split-irqchip-bind-net.sh
 
       - name: Snapshot smoke runner unit tests
-        run: python3 -m unittest discover -s scripts/smoke/cli -p test_snapshot_branch.py
+        run: |
+          python3 -m unittest discover -s scripts/smoke/cli -p test_snapshot_branch.py
+          python3 -m unittest discover -s scripts/smoke/cli -p test_restore_resource_intent.py
 
       - name: Snapshot and branch live smoke
         # The short operation deadline excludes image setup and bounded cleanup.

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -168,6 +168,8 @@ Evolution rules:
 
 Sources: [`crates/db/lib/pool.rs`](crates/db/lib/pool.rs), [`crates/migration/lib/lib.rs`](crates/migration/lib/lib.rs), [`crates/migration/lib/schema_metadata.rs`](crates/migration/lib/schema_metadata.rs), and [`sdk/rust/lib/backend/local/mod.rs`](sdk/rust/lib/backend/local/mod.rs).
 
+Local startup serializes database opening, migration, and snapshot reconciliation using the existing `msb.db.migration.lock` file and shared process-lock helper (`flock` on Unix, `LockFileEx` on Windows). This replaces the former Windows no-op without changing database schemas, lease semantics, or the lock path. Genuine exclusive install/downgrade operations still refuse normal startup. Older Windows binaries that bypass this lock do not participate in the serialization; do not initialize the same home concurrently with them. The shared helper creates owner-only lock files on Unix and refuses symlink lock paths.
+
 Tests should open copies of real older databases, migrate them, exercise the affected behavior, and test every supported reverse migration or refusal path.
 
 ## 7. Home and Runtime Path Layout

--- a/docs/sandboxes/snapshots.mdx
+++ b/docs/sandboxes/snapshots.mdx
@@ -23,6 +23,8 @@ Disk snapshots work with running, paused, stopped, or crashed sandboxes. A runni
 
 Both modes produce the same schema-1 `snapshot.json` descriptor. Its closed `state.kind` is either `file` or `checkpoint`, and `root_disk.layout` records `managed`, `flat`, or `tmpfs`. Checkpoint payloads live in a content-addressed closure rather than a standalone disk file. A tmpfs root has no stopped disk snapshot because its writable state exists only in memory, but it is included in a running full snapshot; such a snapshot must be resumed and cannot use `--disk-only`.
 
+Full restore inherits the captured CPU and memory sizes, including their maximums. Explicit settings from CLI flags, `--conf`, or SDK configuration patches must match; conflicting settings are rejected rather than ignored. Disk-only restore boots afresh and can use different resources.
+
 ## Share restored memory with CoW
 
 On supported Linux, macOS, and Windows hosts, add `--forked` when restoring a full snapshot to share clean memory pages between children. Writes stay private to each child. Without the flag, restore eagerly copies memory. The source needs no special creation option.

--- a/packages/microsandbox-types/rust/lib/domain.rs
+++ b/packages/microsandbox-types/rust/lib/domain.rs
@@ -1154,6 +1154,28 @@ pub enum LogSource {
 // Methods
 //--------------------------------------------------------------------------------------------------
 
+impl SandboxResourcesPatch {
+    /// Whether this patch explicitly sets the initial vCPU count, even to its default value.
+    pub fn has_cpus(&self) -> bool {
+        self.cpus.is_some()
+    }
+
+    /// Whether this patch explicitly sets initial memory, even to its default value.
+    pub fn has_memory_mib(&self) -> bool {
+        self.memory_mib.is_some()
+    }
+
+    /// Whether this patch explicitly sets the maximum vCPU count.
+    pub fn has_max_cpus(&self) -> bool {
+        self.max_cpus.is_some()
+    }
+
+    /// Whether this patch explicitly sets maximum memory.
+    pub fn has_max_memory_mib(&self) -> bool {
+        self.max_memory_mib.is_some()
+    }
+}
+
 impl DiskImageFormat {
     /// Returns the format as a CLI-safe lowercase string.
     pub fn as_str(&self) -> &'static str {

--- a/scripts/smoke/cli/restore-resource-intent.py
+++ b/scripts/smoke/cli/restore-resource-intent.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Live full-restore resource-intent regression matrix in an isolated MSB_HOME.
+
+Set MSB_PATH, MSB_AGENTD_PATH, MSB_LIBKRUNFW_PATH and RESTORE_INTENT_OUT.
+Optional RESTORE_INTENT_LAYOUT selects flat:512M (default) or 512M (layered).
+Every invocation uses EOF stdin, including detached Windows test launchers.
+"""
+
+import hashlib
+import json
+import os
+from pathlib import Path
+import subprocess
+import time
+
+
+binary = os.environ["MSB_PATH"]
+root = Path(os.environ["RESTORE_INTENT_OUT"])
+root.mkdir(parents=True, exist_ok=False)
+home = root / "home"
+env = dict(os.environ, MSB_HOME=str(home))
+image = os.environ.get("MSB_TEST_IMAGE", "mirror.gcr.io/library/alpine:latest")
+layout = os.environ.get("RESTORE_INTENT_LAYOUT", "flat:512M")
+rows = []
+names = []
+
+
+def run(label, *args, fail=False):
+    started = time.perf_counter()
+    command = [binary, *map(str, args)]
+    try:
+        result = subprocess.run(command, env=env, input="", capture_output=True,
+                                text=True, timeout=180)
+    except subprocess.TimeoutExpired:
+        rows.append({"case": label, "argv": command, "exit": "timeout",
+                     "ms": round((time.perf_counter() - started) * 1000, 2)})
+        raise
+    row = {"case": label, "argv": command, "exit": result.returncode,
+           "ms": round((time.perf_counter() - started) * 1000, 2)}
+    rows.append(row)
+    print(json.dumps(row), flush=True)
+    (root / (label + ".stdout")).write_text(result.stdout)
+    (root / (label + ".stderr")).write_text(result.stderr)
+    if (result.returncode != 0) != fail:
+        raise AssertionError(f"{label}: {result.stderr[-3000:]}")
+    return result
+
+
+def verify_child(name, ram=True, memory=512):
+    inspected = json.loads(run(name + "-inspect", "inspect", name, "--format", "json").stdout)
+    resources = inspected["config"]["resources"]
+    assert resources["memory_mib"] == memory, resources
+    if ram:
+        assert resources["cpus"] == resources["max_cpus"] == 2, resources
+        assert resources["max_memory_mib"] == 512, resources
+    guest = run(name + "-markers", "exec", "--no-tty", name, "--", "sh", "-ec",
+                "test \"$(cat /disk-marker)\" = disk-preserved; "
+                + ("test \"$(cat /dev/shm/marker)\" = ram-preserved" if ram
+                   else "test ! -e /dev/shm/marker"))
+    assert guest.returncode == 0
+
+
+success = False
+try:
+    names.append("source")
+    run("source-create", "create", image, "--name", "source", "--root-disk", layout,
+        "--memory", "512M", "--cpus", "2")
+    run("source-markers", "exec", "--no-tty", "source", "--", "sh", "-ec",
+        "echo disk-preserved > /disk-marker; echo ram-preserved > /dev/shm/marker; sync")
+    saved = run("capture", "snapshot", "create", "saved", "--from-sandbox", "source", "--full")
+    member = Path(saved.stdout.strip().splitlines()[-1])
+    descriptor_hash = hashlib.sha256((member / "snapshot.json").read_bytes()).hexdigest()
+    archive = root / "saved.msb"
+    run("save", "snapshot", "save", member, archive)
+    configs = {
+        "absent": "{}\n",
+        "matching": "cpus: 2\nmemory: 512M\n",
+        "smaller": "memory: 128M\n",
+        "larger": "memory: 1G\n",
+        "cpus": "cpus: 1\n",
+    }
+    for name, text in configs.items():
+        (root / (name + ".yaml")).write_text(text)
+
+    for storage, source in (("installed", "source:saved"), ("archive", archive)):
+        for mode in ("eager", "forked"):
+            flags = ["--forked"] if mode == "forked" else []
+            for case in (*configs, "flag"):
+                name = f"{storage}-{mode}-{case}"
+                names.append(name)
+                options = ["--memory", "128M"] if case == "flag" else ["--conf", root / (case + ".yaml")]
+                rejected = case not in ("absent", "matching")
+                result = run(name, "create", "--name", name, "--from-snapshot", source,
+                             *flags, *options, fail=rejected)
+                if rejected:
+                    assert "captured CPU and memory geometry" in result.stderr, result.stderr
+                    run(name + "-no-row", "inspect", name, "--format", "json", fail=True)
+                    assert not (home / "sandboxes" / name).exists(), name
+                else:
+                    verify_child(name)
+                    run(name + "-stop", "stop", name)
+            # A later valid restore must still work after the rejected attempts.
+            name = f"{storage}-{mode}-recovery"
+            names.append(name)
+            run(name, "create", "--name", name, "--from-snapshot", source, *flags)
+            verify_child(name)
+            run(name + "-stop", "stop", name)
+
+    # The guard is specific to resumed CPU/RAM, not disk-only fresh boots.
+    names.append("disk-only")
+    run("disk-only", "create", "--name", "disk-only", "--from-snapshot", "source:saved",
+        "--disk-only", "--conf", root / "smaller.yaml")
+    verify_child("disk-only", ram=False, memory=128)
+    assert hashlib.sha256((member / "snapshot.json").read_bytes()).hexdigest() == descriptor_hash
+    verify_child("source")
+    success = True
+finally:
+    # Only names created by this isolated test are eligible for cleanup.
+    cleanup = []
+    for name in reversed(names):
+        result = subprocess.run([binary, "stop", name], env=env, input="", capture_output=True,
+                                text=True, timeout=30)
+        cleanup.append({"name": name, "exit": result.returncode, "stderr": result.stderr})
+    (root / "results.json").write_text(json.dumps(
+        {"success": success, "layout": layout, "binary": binary, "rows": rows, "cleanup": cleanup}, indent=2))

--- a/scripts/smoke/cli/restore-resource-intent.py
+++ b/scripts/smoke/cli/restore-resource-intent.py
@@ -118,8 +118,21 @@ finally:
     # Only names created by this isolated test are eligible for cleanup.
     cleanup = []
     for name in reversed(names):
-        result = subprocess.run([binary, "stop", name], env=env, input="", capture_output=True,
-                                text=True, timeout=30)
+        try:
+            result = subprocess.run([binary, "stop", name], env=env, input="", capture_output=True,
+                                    text=True, timeout=30)
+        except subprocess.TimeoutExpired as error:
+            # A stuck stop must not skip other VMs or hide the original test failure.
+            # TimeoutExpired may carry bytes even when text=True was requested.
+            stderr = error.stderr or ""
+            if isinstance(stderr, bytes):
+                stderr = stderr.decode(errors="replace")
+            cleanup.append({"name": name, "exit": "timeout", "timeout_seconds": error.timeout,
+                            "stderr": stderr})
+            continue
+        except OSError as error:
+            cleanup.append({"name": name, "exit": "error", "stderr": str(error)})
+            continue
         cleanup.append({"name": name, "exit": result.returncode, "stderr": result.stderr})
     (root / "results.json").write_text(json.dumps(
         {"success": success, "layout": layout, "binary": binary, "rows": rows, "cleanup": cleanup}, indent=2))

--- a/scripts/smoke/cli/test_restore_resource_intent.py
+++ b/scripts/smoke/cli/test_restore_resource_intent.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""VM-free regression tests for restore-resource-intent cleanup and reporting."""
+
+import contextlib
+import io
+import json
+import os
+from pathlib import Path
+import runpy
+import subprocess
+import tempfile
+import unittest
+from unittest import mock
+
+
+SCRIPT = Path(__file__).with_name("restore-resource-intent.py")
+
+
+class RestoreResourceIntentTests(unittest.TestCase):
+    def setUp(self):
+        temporary = tempfile.TemporaryDirectory(prefix="restore-intent-unit-")
+        self.addCleanup(temporary.cleanup)
+        self.root = Path(temporary.name)
+        self.output = self.root / "run"
+        self.snapshot = self.root / "saved"
+        self.snapshot.mkdir()
+        # The harness hashes this fixture before and after the restore matrix.
+        (self.snapshot / "snapshot.json").write_text('{"fixture": "full snapshot"}\n')
+        self.created = []
+        self.rejected = set()
+        self.cleanup_errors = {}
+        self.failed_create = None
+        contexts = contextlib.ExitStack()
+        self.addCleanup(contexts.close)
+        contexts.enter_context(contextlib.redirect_stdout(io.StringIO()))
+        contexts.enter_context(mock.patch.dict(os.environ, {
+            "MSB_PATH": str(self.root / "fake-msb"),
+            "RESTORE_INTENT_OUT": str(self.output),
+            "RESTORE_INTENT_LAYOUT": "flat:512M",
+        }))
+        # Patch the process boundary before runpy: no test command can launch a VM.
+        self.process = contexts.enter_context(mock.patch.object(
+            subprocess, "run", side_effect=self.fake_process,
+        ))
+
+    def fake_process(self, command, **kwargs):
+        self.assertEqual(kwargs["input"], "")
+        self.assertEqual(kwargs["env"]["MSB_HOME"], str(self.output / "home"))
+        if kwargs["timeout"] == 30:
+            self.assertEqual(command[1], "stop")
+            error = self.cleanup_errors.get(command[2])
+            if error is not None:
+                raise error
+            return subprocess.CompletedProcess(command, 0, "", "")
+
+        self.assertEqual(kwargs["timeout"], 180)
+        code, stdout, stderr = 0, "", ""
+        if command[1] == "create":
+            name = command[command.index("--name") + 1]
+            self.created.append(name)
+            if name == self.failed_create:
+                code, stderr = 1, "original create failure"
+            elif name.rsplit("-", 1)[-1] in ("smaller", "larger", "cpus", "flag"):
+                self.rejected.add(name)
+                code, stderr = 1, "captured CPU and memory geometry"
+        elif command[1] == "inspect":
+            name = command[2]
+            if name in self.rejected:
+                code, stderr = 1, "sandbox not found"
+            else:
+                stdout = json.dumps({"config": {"resources": {
+                    "memory_mib": 128 if name == "disk-only" else 512,
+                    "max_memory_mib": 512, "cpus": 2, "max_cpus": 2,
+                }}})
+        elif command[1:3] == ["snapshot", "create"]:
+            stdout = str(self.snapshot) + "\n"
+        else:
+            self.assertTrue(command[1] in ("exec", "stop")
+                            or command[1:3] == ["snapshot", "save"], command)
+        return subprocess.CompletedProcess(command, code, stdout, stderr)
+
+    def report(self):
+        return json.loads((self.output / "results.json").read_text())
+
+    def assert_all_cleanup_attempted(self, report):
+        expected = list(reversed(self.created))
+        attempted = [call.args[0][2] for call in self.process.call_args_list
+                     if call.kwargs["timeout"] == 30]
+        self.assertEqual(attempted, expected)
+        self.assertEqual([row["name"] for row in report["cleanup"]], expected)
+
+    def test_successful_matrix_reports_timeout_and_cleans_remaining_names(self):
+        # TimeoutExpired can carry bytes even when subprocess.run uses text=True.
+        self.cleanup_errors["disk-only"] = subprocess.TimeoutExpired(
+            ["fake-msb", "stop", "disk-only"], 30, stderr=b"partial stop diagnostic\xff\n",
+        )
+        runpy.run_path(str(SCRIPT), run_name="__main__")
+        report = self.report()
+        self.assertTrue(report["success"])
+        self.assertEqual(len(self.created), 30)
+        self.assert_all_cleanup_attempted(report)
+        self.assertEqual(report["cleanup"][0], {
+            "name": "disk-only", "exit": "timeout", "timeout_seconds": 30,
+            "stderr": "partial stop diagnostic\ufffd\n",
+        })
+        self.assertEqual(report["cleanup"][-1], {"name": "source", "exit": 0, "stderr": ""})
+
+    def test_cleanup_timeout_preserves_original_matrix_failure_and_report(self):
+        self.failed_create = "installed-eager-absent"
+        self.cleanup_errors[self.failed_create] = subprocess.TimeoutExpired(
+            ["fake-msb", "stop", self.failed_create], 30, stderr="still stopping",
+        )
+        with self.assertRaisesRegex(AssertionError, "installed-eager-absent: original create failure"):
+            runpy.run_path(str(SCRIPT), run_name="__main__")
+        report = self.report()
+        self.assertFalse(report["success"])
+        self.assertEqual(self.created, ["source", self.failed_create])
+        self.assert_all_cleanup_attempted(report)
+        self.assertEqual(report["rows"][-1]["case"], self.failed_create)
+        self.assertEqual(report["rows"][-1]["exit"], 1)
+        self.assertEqual(report["cleanup"][0]["exit"], "timeout")
+        self.assertEqual(report["cleanup"][0]["stderr"], "still stopping")
+
+    def test_cleanup_launch_error_is_reported_and_remaining_names_are_attempted(self):
+        self.cleanup_errors["disk-only"] = OSError("stop executable unavailable")
+        runpy.run_path(str(SCRIPT), run_name="__main__")
+        report = self.report()
+        self.assertTrue(report["success"])
+        self.assert_all_cleanup_attempted(report)
+        self.assertEqual(report["cleanup"][0], {
+            "name": "disk-only", "exit": "error", "stderr": "stop executable unavailable",
+        })
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/sdk/rust/lib/backend/local/mod.rs
+++ b/sdk/rust/lib/backend/local/mod.rs
@@ -20,20 +20,17 @@ mod sandbox;
 
 use std::{
     collections::{HashMap, HashSet},
+    fs::File,
     num::NonZero,
     path::{Path, PathBuf},
     sync::Arc,
     time::Duration,
 };
-#[cfg(unix)]
-use std::{
-    fs::{File, OpenOptions},
-    os::fd::AsRawFd,
-};
 
 use microsandbox_db::pool::DbPools;
 use microsandbox_migration::{Migrator, MigratorTrait, schema_metadata};
 use microsandbox_types::DeploymentProfile;
+use microsandbox_utils::process_lock::{lock_exclusive, open_lock_file, unlock};
 use sea_orm::{ConnectionTrait, DatabaseBackend, DatabaseConnection, DbErr, Statement};
 use tokio::sync::OnceCell;
 
@@ -99,7 +96,6 @@ pub struct LocalBackendBuilder {
 }
 
 struct MigrationLock {
-    #[cfg(unix)]
     file: File,
 }
 
@@ -551,32 +547,17 @@ impl LocalBackendBuilder {
 }
 
 impl MigrationLock {
-    #[cfg(unix)]
     fn acquire(path: PathBuf) -> MicrosandboxResult<Self> {
-        let file = OpenOptions::new()
-            .create(true)
-            .truncate(false)
-            .read(true)
-            .write(true)
-            .open(&path)
-            .map_err(|err| {
-                MicrosandboxError::Runtime(format!("open migration lock {}: {err}", path.display()))
-            })?;
-
-        if unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX) } != 0 {
-            return Err(MicrosandboxError::Runtime(format!(
-                "lock migration file {}: {}",
-                path.display(),
-                std::io::Error::last_os_error()
-            )));
-        }
+        let file = open_lock_file(&path).map_err(|err| {
+            MicrosandboxError::Runtime(format!("open migration lock {}: {err}", path.display()))
+        })?;
+        // Serialize database opening and artifact reconciliation on Windows too:
+        // SQLite's writer lock alone does not cover the installation lease.
+        lock_exclusive(&file).map_err(|err| {
+            MicrosandboxError::Runtime(format!("lock migration file {}: {err}", path.display()))
+        })?;
 
         Ok(Self { file })
-    }
-
-    #[cfg(not(unix))]
-    fn acquire(_path: PathBuf) -> MicrosandboxResult<Self> {
-        Ok(Self {})
     }
 }
 
@@ -661,10 +642,9 @@ impl From<LocalBackend> for Arc<dyn Backend> {
     }
 }
 
-#[cfg(unix)]
 impl Drop for MigrationLock {
     fn drop(&mut self) {
-        let _ = unsafe { libc::flock(self.file.as_raw_fd(), libc::LOCK_UN) };
+        let _ = unlock(&self.file);
     }
 }
 
@@ -836,6 +816,77 @@ mod tests {
     use crate::backend::with_backend;
     use crate::sandbox::SandboxBuilder;
     use crate::volume::VolumeConfig;
+
+    #[tokio::test]
+    async fn migration_lock_blocks_contenders_and_releases_on_drop() {
+        let tmp = tempfile::tempdir().unwrap();
+        let held = acquire_migration_lock(tmp.path()).await.unwrap();
+        let path = tmp.path().join(format!(
+            "{}.migration.lock",
+            microsandbox_utils::DB_FILENAME
+        ));
+        let probe = open_lock_file(&path).unwrap();
+        assert!(!microsandbox_utils::process_lock::try_lock_exclusive(&probe).unwrap());
+
+        // The contender uses the real blocking acquisition, not a test-only
+        // retry loop. The async runtime must remain usable while it waits.
+        let contender = acquire_migration_lock(tmp.path());
+        tokio::pin!(contender);
+        assert!(
+            tokio::time::timeout(Duration::from_millis(100), &mut contender)
+                .await
+                .is_err()
+        );
+        drop(held);
+        let acquired = tokio::time::timeout(Duration::from_secs(5), contender)
+            .await
+            .expect("migration lock must become available after drop")
+            .unwrap();
+        assert!(!microsandbox_utils::process_lock::try_lock_exclusive(&probe).unwrap());
+        drop(acquired);
+        assert!(microsandbox_utils::process_lock::try_lock_exclusive(&probe).unwrap());
+        unlock(&probe).unwrap();
+    }
+
+    #[tokio::test]
+    async fn concurrent_local_backends_migrate_the_same_home() {
+        let tmp = tempfile::tempdir().unwrap();
+        let snapshots = tmp.path().join("snapshots");
+        let first = LocalBackend::builder()
+            .home(tmp.path())
+            .snapshots_dir(&snapshots)
+            .build();
+        let second = LocalBackend::builder()
+            .home(tmp.path())
+            .snapshots_dir(&snapshots)
+            .build();
+        let (first, second) = tokio::time::timeout(Duration::from_secs(30), async {
+            tokio::join!(first, second)
+        })
+        .await
+        .expect("concurrent startup must complete without a lease collision");
+
+        // Both independent pools must observe the complete canonical schema.
+        for backend in [first.unwrap(), second.unwrap()] {
+            let pools = backend.db().await.unwrap();
+            refuse_schema_ahead(pools.write().inner()).await.unwrap();
+            let count = pools
+                .read()
+                .query_one_raw(Statement::from_string(
+                    DatabaseBackend::Sqlite,
+                    "SELECT COUNT(*) FROM seaql_migrations",
+                ))
+                .await
+                .unwrap()
+                .unwrap()
+                .try_get_by_index::<i64>(0)
+                .unwrap();
+            assert_eq!(count as usize, schema_metadata::migration_ids().count());
+            microsandbox_runtime::maintenance::refuse_if_install_exclusive_held(pools.write())
+                .await
+                .unwrap();
+        }
+    }
 
     #[tokio::test]
     async fn sandbox_config_patch_overlays_global_config_by_field_presence() {
@@ -1106,6 +1157,22 @@ mod tests {
             .await
             .unwrap_err();
         assert!(err.to_string().contains("install operation in progress"));
+
+        // Refusal releases the migration lock without clearing or waiting out
+        // a genuine exclusive installation operation.
+        let _lock = tokio::time::timeout(Duration::from_secs(5), acquire_migration_lock(&db_dir))
+            .await
+            .expect("failed startup must release the migration lock")
+            .unwrap();
+        let path = db_dir.join(microsandbox_utils::DB_FILENAME);
+        let pools = DbPools::open(&path, 1, Duration::from_secs(5), Duration::from_secs(5))
+            .await
+            .unwrap();
+        let error =
+            microsandbox_runtime::maintenance::refuse_if_install_exclusive_held(pools.write())
+                .await
+                .unwrap_err();
+        assert!(error.to_string().contains("install operation in progress"));
     }
 
     #[tokio::test]

--- a/sdk/rust/lib/sandbox/builder.rs
+++ b/sdk/rust/lib/sandbox/builder.rs
@@ -125,6 +125,16 @@ impl SandboxBuilder {
 
     /// Overlay sparse sandbox configuration on the hardcoded and global defaults.
     pub fn overlay(mut self, patch: SandboxConfigPatch) -> Self {
+        // Full restore may inherit omitted geometry, but must reject explicit mismatches.
+        // Preserve field presence before applying the patch; comparing resulting values with
+        // defaults would lose explicit requests that happen to equal those defaults.
+        let patch = patch.modify_resources(|resources| {
+            self.cpus_explicit |= resources.has_cpus();
+            self.memory_explicit |= resources.has_memory_mib();
+            self.max_cpus_explicit |= resources.has_max_cpus();
+            self.max_memory_explicit |= resources.has_max_memory_mib();
+            resources
+        });
         patch.apply_to(&mut self.config.spec);
         self
     }
@@ -2154,8 +2164,8 @@ mod tests {
     #[cfg(feature = "net")]
     use microsandbox_network::secrets::config::{HostPattern, SecretEntry, SecretSubstitution};
     use microsandbox_types::{
-        CpuPlacement, DeploymentProfile, SandboxLogLevel, TransparentHugePagePolicy, VolumeMount,
-        VsockSocketType,
+        CpuPlacement, DeploymentProfile, SandboxConfigPatch, SandboxLogLevel,
+        SandboxResourcesPatch, TransparentHugePagePolicy, VolumeMount, VsockSocketType,
     };
     #[cfg(feature = "net")]
     use microsandbox_types::{PortProtocol, SecretSource};
@@ -2661,6 +2671,136 @@ mod tests {
                 .to_string()
                 .contains("captured CPU and memory geometry")
         );
+    }
+
+    #[test]
+    fn checkpoint_restore_checks_each_explicit_patch_resource() {
+        let state = checkpoint_state_with_geometry(4, 8, 2048, 4096);
+        let cases = [
+            ("cpus", SandboxResourcesPatch::new().cpus(4), false),
+            ("cpus", SandboxResourcesPatch::new().cpus(2), true),
+            ("max_cpus", SandboxResourcesPatch::new().max_cpus(8), false),
+            ("max_cpus", SandboxResourcesPatch::new().max_cpus(4), true),
+            (
+                "memory",
+                SandboxResourcesPatch::new().memory_mib(2048),
+                false,
+            ),
+            ("memory", SandboxResourcesPatch::new().memory_mib(512), true),
+            (
+                "max_memory",
+                SandboxResourcesPatch::new().max_memory_mib(4096),
+                false,
+            ),
+            (
+                "max_memory",
+                SandboxResourcesPatch::new().max_memory_mib(2048),
+                true,
+            ),
+        ];
+
+        for (field, patch, conflicting) in cases {
+            let mut builder =
+                SandboxBuilder::new("restore").overlay(SandboxConfigPatch::new().resources(patch));
+            let intent = builder.restore_override_intent();
+            assert_eq!(intent.cpus, field == "cpus");
+            assert_eq!(intent.max_cpus, field == "max_cpus");
+            assert_eq!(intent.memory, field == "memory");
+            assert_eq!(intent.max_memory, field == "max_memory");
+            let result = apply_checkpoint_resources(&mut builder.config, &state, intent);
+            if conflicting {
+                assert!(
+                    result
+                        .unwrap_err()
+                        .to_string()
+                        .contains("captured CPU and memory geometry"),
+                    "{field}"
+                );
+            } else {
+                result.unwrap();
+                assert_eq!(builder.config.spec.resources.cpus, 4);
+                assert_eq!(builder.config.spec.resources.max_cpus, 8);
+                assert_eq!(builder.config.spec.resources.memory_mib, 2048);
+                assert_eq!(builder.config.spec.resources.max_memory_mib, 4096);
+            }
+        }
+    }
+
+    #[test]
+    fn checkpoint_restore_patch_preserves_omission_and_prior_intent() {
+        // Clearing a patch field means omission, not resetting a previous builder request.
+        let absent = SandboxConfigPatch::new().resources(
+            SandboxResourcesPatch::new()
+                .cpus(2)
+                .clear_cpus()
+                .memory_mib(512)
+                .clear_memory_mib(),
+        );
+        let mut omitted = SandboxBuilder::new("restore").overlay(absent.clone());
+        let intent = omitted.restore_override_intent();
+        assert!(!intent.cpus && !intent.max_cpus && !intent.memory && !intent.max_memory);
+        apply_checkpoint_resources(
+            &mut omitted.config,
+            &checkpoint_state_with_geometry(4, 8, 2048, 4096),
+            intent,
+        )
+        .unwrap();
+
+        let explicit = SandboxBuilder::new("restore")
+            .cpus(4)
+            .max_cpus(8)
+            .memory(2048)
+            .max_memory(4096)
+            .overlay(absent)
+            .overlay(SandboxConfigPatch::new());
+        let intent = explicit.restore_override_intent();
+        assert!(intent.cpus && intent.max_cpus && intent.memory && intent.max_memory);
+        assert_eq!(explicit.config.spec.resources.memory_mib, 2048);
+    }
+
+    #[test]
+    fn checkpoint_restore_patch_tracks_requests_equal_to_defaults() {
+        let mut builder = SandboxBuilder::new("restore");
+        let default_memory = builder.config.spec.resources.memory_mib;
+        builder = builder.overlay(
+            SandboxConfigPatch::new()
+                .resources(SandboxResourcesPatch::new().memory_mib(default_memory)),
+        );
+        let intent = builder.restore_override_intent();
+        assert!(intent.memory);
+        let state =
+            checkpoint_state_with_geometry(4, 8, default_memory + 512, default_memory + 1024);
+        assert!(apply_checkpoint_resources(&mut builder.config, &state, intent).is_err());
+    }
+
+    #[tokio::test]
+    async fn checkpoint_archive_build_retains_patch_resource_intent() {
+        let directory = tempfile::tempdir().unwrap();
+        let archive = directory.path().join("saved.msnap");
+        std::fs::write(&archive, b"archive validation is deferred to the backend").unwrap();
+        let config = SandboxBuilder::new("restore")
+            .from_snapshot(archive.to_string_lossy())
+            .overlay(
+                SandboxConfigPatch::new().resources(
+                    SandboxResourcesPatch::new()
+                        .cpus(2)
+                        .max_cpus(4)
+                        .memory_mib(512)
+                        .max_memory_mib(1024),
+                ),
+            )
+            .build()
+            .await
+            .unwrap();
+
+        // Direct archives cross the builder/backend boundary before geometry is checked.
+        // Both routes must carry the same intent into that later validation.
+        assert_eq!(
+            config.snapshot_archive_source.as_deref(),
+            Some(archive.as_path())
+        );
+        let intent = config.restore_overrides;
+        assert!(intent.cpus && intent.max_cpus && intent.memory && intent.max_memory);
     }
 
     #[test]


### PR DESCRIPTION
## TL;DR

Reject explicit CPU or memory settings that conflict with a full snapshot, and prevent concurrent Windows startup from colliding during snapshot reconciliation. This branch starts directly from `releases/v0.7.0`.

## Description

- Preserve explicit initial and maximum CPU/memory settings through sparse SDK configuration patches and direct archive restore.
- Keep omitted resources inherited from the snapshot, while disk-only restores can still choose different resources.
- Replace the Windows migration-lock no-op with the existing cross-platform process-lock helper, preserving the lock path and genuine install/downgrade lease refusal.
- Add regression tests, an isolated live restore-intent matrix and compatibility notes without changing the database schema or guest protocol.
- The software interrupt-controller fix is in a separate libkrun worktree and is not yet consumed by this branch. Companion PR and dependency wiring are pending the maintainer's choice.

For a full snapshot captured with 512 MiB, omitted memory is inherited:

```bash
msb create alpine --name source --memory 512M --cpus 2
msb snapshot create saved --from-sandbox source --full
msb create --name child --from-snapshot source:saved
```

With `smaller.yaml` containing:

```yaml
memory: 128M
```

The full restore rejects the conflicting request instead of silently creating a 512 MiB VM. Disk-only restore accepts it because it boots afresh:

```bash
msb create --name rejected --from-snapshot source:saved --conf smaller.yaml
msb create --name disk-child --from-snapshot source:saved --disk-only --conf smaller.yaml
```

## Test Plan

- [x] `cargo fmt --all -- --check` and `git diff --check` pass.
- [x] `cargo test -p microsandbox --lib --no-default-features --features local,net` passes: 715 tests, two existing platform-specific ignores.
- [x] `cargo clippy -p microsandbox --lib --no-default-features --features local,net -- -D warnings` passes.
- [x] Run `scripts/smoke/cli/restore-resource-intent.py` in isolated homes on macOS ARM64 and Windows ARM64 with flat and layered disks: installed/archive, eager/forked, omitted/matching/conflicting resources, failure cleanup, recovery and disk-only restore all pass.
- [x] On Windows ARM64, run the original two-worker concurrent snapshot-group suites for flat and layered disks and five rounds of four simultaneous startup calls: both suites and all 20 startup calls pass, with test VMs stopped afterward.




<!-- greptile_comment -->

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no outstanding actionable findings.

The previous cleanup finding was manually resolved after the cleanup loop was updated to catch timeout and launch failures, continue stopping remaining sandboxes, and write the results report; focused tests cover both successful and failing matrix runs. No new blocking or non-blocking defect was established.
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(smoke): preserve reporting after cle..."](https://github.com/superradcompany/microsandbox/commit/8ebb3ba553e3ffd01e2290f74b46fa6cfc175cdc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=62882557)</sub>

**Context used:**

- Knowledge Base — [Rust SDK implementation](https://app.greptile.com/microsandbox/-/custom-context/knowledge-base/superradcompany/microsandbox/-/docs/rust-sdk.md)
- Knowledge Base — [Images, root filesystems, and snapshots](https://app.greptile.com/microsandbox/-/custom-context/knowledge-base/superradcompany/microsandbox/-/docs/images-and-snapshots.md)

<!-- /greptile_comment -->