### PR TITLE
fix(agentd): create standard stream symlinks during initialization

### DIFF
--- a/crates/agentd/lib/init.rs
+++ b/crates/agentd/lib/init.rs
@@ -217,10 +217,21 @@ mod linux {
             None::<&str>,
         )?;
 
-        // /dev/fd → /proc/self/fd
-        if !Path::new("/dev/fd").exists() {
-            unix_fs::symlink("/proc/self/fd", "/dev/fd")
-                .map_err(|e| AgentdError::Init(format!("failed to symlink /dev/fd: {e}")))?;
+        // devtmpfs hides any links from the image and does not create these aliases.
+        for (target, link) in [
+            ("/proc/self/fd", "/dev/fd"),
+            ("/proc/self/fd/0", "/dev/stdin"),
+            ("/proc/self/fd/1", "/dev/stdout"),
+            ("/proc/self/fd/2", "/dev/stderr"),
+        ] {
+            match unix_fs::symlink(target, link) {
+                Ok(()) => {}
+                // A link may already exist even when its descriptor is closed.
+                Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {}
+                Err(e) => {
+                    return Err(AgentdError::Init(format!("failed to symlink {link}: {e}")));
+                }
+            }
         }
 
         Ok(())


### PR DESCRIPTION
## TL;DR
Create `/dev/stdin`, `/dev/stdout`, and `/dev/stderr` during guest initialization so commands such as `printf 'echo hello\n' | bash /dev/stdin` work in sandboxes.

## Description

- Create the standard stream links alongside `/dev/fd`, after mounting `/dev` and `/proc`.
- Preserve existing entries and allow initialization to run again when a stream descriptor is closed.
- Report unexpected symlink errors with the affected path.

## Test Plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --locked -p microsandbox-agentd --target aarch64-unknown-linux-musl --all-targets -- -D warnings`
- [x] `cargo test -p microsandbox-agentd` in a Linux container: 135 tests passed.
- [x] `RUSTFLAGS='-C linker=rust-lld' cargo build --locked --release -p microsandbox-agentd --target aarch64-unknown-linux-musl`
- [x] Linux smoke check using the exact symlink setup block: reproduce the original failure, verify Bash stdin and stdout/stderr redirection, and check repeat initialization with closed descriptors and preservation of existing links.


<!-- greptile_comment -->

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable correctness, security, or repository-rule violations identified.

The links are created after the relevant mounts, recreated after any root pivot, visible to spawned commands, and repeated initialization correctly tolerates existing directory entries.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(agentd): create standard stream syml..."](https://github.com/superradcompany/microsandbox/commit/b3b4c1420fc99beea965052370945d708fec60ed) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=63222751)</sub>

<!-- /greptile_comment -->