### PR TITLE
fix(metrics): read legacy registry ABIs

### DIFF
--- a/crates/metrics-collector/bin/main.rs
+++ b/crates/metrics-collector/bin/main.rs
@@ -241,8 +241,8 @@ async fn main() -> anyhow::Result<()> {
 //--------------------------------------------------------------------------------------------------
 
 async fn run_otel(args: OtelArgs) -> anyhow::Result<()> {
-    let registry_name = resolve_registry_name(args.collector.msb_home.as_deref())?;
-    info!(registry = %registry_name, endpoint = %args.endpoint, "starting msb-metrics otel");
+    let registries = resolve_registry_names(args.collector.msb_home.as_deref())?;
+    info!(registry_count = registries.len(), endpoint = %args.endpoint, "starting msb-metrics otel");
 
     let mut exporter_builder = OtelExporter::builder()
         .endpoint(&args.endpoint)
@@ -263,7 +263,7 @@ async fn run_otel(args: OtelArgs) -> anyhow::Result<()> {
     }
     let exporter = exporter_builder.build().context("build OTel exporter")?;
 
-    let mut builder = MetricsCollector::builder(registry_name)
+    let mut builder = MetricsCollector::builder_for_registries(registries)
         .collect_interval(args.collector.collect_interval)
         .flush_interval(args.collector.flush_interval)
         .max_buffered_collections(args.collector.max_buffered)
@@ -290,11 +290,14 @@ async fn run_otel(args: OtelArgs) -> anyhow::Result<()> {
 }
 
 async fn run_stdout(args: StdoutArgs) -> anyhow::Result<()> {
-    let registry_name = resolve_registry_name(args.collector.msb_home.as_deref())?;
-    info!(registry = %registry_name, "starting msb-metrics stdout");
+    let registries = resolve_registry_names(args.collector.msb_home.as_deref())?;
+    info!(
+        registry_count = registries.len(),
+        "starting msb-metrics stdout"
+    );
 
     let exporter = StdoutExporter::new();
-    let mut builder = MetricsCollector::builder(registry_name)
+    let mut builder = MetricsCollector::builder_for_registries(registries)
         .collect_interval(args.collector.collect_interval)
         .flush_interval(args.collector.flush_interval)
         .max_buffered_collections(args.collector.max_buffered)
@@ -359,13 +362,22 @@ fn resolve_msb_home(msb_home: Option<&std::path::Path>) -> anyhow::Result<PathBu
     }
 }
 
-/// Derive the shm registry name from the resolved `MSB_HOME`.
-fn resolve_registry_name(msb_home: Option<&std::path::Path>) -> anyhow::Result<String> {
+/// Derive every readable shm registry name from the resolved `MSB_HOME`.
+fn resolve_registry_names(
+    msb_home: Option<&std::path::Path>,
+) -> anyhow::Result<Vec<(String, u32)>> {
     let home = resolve_msb_home(msb_home)?;
-    Ok(microsandbox_utils::metrics_registry_shm_name(
-        &home,
-        microsandbox_metrics::REGISTRY_ABI_VERSION,
-    ))
+
+    Ok(microsandbox_metrics::READABLE_REGISTRY_ABI_VERSIONS
+        .iter()
+        .copied()
+        .map(|abi_version| {
+            (
+                microsandbox_utils::metrics_registry_shm_name(&home, abi_version),
+                abi_version,
+            )
+        })
+        .collect())
 }
 
 /// Path to the catalog DB (`$MSB_HOME/db/msb.db`) used for label lookups. The
@@ -433,16 +445,22 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_resolve_registry_name_follows_abi_version() {
+    fn test_resolve_registry_names_include_legacy_and_current_abis() {
         let home = std::path::Path::new("/tmp/msb-metrics-home");
 
         assert_eq!(microsandbox_metrics::REGISTRY_ABI_VERSION, 3);
         assert_eq!(
-            resolve_registry_name(Some(home)).unwrap(),
-            microsandbox_utils::metrics_registry_shm_name(
-                home,
-                microsandbox_metrics::REGISTRY_ABI_VERSION,
-            )
+            resolve_registry_names(Some(home)).unwrap(),
+            vec![
+                (microsandbox_utils::metrics_registry_shm_name(home, 2), 2,),
+                (
+                    microsandbox_utils::metrics_registry_shm_name(
+                        home,
+                        microsandbox_metrics::REGISTRY_ABI_VERSION,
+                    ),
+                    microsandbox_metrics::REGISTRY_ABI_VERSION,
+                ),
+            ]
         );
     }
 }

--- a/crates/metrics-collector/lib/core/builder.rs
+++ b/crates/metrics-collector/lib/core/builder.rs
@@ -127,12 +127,20 @@ impl Default for MetricsExporterConfig {
 impl MetricsCollectorBuilder {
     /// Construct a builder that reads from the named shm registry.
     pub(crate) fn new(registry_name: String) -> Self {
+        Self::new_for_registries(vec![(
+            registry_name,
+            microsandbox_metrics::REGISTRY_ABI_VERSION,
+        )])
+    }
+
+    /// Construct a builder that merges snapshots from compatible registries.
+    pub(crate) fn new_for_registries(registries: Vec<(String, u32)>) -> Self {
         Self {
             collect_interval: DEFAULT_COLLECT_INTERVAL,
             max_sample_age: Some(DEFAULT_MAX_SAMPLE_AGE),
             default_collector_config: MetricsExporterConfig::default(),
             collectors: Vec::new(),
-            collect_fn: registry_collect_fn(registry_name),
+            collect_fn: registry_collect_fn(registries),
         }
     }
 

--- a/crates/metrics-collector/lib/core/driver.rs
+++ b/crates/metrics-collector/lib/core/driver.rs
@@ -101,6 +101,16 @@ impl MetricsCollector {
         MetricsCollectorBuilder::new(registry_name.into())
     }
 
+    /// Build a collector that reads and merges multiple registry ABI names.
+    ///
+    /// When the same sandbox run appears in more than one registry, the
+    /// snapshot from the highest ABI version wins.
+    pub fn builder_for_registries(
+        registries: impl IntoIterator<Item = (String, u32)>,
+    ) -> MetricsCollectorBuilder {
+        MetricsCollectorBuilder::new_for_registries(registries.into_iter().collect())
+    }
+
     /// Construct a driver from validated configuration. Called by the builder.
     pub(crate) fn from_config(config: CollectorConfig) -> Self {
         Self {

--- a/crates/metrics-collector/lib/core/reader.rs
+++ b/crates/metrics-collector/lib/core/reader.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use futures::future::BoxFuture;
-use microsandbox_metrics::{MetricsError, MetricsRegistry};
+use microsandbox_metrics::{MetricsError, MetricsRegistryReader, REGISTRY_ABI_VERSION};
 
 use crate::error::MetricsCollectorResult;
 
@@ -32,22 +32,41 @@ pub(crate) type CollectFn =
 /// Build a `CollectFn` that opens the named shm registry on each tick and
 /// reads its active snapshot. Returns an empty collection if the registry
 /// hasn't been created yet (no sandboxes running).
-pub(crate) fn registry_collect_fn(registry_name: String) -> CollectFn {
+pub(crate) fn registry_collect_fn(registries: Vec<(String, u32)>) -> CollectFn {
     Arc::new(move || {
-        let name = registry_name.clone();
+        let registries = registries.clone();
         Box::pin(async move {
             let collected_at = chrono::Utc::now();
-            let sandboxes = match MetricsRegistry::open(&name) {
-                Ok(registry) => registry
-                    .active_snapshot()?
-                    .into_iter()
-                    .map(SandboxMetricSnapshot::from)
-                    .collect(),
-                Err(MetricsError::Io(ref e)) if e.raw_os_error() == Some(libc::ENOENT) => {
-                    Vec::new()
+            let mut snapshots = Vec::new();
+
+            for (name, abi_version) in registries {
+                let registry = match MetricsRegistryReader::open(&name, abi_version) {
+                    Ok(registry) => registry,
+                    Err(MetricsError::Io(ref error))
+                        if error.kind() == std::io::ErrorKind::NotFound
+                            || error.raw_os_error() == Some(libc::ENOENT) =>
+                    {
+                        continue;
+                    }
+                    Err(error) if abi_version != REGISTRY_ABI_VERSION => {
+                        tracing::warn!(
+                            registry = %name,
+                            abi_version,
+                            %error,
+                            "skipping unreadable legacy metrics registry"
+                        );
+                        continue;
+                    }
+                    Err(error) => return Err(error.into()),
+                };
+
+                for snapshot in registry.active_snapshot()? {
+                    snapshots.push((abi_version, SandboxMetricSnapshot::from(snapshot)));
                 }
-                Err(err) => return Err(err.into()),
-            };
+            }
+
+            let sandboxes = merge_snapshots(snapshots);
+
             Ok(MetricsCollection {
                 collected_at,
                 sandboxes,
@@ -55,6 +74,36 @@ pub(crate) fn registry_collect_fn(registry_name: String) -> CollectFn {
             })
         })
     })
+}
+
+fn merge_snapshots(
+    snapshots: impl IntoIterator<Item = (u32, SandboxMetricSnapshot)>,
+) -> Vec<SandboxMetricSnapshot> {
+    let mut merged = HashMap::new();
+
+    for (abi_version, snapshot) in snapshots {
+        let identity = (snapshot.sandbox_id, snapshot.run_id);
+        let replace = merged
+            .get(&identity)
+            .is_none_or(|(existing_version, _)| abi_version >= *existing_version);
+        if replace {
+            merged.insert(identity, (abi_version, snapshot));
+        }
+    }
+
+    let mut snapshots = merged
+        .into_values()
+        .map(|(_, snapshot)| snapshot)
+        .collect::<Vec<_>>();
+    snapshots.sort_by(|left, right| {
+        (left.sandbox_id, left.run_id, &left.name).cmp(&(
+            right.sandbox_id,
+            right.run_id,
+            &right.name,
+        ))
+    });
+
+    snapshots
 }
 
 /// Run the base collect, then resolve and attach per-sandbox labels.
@@ -132,7 +181,96 @@ pub(crate) fn filter_stale_samples(base: CollectFn, max_age: Duration) -> Collec
 
 #[cfg(test)]
 mod tests {
+    use microsandbox_metrics::MetricsRegistry;
+
     use super::*;
+
+    fn unique_registry_name(tag: &str) -> String {
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+
+        let short_tag = &tag[..tag.len().min(5)];
+
+        format!("/mcr-{short_tag}-{:x}", nanos & 0xffff_ffff)
+    }
+
+    #[cfg(unix)]
+    fn unlink_registry(name: &str) {
+        let name = std::ffi::CString::new(name).unwrap();
+
+        unsafe { libc::shm_unlink(name.as_ptr()) };
+    }
+
+    #[cfg(target_os = "windows")]
+    fn unlink_registry(_name: &str) {}
+
+    fn snapshot(sandbox_id: i32, run_id: i32, name: &str) -> SandboxMetricSnapshot {
+        let mut snapshot = super::super::mocks::collection(sandbox_id)
+            .sandboxes
+            .remove(0);
+        snapshot.run_id = run_id;
+        snapshot.name = name.to_string();
+        snapshot
+    }
+
+    #[test]
+    fn merge_prefers_the_newest_abi_for_one_runtime() {
+        let snapshots = merge_snapshots([
+            (2, snapshot(1, 10, "legacy")),
+            (REGISTRY_ABI_VERSION, snapshot(1, 10, "current")),
+            (2, snapshot(2, 20, "legacy-only")),
+        ]);
+
+        assert_eq!(snapshots.len(), 2);
+        assert_eq!(snapshots[0].name, "current");
+        assert_eq!(snapshots[1].name, "legacy-only");
+    }
+
+    #[tokio::test]
+    async fn missing_registries_produce_an_empty_collection() {
+        let collect = registry_collect_fn(vec![
+            (unique_registry_name("missing-v2"), 2),
+            (
+                unique_registry_name("missing-current"),
+                REGISTRY_ABI_VERSION,
+            ),
+        ]);
+
+        let collection = collect().await.unwrap();
+
+        assert!(collection.sandboxes.is_empty());
+    }
+
+    #[tokio::test]
+    async fn unreadable_legacy_registry_does_not_block_current_collection() {
+        let name = unique_registry_name("wrong-abi");
+        let registry = MetricsRegistry::open_or_create(&name, 1).unwrap();
+        let collect = registry_collect_fn(vec![
+            (name.clone(), 2),
+            (name.clone(), REGISTRY_ABI_VERSION),
+        ]);
+
+        let collection = collect().await.unwrap();
+
+        assert!(collection.sandboxes.is_empty());
+        drop(registry);
+        unlink_registry(&name);
+    }
+
+    #[tokio::test]
+    async fn registry_that_disappears_between_ticks_becomes_empty() {
+        let name = unique_registry_name("disappears");
+        let registry = MetricsRegistry::open_or_create(&name, 1).unwrap();
+        let collect = registry_collect_fn(vec![(name.clone(), REGISTRY_ABI_VERSION)]);
+
+        assert!(collect().await.unwrap().sandboxes.is_empty());
+        unlink_registry(&name);
+        assert!(collect().await.unwrap().sandboxes.is_empty());
+
+        drop(registry);
+    }
 
     /// In-memory [`LabelSource`] returning labels for known ids only.
     struct MapSource(super::super::types::SandboxLabels);
@@ -178,7 +316,7 @@ mod tests {
             Some([("user.id".to_string(), "alice".to_string())].as_slice())
         );
         // Sandbox 2 has no labels, so no entry is added.
-        assert!(collection.labels.get(&2).is_none());
+        assert!(!collection.labels.contains_key(&2));
     }
 
     #[tokio::test]

--- a/crates/metrics/lib/compatibility.rs
+++ b/crates/metrics/lib/compatibility.rs
@@ -1,0 +1,386 @@
+//! Read-only compatibility for metrics registries created by older runtimes.
+
+use std::ffi::CString;
+use std::sync::atomic::{
+    AtomicI32, AtomicI64, AtomicU8, AtomicU16, AtomicU32, AtomicU64, Ordering,
+};
+
+use crate::layout::{
+    HEADER_SIZE, Header, NAME_BYTES, REGISTRY_VERSION, SAMPLE_FLAG_MEMORY_AVAILABLE,
+    SAMPLE_FLAG_MEMORY_HOST_RESIDENT, SLOT_ACTIVE, SLOT_SIZE, registry_size,
+};
+use crate::registry::{
+    MappedRegion, WaitForReadyError, flag_value, ms_to_datetime, open_existing_region,
+    validate_header_version, wait_for_ready,
+};
+use crate::{LiveMetric, LiveMetricState, MetricsError, MetricsRegistry, MetricsResult};
+
+//--------------------------------------------------------------------------------------------------
+// Constants
+//--------------------------------------------------------------------------------------------------
+
+const LEGACY_REGISTRY_VERSION_V2: u32 = 2;
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// Read-only view over a supported metrics registry ABI.
+///
+/// This is intentionally separate from [`MetricsRegistry`]: callers cannot
+/// reserve or release slots through it, and legacy layouts are never mutated.
+pub struct MetricsRegistryReader {
+    inner: MetricsRegistryReaderInner,
+}
+
+enum MetricsRegistryReaderInner {
+    Current(MetricsRegistry),
+    V2(LegacyRegistryV2),
+}
+
+struct LegacyRegistryV2 {
+    mapping: MappedRegion,
+    capacity: u32,
+}
+
+/// Metrics slot layout used by registry ABI v2.
+#[repr(C)]
+struct SlotV2 {
+    state: AtomicU32,
+    generation: AtomicU64,
+    seq: AtomicU64,
+    sandbox_id: AtomicI32,
+    run_id: AtomicI32,
+    pid: AtomicI32,
+    _pad0: u32,
+    started_at_unix_ms: AtomicI64,
+    sampled_at_unix_ms: AtomicI64,
+    sample_flags: AtomicU32,
+    memory_limit_bytes: AtomicU64,
+    vcpu_time_ns: AtomicU64,
+    cpu_percent_bits: AtomicU32,
+    memory_bytes: AtomicU64,
+    memory_available_bytes: AtomicU64,
+    memory_host_resident_bytes: AtomicU64,
+    disk_read_bytes: AtomicU64,
+    disk_write_bytes: AtomicU64,
+    net_rx_bytes: AtomicU64,
+    net_tx_bytes: AtomicU64,
+    name_len: AtomicU16,
+    _pad1: [AtomicU8; 6],
+    name_bytes: [AtomicU8; NAME_BYTES],
+    _tail: [u8; SLOT_SIZE - 152 - NAME_BYTES],
+}
+
+const _: () = assert!(std::mem::size_of::<SlotV2>() == SLOT_SIZE);
+
+//--------------------------------------------------------------------------------------------------
+// Methods
+//--------------------------------------------------------------------------------------------------
+
+impl MetricsRegistryReader {
+    /// Open an existing registry using one explicitly supported ABI layout.
+    pub fn open(name: &str, abi_version: u32) -> MetricsResult<Self> {
+        let inner = match abi_version {
+            REGISTRY_VERSION => MetricsRegistryReaderInner::Current(MetricsRegistry::open(name)?),
+            LEGACY_REGISTRY_VERSION_V2 => MetricsRegistryReaderInner::V2(open_v2_registry(name)?),
+            version => {
+                return Err(MetricsError::Custom(format!(
+                    "unsupported readable registry version: {version}"
+                )));
+            }
+        };
+
+        Ok(Self { inner })
+    }
+
+    /// Snapshot every active slot without mutating legacy registries.
+    pub fn active_snapshot(&self) -> MetricsResult<Vec<LiveMetric>> {
+        match &self.inner {
+            MetricsRegistryReaderInner::Current(registry) => registry.active_snapshot(),
+            MetricsRegistryReaderInner::V2(registry) => Ok(registry.active_snapshot()),
+        }
+    }
+}
+
+impl LegacyRegistryV2 {
+    fn active_snapshot(&self) -> Vec<LiveMetric> {
+        (0..self.capacity)
+            .filter_map(|index| self.read_slot(index))
+            .collect()
+    }
+
+    fn read_slot(&self, index: u32) -> Option<LiveMetric> {
+        let slot = self.slot(index);
+
+        for _ in 0..4096 {
+            if slot.state.load(Ordering::Acquire) != SLOT_ACTIVE {
+                return None;
+            }
+
+            let generation_before = slot.generation.load(Ordering::Acquire);
+            let sequence_before = slot.seq.load(Ordering::Acquire);
+            if sequence_before & 1 == 1 {
+                std::hint::spin_loop();
+                continue;
+            }
+
+            let sandbox_id = slot.sandbox_id.load(Ordering::Relaxed);
+            let run_id = slot.run_id.load(Ordering::Relaxed);
+            let pid = slot.pid.load(Ordering::Relaxed);
+            let started_at_ms = slot.started_at_unix_ms.load(Ordering::Relaxed);
+            let sampled_at_ms = slot.sampled_at_unix_ms.load(Ordering::Relaxed);
+            let sample_flags = slot.sample_flags.load(Ordering::Relaxed);
+            let memory_limit = slot.memory_limit_bytes.load(Ordering::Relaxed);
+            let vcpu_time_ns = slot.vcpu_time_ns.load(Ordering::Relaxed);
+            let cpu_bits = slot.cpu_percent_bits.load(Ordering::Relaxed);
+            let memory = slot.memory_bytes.load(Ordering::Relaxed);
+            let memory_available = slot.memory_available_bytes.load(Ordering::Relaxed);
+            let memory_host_resident = slot.memory_host_resident_bytes.load(Ordering::Relaxed);
+            let disk_read = slot.disk_read_bytes.load(Ordering::Relaxed);
+            let disk_write = slot.disk_write_bytes.load(Ordering::Relaxed);
+            let net_rx = slot.net_rx_bytes.load(Ordering::Relaxed);
+            let net_tx = slot.net_tx_bytes.load(Ordering::Relaxed);
+            let name = read_v2_name(slot);
+
+            let sequence_after = slot.seq.load(Ordering::Acquire);
+            let generation_after = slot.generation.load(Ordering::Acquire);
+            let state_after = slot.state.load(Ordering::Acquire);
+            if sequence_before != sequence_after
+                || sequence_after & 1 == 1
+                || generation_before != generation_after
+                || state_after != SLOT_ACTIVE
+            {
+                std::hint::spin_loop();
+                continue;
+            }
+
+            if sampled_at_ms <= 0 {
+                return None;
+            }
+
+            let timestamp = ms_to_datetime(sampled_at_ms);
+            let started_at = ms_to_datetime(started_at_ms);
+            let uptime = timestamp
+                .signed_duration_since(started_at)
+                .to_std()
+                .unwrap_or_default();
+
+            return Some(LiveMetric {
+                state: LiveMetricState::Active,
+                sandbox_id,
+                run_id,
+                pid,
+                name,
+                timestamp,
+                uptime,
+                cpu_percent: f32::from_bits(cpu_bits),
+                vcpu_time_ns,
+                memory_bytes: memory,
+                memory_available_bytes: flag_value(
+                    sample_flags,
+                    SAMPLE_FLAG_MEMORY_AVAILABLE,
+                    memory_available,
+                ),
+                memory_host_resident_bytes: flag_value(
+                    sample_flags,
+                    SAMPLE_FLAG_MEMORY_HOST_RESIDENT,
+                    memory_host_resident,
+                ),
+                memory_limit_bytes: memory_limit,
+                disk_read_bytes: disk_read,
+                disk_write_bytes: disk_write,
+                net_rx_bytes: net_rx,
+                net_tx_bytes: net_tx,
+                upper_used_bytes: None,
+                upper_free_bytes: None,
+                upper_host_allocated_bytes: None,
+            });
+        }
+
+        None
+    }
+
+    fn slot(&self, index: u32) -> &SlotV2 {
+        debug_assert!(index < self.capacity);
+        let offset = HEADER_SIZE + (index as usize) * SLOT_SIZE;
+
+        unsafe { &*(self.mapping.as_ptr().add(offset) as *const SlotV2) }
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+fn open_v2_registry(name: &str) -> MetricsResult<LegacyRegistryV2> {
+    let name = CString::new(name)
+        .map_err(|_| MetricsError::Custom("registry name contains NUL byte".into()))?;
+    let header_mapping = open_existing_region(&name, HEADER_SIZE)?.ok_or_else(|| {
+        MetricsError::from(std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            "metrics registry does not exist",
+        ))
+    })?;
+    let header = unsafe { &*(header_mapping.as_ptr() as *const Header) };
+
+    match wait_for_ready(header) {
+        Ok(()) => {}
+        Err(WaitForReadyError::Stuck) => {
+            return Err(MetricsError::Custom(
+                "metrics registry is still initializing".into(),
+            ));
+        }
+        Err(WaitForReadyError::Invalid(state)) => {
+            return Err(MetricsError::Custom(format!(
+                "invalid registry header state: {state}"
+            )));
+        }
+    }
+
+    validate_header_version(header, LEGACY_REGISTRY_VERSION_V2, None)?;
+    let capacity = header.capacity;
+    drop(header_mapping);
+
+    let mapping = open_existing_region(&name, registry_size(capacity))?
+        .ok_or_else(|| MetricsError::Custom("registry disappeared during open".into()))?;
+    let header = unsafe { &*(mapping.as_ptr() as *const Header) };
+
+    validate_header_version(header, LEGACY_REGISTRY_VERSION_V2, Some(capacity))?;
+
+    Ok(LegacyRegistryV2 { mapping, capacity })
+}
+
+fn read_v2_name(slot: &SlotV2) -> String {
+    let len = (slot.name_len.load(Ordering::Relaxed) as usize).min(NAME_BYTES);
+    let mut bytes = [0u8; NAME_BYTES];
+    for (index, byte) in bytes.iter_mut().enumerate().take(len) {
+        *byte = slot.name_bytes[index].load(Ordering::Relaxed);
+    }
+
+    String::from_utf8_lossy(&bytes[..len]).into_owned()
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests
+//--------------------------------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use chrono::Utc;
+
+    use super::*;
+    use crate::layout::{
+        HEADER_STATE_INITIALIZING, HEADER_STATE_READY, REGISTRY_MAGIC, SAMPLE_FLAG_CPU,
+        SAMPLE_FLAG_MEMORY_USED,
+    };
+    use crate::registry::{create_region, unlink_region};
+
+    fn unique_name(tag: &str) -> String {
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+
+        format!("/msb-mtc-{tag}-{}", nanos & 0xffff_ffff)
+    }
+
+    fn create_v2_registry(name: &str, sandbox_id: i32, run_id: i32) -> MappedRegion {
+        let name = CString::new(name).unwrap();
+        let mapping = create_region(&name, registry_size(1)).unwrap();
+        let header = unsafe { &mut *(mapping.as_ptr() as *mut Header) };
+
+        header
+            .state
+            .store(HEADER_STATE_INITIALIZING, Ordering::Release);
+        header.magic = REGISTRY_MAGIC;
+        header.version = LEGACY_REGISTRY_VERSION_V2;
+        header.header_len = HEADER_SIZE as u32;
+        header.slot_len = SLOT_SIZE as u32;
+        header.capacity = 1;
+        header.created_at_unix_ms = Utc::now().timestamp_millis();
+        header.global_generation.store(1, Ordering::Release);
+
+        let slot = unsafe { &*(mapping.as_ptr().add(HEADER_SIZE) as *const SlotV2) };
+        let now = Utc::now();
+        slot.generation.store(1, Ordering::Release);
+        slot.seq.store(2, Ordering::Release);
+        slot.sandbox_id.store(sandbox_id, Ordering::Relaxed);
+        slot.run_id.store(run_id, Ordering::Relaxed);
+        slot.pid.store(42, Ordering::Relaxed);
+        slot.started_at_unix_ms.store(
+            (now - chrono::Duration::seconds(3)).timestamp_millis(),
+            Ordering::Relaxed,
+        );
+        slot.sampled_at_unix_ms
+            .store(now.timestamp_millis(), Ordering::Relaxed);
+        slot.sample_flags.store(
+            SAMPLE_FLAG_CPU | SAMPLE_FLAG_MEMORY_USED | SAMPLE_FLAG_MEMORY_AVAILABLE,
+            Ordering::Relaxed,
+        );
+        slot.memory_limit_bytes.store(4096, Ordering::Relaxed);
+        slot.vcpu_time_ns.store(23, Ordering::Relaxed);
+        slot.cpu_percent_bits
+            .store(12.5_f32.to_bits(), Ordering::Relaxed);
+        slot.memory_bytes.store(1024, Ordering::Relaxed);
+        slot.memory_available_bytes.store(3072, Ordering::Relaxed);
+        slot.disk_read_bytes.store(11, Ordering::Relaxed);
+        slot.disk_write_bytes.store(12, Ordering::Relaxed);
+        slot.net_rx_bytes.store(13, Ordering::Relaxed);
+        slot.net_tx_bytes.store(14, Ordering::Relaxed);
+
+        let sandbox_name = b"legacy-sandbox";
+        slot.name_len
+            .store(sandbox_name.len() as u16, Ordering::Relaxed);
+        for (index, byte) in sandbox_name.iter().enumerate() {
+            slot.name_bytes[index].store(*byte, Ordering::Relaxed);
+        }
+
+        slot.state.store(SLOT_ACTIVE, Ordering::Release);
+        header.state.store(HEADER_STATE_READY, Ordering::Release);
+
+        mapping
+    }
+
+    fn cleanup(name: &str) {
+        let name = CString::new(name).unwrap();
+
+        unlink_region(&name);
+    }
+
+    #[test]
+    fn reader_supports_v2_without_upper_disk_fields() {
+        let name = unique_name("v2");
+        let _mapping = create_v2_registry(&name, 7, 99);
+        let reader = MetricsRegistryReader::open(&name, LEGACY_REGISTRY_VERSION_V2).unwrap();
+
+        let snapshots = reader.active_snapshot().unwrap();
+
+        assert_eq!(snapshots.len(), 1);
+        let snapshot = &snapshots[0];
+        assert_eq!(snapshot.sandbox_id, 7);
+        assert_eq!(snapshot.run_id, 99);
+        assert_eq!(snapshot.name, "legacy-sandbox");
+        assert_eq!(snapshot.cpu_percent, 12.5);
+        assert_eq!(snapshot.memory_available_bytes, Some(3072));
+        assert_eq!(snapshot.upper_used_bytes, None);
+        assert_eq!(snapshot.upper_free_bytes, None);
+        assert_eq!(snapshot.upper_host_allocated_bytes, None);
+
+        cleanup(&name);
+    }
+
+    #[test]
+    fn reader_rejects_an_unexpected_registry_version() {
+        let name = unique_name("v2bad");
+        let _mapping = create_v2_registry(&name, 7, 99);
+
+        let error = match MetricsRegistryReader::open(&name, REGISTRY_VERSION) {
+            Ok(_) => panic!("v2 registry unexpectedly opened as current ABI"),
+            Err(error) => error,
+        };
+
+        assert!(error.to_string().contains("incompatible registry version"));
+        cleanup(&name);
+    }
+}

--- a/crates/metrics/lib/compatibility.rs
+++ b/crates/metrics/lib/compatibility.rs
@@ -10,7 +10,7 @@ use crate::layout::{
     SAMPLE_FLAG_MEMORY_HOST_RESIDENT, SLOT_ACTIVE, SLOT_SIZE, registry_size,
 };
 use crate::registry::{
-    MappedRegion, WaitForReadyError, flag_value, ms_to_datetime, open_existing_region,
+    MappedRegion, WaitForReadyError, flag_value, ms_to_datetime, open_existing_read_only_region,
     validate_header_version, wait_for_ready,
 };
 use crate::{LiveMetric, LiveMetricState, MetricsError, MetricsRegistry, MetricsResult};
@@ -72,7 +72,30 @@ struct SlotV2 {
     _tail: [u8; SLOT_SIZE - 152 - NAME_BYTES],
 }
 
-const _: () = assert!(std::mem::size_of::<SlotV2>() == SLOT_SIZE);
+const _: () = {
+    assert!(std::mem::size_of::<SlotV2>() == SLOT_SIZE);
+    assert!(std::mem::offset_of!(SlotV2, state) == 0x00);
+    assert!(std::mem::offset_of!(SlotV2, generation) == 0x08);
+    assert!(std::mem::offset_of!(SlotV2, seq) == 0x10);
+    assert!(std::mem::offset_of!(SlotV2, sandbox_id) == 0x18);
+    assert!(std::mem::offset_of!(SlotV2, run_id) == 0x1c);
+    assert!(std::mem::offset_of!(SlotV2, pid) == 0x20);
+    assert!(std::mem::offset_of!(SlotV2, started_at_unix_ms) == 0x28);
+    assert!(std::mem::offset_of!(SlotV2, sampled_at_unix_ms) == 0x30);
+    assert!(std::mem::offset_of!(SlotV2, sample_flags) == 0x38);
+    assert!(std::mem::offset_of!(SlotV2, memory_limit_bytes) == 0x40);
+    assert!(std::mem::offset_of!(SlotV2, vcpu_time_ns) == 0x48);
+    assert!(std::mem::offset_of!(SlotV2, cpu_percent_bits) == 0x50);
+    assert!(std::mem::offset_of!(SlotV2, memory_bytes) == 0x58);
+    assert!(std::mem::offset_of!(SlotV2, memory_available_bytes) == 0x60);
+    assert!(std::mem::offset_of!(SlotV2, memory_host_resident_bytes) == 0x68);
+    assert!(std::mem::offset_of!(SlotV2, disk_read_bytes) == 0x70);
+    assert!(std::mem::offset_of!(SlotV2, disk_write_bytes) == 0x78);
+    assert!(std::mem::offset_of!(SlotV2, net_rx_bytes) == 0x80);
+    assert!(std::mem::offset_of!(SlotV2, net_tx_bytes) == 0x88);
+    assert!(std::mem::offset_of!(SlotV2, name_len) == 0x90);
+    assert!(std::mem::offset_of!(SlotV2, name_bytes) == 0x98);
+};
 
 //--------------------------------------------------------------------------------------------------
 // Methods
@@ -216,7 +239,7 @@ impl LegacyRegistryV2 {
 fn open_v2_registry(name: &str) -> MetricsResult<LegacyRegistryV2> {
     let name = CString::new(name)
         .map_err(|_| MetricsError::Custom("registry name contains NUL byte".into()))?;
-    let header_mapping = open_existing_region(&name, HEADER_SIZE)?.ok_or_else(|| {
+    let header_mapping = open_existing_read_only_region(&name, HEADER_SIZE)?.ok_or_else(|| {
         MetricsError::from(std::io::Error::new(
             std::io::ErrorKind::NotFound,
             "metrics registry does not exist",
@@ -242,7 +265,7 @@ fn open_v2_registry(name: &str) -> MetricsResult<LegacyRegistryV2> {
     let capacity = header.capacity;
     drop(header_mapping);
 
-    let mapping = open_existing_region(&name, registry_size(capacity))?
+    let mapping = open_existing_read_only_region(&name, registry_size(capacity))?
         .ok_or_else(|| MetricsError::Custom("registry disappeared during open".into()))?;
     let header = unsafe { &*(mapping.as_ptr() as *const Header) };
 
@@ -288,7 +311,7 @@ mod tests {
     fn create_v2_registry(name: &str, sandbox_id: i32, run_id: i32) -> MappedRegion {
         let name = CString::new(name).unwrap();
         let mapping = create_region(&name, registry_size(1)).unwrap();
-        let header = unsafe { &mut *(mapping.as_ptr() as *mut Header) };
+        let header = unsafe { &mut *(mapping.as_mut_ptr() as *mut Header) };
 
         header
             .state
@@ -301,7 +324,7 @@ mod tests {
         header.created_at_unix_ms = Utc::now().timestamp_millis();
         header.global_generation.store(1, Ordering::Release);
 
-        let slot = unsafe { &*(mapping.as_ptr().add(HEADER_SIZE) as *const SlotV2) };
+        let slot = unsafe { &*(mapping.as_mut_ptr().add(HEADER_SIZE) as *const SlotV2) };
         let now = Utc::now();
         slot.generation.store(1, Ordering::Release);
         slot.seq.store(2, Ordering::Release);

--- a/crates/metrics/lib/layout.rs
+++ b/crates/metrics/lib/layout.rs
@@ -93,6 +93,13 @@ pub const REGISTRY_VERSION: u32 = 3;
 /// value so incompatible slot layouts never share the same POSIX shm object.
 pub const REGISTRY_ABI_VERSION: u32 = REGISTRY_VERSION;
 
+/// Registry ABI versions that the read-only metrics path can consume.
+///
+/// Writers always use [`REGISTRY_ABI_VERSION`]. Keeping the previous ABI
+/// readable lets a newly deployed collector continue observing sandboxes
+/// whose runtime processes predate the rollout.
+pub const READABLE_REGISTRY_ABI_VERSIONS: &[u32] = &[2, REGISTRY_ABI_VERSION];
+
 /// Default slot capacity used by the host process when global config does
 /// not override it. At 512 bytes per slot, 1024 slots = ~512 KiB plus the
 /// 256-byte header — enough headroom for the documented 20–560 sandbox

--- a/crates/metrics/lib/lib.rs
+++ b/crates/metrics/lib/lib.rs
@@ -7,6 +7,7 @@
 
 #![warn(missing_docs)]
 
+mod compatibility;
 mod error;
 mod layout;
 mod registry;
@@ -16,9 +17,12 @@ mod snapshot;
 // Re-Exports
 //--------------------------------------------------------------------------------------------------
 
+pub use compatibility::MetricsRegistryReader;
 pub use error::{MetricsError, MetricsResult};
 /// Maximum bytes reserved for a sandbox name inside a fixed metrics slot.
-pub use layout::{NAME_BYTES as SLOT_NAME_BYTES, REGISTRY_ABI_VERSION};
+pub use layout::{
+    NAME_BYTES as SLOT_NAME_BYTES, READABLE_REGISTRY_ABI_VERSIONS, REGISTRY_ABI_VERSION,
+};
 pub use registry::{
     ActivateSlot, MetricsRegistry, MetricsSlotWriter, ReleaseMode, ReserveSlot, SampleWrite,
     SlotReservation, default_capacity,

--- a/crates/metrics/lib/registry.rs
+++ b/crates/metrics/lib/registry.rs
@@ -30,8 +30,8 @@ use windows_sys::Win32::Foundation::{
 };
 #[cfg(target_os = "windows")]
 use windows_sys::Win32::System::Memory::{
-    CreateFileMappingW, FILE_MAP_ALL_ACCESS, MEMORY_MAPPED_VIEW_ADDRESS, MapViewOfFile,
-    OpenFileMappingW, PAGE_READWRITE, UnmapViewOfFile,
+    CreateFileMappingW, FILE_MAP_ALL_ACCESS, FILE_MAP_READ, MEMORY_MAPPED_VIEW_ADDRESS,
+    MapViewOfFile, OpenFileMappingW, PAGE_READWRITE, UnmapViewOfFile,
 };
 #[cfg(target_os = "windows")]
 use windows_sys::Win32::System::Threading::{
@@ -163,7 +163,12 @@ pub(crate) struct MappedRegion {
 
 impl MappedRegion {
     /// Return the base address of the mapped shared-memory region.
-    pub(crate) fn as_ptr(&self) -> *mut u8 {
+    pub(crate) fn as_ptr(&self) -> *const u8 {
+        self.ptr.as_ptr().cast_const()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn as_mut_ptr(&self) -> *mut u8 {
         self.ptr.as_ptr()
     }
 }
@@ -989,11 +994,34 @@ fn create_and_init(
 }
 
 #[cfg(unix)]
-pub(crate) fn open_existing_region(
+fn open_existing_region(
     name: &std::ffi::CStr,
     map_len: usize,
 ) -> MetricsResult<Option<MappedRegion>> {
-    let fd = unsafe { libc::shm_open(name.as_ptr(), libc::O_RDWR, 0) };
+    open_existing_unix_region(
+        name,
+        map_len,
+        libc::O_RDWR,
+        libc::PROT_READ | libc::PROT_WRITE,
+    )
+}
+
+#[cfg(unix)]
+pub(crate) fn open_existing_read_only_region(
+    name: &std::ffi::CStr,
+    map_len: usize,
+) -> MetricsResult<Option<MappedRegion>> {
+    open_existing_unix_region(name, map_len, libc::O_RDONLY, libc::PROT_READ)
+}
+
+#[cfg(unix)]
+fn open_existing_unix_region(
+    name: &std::ffi::CStr,
+    map_len: usize,
+    open_flags: libc::c_int,
+    protection: libc::c_int,
+) -> MetricsResult<Option<MappedRegion>> {
+    let fd = unsafe { libc::shm_open(name.as_ptr(), open_flags, 0) };
     if fd < 0 {
         let err = std::io::Error::last_os_error();
         if err.raw_os_error() == Some(libc::ENOENT) {
@@ -1011,7 +1039,7 @@ pub(crate) fn open_existing_region(
         libc::mmap(
             std::ptr::null_mut(),
             map_len,
-            libc::PROT_READ | libc::PROT_WRITE,
+            protection,
             libc::MAP_SHARED,
             fd,
             0,
@@ -1029,12 +1057,29 @@ pub(crate) fn open_existing_region(
 }
 
 #[cfg(target_os = "windows")]
-pub(crate) fn open_existing_region(
+fn open_existing_region(
     name: &std::ffi::CStr,
     map_len: usize,
 ) -> MetricsResult<Option<MappedRegion>> {
+    open_existing_windows_region(name, map_len, FILE_MAP_ALL_ACCESS)
+}
+
+#[cfg(target_os = "windows")]
+pub(crate) fn open_existing_read_only_region(
+    name: &std::ffi::CStr,
+    map_len: usize,
+) -> MetricsResult<Option<MappedRegion>> {
+    open_existing_windows_region(name, map_len, FILE_MAP_READ)
+}
+
+#[cfg(target_os = "windows")]
+fn open_existing_windows_region(
+    name: &std::ffi::CStr,
+    map_len: usize,
+    desired_access: u32,
+) -> MetricsResult<Option<MappedRegion>> {
     let name = windows_mapping_name(name)?;
-    let handle = unsafe { OpenFileMappingW(FILE_MAP_ALL_ACCESS, 0, name.as_ptr()) };
+    let handle = unsafe { OpenFileMappingW(desired_access, 0, name.as_ptr()) };
     if handle.is_null() {
         let err = std::io::Error::last_os_error();
         if err.raw_os_error() == Some(ERROR_FILE_NOT_FOUND as i32) {
@@ -1043,7 +1088,7 @@ pub(crate) fn open_existing_region(
         return Err(err.into());
     }
 
-    map_windows_region(handle, map_len).map(Some)
+    map_windows_region(handle, map_len, desired_access).map(Some)
 }
 
 #[cfg(unix)]
@@ -1119,7 +1164,7 @@ pub(crate) fn create_region(name: &std::ffi::CStr, map_len: usize) -> MetricsRes
         return Err(MetricsError::AlreadyExists);
     }
 
-    map_windows_region(handle, map_len)
+    map_windows_region(handle, map_len, FILE_MAP_ALL_ACCESS)
 }
 
 #[cfg(all(unix, test))]
@@ -1134,8 +1179,12 @@ pub(crate) fn unlink_region(name: &std::ffi::CStr) {
 pub(crate) fn unlink_region(_name: &std::ffi::CStr) {}
 
 #[cfg(target_os = "windows")]
-fn map_windows_region(handle: HANDLE, map_len: usize) -> MetricsResult<MappedRegion> {
-    let ptr = unsafe { MapViewOfFile(handle, FILE_MAP_ALL_ACCESS, 0, 0, map_len) };
+fn map_windows_region(
+    handle: HANDLE,
+    map_len: usize,
+    desired_access: u32,
+) -> MetricsResult<MappedRegion> {
+    let ptr = unsafe { MapViewOfFile(handle, desired_access, 0, 0, map_len) };
     if ptr.Value.is_null() {
         let err = std::io::Error::last_os_error();
         unsafe { CloseHandle(handle) };

--- a/crates/metrics/lib/registry.rs
+++ b/crates/metrics/lib/registry.rs
@@ -153,12 +153,19 @@ struct RegistryInner {
     capacity: u32,
 }
 
-struct MappedRegion {
+pub(crate) struct MappedRegion {
     ptr: NonNull<u8>,
     #[cfg(unix)]
     len: usize,
     #[cfg(target_os = "windows")]
     handle: HANDLE,
+}
+
+impl MappedRegion {
+    /// Return the base address of the mapped shared-memory region.
+    pub(crate) fn as_ptr(&self) -> *mut u8 {
+        self.ptr.as_ptr()
+    }
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -982,7 +989,7 @@ fn create_and_init(
 }
 
 #[cfg(unix)]
-fn open_existing_region(
+pub(crate) fn open_existing_region(
     name: &std::ffi::CStr,
     map_len: usize,
 ) -> MetricsResult<Option<MappedRegion>> {
@@ -1022,7 +1029,7 @@ fn open_existing_region(
 }
 
 #[cfg(target_os = "windows")]
-fn open_existing_region(
+pub(crate) fn open_existing_region(
     name: &std::ffi::CStr,
     map_len: usize,
 ) -> MetricsResult<Option<MappedRegion>> {
@@ -1040,7 +1047,7 @@ fn open_existing_region(
 }
 
 #[cfg(unix)]
-fn create_region(name: &std::ffi::CStr, map_len: usize) -> MetricsResult<MappedRegion> {
+pub(crate) fn create_region(name: &std::ffi::CStr, map_len: usize) -> MetricsResult<MappedRegion> {
     let fd = unsafe {
         libc::shm_open(
             name.as_ptr(),
@@ -1091,7 +1098,7 @@ fn create_region(name: &std::ffi::CStr, map_len: usize) -> MetricsResult<MappedR
 }
 
 #[cfg(target_os = "windows")]
-fn create_region(name: &std::ffi::CStr, map_len: usize) -> MetricsResult<MappedRegion> {
+pub(crate) fn create_region(name: &std::ffi::CStr, map_len: usize) -> MetricsResult<MappedRegion> {
     let name = windows_mapping_name(name)?;
     let max_size = map_len as u64;
     let handle = unsafe {
@@ -1116,7 +1123,7 @@ fn create_region(name: &std::ffi::CStr, map_len: usize) -> MetricsResult<MappedR
 }
 
 #[cfg(all(unix, test))]
-fn unlink_region(name: &std::ffi::CStr) {
+pub(crate) fn unlink_region(name: &std::ffi::CStr) {
     unsafe {
         libc::shm_unlink(name.as_ptr());
     }
@@ -1124,7 +1131,7 @@ fn unlink_region(name: &std::ffi::CStr) {
 
 #[cfg(target_os = "windows")]
 #[cfg(test)]
-fn unlink_region(_name: &std::ffi::CStr) {}
+pub(crate) fn unlink_region(_name: &std::ffi::CStr) {}
 
 #[cfg(target_os = "windows")]
 fn map_windows_region(handle: HANDLE, map_len: usize) -> MetricsResult<MappedRegion> {
@@ -1165,14 +1172,14 @@ fn windows_mapping_name(name: &std::ffi::CStr) -> MetricsResult<Vec<u16>> {
 }
 
 /// Outcome of `wait_for_ready`.
-enum WaitForReadyError {
+pub(crate) enum WaitForReadyError {
     /// The header was still `UNINIT`/`INITIALIZING` when the wait expired.
     Stuck,
     /// The header carried an unrecognised state value.
     Invalid(u32),
 }
 
-fn wait_for_ready(header: &Header) -> Result<(), WaitForReadyError> {
+pub(crate) fn wait_for_ready(header: &Header) -> Result<(), WaitForReadyError> {
     let deadline = Instant::now() + INIT_WAIT_TIMEOUT;
     loop {
         let state = header.state.load(Ordering::Acquire);
@@ -1190,16 +1197,24 @@ fn wait_for_ready(header: &Header) -> Result<(), WaitForReadyError> {
 }
 
 fn validate_header(header: &Header, expected_capacity: Option<u32>) -> MetricsResult<()> {
+    validate_header_version(header, REGISTRY_VERSION, expected_capacity)
+}
+
+pub(crate) fn validate_header_version(
+    header: &Header,
+    expected_version: u32,
+    expected_capacity: Option<u32>,
+) -> MetricsResult<()> {
     if header.magic != REGISTRY_MAGIC {
         return Err(MetricsError::Custom(format!(
             "invalid registry magic: 0x{:x}",
             header.magic
         )));
     }
-    if header.version != REGISTRY_VERSION {
+    if header.version != expected_version {
         return Err(MetricsError::Custom(format!(
-            "incompatible registry version: {}",
-            header.version
+            "incompatible registry version: {} (expected {expected_version})",
+            header.version,
         )));
     }
     if header.header_len as usize != HEADER_SIZE {
@@ -1278,7 +1293,7 @@ fn read_name(slot: &Slot) -> String {
     String::from_utf8_lossy(&bytes[..len]).into_owned()
 }
 
-fn flag_value(flags: u32, flag: u32, value: u64) -> Option<u64> {
+pub(crate) fn flag_value(flags: u32, flag: u32, value: u64) -> Option<u64> {
     if flag_set(flags, flag) {
         Some(value)
     } else {
@@ -1387,7 +1402,7 @@ fn pid_is_alive(pid: i32) -> bool {
     ok != 0 && exit_code == STILL_ACTIVE as u32
 }
 
-fn ms_to_datetime(ms: i64) -> DateTime<Utc> {
+pub(crate) fn ms_to_datetime(ms: i64) -> DateTime<Utc> {
     if ms <= 0 {
         return DateTime::<Utc>::UNIX_EPOCH;
     }


### PR DESCRIPTION
## what

- let `msb-metrics` read both the v2 and current v3 shared-memory registries
- merge snapshots by sandbox and run, preferring the newest ABI
- keep legacy registries read-only and tolerate missing or unreadable legacy mappings

## why

Long-running sandbox runtimes keep writing to the registry ABI they started with. After a collector-only rollout, those sandboxes disappeared from per-sandbox metrics even though they were still running.

## test

- `cargo test -p microsandbox-metrics -p microsandbox-metrics-collector`
- `cargo clippy -p microsandbox-metrics -p microsandbox-metrics-collector --all-targets -- -D warnings`
- repository commit hooks



<!-- greptile_comment -->

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with both previously identified compatibility concerns fully addressed and no new actionable failures found.

The legacy reader now uses read-only OS mapping permissions, and compile-time assertions freeze every relevant v2 slot offset. Both previous threads were manually resolved without explanatory replies; the current code nevertheless directly addresses their findings.
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(metrics): make legacy registry reads..."](https://github.com/superradcompany/microsandbox/commit/2d0e666724fd8386c722964e4a7ac83675f58940) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=63480418)</sub>

<!-- /greptile_comment -->