### PR TITLE
fix(filesystem): serve macOS shares without volfs by anchor-walk reopen

### DIFF
--- a/crates/filesystem/lib/backends/passthroughfs/unix/builder.rs
+++ b/crates/filesystem/lib/backends/passthroughfs/unix/builder.rs
@@ -204,6 +204,9 @@ impl PassthroughFsBuilder {
             unsafe { File::from_raw_fd(fd) }
         };
 
+        #[cfg(target_os = "macos")]
+        let volfs_supported = AtomicBool::new(super::probe_volfs_support(root_fd.as_raw_fd()));
+
         let cfg = cfg_probe;
 
         let quota = cfg.quota_bytes.map(|limit| {
@@ -229,6 +232,8 @@ impl PassthroughFsBuilder {
             has_openat2,
             #[cfg(target_os = "linux")]
             proc_self_fd,
+            #[cfg(target_os = "macos")]
+            volfs_supported,
             quota,
         })
     }

--- a/crates/filesystem/lib/backends/passthroughfs/unix/builder.rs
+++ b/crates/filesystem/lib/backends/passthroughfs/unix/builder.rs
@@ -235,6 +235,10 @@ impl PassthroughFsBuilder {
             #[cfg(target_os = "macos")]
             volfs_supported,
             quota,
+            #[cfg(all(test, target_os = "macos"))]
+            before_blocking_fifo_open: std::sync::RwLock::new(None),
+            #[cfg(all(test, target_os = "macos"))]
+            fifo_endpoint_opens: std::sync::atomic::AtomicUsize::new(0),
         })
     }
 }

--- a/crates/filesystem/lib/backends/passthroughfs/unix/builder.rs
+++ b/crates/filesystem/lib/backends/passthroughfs/unix/builder.rs
@@ -239,6 +239,8 @@ impl PassthroughFsBuilder {
             before_blocking_fifo_open: std::sync::RwLock::new(None),
             #[cfg(all(test, target_os = "macos"))]
             fifo_endpoint_opens: std::sync::atomic::AtomicUsize::new(0),
+            #[cfg(all(test, target_os = "macos"))]
+            before_name_bound_syscall: std::sync::RwLock::new(None),
         })
     }
 }

--- a/crates/filesystem/lib/backends/passthroughfs/unix/create_ops.rs
+++ b/crates/filesystem/lib/backends/passthroughfs/unix/create_ops.rs
@@ -468,9 +468,16 @@ pub(crate) fn do_link(
 
     #[cfg(target_os = "macos")]
     {
-        let inodes = fs.inodes.read().unwrap();
-        let data = inodes.get(&inode).ok_or_else(platform::ebadf)?;
-        let src_path = format!("/.vol/{}/{}\0", data.dev, data.ino);
+        // Compute the source path in a short-lived block so the inode-table
+        // read guard is dropped before get_inode_fd runs: in anchor mode that
+        // call can reach repair_anchor, which takes the write lock, and a
+        // nested read() on the same RwLock can deadlock against a queued
+        // writer.
+        let src_path = {
+            let inodes = fs.inodes.read().unwrap();
+            let data = inodes.get(&inode).ok_or_else(platform::ebadf)?;
+            format!("/.vol/{}/{}\0", data.dev, data.ino)
+        };
         let newparent_fd = inode::get_inode_fd(fs, newparent)?;
 
         let ret = unsafe {

--- a/crates/filesystem/lib/backends/passthroughfs/unix/create_ops.rs
+++ b/crates/filesystem/lib/backends/passthroughfs/unix/create_ops.rs
@@ -562,10 +562,16 @@ pub(crate) fn do_readlink(fs: &PassthroughFs, _ctx: Context, ino: u64) -> io::Re
 
     #[cfg(target_os = "macos")]
     {
-        // On macOS we create real symlinks, so verify it's actually a symlink first.
-        let st = inode::stat_inode(fs, ino)?;
-        if platform::mode_file_type(st.st_mode) != platform::MODE_LNK {
-            return Err(platform::einval());
+        // On macOS we create real symlinks. In volfs mode the type is checked
+        // first because the identity path would otherwise open the target. In
+        // anchor mode the check is left to `readlinkat`, which answers EINVAL
+        // for anything that is not a symlink; a `stat_inode` pre-check there
+        // would only pay for a second anchor walk.
+        if !fs.anchor_mode() {
+            let st = inode::stat_inode(fs, ino)?;
+            if platform::mode_file_type(st.st_mode) != platform::MODE_LNK {
+                return Err(platform::einval());
+            }
         }
 
         let mut buf = vec![0u8; libc::PATH_MAX as usize];

--- a/crates/filesystem/lib/backends/passthroughfs/unix/create_ops.rs
+++ b/crates/filesystem/lib/backends/passthroughfs/unix/create_ops.rs
@@ -425,7 +425,9 @@ pub(crate) fn do_symlink(
 /// Create a hard link.
 ///
 /// On Linux, uses `/proc/self/fd/N` with `AT_SYMLINK_FOLLOW` to link by fd reference.
-/// On macOS, uses `/.vol/dev/ino` to reference the source inode by identity.
+/// On macOS, uses `/.vol/dev/ino` to reference the source inode by identity when
+/// volfs is available; in anchor mode the source is resolved to a (dirfd, name)
+/// pair by anchor walk.
 pub(crate) fn do_link(
     fs: &PassthroughFs,
     _ctx: Context,
@@ -468,29 +470,40 @@ pub(crate) fn do_link(
 
     #[cfg(target_os = "macos")]
     {
-        // Compute the source path in a short-lived block so the inode-table
-        // read guard is dropped before get_inode_fd runs: in anchor mode that
-        // call can reach repair_anchor, which takes the write lock, and a
-        // nested read() on the same RwLock can deadlock against a queued
-        // writer.
-        let src_path = {
+        // Both `get_inode_fd` and `anchor_parent_and_name_macos` may take the
+        // inode-table write lock (the latter via `repair_anchor`), so neither
+        // may run while a read guard on `fs.inodes` is held.
+        let newparent_fd = inode::get_inode_fd(fs, newparent)?;
+        if fs.anchor_mode() {
+            let (src_dir, src_name) = inode::anchor_parent_and_name_macos(fs, inode)?;
+            let ret = unsafe {
+                libc::linkat(
+                    src_dir.raw(),
+                    src_name.as_ptr(),
+                    newparent_fd.raw(),
+                    newname.as_ptr(),
+                    0,
+                )
+            };
+            if ret < 0 {
+                return Err(platform::linux_error(io::Error::last_os_error()));
+            }
+        } else {
             let inodes = fs.inodes.read().unwrap();
             let data = inodes.get(&inode).ok_or_else(platform::ebadf)?;
-            format!("/.vol/{}/{}\0", data.dev, data.ino)
-        };
-        let newparent_fd = inode::get_inode_fd(fs, newparent)?;
-
-        let ret = unsafe {
-            libc::linkat(
-                libc::AT_FDCWD,
-                src_path.as_ptr() as *const libc::c_char,
-                newparent_fd.raw(),
-                newname.as_ptr(),
-                0,
-            )
-        };
-        if ret < 0 {
-            return Err(platform::linux_error(io::Error::last_os_error()));
+            let src_path = format!("/.vol/{}/{}\0", data.dev, data.ino);
+            let ret = unsafe {
+                libc::linkat(
+                    libc::AT_FDCWD,
+                    src_path.as_ptr() as *const libc::c_char,
+                    newparent_fd.raw(),
+                    newname.as_ptr(),
+                    0,
+                )
+            };
+            if ret < 0 {
+                return Err(platform::linux_error(io::Error::last_os_error()));
+            }
         }
     }
 
@@ -555,23 +568,42 @@ pub(crate) fn do_readlink(fs: &PassthroughFs, _ctx: Context, ino: u64) -> io::Re
             return Err(platform::einval());
         }
 
-        let inodes = fs.inodes.read().unwrap();
-        let data = inodes.get(&ino).ok_or_else(platform::ebadf)?;
-        let path = format!("/.vol/{}/{}\0", data.dev, data.ino);
-
         let mut buf = vec![0u8; libc::PATH_MAX as usize];
-        let ret = unsafe {
-            libc::readlinkat(
-                libc::AT_FDCWD,
-                path.as_ptr() as *const libc::c_char,
-                buf.as_mut_ptr() as *mut libc::c_char,
-                buf.len(),
-            )
+        let len = if fs.anchor_mode() {
+            let (dir, name) = inode::anchor_parent_and_name_macos(fs, ino)?;
+            let ret = unsafe {
+                libc::readlinkat(
+                    dir.raw(),
+                    name.as_ptr(),
+                    buf.as_mut_ptr() as *mut libc::c_char,
+                    buf.len(),
+                )
+            };
+            // Capture errno here, before `dir` drops (its Drop calls
+            // `close`, which can clobber the syscall's errno).
+            if ret < 0 {
+                let err = io::Error::last_os_error();
+                return Err(platform::linux_error(err));
+            }
+            ret
+        } else {
+            let inodes = fs.inodes.read().unwrap();
+            let data = inodes.get(&ino).ok_or_else(platform::ebadf)?;
+            let path = format!("/.vol/{}/{}\0", data.dev, data.ino);
+            let ret = unsafe {
+                libc::readlinkat(
+                    libc::AT_FDCWD,
+                    path.as_ptr() as *const libc::c_char,
+                    buf.as_mut_ptr() as *mut libc::c_char,
+                    buf.len(),
+                )
+            };
+            if ret < 0 {
+                return Err(platform::linux_error(io::Error::last_os_error()));
+            }
+            ret
         };
-        if ret < 0 {
-            return Err(platform::linux_error(io::Error::last_os_error()));
-        }
-        buf.truncate(ret as usize);
+        buf.truncate(len as usize);
         Ok(buf)
     }
 }

--- a/crates/filesystem/lib/backends/passthroughfs/unix/create_ops.rs
+++ b/crates/filesystem/lib/backends/passthroughfs/unix/create_ops.rs
@@ -606,7 +606,16 @@ pub(crate) fn do_readlink(fs: &PassthroughFs, _ctx: Context, ino: u64) -> io::Re
 
         let mut buf = vec![0u8; libc::PATH_MAX as usize];
         let len = if fs.anchor_mode() {
+            let expected = {
+                let inodes = fs.inodes.read().unwrap();
+                let data = inodes.get(&ino).ok_or_else(platform::ebadf)?;
+                (data.dev, data.ino)
+            };
             let (dir, name) = inode::anchor_parent_and_name_macos(fs, ino)?;
+
+            #[cfg(test)]
+            fs.run_name_bound_hook();
+
             let ret = unsafe {
                 libc::readlinkat(
                     dir.raw(),
@@ -622,6 +631,16 @@ pub(crate) fn do_readlink(fs: &PassthroughFs, _ctx: Context, ino: u64) -> io::Re
                 return Err(platform::linux_error(err));
             }
 
+            // macOS cannot read a link through a descriptor, so `readlinkat`
+            // resolves the name again after the anchor verified it. Checking
+            // the identity once more detects a substitution that is still in
+            // place when the check runs. It does not detect a swap that is put
+            // back: verify A, substitute B, read B's target, restore A, and
+            // the check passes on A while the answer came from B.
+            let st = platform::fstatat_nofollow(dir.raw(), &name)?;
+            if platform::stat_ino(&st) != expected.1 || platform::stat_dev(&st) != expected.0 {
+                return Err(platform::enoent());
+            }
             ret
         } else {
             let inodes = fs.inodes.read().unwrap();

--- a/crates/filesystem/lib/backends/passthroughfs/unix/create_ops.rs
+++ b/crates/filesystem/lib/backends/passthroughfs/unix/create_ops.rs
@@ -475,7 +475,16 @@ pub(crate) fn do_link(
         // may run while a read guard on `fs.inodes` is held.
         let newparent_fd = inode::get_inode_fd(fs, newparent)?;
         if fs.anchor_mode() {
+            let expected = {
+                let inodes = fs.inodes.read().unwrap();
+                let data = inodes.get(&inode).ok_or_else(platform::ebadf)?;
+                (data.dev, data.ino)
+            };
             let (src_dir, src_name) = inode::anchor_parent_and_name_macos(fs, inode)?;
+
+            #[cfg(test)]
+            fs.run_name_bound_hook();
+
             let ret = unsafe {
                 libc::linkat(
                     src_dir.raw(),
@@ -486,7 +495,28 @@ pub(crate) fn do_link(
                 )
             };
             if ret < 0 {
-                return Err(platform::linux_error(io::Error::last_os_error()));
+                // Capture errno before `src_dir` drops: its Drop closes the
+                // fd, and close(2) can clobber errno.
+                let err = io::Error::last_os_error();
+                return Err(platform::linux_error(err));
+            }
+
+            // macOS has no fd-relative `linkat` — linking `/dev/fd/N` answers
+            // EPERM — so the source name is resolved twice: once by the anchor
+            // verification, once by the syscall. Checking what the new entry
+            // actually holds detects a source swapped between the two, and the
+            // guest gets ENOENT instead of an entry for the replacement.
+            //
+            // The link `linkat` created is deliberately left in place. It is
+            // the same on-disk outcome an unchecked `linkat` would have
+            // produced, and removing it by name would be a second name-based
+            // race that could delete an entry another writer had put there in
+            // the meantime. Permissions therefore behave exactly as a plain
+            // `linkat`: nothing here needs rights the caller did not already
+            // have.
+            let st = platform::fstatat_nofollow(newparent_fd.raw(), newname)?;
+            if platform::stat_ino(&st) != expected.1 || platform::stat_dev(&st) != expected.0 {
+                return Err(platform::enoent());
             }
         } else {
             let inodes = fs.inodes.read().unwrap();
@@ -591,6 +621,7 @@ pub(crate) fn do_readlink(fs: &PassthroughFs, _ctx: Context, ino: u64) -> io::Re
                 let err = io::Error::last_os_error();
                 return Err(platform::linux_error(err));
             }
+
             ret
         } else {
             let inodes = fs.inodes.read().unwrap();

--- a/crates/filesystem/lib/backends/passthroughfs/unix/inode.rs
+++ b/crates/filesystem/lib/backends/passthroughfs/unix/inode.rs
@@ -17,10 +17,11 @@
 //! inode is `fstat`'d first and real host symlinks are rejected before reopen.
 
 #[cfg(target_os = "linux")]
-use std::os::fd::{FromRawFd, RawFd};
+use std::fs::File;
 #[cfg(target_os = "linux")]
-use std::{collections::HashSet, fs::File};
+use std::os::fd::{FromRawFd, RawFd};
 use std::{
+    collections::HashSet,
     ffi::CStr,
     io,
     os::fd::AsRawFd,
@@ -28,7 +29,6 @@ use std::{
 };
 
 use super::PassthroughFs;
-#[cfg(target_os = "linux")]
 use crate::backends::shared::inode_table::NamespaceAlias;
 use crate::{
     Entry,
@@ -226,7 +226,7 @@ pub(crate) fn do_lookup(fs: &PassthroughFs, parent: u64, name: &CStr) -> io::Res
     return do_lookup_linux(fs, parent, parent_fd.raw(), name);
 
     #[cfg(target_os = "macos")]
-    return do_lookup_macos(fs, parent_fd.raw(), name);
+    return do_lookup_macos(fs, parent, parent_fd.raw(), name);
 }
 
 /// Linux lookup: open → statx(AT_EMPTY_PATH) → patched_stat (3 syscalls).
@@ -335,7 +335,12 @@ fn do_lookup_linux(
 /// path scheme references files by device+inode identity, making it
 /// stable across renames — similar to Linux's `/proc/self/fd/N`.
 #[cfg(target_os = "macos")]
-fn do_lookup_macos(fs: &PassthroughFs, parent_fd: i32, name: &CStr) -> io::Result<Entry> {
+fn do_lookup_macos(
+    fs: &PassthroughFs,
+    parent: u64,
+    parent_fd: i32,
+    name: &CStr,
+) -> io::Result<Entry> {
     let st = platform::fstatat_nofollow(parent_fd, name)?;
     let alt_key = InodeAltKey::new(platform::stat_ino(&st), platform::stat_dev(&st));
 
@@ -349,10 +354,13 @@ fn do_lookup_macos(fs: &PassthroughFs, parent_fd: i32, name: &CStr) -> io::Resul
         fs.cfg.bind_identity_map.as_ref(),
     )?;
 
-    // Fast path: most lookups hit an already-tracked inode and only need a
-    // refcount bump. We still recheck under the write lock below before
-    // inserting to close the concurrent registration race.
-    {
+    let anchor_mode = fs.anchor_mode();
+    let alias = anchor_mode.then(|| NamespaceAlias::new(parent, name.to_bytes()));
+
+    // Fast path (volfs mode only): most lookups hit an already-tracked inode
+    // and only need a refcount bump. Anchor mode always takes the write lock
+    // because it must record the alias.
+    if !anchor_mode {
         let inodes = fs.inodes.read().unwrap();
         if let Some(data) = inodes.get_alt(&alt_key) {
             data.refcount.fetch_add(1, Ordering::Acquire);
@@ -370,8 +378,11 @@ fn do_lookup_macos(fs: &PassthroughFs, parent_fd: i32, name: &CStr) -> io::Resul
     // Recheck under the write lock so concurrent lookups cannot register two
     // synthetic inode numbers for the same host identity.
     let mut inodes = fs.inodes.write().unwrap();
-    if let Some(data) = inodes.get_alt(&alt_key) {
+    if let Some(data) = inodes.get_alt(&alt_key).cloned() {
         data.refcount.fetch_add(1, Ordering::Acquire);
+        if let Some(alias) = alias {
+            register_alias_locked(&mut inodes, &data, alias);
+        }
         return Ok(Entry {
             inode: data.inode,
             generation: 0,
@@ -388,10 +399,16 @@ fn do_lookup_macos(fs: &PassthroughFs, parent_fd: i32, name: &CStr) -> io::Resul
         ino: platform::stat_ino(&st),
         dev: platform::stat_dev(&st),
         refcount: std::sync::atomic::AtomicU64::new(1),
-        #[cfg(target_os = "macos")]
+        anchor_parent: std::sync::atomic::AtomicU64::new(0),
+        anchor_name: std::sync::RwLock::new(Vec::new()),
+        aliases: std::sync::RwLock::new(std::collections::BTreeSet::new()),
+        anchor_children: std::sync::atomic::AtomicU64::new(0),
         unlinked_fd: std::sync::atomic::AtomicI64::new(-1),
     });
-    inodes.insert(inode_num, alt_key, data);
+    inodes.insert(inode_num, alt_key, data.clone());
+    if let Some(alias) = alias {
+        register_alias_locked(&mut inodes, &data, alias);
+    }
 
     Ok(Entry {
         inode: inode_num,
@@ -491,17 +508,7 @@ pub(crate) fn forget_one_locked(
                 .is_ok()
             {
                 if new == 0 {
-                    #[cfg(target_os = "linux")]
                     maybe_remove_inode_locked(inodes, inode);
-
-                    #[cfg(target_os = "macos")]
-                    {
-                        let ufd = data.unlinked_fd.load(Ordering::Acquire);
-                        if ufd >= 0 {
-                            unsafe { libc::close(ufd as i32) };
-                        }
-                        inodes.remove(&inode);
-                    }
                 }
                 break;
             }
@@ -602,7 +609,7 @@ fn inode_alt_key(data: &InodeData) -> InodeAltKey {
     InodeAltKey::new(data.ino, data.dev, data.mnt_id)
 }
 
-#[cfg(target_os = "linux")]
+#[allow(dead_code)]
 fn current_anchor_alias(data: &InodeData) -> Option<NamespaceAlias> {
     let parent = data.anchor_parent.load(Ordering::Acquire);
     if parent == 0 {
@@ -615,7 +622,7 @@ fn current_anchor_alias(data: &InodeData) -> Option<NamespaceAlias> {
     })
 }
 
-#[cfg(target_os = "linux")]
+#[allow(dead_code)]
 fn candidate_aliases(
     data: &InodeData,
     current_anchor: Option<NamespaceAlias>,
@@ -636,7 +643,7 @@ fn candidate_aliases(
     result
 }
 
-#[cfg(target_os = "linux")]
+#[allow(dead_code)]
 fn build_alias_components_locked(
     inodes: &MultikeyBTreeMap<u64, InodeAltKey, Arc<InodeData>>,
     alias: &NamespaceAlias,
@@ -652,7 +659,7 @@ fn build_alias_components_locked(
     Ok(components)
 }
 
-#[cfg(target_os = "linux")]
+#[allow(dead_code)]
 fn build_anchor_components_locked(
     inodes: &MultikeyBTreeMap<u64, InodeAltKey, Arc<InodeData>>,
     inode: u64,
@@ -670,7 +677,7 @@ fn build_anchor_components_locked(
     build_alias_components_locked(inodes, &alias, seen)
 }
 
-#[cfg(target_os = "linux")]
+#[allow(dead_code)]
 fn validate_component(component: &[u8]) -> io::Result<()> {
     if component.is_empty() || component == b"." {
         return Err(platform::einval());
@@ -779,7 +786,7 @@ fn dup_retained_fd_linux(data: &InodeData) -> io::Result<Option<RawFd>> {
     Ok(Some(fd))
 }
 
-#[cfg(target_os = "linux")]
+#[allow(dead_code)]
 fn repair_anchor(fs: &PassthroughFs, inode: u64, alias: &NamespaceAlias) {
     let mut inodes = fs.inodes.write().unwrap();
     let Some(data) = inodes.get(&inode).cloned() else {
@@ -791,7 +798,6 @@ fn repair_anchor(fs: &PassthroughFs, inode: u64, alias: &NamespaceAlias) {
     set_anchor_locked(&mut inodes, &data, Some(alias));
 }
 
-#[cfg(target_os = "linux")]
 pub(crate) fn register_alias_locked(
     inodes: &mut MultikeyBTreeMap<u64, InodeAltKey, Arc<InodeData>>,
     data: &Arc<InodeData>,
@@ -803,7 +809,7 @@ pub(crate) fn register_alias_locked(
     }
 }
 
-#[cfg(target_os = "linux")]
+#[allow(dead_code)]
 pub(crate) fn remove_alias_locked(
     inodes: &mut MultikeyBTreeMap<u64, InodeAltKey, Arc<InodeData>>,
     data: &Arc<InodeData>,
@@ -822,7 +828,6 @@ pub(crate) fn remove_alias_locked(
     data.aliases.read().unwrap().is_empty()
 }
 
-#[cfg(target_os = "linux")]
 fn set_anchor_locked(
     inodes: &mut MultikeyBTreeMap<u64, InodeAltKey, Arc<InodeData>>,
     data: &Arc<InodeData>,
@@ -849,7 +854,6 @@ fn set_anchor_locked(
     }
 }
 
-#[cfg(target_os = "linux")]
 fn decrement_anchor_children_locked(
     inodes: &mut MultikeyBTreeMap<u64, InodeAltKey, Arc<InodeData>>,
     inode: u64,
@@ -875,7 +879,6 @@ fn decrement_anchor_children_locked(
     maybe_remove_inode_locked(inodes, inode);
 }
 
-#[cfg(target_os = "linux")]
 fn maybe_remove_inode_locked(
     inodes: &mut MultikeyBTreeMap<u64, InodeAltKey, Arc<InodeData>>,
     inode: u64,
@@ -896,7 +899,17 @@ fn maybe_remove_inode_locked(
 
     let anchor_parent = data.anchor_parent.load(Ordering::Acquire);
     if let Some(removed) = inodes.remove(&inode) {
-        let _ = removed.retained_fd.lock().unwrap().take();
+        #[cfg(target_os = "linux")]
+        {
+            let _ = removed.retained_fd.lock().unwrap().take();
+        }
+        #[cfg(target_os = "macos")]
+        {
+            let ufd = removed.unlinked_fd.load(Ordering::Acquire);
+            if ufd >= 0 {
+                unsafe { libc::close(ufd as i32) };
+            }
+        }
     }
 
     if anchor_parent != 0 {

--- a/crates/filesystem/lib/backends/passthroughfs/unix/inode.rs
+++ b/crates/filesystem/lib/backends/passthroughfs/unix/inode.rs
@@ -19,12 +19,12 @@
 #[cfg(target_os = "linux")]
 use std::fs::File;
 #[cfg(target_os = "linux")]
-use std::os::fd::{FromRawFd, RawFd};
+use std::os::fd::FromRawFd;
 use std::{
     collections::HashSet,
     ffi::CStr,
     io,
-    os::fd::AsRawFd,
+    os::fd::{AsRawFd, RawFd},
     sync::{Arc, atomic::Ordering},
 };
 
@@ -204,6 +204,293 @@ fn open_macos_inode_reopen(path: *const libc::c_char, flags: i32) -> io::Result<
     ))
 }
 
+/// Walk `components` from the share root with `openat(O_NOFOLLOW)` per step.
+///
+/// Intermediate components open with `O_DIRECTORY`; the last component opens
+/// with `flags`. A symlink swapped in for an intermediate directory fails
+/// closed as `ENOTDIR` — the same "stale alias" signal as a renamed-away
+/// directory. A symlink at the final component fails as `ELOOP`, unless
+/// `final_symlink` is set, in which case the link itself is opened via
+/// `O_SYMLINK` so its own identity and metadata can still be read. `..`,
+/// empty, or slash-bearing components are refused before any syscall. The
+/// caller owns the returned fd.
+#[cfg(target_os = "macos")]
+pub(crate) fn secure_open_path_macos(
+    fs: &PassthroughFs,
+    components: &[Vec<u8>],
+    flags: i32,
+    final_symlink: bool,
+) -> io::Result<RawFd> {
+    let root_fd = unsafe { libc::fcntl(fs.root_fd.as_raw_fd(), libc::F_DUPFD_CLOEXEC, 0) };
+    if root_fd < 0 {
+        return Err(platform::linux_error(io::Error::last_os_error()));
+    }
+    if components.is_empty() {
+        return Ok(root_fd);
+    }
+
+    let mut current_fd = root_fd;
+    for (index, component) in components.iter().enumerate() {
+        if let Err(err) = validate_component(component) {
+            unsafe { libc::close(current_fd) };
+            return Err(err);
+        }
+        let name = match std::ffi::CString::new(component.as_slice()) {
+            Ok(name) => name,
+            Err(_) => {
+                unsafe { libc::close(current_fd) };
+                return Err(platform::einval());
+            }
+        };
+        let is_last = index + 1 == components.len();
+        let open_flags = if is_last {
+            flags | libc::O_NOFOLLOW | libc::O_CLOEXEC
+        } else {
+            libc::O_RDONLY | libc::O_NOFOLLOW | libc::O_DIRECTORY | libc::O_CLOEXEC
+        };
+        let next_fd = unsafe { libc::openat(current_fd, name.as_ptr(), open_flags) };
+        if next_fd >= 0 {
+            unsafe { libc::close(current_fd) };
+            current_fd = next_fd;
+            continue;
+        }
+
+        // Capture errno immediately: any intervening syscall (including the
+        // close below) can clobber it before we get to inspect it.
+        let open_err = io::Error::last_os_error();
+
+        if is_last && final_symlink && open_err.raw_os_error() == Some(libc::ELOOP) {
+            let symlink_flags = (flags & !libc::O_NOFOLLOW) | libc::O_SYMLINK | libc::O_CLOEXEC;
+            let symlink_fd = unsafe { libc::openat(current_fd, name.as_ptr(), symlink_flags) };
+            if symlink_fd >= 0 {
+                unsafe { libc::close(current_fd) };
+                return Ok(symlink_fd);
+            }
+            let symlink_err = io::Error::last_os_error();
+            unsafe { libc::close(current_fd) };
+            return Err(platform::linux_error(symlink_err));
+        }
+
+        unsafe { libc::close(current_fd) };
+        if !is_last && open_err.raw_os_error() == Some(libc::ELOOP) {
+            return Err(platform::enotdir());
+        }
+        return Err(platform::linux_error(open_err));
+    }
+
+    Ok(current_fd)
+}
+
+/// Confirm an anchor-walked fd is the inode we admitted at lookup time.
+#[cfg(target_os = "macos")]
+fn validate_identity_macos(fd: RawFd, data: &InodeData) -> io::Result<()> {
+    let st = platform::fstat(fd)?;
+    if platform::stat_ino(&st) != data.ino || platform::stat_dev(&st) != data.dev {
+        return Err(platform::enoent());
+    }
+    Ok(())
+}
+
+/// Reopen a tracked inode by anchor walk with `flags` on the final component.
+///
+/// The root inode has no alias and resolves directly to a dup of `root_fd`.
+/// For every other inode, tries the current anchor first, then every other
+/// known alias. A stale alias — the final component failing `ENOENT` or
+/// `ENOTDIR`, or an identity mismatch on open — means "try the next alias";
+/// any other error (fd exhaustion, permissions, I/O, or `ELOOP` when
+/// `final_symlink` is false and the target really is a symlink) is a
+/// host-side problem and is preserved so it is not misreported as a missing
+/// file. When a non-current alias succeeds the anchor is repaired to it.
+#[cfg(target_os = "macos")]
+pub(crate) fn open_anchor_fd_macos(
+    fs: &PassthroughFs,
+    inode: u64,
+    flags: i32,
+    final_symlink: bool,
+) -> io::Result<RawFd> {
+    if inode == 1 {
+        return secure_open_path_macos(fs, &[], flags, final_symlink);
+    }
+
+    let inodes = fs.inodes.read().unwrap();
+    let data = inodes.get(&inode).cloned().ok_or_else(platform::ebadf)?;
+
+    let current_anchor = current_anchor_alias(&data);
+    let candidates = candidate_aliases(&data, current_anchor.clone());
+    let mut host_err: Option<io::Error> = None;
+    for alias in candidates {
+        let mut seen = HashSet::new();
+        let components = match build_alias_components_locked(&inodes, &alias, &mut seen) {
+            Ok(components) => components,
+            Err(_) => continue,
+        };
+        let fd = match secure_open_path_macos(fs, &components, flags, final_symlink) {
+            Ok(fd) => fd,
+            Err(err) => {
+                let stale = [platform::enoent(), platform::enotdir()]
+                    .iter()
+                    .any(|stale| stale.raw_os_error() == err.raw_os_error());
+                if !stale {
+                    host_err = Some(err);
+                }
+                continue;
+            }
+        };
+        match validate_identity_macos(fd, &data) {
+            Ok(()) => {
+                drop(inodes);
+                if current_anchor.as_ref() != Some(&alias) {
+                    repair_anchor(fs, inode, &alias);
+                }
+                return Ok(fd);
+            }
+            Err(err) => {
+                unsafe { libc::close(fd) };
+                if err.raw_os_error() != platform::enoent().raw_os_error() {
+                    host_err = Some(err);
+                }
+            }
+        }
+    }
+
+    Err(host_err.unwrap_or_else(platform::enoent))
+}
+
+/// Reopen a tracked inode for `*at()`/getattr use via a single anchor walk.
+///
+/// `O_RDONLY` opens cleanly for both files and directories on macOS, so one
+/// walk covers both cases (no need for a directory-first, file-second retry
+/// pair). `final_symlink` is set so a symlink target can still be opened —
+/// via `O_SYMLINK` — and stat'ed instead of failing `ELOOP`.
+#[cfg(target_os = "macos")]
+fn open_anchor_reopen_macos(fs: &PassthroughFs, inode: u64) -> io::Result<RawFd> {
+    open_anchor_fd_macos(fs, inode, libc::O_RDONLY, true)
+}
+
+/// Open the anchor's parent directory and return it with the entry name.
+///
+/// Used by operations that need a `(dirfd, name)` pair on macOS instead of an
+/// fd on the inode itself: readlink, symlink times, symlink-fd opens, and hard
+/// link sources. The name is verified to still refer to the tracked identity.
+///
+/// Unused until a later change wires it into those operations.
+#[cfg(target_os = "macos")]
+#[allow(dead_code)]
+pub(crate) fn anchor_parent_and_name_macos(
+    fs: &PassthroughFs,
+    inode: u64,
+) -> io::Result<(InodeFd, std::ffi::CString)> {
+    let inodes = fs.inodes.read().unwrap();
+    let data = inodes.get(&inode).cloned().ok_or_else(platform::ebadf)?;
+    let current_anchor = current_anchor_alias(&data);
+    let candidates = candidate_aliases(&data, current_anchor.clone());
+    let mut host_err: Option<io::Error> = None;
+    for alias in candidates {
+        let mut seen = HashSet::new();
+        let components = match build_alias_components_locked(&inodes, &alias, &mut seen) {
+            Ok(components) => components,
+            Err(_) => continue,
+        };
+        let Some((name, parents)) = components.split_last() else {
+            continue;
+        };
+        let parent_fd =
+            match secure_open_path_macos(fs, parents, libc::O_RDONLY | libc::O_DIRECTORY, false) {
+                Ok(fd) => fd,
+                Err(err) => {
+                    let stale = [platform::enoent(), platform::enotdir()]
+                        .iter()
+                        .any(|stale| stale.raw_os_error() == err.raw_os_error());
+                    if !stale {
+                        host_err = Some(err);
+                    }
+                    continue;
+                }
+            };
+        let name = match std::ffi::CString::new(name.as_slice()) {
+            Ok(name) => name,
+            Err(_) => {
+                unsafe { libc::close(parent_fd) };
+                continue;
+            }
+        };
+        match platform::fstatat_nofollow(parent_fd, &name) {
+            Ok(st)
+                if platform::stat_ino(&st) == data.ino && platform::stat_dev(&st) == data.dev =>
+            {
+                drop(inodes);
+                if current_anchor.as_ref() != Some(&alias) {
+                    repair_anchor(fs, inode, &alias);
+                }
+                return Ok((
+                    InodeFd {
+                        fd: parent_fd,
+                        owned: true,
+                    },
+                    name,
+                ));
+            }
+            Ok(_) => {
+                // Name resolves, but to a different identity: stale alias.
+                unsafe { libc::close(parent_fd) };
+            }
+            Err(err) => {
+                unsafe { libc::close(parent_fd) };
+                let stale = [platform::enoent(), platform::enotdir()]
+                    .iter()
+                    .any(|stale| stale.raw_os_error() == err.raw_os_error());
+                if !stale {
+                    host_err = Some(err);
+                }
+            }
+        }
+    }
+    Err(host_err.unwrap_or_else(platform::enoent))
+}
+
+/// Open a just-stat'ed child of `parent_fd` for stat patching in anchor mode.
+///
+/// Mirrors `open_macos_path_for_stat`, but relative to the parent directory
+/// instead of a volfs identity path.
+#[cfg(target_os = "macos")]
+pub(crate) fn open_child_for_stat_macos(parent_fd: i32, name: &CStr) -> io::Result<i32> {
+    let fd = unsafe {
+        libc::openat(
+            parent_fd,
+            name.as_ptr(),
+            libc::O_RDONLY | libc::O_CLOEXEC | libc::O_NOFOLLOW,
+        )
+    };
+    if fd >= 0 {
+        return Ok(fd);
+    }
+    let err = io::Error::last_os_error();
+    if err.raw_os_error() == Some(libc::ELOOP) {
+        let fd = unsafe {
+            libc::openat(
+                parent_fd,
+                name.as_ptr(),
+                libc::O_RDONLY | libc::O_CLOEXEC | libc::O_SYMLINK,
+            )
+        };
+        if fd >= 0 {
+            return Ok(fd);
+        }
+        return Err(platform::linux_error(io::Error::last_os_error()));
+    }
+    let fd = unsafe {
+        libc::openat(
+            parent_fd,
+            name.as_ptr(),
+            libc::O_RDONLY | libc::O_CLOEXEC | libc::O_NOFOLLOW | libc::O_DIRECTORY,
+        )
+    };
+    if fd < 0 {
+        return Err(platform::linux_error(io::Error::last_os_error()));
+    }
+    Ok(fd)
+}
+
 #[cfg(target_os = "macos")]
 pub(crate) fn vol_path(dev: u64, ino: u64) -> std::ffi::CString {
     use std::ffi::CString;
@@ -341,20 +628,59 @@ fn do_lookup_macos(
     parent_fd: i32,
     name: &CStr,
 ) -> io::Result<Entry> {
-    let st = platform::fstatat_nofollow(parent_fd, name)?;
-    let alt_key = InodeAltKey::new(platform::stat_ino(&st), platform::stat_dev(&st));
-
-    // Open a real fd for xattr access via /.vol/dev/ino.
-    let patched = open_and_patch_stat_macos(
-        platform::stat_dev(&st),
-        platform::stat_ino(&st),
-        st,
-        fs.cfg.xattr_enabled(),
-        fs.cfg.strict_enabled(),
-        fs.cfg.bind_identity_map.as_ref(),
-    )?;
-
     let anchor_mode = fs.anchor_mode();
+
+    // In anchor mode, open first and take both identity and metadata from
+    // that one fd, so a host-side replacement between the stat and the open
+    // cannot patch one inode's attributes with another inode's xattr data.
+    // Falls back to fstatat + unpatched stat only when the entry cannot be
+    // opened for a permission reason (no xattr could be read there either).
+    let (st, patched) = if anchor_mode {
+        match open_child_for_stat_macos(parent_fd, name) {
+            Ok(fd) => {
+                let st = match platform::fstat(fd) {
+                    Ok(st) => st,
+                    Err(err) => {
+                        unsafe { libc::close(fd) };
+                        return Err(err);
+                    }
+                };
+                let patched = patch_stat_with_open_macos(
+                    Ok(fd),
+                    st,
+                    fs.cfg.xattr_enabled(),
+                    fs.cfg.strict_enabled(),
+                    fs.cfg.bind_identity_map.as_ref(),
+                )?;
+                (st, patched)
+            }
+            Err(err) if matches!(err.raw_os_error(), Some(libc::EACCES) | Some(libc::EPERM)) => {
+                let st = platform::fstatat_nofollow(parent_fd, name)?;
+                let patched = patch_stat_with_open_macos(
+                    Err(err),
+                    st,
+                    fs.cfg.xattr_enabled(),
+                    fs.cfg.strict_enabled(),
+                    fs.cfg.bind_identity_map.as_ref(),
+                )?;
+                (st, patched)
+            }
+            Err(err) => return Err(err),
+        }
+    } else {
+        let st = platform::fstatat_nofollow(parent_fd, name)?;
+        let patched = open_and_patch_stat_macos(
+            platform::stat_dev(&st),
+            platform::stat_ino(&st),
+            st,
+            fs.cfg.xattr_enabled(),
+            fs.cfg.strict_enabled(),
+            fs.cfg.bind_identity_map.as_ref(),
+        )?;
+        (st, patched)
+    };
+
+    let alt_key = InodeAltKey::new(platform::stat_ino(&st), platform::stat_dev(&st));
     let alias = anchor_mode.then(|| NamespaceAlias::new(parent, name.to_bytes()));
 
     // Fast path (volfs mode only): most lookups hit an already-tracked inode
@@ -420,6 +746,38 @@ fn do_lookup_macos(
     })
 }
 
+/// Apply stat patching using an already-attempted fd open.
+///
+/// Falls back to the unpatched (identity-mapped) stat when the open failed,
+/// which keeps lookups working on hosts where neither volfs nor a relative
+/// reopen is possible for this entry.
+#[cfg(target_os = "macos")]
+fn patch_stat_with_open_macos(
+    opened: io::Result<i32>,
+    st: stat64,
+    xattr_enabled: bool,
+    strict: bool,
+    bind_identity_map: Option<&crate::backends::shared::stat_override::BindIdentityMapHandle>,
+) -> io::Result<stat64> {
+    if let Ok(fd) = opened {
+        let result = crate::backends::shared::stat_override::patched_stat(
+            fd,
+            st,
+            xattr_enabled,
+            strict,
+            bind_identity_map,
+        );
+        unsafe { libc::close(fd) };
+        return result;
+    }
+
+    let mut st = st;
+    if xattr_enabled {
+        crate::backends::shared::stat_override::apply_bind_identity_map(&mut st, bind_identity_map);
+    }
+    Ok(st)
+}
+
 /// Open a real fd via `/.vol/dev/ino` for xattr access and apply stat patching.
 ///
 /// Tries O_RDONLY first, then O_RDONLY|O_DIRECTORY (for directories that reject
@@ -436,28 +794,13 @@ fn open_and_patch_stat_macos(
     bind_identity_map: Option<&crate::backends::shared::stat_override::BindIdentityMapHandle>,
 ) -> io::Result<stat64> {
     let path = vol_path(dev, ino);
-
-    // Try regular file open first. If the inode is a symlink, fall back to
-    // O_SYMLINK so we can read override metadata from the link itself without
-    // following it.
-    if let Ok(fd) = open_macos_path_for_stat(path.as_ptr()) {
-        let result = crate::backends::shared::stat_override::patched_stat(
-            fd,
-            st,
-            xattr_enabled,
-            strict,
-            bind_identity_map,
-        );
-        unsafe { libc::close(fd) };
-        return result;
-    }
-
-    // Can't open — return the safe mapped fallback when stat virtualization is on.
-    let mut st = st;
-    if xattr_enabled {
-        crate::backends::shared::stat_override::apply_bind_identity_map(&mut st, bind_identity_map);
-    }
-    Ok(st)
+    patch_stat_with_open_macos(
+        open_macos_path_for_stat(path.as_ptr()),
+        st,
+        xattr_enabled,
+        strict,
+        bind_identity_map,
+    )
 }
 
 #[cfg(target_os = "macos")]
@@ -545,7 +888,7 @@ pub(crate) fn get_inode_fd(fs: &PassthroughFs, inode: u64) -> io::Result<InodeFd
     #[cfg(target_os = "macos")]
     {
         let inodes = fs.inodes.read().unwrap();
-        let data = inodes.get(&inode).ok_or_else(platform::ebadf)?;
+        let data = inodes.get(&inode).cloned().ok_or_else(platform::ebadf)?;
 
         // Try unlinked_fd first — /.vol/ path is invalid after unlink.
         let ufd = data.unlinked_fd.load(Ordering::Acquire);
@@ -556,6 +899,11 @@ pub(crate) fn get_inode_fd(fs: &PassthroughFs, inode: u64) -> io::Result<InodeFd
             }
         }
 
+        if fs.anchor_mode() {
+            drop(inodes);
+            let fd = open_anchor_reopen_macos(fs, inode)?;
+            return Ok(InodeFd { fd, owned: true });
+        }
         let fd = open_vol_fd(data.dev, data.ino)?;
         Ok(InodeFd { fd, owned: true })
     }
@@ -609,7 +957,6 @@ fn inode_alt_key(data: &InodeData) -> InodeAltKey {
     InodeAltKey::new(data.ino, data.dev, data.mnt_id)
 }
 
-#[allow(dead_code)]
 fn current_anchor_alias(data: &InodeData) -> Option<NamespaceAlias> {
     let parent = data.anchor_parent.load(Ordering::Acquire);
     if parent == 0 {
@@ -622,7 +969,6 @@ fn current_anchor_alias(data: &InodeData) -> Option<NamespaceAlias> {
     })
 }
 
-#[allow(dead_code)]
 fn candidate_aliases(
     data: &InodeData,
     current_anchor: Option<NamespaceAlias>,
@@ -643,7 +989,6 @@ fn candidate_aliases(
     result
 }
 
-#[allow(dead_code)]
 fn build_alias_components_locked(
     inodes: &MultikeyBTreeMap<u64, InodeAltKey, Arc<InodeData>>,
     alias: &NamespaceAlias,
@@ -659,7 +1004,6 @@ fn build_alias_components_locked(
     Ok(components)
 }
 
-#[allow(dead_code)]
 fn build_anchor_components_locked(
     inodes: &MultikeyBTreeMap<u64, InodeAltKey, Arc<InodeData>>,
     inode: u64,
@@ -677,7 +1021,6 @@ fn build_anchor_components_locked(
     build_alias_components_locked(inodes, &alias, seen)
 }
 
-#[allow(dead_code)]
 fn validate_component(component: &[u8]) -> io::Result<()> {
     if component.is_empty() || component == b"." {
         return Err(platform::einval());
@@ -786,7 +1129,6 @@ fn dup_retained_fd_linux(data: &InodeData) -> io::Result<Option<RawFd>> {
     Ok(Some(fd))
 }
 
-#[allow(dead_code)]
 fn repair_anchor(fs: &PassthroughFs, inode: u64, alias: &NamespaceAlias) {
     let mut inodes = fs.inodes.write().unwrap();
     let Some(data) = inodes.get(&inode).cloned() else {
@@ -965,7 +1307,7 @@ pub(crate) fn open_inode_fd(fs: &PassthroughFs, inode: u64, flags: i32) -> io::R
     #[cfg(target_os = "macos")]
     {
         let inodes = fs.inodes.read().unwrap();
-        let data = inodes.get(&inode).ok_or_else(platform::ebadf)?;
+        let data = inodes.get(&inode).cloned().ok_or_else(platform::ebadf)?;
 
         // If the file was unlinked, dup the preserved fd instead of using /.vol/ path.
         let ufd = data.unlinked_fd.load(Ordering::Acquire);
@@ -977,6 +1319,33 @@ pub(crate) fn open_inode_fd(fs: &PassthroughFs, inode: u64, flags: i32) -> io::R
             // Fall through to /.vol/ path if dup fails.
         }
 
+        if fs.anchor_mode() {
+            drop(inodes);
+            // A reopen targets an already-admitted inode by identity, not a
+            // fresh path lookup: O_CREAT makes no sense here (do_create
+            // already created the file before this reopen runs), and
+            // O_TRUNC must not reach the walk's final openat, or a
+            // host-side replacement at the anchored name would be
+            // truncated before validate_identity_macos gets a chance to
+            // reject it. Truncate only after the identity check passes.
+            // O_EXCL is meaningless without O_CREAT (nothing left to
+            // exclude against) and must NOT be rejected here: do_create's
+            // reopen of a just-created file
+            // (open_inode_fd(fs, entry.inode, open_flags & !O_CREAT)) keeps
+            // O_EXCL set, so rejecting it would break every guest
+            // O_CREAT|O_EXCL create in anchor mode.
+            if flags & libc::O_CREAT != 0 {
+                return Err(platform::einval());
+            }
+            let walk_flags = flags & !(libc::O_NOFOLLOW | libc::O_TRUNC | libc::O_EXCL);
+            let fd = open_anchor_fd_macos(fs, inode, walk_flags, false)?;
+            if flags & libc::O_TRUNC != 0 && unsafe { libc::ftruncate(fd, 0) } < 0 {
+                let err = io::Error::last_os_error();
+                unsafe { libc::close(fd) };
+                return Err(platform::linux_error(err));
+            }
+            return Ok(fd);
+        }
         let path = vol_path(data.dev, data.ino);
         open_macos_inode_reopen(path.as_ptr(), flags)
     }
@@ -1013,7 +1382,7 @@ pub(crate) fn stat_inode(fs: &PassthroughFs, inode: u64) -> io::Result<stat64> {
     #[cfg(target_os = "macos")]
     {
         let inodes = fs.inodes.read().unwrap();
-        let data = inodes.get(&inode).ok_or_else(platform::ebadf)?;
+        let data = inodes.get(&inode).cloned().ok_or_else(platform::ebadf)?;
 
         // Try unlinked_fd first — /.vol/ path is invalid after unlink.
         let ufd = data.unlinked_fd.load(Ordering::Acquire);
@@ -1026,6 +1395,22 @@ pub(crate) fn stat_inode(fs: &PassthroughFs, inode: u64) -> io::Result<stat64> {
                 fs.cfg.strict_enabled(),
                 fs.cfg.bind_identity_map.as_ref(),
             );
+        }
+
+        if fs.anchor_mode() {
+            drop(inodes);
+            let fd = open_anchor_reopen_macos(fs, inode)?;
+            let result = platform::fstat(fd).and_then(|st| {
+                crate::backends::shared::stat_override::patched_stat(
+                    fd,
+                    st,
+                    fs.cfg.xattr_enabled(),
+                    fs.cfg.strict_enabled(),
+                    fs.cfg.bind_identity_map.as_ref(),
+                )
+            });
+            unsafe { libc::close(fd) };
+            return result;
         }
 
         if let Ok(fd) = open_vol_fd(data.dev, data.ino) {

--- a/crates/filesystem/lib/backends/passthroughfs/unix/inode.rs
+++ b/crates/filesystem/lib/backends/passthroughfs/unix/inode.rs
@@ -6,8 +6,24 @@
 //! yielding 3 syscalls instead of the naive 4 (fstatat + statx + open + getxattr). The stat
 //! is taken on the *opened* fd, eliminating TOCTOU between stat and open.
 //!
-//! macOS lookup uses fstatat → inode table check → register, with a separate fd open
-//! via `/.vol/dev/ino` for xattr access (since macOS doesn't store per-inode O_PATH fds).
+//! macOS lookup uses fstatat → inode table check → register, and reopens tracked
+//! inodes in one of two modes, chosen once per share by the volfs probe:
+//!
+//! - Volfs mode, used when the share root's filesystem answers `/.vol/<dev>/<ino>`
+//!   lookups: an inode is reopened by its identity path, which stays valid across
+//!   host-side renames.
+//! - Anchor mode, used when it does not (FSKit-backed volumes such as exFAT on
+//!   macOS 15 reject every volfs lookup): an inode is reopened by an
+//!   `openat(O_NOFOLLOW)` walk from the retained root fd along a recorded
+//!   (parent inode, name) alias, followed by an `(st_dev, st_ino)` check on the
+//!   opened fd.
+//!
+//! Residual guarantees in anchor mode: identity is always verified after the open,
+//! so a host-side replacement of an anchored name is refused rather than served;
+//! path-based resolution can still go stale while the walk runs if the host renames
+//! an intermediate directory (the same exposure the Linux backend has); and the hard
+//! link source and readlink are name-bound between the verification and the syscall,
+//! because macOS has no fd-relative form of either call.
 //!
 //! ## Procfd Reopen
 //!
@@ -164,6 +180,21 @@ pub(crate) fn store_unlinked_fd(data: &InodeData, fd: i32) {
     }
 }
 
+/// Whether a walk failure means "this alias no longer names the inode".
+///
+/// A final component that is missing, or an intermediate component that is no
+/// longer a directory, is the stale-alias signal: the caller tries the next
+/// alias. Every other error is a host-side condition and must be preserved.
+#[cfg(target_os = "macos")]
+fn is_stale_walk_error(err: &io::Error) -> bool {
+    matches!(
+        err.raw_os_error(),
+        Some(code)
+            if Some(code) == platform::enoent().raw_os_error()
+                || Some(code) == platform::enotdir().raw_os_error()
+    )
+}
+
 #[cfg(target_os = "macos")]
 fn is_unsupported_macos_reopen_flag(err: &io::Error) -> bool {
     matches!(
@@ -293,7 +324,11 @@ fn validate_identity_macos(fd: RawFd, data: &InodeData) -> io::Result<()> {
 
 /// Reopen a tracked inode by anchor walk with `flags` on the final component.
 ///
-/// The root inode has no alias and resolves directly to a dup of `root_fd`.
+/// The root inode has no alias and resolves by opening `"."` relative to
+/// `root_fd`. That is a fresh file description, not a dup: a dup would share
+/// `root_fd`'s seek offset, so two concurrent root directory handles would
+/// corrupt each other's `readdir`, and a write-intent reopen of the root would
+/// hand back a readable fd instead of failing `EISDIR`.
 /// For every other inode, tries the current anchor first, then every other
 /// known alias. A stale alias — the final component failing `ENOENT` or
 /// `ENOTDIR`, or an identity mismatch on open — means "try the next alias";
@@ -309,7 +344,13 @@ pub(crate) fn open_anchor_fd_macos(
     final_symlink: bool,
 ) -> io::Result<RawFd> {
     if inode == 1 {
-        return secure_open_path_macos(fs, &[], flags, final_symlink);
+        // `.` is never a symlink, so dropping O_NOFOLLOW here is safe.
+        let open_flags = (flags & !libc::O_NOFOLLOW) | libc::O_DIRECTORY | libc::O_CLOEXEC;
+        let fd = unsafe { libc::openat(fs.root_fd.as_raw_fd(), c".".as_ptr(), open_flags) };
+        if fd < 0 {
+            return Err(platform::linux_error(io::Error::last_os_error()));
+        }
+        return Ok(fd);
     }
 
     let inodes = fs.inodes.read().unwrap();
@@ -327,10 +368,7 @@ pub(crate) fn open_anchor_fd_macos(
         let fd = match secure_open_path_macos(fs, &components, flags, final_symlink) {
             Ok(fd) => fd,
             Err(err) => {
-                let stale = [platform::enoent(), platform::enotdir()]
-                    .iter()
-                    .any(|stale| stale.raw_os_error() == err.raw_os_error());
-                if !stale {
+                if !is_stale_walk_error(&err) {
                     host_err = Some(err);
                 }
                 continue;
@@ -356,15 +394,127 @@ pub(crate) fn open_anchor_fd_macos(
     Err(host_err.unwrap_or_else(platform::enoent))
 }
 
+/// Clear `O_NONBLOCK` on a descriptor that was opened non-blocking only so the
+/// open itself could not park the caller.
+#[cfg(target_os = "macos")]
+pub(crate) fn clear_nonblock_macos(fd: RawFd) -> io::Result<()> {
+    let flags = unsafe { libc::fcntl(fd, libc::F_GETFL) };
+    if flags < 0 {
+        return Err(platform::linux_error(io::Error::last_os_error()));
+    }
+    if unsafe { libc::fcntl(fd, libc::F_SETFL, flags & !libc::O_NONBLOCK) } < 0 {
+        return Err(platform::linux_error(io::Error::last_os_error()));
+    }
+    Ok(())
+}
+
+/// Open the final component of an I/O reopen, counting FIFO endpoint opens.
+///
+/// Every endpoint open this path makes goes through here, so a test can see
+/// exactly how many times the reopen touched a FIFO — an endpoint that is
+/// opened and thrown away is otherwise invisible from outside the process.
+/// The count is taken before the syscall: the attempt is what completes a
+/// rendezvous, whether or not it succeeds.
+#[cfg(target_os = "macos")]
+fn open_endpoint_macos(
+    fs: &PassthroughFs,
+    parent_fd: RawFd,
+    name: &CStr,
+    flags: i32,
+    is_fifo: bool,
+) -> RawFd {
+    #[cfg(test)]
+    if is_fifo {
+        fs.fifo_endpoint_opens.fetch_add(1, Ordering::AcqRel);
+    }
+    #[cfg(not(test))]
+    let _ = is_fifo;
+    let _ = fs;
+    unsafe { libc::openat(parent_fd, name.as_ptr(), flags) }
+}
+
+/// Reopen a tracked inode for guest I/O.
+///
+/// No file is ever opened here "just to look at it". A non-blocking read-open
+/// of a FIFO completes the rendezvous with a waiting writer, so a probe fd
+/// that is opened, inspected and thrown away can take a writer's bytes with
+/// it. The entry is therefore identified by `fstatat` on the verified parent,
+/// and exactly one open follows:
+///
+/// - A FIFO is opened blocking, the way the guest asked. The inode-table guard
+///   is already released by then, so only this worker waits, never the table.
+/// - Everything else is opened non-blocking and has the flag cleared once its
+///   identity is confirmed. The entry is not a FIFO, so the flag changes
+///   nothing except that a FIFO swapped in under the name between the
+///   `fstatat` and the open cannot park this worker; such a replacement is
+///   refused by the identity check that follows.
+///
+/// A guest that asked for `O_NONBLOCK` gets a single non-blocking open with no
+/// parent stat at all: nothing here waits, and a peerless write-open answers
+/// `ENXIO`, as POSIX says it should. The root inode takes the same path — it
+/// has no parent entry to stat, and a directory can never be a FIFO.
+#[cfg(target_os = "macos")]
+fn open_anchor_io_fd_macos(fs: &PassthroughFs, inode: u64, flags: i32) -> io::Result<RawFd> {
+    if flags & libc::O_NONBLOCK != 0 || inode == 1 {
+        return open_anchor_fd_macos(fs, inode, flags, false);
+    }
+
+    let data = {
+        let inodes = fs.inodes.read().unwrap();
+        inodes.get(&inode).cloned().ok_or_else(platform::ebadf)?
+    };
+    let (dir, name, st) = anchor_parent_name_stat_macos(fs, inode)?;
+    let is_fifo = st.st_mode & libc::S_IFMT == libc::S_IFIFO;
+    let open_flags = if is_fifo {
+        flags | libc::O_NOFOLLOW | libc::O_CLOEXEC
+    } else {
+        flags | libc::O_NONBLOCK | libc::O_NOFOLLOW | libc::O_CLOEXEC
+    };
+
+    // The blocking open is the only place an anchor reopen waits on another
+    // process, so tests take their timing from here instead of guessing.
+    #[cfg(test)]
+    if is_fifo {
+        let hook = fs.before_blocking_fifo_open.read().unwrap().clone();
+        if let Some(hook) = hook {
+            hook();
+        }
+    }
+
+    let fd = open_endpoint_macos(fs, dir.raw(), &name, open_flags, is_fifo);
+    if fd < 0 {
+        // Capture errno before `dir` drops: its Drop closes the fd, and
+        // close(2) can clobber errno.
+        let err = io::Error::last_os_error();
+        return Err(platform::linux_error(err));
+    }
+    // The name was verified before the open, so a mismatch here means the
+    // entry was replaced in between: refuse it rather than serve it.
+    if let Err(err) = validate_identity_macos(fd, &data) {
+        unsafe { libc::close(fd) };
+        return Err(err);
+    }
+    if !is_fifo && let Err(err) = clear_nonblock_macos(fd) {
+        unsafe { libc::close(fd) };
+        return Err(err);
+    }
+    Ok(fd)
+}
+
 /// Reopen a tracked inode for `*at()`/getattr use via a single anchor walk.
 ///
 /// `O_RDONLY` opens cleanly for both files and directories on macOS, so one
 /// walk covers both cases (no need for a directory-first, file-second retry
 /// pair). `final_symlink` is set so a symlink target can still be opened —
 /// via `O_SYMLINK` — and stat'ed instead of failing `ELOOP`.
+///
+/// `O_NONBLOCK` keeps a tracked FIFO from parking the FUSE worker until a
+/// writer appears; the fd is used only for `fstat` and `fgetxattr`, never
+/// handed to the guest, so the flag cannot leak into a guest handle. It also
+/// carries into the `O_SYMLINK` retry inside the walk.
 #[cfg(target_os = "macos")]
 fn open_anchor_reopen_macos(fs: &PassthroughFs, inode: u64) -> io::Result<RawFd> {
-    open_anchor_fd_macos(fs, inode, libc::O_RDONLY, true)
+    open_anchor_fd_macos(fs, inode, libc::O_RDONLY | libc::O_NONBLOCK, true)
 }
 
 /// Open the anchor's parent directory and return it with the entry name.
@@ -372,11 +522,31 @@ fn open_anchor_reopen_macos(fs: &PassthroughFs, inode: u64) -> io::Result<RawFd>
 /// Used by operations that need a `(dirfd, name)` pair on macOS instead of an
 /// fd on the inode itself: readlink, symlink times, symlink-fd opens, and hard
 /// link sources. The name is verified to still refer to the tracked identity.
+///
+/// The root inode is refused: it is inode 1 by FUSE convention and has no
+/// parent entry inside the share, so there is no `(dirfd, name)` pair for it.
 #[cfg(target_os = "macos")]
 pub(crate) fn anchor_parent_and_name_macos(
     fs: &PassthroughFs,
     inode: u64,
 ) -> io::Result<(InodeFd, std::ffi::CString)> {
+    anchor_parent_name_stat_macos(fs, inode).map(|(dir, name, _)| (dir, name))
+}
+
+/// `anchor_parent_and_name_macos` plus the `fstatat` the verification used.
+///
+/// The entry's type decides how the caller may open it, and that answer has to
+/// come from the stat that verified the identity — not from opening the entry
+/// to find out, which for a FIFO would already be a rendezvous.
+#[cfg(target_os = "macos")]
+fn anchor_parent_name_stat_macos(
+    fs: &PassthroughFs,
+    inode: u64,
+) -> io::Result<(InodeFd, std::ffi::CString, stat64)> {
+    if inode == 1 {
+        return Err(platform::einval());
+    }
+
     let inodes = fs.inodes.read().unwrap();
     let data = inodes.get(&inode).cloned().ok_or_else(platform::ebadf)?;
     let current_anchor = current_anchor_alias(&data);
@@ -395,10 +565,7 @@ pub(crate) fn anchor_parent_and_name_macos(
             match secure_open_path_macos(fs, parents, libc::O_RDONLY | libc::O_DIRECTORY, false) {
                 Ok(fd) => fd,
                 Err(err) => {
-                    let stale = [platform::enoent(), platform::enotdir()]
-                        .iter()
-                        .any(|stale| stale.raw_os_error() == err.raw_os_error());
-                    if !stale {
+                    if !is_stale_walk_error(&err) {
                         host_err = Some(err);
                     }
                     continue;
@@ -425,6 +592,7 @@ pub(crate) fn anchor_parent_and_name_macos(
                         owned: true,
                     },
                     name,
+                    st,
                 ));
             }
             Ok(_) => {
@@ -433,10 +601,7 @@ pub(crate) fn anchor_parent_and_name_macos(
             }
             Err(err) => {
                 unsafe { libc::close(parent_fd) };
-                let stale = [platform::enoent(), platform::enotdir()]
-                    .iter()
-                    .any(|stale| stale.raw_os_error() == err.raw_os_error());
-                if !stale {
+                if !is_stale_walk_error(&err) {
                     host_err = Some(err);
                 }
             }
@@ -449,13 +614,17 @@ pub(crate) fn anchor_parent_and_name_macos(
 ///
 /// Mirrors `open_macos_path_for_stat`, but relative to the parent directory
 /// instead of a volfs identity path.
+///
+/// `O_NONBLOCK` keeps a FIFO child from parking the FUSE worker until a writer
+/// appears. The fd never reaches the guest: the caller uses it for `fstat` and
+/// `fgetxattr` and then closes it.
 #[cfg(target_os = "macos")]
 pub(crate) fn open_child_for_stat_macos(parent_fd: i32, name: &CStr) -> io::Result<i32> {
     let fd = unsafe {
         libc::openat(
             parent_fd,
             name.as_ptr(),
-            libc::O_RDONLY | libc::O_CLOEXEC | libc::O_NOFOLLOW,
+            libc::O_RDONLY | libc::O_CLOEXEC | libc::O_NOFOLLOW | libc::O_NONBLOCK,
         )
     };
     if fd >= 0 {
@@ -467,7 +636,7 @@ pub(crate) fn open_child_for_stat_macos(parent_fd: i32, name: &CStr) -> io::Resu
             libc::openat(
                 parent_fd,
                 name.as_ptr(),
-                libc::O_RDONLY | libc::O_CLOEXEC | libc::O_SYMLINK,
+                libc::O_RDONLY | libc::O_CLOEXEC | libc::O_SYMLINK | libc::O_NONBLOCK,
             )
         };
         if fd >= 0 {
@@ -630,8 +799,10 @@ fn do_lookup_macos(
     // In anchor mode, open first and take both identity and metadata from
     // that one fd, so a host-side replacement between the stat and the open
     // cannot patch one inode's attributes with another inode's xattr data.
-    // Falls back to fstatat + unpatched stat only when the entry cannot be
-    // opened for a permission reason (no xattr could be read there either).
+    // Falls back to fstatat + unpatched stat whenever the entry cannot be
+    // opened at all — a denied permission, a socket, a device node the host
+    // refuses to open — because volfs mode reports those entries too. Only an
+    // fstatat failure fails the lookup.
     let (st, patched) = if anchor_mode {
         match open_child_for_stat_macos(parent_fd, name) {
             Ok(fd) => {
@@ -651,7 +822,7 @@ fn do_lookup_macos(
                 )?;
                 (st, patched)
             }
-            Err(err) if matches!(err.raw_os_error(), Some(libc::EACCES) | Some(libc::EPERM)) => {
+            Err(err) => {
                 let st = platform::fstatat_nofollow(parent_fd, name)?;
                 let patched = patch_stat_with_open_macos(
                     Err(err),
@@ -662,7 +833,6 @@ fn do_lookup_macos(
                 )?;
                 (st, patched)
             }
-            Err(err) => return Err(err),
         }
     } else {
         let st = platform::fstatat_nofollow(parent_fd, name)?;
@@ -1166,6 +1336,37 @@ pub(crate) fn remove_alias_locked(
     data.aliases.read().unwrap().is_empty()
 }
 
+/// Hold a parent inode in the table while a caller reshuffles anchors.
+///
+/// A forgotten directory survives only through the children anchored to it,
+/// so it is collected as soon as its last anchored child moves away. An
+/// exchange across directories moves two children one after the other, and
+/// the parent the second move is about to re-anchor to can disappear in
+/// between — leaving the second child pointing at a parent that is no longer
+/// in the table, and so unresolvable. Pinning both parents for the length of
+/// the exchange closes that window. Returns whether a pin was taken.
+#[cfg(target_os = "macos")]
+pub(crate) fn pin_anchor_parent_locked(
+    inodes: &MultikeyBTreeMap<u64, InodeAltKey, Arc<InodeData>>,
+    inode: u64,
+) -> bool {
+    let Some(data) = inodes.get(&inode) else {
+        return false;
+    };
+    data.anchor_children.fetch_add(1, Ordering::AcqRel);
+    true
+}
+
+/// Release a pin taken by `pin_anchor_parent_locked`, collecting the inode if
+/// nothing else holds it any more.
+#[cfg(target_os = "macos")]
+pub(crate) fn unpin_anchor_parent_locked(
+    inodes: &mut MultikeyBTreeMap<u64, InodeAltKey, Arc<InodeData>>,
+    inode: u64,
+) {
+    decrement_anchor_children_locked(inodes, inode);
+}
+
 fn set_anchor_locked(
     inodes: &mut MultikeyBTreeMap<u64, InodeAltKey, Arc<InodeData>>,
     data: &Arc<InodeData>,
@@ -1236,17 +1437,12 @@ fn maybe_remove_inode_locked(
     }
 
     let anchor_parent = data.anchor_parent.load(Ordering::Acquire);
-    if let Some(removed) = inodes.remove(&inode) {
+    if let Some(_removed) = inodes.remove(&inode) {
+        // On macOS the retained fd is closed by `Drop for InodeData` when the
+        // last `Arc` goes away, so removal must not close it here as well.
         #[cfg(target_os = "linux")]
         {
-            let _ = removed.retained_fd.lock().unwrap().take();
-        }
-        #[cfg(target_os = "macos")]
-        {
-            let ufd = removed.unlinked_fd.load(Ordering::Acquire);
-            if ufd >= 0 {
-                unsafe { libc::close(ufd as i32) };
-            }
+            let _ = _removed.retained_fd.lock().unwrap().take();
         }
     }
 
@@ -1334,7 +1530,7 @@ pub(crate) fn open_inode_fd(fs: &PassthroughFs, inode: u64, flags: i32) -> io::R
                 return Err(platform::einval());
             }
             let walk_flags = flags & !(libc::O_NOFOLLOW | libc::O_TRUNC | libc::O_EXCL);
-            let fd = open_anchor_fd_macos(fs, inode, walk_flags, false)?;
+            let fd = open_anchor_io_fd_macos(fs, inode, walk_flags)?;
             if flags & libc::O_TRUNC != 0 && unsafe { libc::ftruncate(fd, 0) } < 0 {
                 let err = io::Error::last_os_error();
                 unsafe { libc::close(fd) };

--- a/crates/filesystem/lib/backends/passthroughfs/unix/inode.rs
+++ b/crates/filesystem/lib/backends/passthroughfs/unix/inode.rs
@@ -372,10 +372,7 @@ fn open_anchor_reopen_macos(fs: &PassthroughFs, inode: u64) -> io::Result<RawFd>
 /// Used by operations that need a `(dirfd, name)` pair on macOS instead of an
 /// fd on the inode itself: readlink, symlink times, symlink-fd opens, and hard
 /// link sources. The name is verified to still refer to the tracked identity.
-///
-/// Unused until a later change wires it into those operations.
 #[cfg(target_os = "macos")]
-#[allow(dead_code)]
 pub(crate) fn anchor_parent_and_name_macos(
     fs: &PassthroughFs,
     inode: u64,
@@ -1151,7 +1148,6 @@ pub(crate) fn register_alias_locked(
     }
 }
 
-#[allow(dead_code)]
 pub(crate) fn remove_alias_locked(
     inodes: &mut MultikeyBTreeMap<u64, InodeAltKey, Arc<InodeData>>,
     data: &Arc<InodeData>,

--- a/crates/filesystem/lib/backends/passthroughfs/unix/inode.rs
+++ b/crates/filesystem/lib/backends/passthroughfs/unix/inode.rs
@@ -20,10 +20,29 @@
 //!
 //! Residual guarantees in anchor mode: identity is always verified after the open,
 //! so a host-side replacement of an anchored name is refused rather than served;
-//! path-based resolution can still go stale while the walk runs if the host renames
-//! an intermediate directory (the same exposure the Linux backend has); and the hard
-//! link source and readlink are name-bound between the verification and the syscall,
-//! because macOS has no fd-relative form of either call.
+//! and path-based resolution can still go stale while the walk runs if the host
+//! renames an intermediate directory — that one exposure is shared with the
+//! Linux backend.
+//!
+//! The hard link source is name-bound in anchor mode, which is a macOS-only
+//! exposure: Linux links through `/proc/self/fd/N`, which is bound to the
+//! inode, while macOS has no fd-relative `linkat`. The source name is
+//! therefore resolved twice — once by the anchor verification, once by the
+//! syscall — and the created entry's identity is checked afterwards, reporting
+//! `ENOENT` when it does not hold the tracked inode.
+//!
+//! A source swapped before the `linkat` is detected even if the host puts the
+//! original name back afterwards: the created entry pins whichever inode the
+//! syscall captured, so the check still sees the replacement. That entry is
+//! left in place — it is the outcome an unchecked `linkat` would have had, and
+//! removing it by name would be a second name-based race — so the guest is
+//! refused while the host keeps the link.
+//!
+//! The check assumes `newname` still names the entry `linkat` created. A host
+//! that replaces the destination name before the `fstatat`, or between it and
+//! the `do_lookup` that follows, is a retained destination-name race: the
+//! source swap-and-restore alone is detected, this is not.
+//!
 //!
 //! ## Procfd Reopen
 //!

--- a/crates/filesystem/lib/backends/passthroughfs/unix/inode.rs
+++ b/crates/filesystem/lib/backends/passthroughfs/unix/inode.rs
@@ -43,6 +43,13 @@
 //! the `do_lookup` that follows, is a retained destination-name race: the
 //! source swap-and-restore alone is detected, this is not.
 //!
+//! readlink is name-bound in the same way: Linux reads a real symlink with
+//! `readlinkat(fd, "")`, which is identity-bound, while macOS cannot read a
+//! link through a descriptor at all, so its identity is checked again after
+//! the call too. Nothing pins the answer there, so a swap that is put back
+//! inside the window is not detected: verify A, substitute B, read B's target,
+//! restore A, and the check passes on A while the answer came from B.
+//!
 //!
 //! ## Procfd Reopen
 //!

--- a/crates/filesystem/lib/backends/passthroughfs/unix/metadata.rs
+++ b/crates/filesystem/lib/backends/passthroughfs/unix/metadata.rs
@@ -11,6 +11,8 @@
 //! (the host process lacks `CAP_CHOWN`). Size changes use real `ftruncate`, and timestamp
 //! changes use real `futimens`.
 
+#[cfg(target_os = "macos")]
+use std::ffi::CStr;
 use std::{
     fs::File,
     io,
@@ -20,6 +22,8 @@ use std::{
 
 use super::host_mode::{fchmod_mirror, fchmod_raw, host_strip_priv_bits, mirror_eligible_type};
 use super::{PassthroughFs, inode};
+#[cfg(target_os = "macos")]
+use crate::backends::shared::inode_table::InodeAltKey;
 use crate::{
     Context, SetattrValid,
     backends::shared::{init_binary, platform, stat_override},
@@ -223,7 +227,11 @@ pub(crate) fn do_setattr(
 
         #[cfg(target_os = "macos")]
         if guest_file_type == platform::MODE_LNK {
-            set_symlink_times_macos(fs, ino, &times)?;
+            // `fd` is the verified O_SYMLINK descriptor opened above. That
+            // holds because a FUSE handle on a symlink cannot exist: opening a
+            // symlink inode for I/O fails ELOOP, so `handle` is None here.
+            debug_assert!(handle.is_none(), "symlink setattr cannot carry a handle");
+            set_symlink_times_macos(fs, ino, fd, &times)?;
         } else {
             let ret = unsafe { libc::futimens(fd, times.as_ptr()) };
             if ret < 0 {
@@ -329,6 +337,56 @@ fn stat_handle(fs: &PassthroughFs, handle: u64) -> io::Result<stat64> {
     )
 }
 
+/// Open `name` under `parent_fd` with `O_SYMLINK` and confirm the opened link
+/// is the `expected` identity.
+///
+/// Split out of `open_symlink_inode_fd_macos` so this check can be exercised
+/// on its own. The parent-and-name resolution already refuses a name that no
+/// longer holds the tracked inode, so a test that replaces the entry before
+/// that step never reaches the open and proves nothing about the check here.
+/// This is the window the check covers: the entry is replaced after the name
+/// was verified and before the open.
+///
+/// `O_NONBLOCK` keeps a replacement FIFO from parking the caller, and the
+/// `fstat` comparison closes the substitution gap: on mismatch the fd is
+/// closed and `ENOENT` is returned instead of operating on the wrong file.
+#[cfg(target_os = "macos")]
+pub(crate) fn open_verified_symlink_fd(
+    parent_fd: i32,
+    name: &CStr,
+    expected: InodeAltKey,
+) -> io::Result<i32> {
+    let fd = unsafe {
+        libc::openat(
+            parent_fd,
+            name.as_ptr(),
+            libc::O_RDONLY | libc::O_CLOEXEC | libc::O_SYMLINK | libc::O_NONBLOCK,
+        )
+    };
+    // Capture errno here, before any caller-owned fd drops: close(2) can
+    // clobber the syscall's errno.
+    if fd < 0 {
+        let err = io::Error::last_os_error();
+        return Err(platform::linux_error(err));
+    }
+    match platform::fstat(fd) {
+        Ok(st)
+            if platform::stat_ino(&st) == expected.ino
+                && platform::stat_dev(&st) == expected.dev =>
+        {
+            Ok(fd)
+        }
+        Ok(_) => {
+            unsafe { libc::close(fd) };
+            Err(platform::enoent())
+        }
+        Err(err) => {
+            unsafe { libc::close(fd) };
+            Err(err)
+        }
+    }
+}
+
 fn clone_handle_file(fs: &PassthroughFs, handle: u64) -> io::Result<File> {
     let handles = fs.handles.read().unwrap();
     let data = handles.get(&handle).ok_or_else(platform::ebadf)?;
@@ -356,34 +414,8 @@ pub(crate) fn open_symlink_inode_fd_macos(fs: &PassthroughFs, ino: u64) -> io::R
             inodes.get(&ino).cloned().ok_or_else(platform::ebadf)?
         };
         let (dir, name) = inode::anchor_parent_and_name_macos(fs, ino)?;
-        let fd = unsafe {
-            libc::openat(
-                dir.raw(),
-                name.as_ptr(),
-                libc::O_RDONLY | libc::O_CLOEXEC | libc::O_SYMLINK | libc::O_NONBLOCK,
-            )
-        };
-        // Capture errno here, before `dir` drops (its Drop calls `close`,
-        // which can clobber the syscall's errno).
-        if fd < 0 {
-            let err = io::Error::last_os_error();
-            return Err(platform::linux_error(err));
-        }
-        return match platform::fstat(fd) {
-            Ok(st)
-                if platform::stat_ino(&st) == data.ino && platform::stat_dev(&st) == data.dev =>
-            {
-                Ok(fd)
-            }
-            Ok(_) => {
-                unsafe { libc::close(fd) };
-                Err(platform::enoent())
-            }
-            Err(err) => {
-                unsafe { libc::close(fd) };
-                Err(err)
-            }
-        };
+        let expected = InodeAltKey::new(data.ino, data.dev);
+        return open_verified_symlink_fd(dir.raw(), &name, expected);
     }
 
     let inodes = fs.inodes.read().unwrap();
@@ -402,22 +434,24 @@ pub(crate) fn open_symlink_inode_fd_macos(fs: &PassthroughFs, ino: u64) -> io::R
     Ok(fd)
 }
 
+/// Apply symlink timestamps on macOS.
+///
+/// In anchor mode `fd` is used directly: `do_setattr` already opened the
+/// symlink through `open_symlink_inode_fd_macos`, which verified the fd's
+/// identity, so `futimens` on it is bound to the tracked inode instead of the
+/// name a `utimensat` would trust — and the anchor walk runs once instead of
+/// twice. Volfs mode keeps the identity-path `utimensat`.
 #[cfg(target_os = "macos")]
 fn set_symlink_times_macos(
     fs: &PassthroughFs,
     ino: u64,
+    fd: i32,
     times: &[libc::timespec; 2],
 ) -> io::Result<()> {
     if fs.anchor_mode() {
-        // `open_symlink_inode_fd_macos` already verifies the fd's identity,
-        // so `futimens` on it is bound to the tracked inode instead of the
-        // name a name-based `utimensat` would trust.
-        let fd = open_symlink_inode_fd_macos(fs, ino)?;
         let ret = unsafe { libc::futimens(fd, times.as_ptr()) };
-        let err = (ret < 0).then(io::Error::last_os_error);
-        unsafe { libc::close(fd) };
-        if let Some(err) = err {
-            return Err(platform::linux_error(err));
+        if ret < 0 {
+            return Err(platform::linux_error(io::Error::last_os_error()));
         }
         return Ok(());
     }

--- a/crates/filesystem/lib/backends/passthroughfs/unix/metadata.rs
+++ b/crates/filesystem/lib/backends/passthroughfs/unix/metadata.rs
@@ -336,8 +336,56 @@ fn clone_handle_file(fs: &PassthroughFs, handle: u64) -> io::Result<File> {
     file.try_clone().map_err(platform::linux_error)
 }
 
+/// Open an `O_SYMLINK` fd on the tracked symlink inode.
+///
+/// In anchor mode, the anchor's parent-plus-name pair is name-based, so a
+/// host-side replacement of the entry between the anchor walk and the
+/// `openat` could hand back a different file: a replacement regular file
+/// would then take xattr/chmod operations meant for the symlink, and a
+/// replacement FIFO would block the open. `O_NONBLOCK` prevents the FIFO
+/// hang, and the post-open `fstat` identity check (against the inode's
+/// tracked `(dev, ino)`, cloned out of the inode table before the anchor
+/// walk so no read guard is held across it) closes the file-substitution
+/// gap: on mismatch the fd is closed and `ENOENT` is returned instead of
+/// operating on the wrong file.
 #[cfg(target_os = "macos")]
 pub(crate) fn open_symlink_inode_fd_macos(fs: &PassthroughFs, ino: u64) -> io::Result<i32> {
+    if fs.anchor_mode() {
+        let data = {
+            let inodes = fs.inodes.read().unwrap();
+            inodes.get(&ino).cloned().ok_or_else(platform::ebadf)?
+        };
+        let (dir, name) = inode::anchor_parent_and_name_macos(fs, ino)?;
+        let fd = unsafe {
+            libc::openat(
+                dir.raw(),
+                name.as_ptr(),
+                libc::O_RDONLY | libc::O_CLOEXEC | libc::O_SYMLINK | libc::O_NONBLOCK,
+            )
+        };
+        // Capture errno here, before `dir` drops (its Drop calls `close`,
+        // which can clobber the syscall's errno).
+        if fd < 0 {
+            let err = io::Error::last_os_error();
+            return Err(platform::linux_error(err));
+        }
+        return match platform::fstat(fd) {
+            Ok(st)
+                if platform::stat_ino(&st) == data.ino && platform::stat_dev(&st) == data.dev =>
+            {
+                Ok(fd)
+            }
+            Ok(_) => {
+                unsafe { libc::close(fd) };
+                Err(platform::enoent())
+            }
+            Err(err) => {
+                unsafe { libc::close(fd) };
+                Err(err)
+            }
+        };
+    }
+
     let inodes = fs.inodes.read().unwrap();
     let data = inodes.get(&ino).ok_or_else(platform::ebadf)?;
     let path = inode::vol_path(data.dev, data.ino);
@@ -360,6 +408,20 @@ fn set_symlink_times_macos(
     ino: u64,
     times: &[libc::timespec; 2],
 ) -> io::Result<()> {
+    if fs.anchor_mode() {
+        // `open_symlink_inode_fd_macos` already verifies the fd's identity,
+        // so `futimens` on it is bound to the tracked inode instead of the
+        // name a name-based `utimensat` would trust.
+        let fd = open_symlink_inode_fd_macos(fs, ino)?;
+        let ret = unsafe { libc::futimens(fd, times.as_ptr()) };
+        let err = (ret < 0).then(io::Error::last_os_error);
+        unsafe { libc::close(fd) };
+        if let Some(err) = err {
+            return Err(platform::linux_error(err));
+        }
+        return Ok(());
+    }
+
     let inodes = fs.inodes.read().unwrap();
     let data = inodes.get(&ino).ok_or_else(platform::ebadf)?;
     let path = inode::vol_path(data.dev, data.ino);

--- a/crates/filesystem/lib/backends/passthroughfs/unix/mod.rs
+++ b/crates/filesystem/lib/backends/passthroughfs/unix/mod.rs
@@ -222,6 +222,18 @@ pub struct PassthroughFs {
     #[cfg(target_os = "linux")]
     pub(crate) proc_self_fd: File,
 
+    /// Whether the share root's filesystem answers `/.vol/<dev>/<ino>` lookups.
+    ///
+    /// Probed once at construction. FSKit-backed filesystems on macOS 15+
+    /// (exFAT, for example) have no volfs; such shares resolve inodes by
+    /// anchor walk from `root_fd` instead of by identity path.
+    ///
+    /// Read by `anchor_mode`; consumed by the anchor-walk fallback added in a
+    /// later change.
+    #[cfg(target_os = "macos")]
+    #[allow(dead_code)]
+    pub(crate) volfs_supported: AtomicBool,
+
     /// Optional guest-write byte budget for this mount's subtree.
     pub(crate) quota: Option<super::quota::DirQuota>,
 }
@@ -329,6 +341,9 @@ impl PassthroughFs {
             unsafe { File::from_raw_fd(fd) }
         };
 
+        #[cfg(target_os = "macos")]
+        let volfs_supported = AtomicBool::new(probe_volfs_support(root_fd.as_raw_fd()));
+
         let quota = cfg.quota_bytes.map(|limit| {
             super::quota::DirQuota::new(
                 cfg.quota_root
@@ -352,12 +367,26 @@ impl PassthroughFs {
             has_openat2,
             #[cfg(target_os = "linux")]
             proc_self_fd,
+            #[cfg(target_os = "macos")]
+            volfs_supported,
             quota,
         })
     }
 }
 
 impl PassthroughFs {
+    /// Whether this share resolves inodes by anchor walk instead of `/.vol`.
+    ///
+    /// Unused outside tests until a later change wires the anchor-walk
+    /// fallback into inode resolution.
+    #[cfg(target_os = "macos")]
+    #[allow(dead_code)]
+    pub(crate) fn anchor_mode(&self) -> bool {
+        !self
+            .volfs_supported
+            .load(std::sync::atomic::Ordering::Acquire)
+    }
+
     /// Register root inode (inode 1) in the inode table.
     ///
     /// Called during `init()`. The guest kernel sends GETATTR on the root inode
@@ -400,13 +429,9 @@ impl PassthroughFs {
             refcount: AtomicU64::new(2), // libfuse convention: root gets refcount 2
             #[cfg(target_os = "linux")]
             mnt_id,
-            #[cfg(target_os = "linux")]
             anchor_parent: AtomicU64::new(0),
-            #[cfg(target_os = "linux")]
             anchor_name: RwLock::new(Vec::new()),
-            #[cfg(target_os = "linux")]
             aliases: RwLock::new(std::collections::BTreeSet::new()),
-            #[cfg(target_os = "linux")]
             anchor_children: AtomicU64::new(0),
             #[cfg(target_os = "linux")]
             retained_fd: Mutex::new(None),
@@ -978,6 +1003,36 @@ pub(crate) fn open_root(cfg: &PassthroughConfig) -> io::Result<File> {
     } else {
         open_dir_follow(&cfg.root_dir)
     }
+}
+
+/// Probe whether the filesystem holding `root_fd` supports volfs identity paths.
+///
+/// Opens `/.vol/<dev>/<ino>` for the root directory itself. FSKit-backed
+/// filesystems return ENOENT for every volfs path; a successful open means the
+/// backend can keep using identity paths for this share.
+#[cfg(target_os = "macos")]
+pub(crate) fn probe_volfs_support(root_fd: RawFd) -> bool {
+    let Ok(st) = platform::fstat(root_fd) else {
+        return false;
+    };
+    probe_volfs_path(platform::stat_dev(&st), platform::stat_ino(&st))
+}
+
+/// Open one volfs directory path and report whether it resolved.
+#[cfg(target_os = "macos")]
+pub(crate) fn probe_volfs_path(dev: u64, ino: u64) -> bool {
+    let path = inode::vol_path(dev, ino);
+    let fd = unsafe {
+        libc::open(
+            path.as_ptr(),
+            libc::O_RDONLY | libc::O_DIRECTORY | libc::O_CLOEXEC,
+        )
+    };
+    if fd < 0 {
+        return false;
+    }
+    unsafe { libc::close(fd) };
+    true
 }
 
 /// Open a directory by path, following symlinks (`O_DIRECTORY`).

--- a/crates/filesystem/lib/backends/passthroughfs/unix/mod.rs
+++ b/crates/filesystem/lib/backends/passthroughfs/unix/mod.rs
@@ -229,11 +229,28 @@ pub struct PassthroughFs {
     /// anchor walk from `root_fd` instead of by identity path.
     ///
     /// Read by `anchor_mode`, which gates the anchor-walk reopen fallback.
+    /// Atomic so tests can force the fallback on a volfs-capable host.
     #[cfg(target_os = "macos")]
     pub(crate) volfs_supported: AtomicBool,
 
     /// Optional guest-write byte budget for this mount's subtree.
     pub(crate) quota: Option<super::quota::DirQuota>,
+
+    /// Test-only hook fired immediately before a blocking FIFO open.
+    ///
+    /// That open is the one point where an anchor reopen waits on another
+    /// process, so tests synchronise on it instead of guessing with a sleep.
+    #[cfg(all(test, target_os = "macos"))]
+    pub(crate) before_blocking_fifo_open: RwLock<Option<Arc<dyn Fn() + Send + Sync>>>,
+
+    /// Test-only count of FIFO endpoint opens attempted by the anchor reopen
+    /// path.
+    ///
+    /// Opening a FIFO endpoint is a rendezvous, so the reopen path must do it
+    /// exactly once per guest open. Counting the attempt rather than the
+    /// result lets a test see an endpoint that was opened and thrown away.
+    #[cfg(all(test, target_os = "macos"))]
+    pub(crate) fifo_endpoint_opens: std::sync::atomic::AtomicUsize,
 }
 
 /// Open directory handle with a lazy point-in-time snapshot.
@@ -368,6 +385,10 @@ impl PassthroughFs {
             #[cfg(target_os = "macos")]
             volfs_supported,
             quota,
+            #[cfg(all(test, target_os = "macos"))]
+            before_blocking_fifo_open: RwLock::new(None),
+            #[cfg(all(test, target_os = "macos"))]
+            fifo_endpoint_opens: std::sync::atomic::AtomicUsize::new(0),
         })
     }
 }

--- a/crates/filesystem/lib/backends/passthroughfs/unix/mod.rs
+++ b/crates/filesystem/lib/backends/passthroughfs/unix/mod.rs
@@ -228,10 +228,8 @@ pub struct PassthroughFs {
     /// (exFAT, for example) have no volfs; such shares resolve inodes by
     /// anchor walk from `root_fd` instead of by identity path.
     ///
-    /// Read by `anchor_mode`; consumed by the anchor-walk fallback added in a
-    /// later change.
+    /// Read by `anchor_mode`, which gates the anchor-walk reopen fallback.
     #[cfg(target_os = "macos")]
-    #[allow(dead_code)]
     pub(crate) volfs_supported: AtomicBool,
 
     /// Optional guest-write byte budget for this mount's subtree.
@@ -376,11 +374,7 @@ impl PassthroughFs {
 
 impl PassthroughFs {
     /// Whether this share resolves inodes by anchor walk instead of `/.vol`.
-    ///
-    /// Unused outside tests until a later change wires the anchor-walk
-    /// fallback into inode resolution.
     #[cfg(target_os = "macos")]
-    #[allow(dead_code)]
     pub(crate) fn anchor_mode(&self) -> bool {
         !self
             .volfs_supported

--- a/crates/filesystem/lib/backends/passthroughfs/unix/mod.rs
+++ b/crates/filesystem/lib/backends/passthroughfs/unix/mod.rs
@@ -251,6 +251,15 @@ pub struct PassthroughFs {
     /// result lets a test see an endpoint that was opened and thrown away.
     #[cfg(all(test, target_os = "macos"))]
     pub(crate) fifo_endpoint_opens: std::sync::atomic::AtomicUsize,
+
+    /// Test-only hook fired between an anchor resolution and the name-bound
+    /// syscall that follows it.
+    ///
+    /// `linkat` names its source again after the anchor has verified it, so
+    /// tests need to act exactly in that window to prove the post-syscall
+    /// identity check does its job.
+    #[cfg(all(test, target_os = "macos"))]
+    pub(crate) before_name_bound_syscall: RwLock<Option<Arc<dyn Fn() + Send + Sync>>>,
 }
 
 /// Open directory handle with a lazy point-in-time snapshot.
@@ -389,11 +398,25 @@ impl PassthroughFs {
             before_blocking_fifo_open: RwLock::new(None),
             #[cfg(all(test, target_os = "macos"))]
             fifo_endpoint_opens: std::sync::atomic::AtomicUsize::new(0),
+            #[cfg(all(test, target_os = "macos"))]
+            before_name_bound_syscall: RwLock::new(None),
         })
     }
 }
 
 impl PassthroughFs {
+    /// Run the test-only name-bound syscall hook, if one is installed.
+    ///
+    /// The guard is released before the callback runs, so a hook may call back
+    /// into the filesystem.
+    #[cfg(all(test, target_os = "macos"))]
+    pub(crate) fn run_name_bound_hook(&self) {
+        let hook = self.before_name_bound_syscall.read().unwrap().clone();
+        if let Some(hook) = hook {
+            hook();
+        }
+    }
+
     /// Whether this share resolves inodes by anchor walk instead of `/.vol`.
     #[cfg(target_os = "macos")]
     pub(crate) fn anchor_mode(&self) -> bool {

--- a/crates/filesystem/lib/backends/passthroughfs/unix/mod.rs
+++ b/crates/filesystem/lib/backends/passthroughfs/unix/mod.rs
@@ -258,6 +258,8 @@ pub struct PassthroughFs {
     /// `linkat` names its source again after the anchor has verified it, so
     /// tests need to act exactly in that window to prove the post-syscall
     /// identity check does its job.
+    /// `readlinkat` names its entry again in the same way, and its own
+    /// post-call check is proved through this hook too.
     #[cfg(all(test, target_os = "macos"))]
     pub(crate) before_name_bound_syscall: RwLock<Option<Arc<dyn Fn() + Send + Sync>>>,
 }

--- a/crates/filesystem/lib/backends/passthroughfs/unix/remove_ops.rs
+++ b/crates/filesystem/lib/backends/passthroughfs/unix/remove_ops.rs
@@ -66,14 +66,56 @@ pub(crate) fn do_unlink(
         None => None,
     };
 
-    // On macOS, grab an fd before unlink to keep the file data alive.
+    // In anchor mode the alias must be dropped even for entries that cannot be
+    // opened at all (a symlink fails ELOOP, a socket ENXIO), so take the
+    // identity from the directory entry itself before the unlink, exactly as
+    // `do_rmdir` does.
     #[cfg(target_os = "macos")]
-    let pre_unlink_fd = {
+    let pre_unlink_stat = if fs.anchor_mode() {
+        platform::fstatat_nofollow(parent_fd.raw(), name).ok()
+    } else {
+        None
+    };
+
+    #[cfg(target_os = "macos")]
+    let pre_unlink_key = pre_unlink_stat.as_ref().map(|st| {
+        crate::backends::shared::inode_table::InodeAltKey::new(
+            platform::stat_ino(st),
+            platform::stat_dev(st),
+        )
+    });
+
+    // Opening a FIFO endpoint is never harmless: a read-open completes the
+    // rendezvous with a waiting writer, so this open could take bytes meant
+    // for the guest and then drop them when the descriptor is released.
+    // Removing a name needs no endpoint — there is no file content to keep
+    // reachable behind a FIFO — so the entry is simply not opened. The
+    // trade-off is that an unlinked FIFO keeps no descriptor, so once its
+    // last name is gone an operation that has only the inode to work from
+    // returns ENOENT where a regular file would still be served; retaining a
+    // reader instead would hold the FIFO open behind the guest's back and
+    // suppress its broken-pipe semantics. Handles keep their own descriptors
+    // and are unaffected.
+    #[cfg(target_os = "macos")]
+    let entry_is_fifo = pre_unlink_stat
+        .as_ref()
+        .is_some_and(|st| st.st_mode & libc::S_IFMT == libc::S_IFIFO);
+
+    // On macOS, grab an fd before unlink to keep the file data alive. A FIFO
+    // is skipped outright, as explained above. `O_NONBLOCK` still guards the
+    // remaining cases, where the entry's type is not known in advance (volfs
+    // mode takes no pre-unlink stat) and a blocking open would park the FUSE
+    // worker. The flag is cleared again once the fd is verified, so a retained
+    // descriptor keeps the blocking semantics the guest expects.
+    #[cfg(target_os = "macos")]
+    let pre_unlink_fd = if entry_is_fifo {
+        None
+    } else {
         let fd = unsafe {
             libc::openat(
                 parent_fd.raw(),
                 name.as_ptr(),
-                libc::O_RDONLY | libc::O_CLOEXEC | libc::O_NOFOLLOW,
+                libc::O_RDONLY | libc::O_CLOEXEC | libc::O_NOFOLLOW | libc::O_NONBLOCK,
             )
         };
         if fd >= 0 { Some(fd) } else { None }
@@ -81,15 +123,12 @@ pub(crate) fn do_unlink(
 
     let ret = unsafe { libc::unlinkat(parent_fd.raw(), name.as_ptr(), 0) };
     if ret < 0 {
-        #[cfg(target_os = "linux")]
+        // Capture errno before the close: close(2) can overwrite it.
+        let err = io::Error::last_os_error();
         if let Some(fd) = pre_unlink_fd {
             unsafe { libc::close(fd) };
         }
-        #[cfg(target_os = "macos")]
-        if let Some(fd) = pre_unlink_fd {
-            unsafe { libc::close(fd) };
-        }
-        return Err(platform::linux_error(io::Error::last_os_error()));
+        return Err(platform::linux_error(err));
     }
 
     #[cfg(target_os = "linux")]
@@ -113,27 +152,81 @@ pub(crate) fn do_unlink(
     }
 
     // Store the fd in InodeData so open_inode_fd can use it. In anchor mode
-    // also drop the alias so no reopen tries the removed name.
+    // also drop the alias so no reopen tries the removed name — that part runs
+    // off the pre-unlink directory-entry identity, so it works for entries the
+    // pre-unlink open could not obtain an fd for.
     #[cfg(target_os = "macos")]
-    if let Some(fd) = pre_unlink_fd {
+    if fs.anchor_mode() {
+        // The key and the fd come from two syscalls, so the host can replace
+        // the name between them. A replacement's fd must never be retained as
+        // this inode's data: every later retained-fd read dups or stats it
+        // before any anchor verification runs. Keep it only when it is the
+        // same file the key names; the alias still goes away either way.
+        let verified_fd = match pre_unlink_fd {
+            Some(fd) => match (pre_unlink_key, platform::fstat(fd)) {
+                (Some(key), Ok(st))
+                    if platform::stat_ino(&st) == key.ino && platform::stat_dev(&st) == key.dev =>
+                {
+                    // The unlink itself already succeeded, so a failure to
+                    // restore the blocking flag cannot be reported to the
+                    // guest as a failed unlink. Keep the descriptor — dropping
+                    // it would cost the guest access to the data behind its
+                    // open handles — and say so in the log, because the
+                    // retained fd then reads non-blocking.
+                    if let Err(err) = inode::clear_nonblock_macos(fd) {
+                        tracing::warn!(
+                            ?err,
+                            "macos passthrough kept an unlinked descriptor with O_NONBLOCK set"
+                        );
+                    }
+                    Some(fd)
+                }
+                _ => {
+                    unsafe { libc::close(fd) };
+                    None
+                }
+            },
+            None => None,
+        };
+
+        let mut kept_fd = false;
+        if let Some(alt_key) = pre_unlink_key {
+            let alias = NamespaceAlias::new(parent, name.to_bytes());
+            let mut inodes = fs.inodes.write().unwrap();
+            if let Some(data) = inodes.get_alt(&alt_key).cloned() {
+                let detached = inode::remove_alias_locked(&mut inodes, &data, &alias);
+                if detached && let Some(fd) = verified_fd {
+                    inode::store_unlinked_fd(&data, fd);
+                    kept_fd = true;
+                }
+            }
+        }
+        if !kept_fd && let Some(fd) = verified_fd {
+            unsafe { libc::close(fd) };
+        }
+    } else if let Some(fd) = pre_unlink_fd {
         match platform::fstat(fd) {
             Ok(st) => {
                 let alt_key = crate::backends::shared::inode_table::InodeAltKey::new(
                     st.st_ino,
                     platform::stat_dev(&st),
                 );
-                let mut inodes = fs.inodes.write().unwrap();
+                // Volfs mode only reads the table here, exactly as it did
+                // before anchor mode existed.
+                let inodes = fs.inodes.read().unwrap();
                 match inodes.get_alt(&alt_key).cloned() {
-                    Some(data) if fs.anchor_mode() => {
-                        let alias = NamespaceAlias::new(parent, name.to_bytes());
-                        let detached = inode::remove_alias_locked(&mut inodes, &data, &alias);
-                        if detached {
-                            inode::store_unlinked_fd(&data, fd);
-                        } else {
-                            unsafe { libc::close(fd) };
+                    Some(data) => {
+                        // As above: the unlink has happened, so the descriptor
+                        // is kept and the flag failure is reported in the log
+                        // instead of being turned into a guest-visible error.
+                        if let Err(err) = inode::clear_nonblock_macos(fd) {
+                            tracing::warn!(
+                                ?err,
+                                "macos passthrough kept an unlinked descriptor with O_NONBLOCK set"
+                            );
                         }
+                        inode::store_unlinked_fd(&data, fd)
                     }
-                    Some(data) => inode::store_unlinked_fd(&data, fd),
                     None => unsafe {
                         libc::close(fd);
                     },
@@ -395,8 +488,11 @@ pub(crate) fn do_rename(
             None
         };
         // Keep the replaced target readable through open handles, as unlink does.
-        // O_NONBLOCK guards against a target that is a FIFO: without it, an
-        // open on a FIFO with no writer would block the FUSE worker.
+        // A FIFO target is never opened: a read-open would complete the
+        // rendezvous with a waiting writer and then discard its bytes, and a
+        // FIFO has no content to keep reachable anyway. For every other type
+        // `O_NONBLOCK` guards against a FIFO swapped in under the name between
+        // the stat and the open.
         let target_probe = if anchor_mode {
             match platform::fstatat_nofollow(new_fd.raw(), newname) {
                 Ok(st) => {
@@ -404,14 +500,50 @@ pub(crate) fn do_rename(
                         platform::stat_ino(&st),
                         platform::stat_dev(&st),
                     );
-                    let fd = unsafe {
-                        libc::openat(
-                            new_fd.raw(),
-                            newname.as_ptr(),
-                            libc::O_RDONLY | libc::O_CLOEXEC | libc::O_NOFOLLOW | libc::O_NONBLOCK,
-                        )
+                    let fd = if st.st_mode & libc::S_IFMT == libc::S_IFIFO {
+                        -1
+                    } else {
+                        unsafe {
+                            libc::openat(
+                                new_fd.raw(),
+                                newname.as_ptr(),
+                                libc::O_RDONLY
+                                    | libc::O_CLOEXEC
+                                    | libc::O_NOFOLLOW
+                                    | libc::O_NONBLOCK,
+                            )
+                        }
                     };
-                    Some((if fd >= 0 { Some(fd) } else { None }, key))
+                    // The stat and the open are two steps, so the name can be
+                    // replaced between them. Without this check the fd of the
+                    // replacement would be retained under the original
+                    // target's identity, and every later retained-fd access
+                    // would skip the anchor identity check.
+                    let fd = if fd >= 0 {
+                        match platform::fstat(fd) {
+                            Ok(opened)
+                                if platform::stat_ino(&opened) == key.ino
+                                    && platform::stat_dev(&opened) == key.dev =>
+                            {
+                                // Nothing has been mutated yet, so a failure
+                                // to restore the blocking flag aborts the
+                                // rename instead of handing the guest a
+                                // descriptor with flags it never asked for.
+                                if let Err(err) = inode::clear_nonblock_macos(fd) {
+                                    unsafe { libc::close(fd) };
+                                    return Err(err);
+                                }
+                                Some(fd)
+                            }
+                            _ => {
+                                unsafe { libc::close(fd) };
+                                None
+                            }
+                        }
+                    } else {
+                        None
+                    };
+                    Some((fd, key))
                 }
                 Err(err) if err.raw_os_error() == Some(libc::ENOENT) => None,
                 Err(err) => return Err(err),
@@ -430,10 +562,12 @@ pub(crate) fn do_rename(
                 )
             };
             if ret < 0 {
+                // Capture errno before the close: close(2) can overwrite it.
+                let err = io::Error::last_os_error();
                 if let Some((Some(fd), _)) = target_probe.as_ref() {
                     unsafe { libc::close(*fd) };
                 }
-                return Err(platform::linux_error(io::Error::last_os_error()));
+                return Err(platform::linux_error(err));
             }
         } else {
             // macOS uses renamex_np for RENAME_SWAP and RENAME_EXCL.
@@ -459,10 +593,12 @@ pub(crate) fn do_rename(
                 )
             };
             if ret < 0 {
+                // Capture errno before the close: close(2) can overwrite it.
+                let err = io::Error::last_os_error();
                 if let Some((Some(fd), _)) = target_probe.as_ref() {
                     unsafe { libc::close(*fd) };
                 }
-                return Err(platform::linux_error(io::Error::last_os_error()));
+                return Err(platform::linux_error(err));
             }
         }
 
@@ -472,6 +608,13 @@ pub(crate) fn do_rename(
             let mut inodes = fs.inodes.write().unwrap();
             let source_data = inodes.get_alt(&source_key).cloned();
 
+            // Each move registers the new alias before removing the old one.
+            // The reverse order can collect the new parent: if the guest has
+            // already forgotten it and the removed alias was its last
+            // dependent, the parent record disappears before the child is
+            // attached to it, and the child becomes unresolvable. Registering
+            // first raises the new parent's dependent count before the old
+            // parent's count drops, and a same-parent rename nets to zero.
             if flags & RENAME_EXCHANGE != 0 {
                 if let Some((fd, target_key)) = target_probe.as_ref()
                     && *target_key == source_key
@@ -482,25 +625,56 @@ pub(crate) fn do_rename(
                     return Ok(());
                 }
 
+                // An exchange moves two entries, and each move can drop the
+                // last anchored child of a directory the guest has already
+                // forgotten. Collecting that directory between the two moves
+                // would strand the second entry on a parent that is no longer
+                // in the table. Pinning both directories defers any such
+                // collection until both anchors are installed. Registering the
+                // new alias first is not enough on its own: an inode that
+                // already has an anchor keeps its dependency counts unchanged
+                // until the old alias goes away.
+                let pinned_olddir = inode::pin_anchor_parent_locked(&inodes, olddir);
+                let pinned_newdir = inode::pin_anchor_parent_locked(&inodes, newdir);
+
                 if let Some(source) = source_data.as_ref() {
-                    let _ = inode::remove_alias_locked(&mut inodes, source, &old_alias);
                     inode::register_alias_locked(&mut inodes, source, new_alias.clone());
+                    let _ = inode::remove_alias_locked(&mut inodes, source, &old_alias);
                 }
                 if let Some((fd, target_key)) = target_probe {
                     if target_key != source_key
                         && let Some(target) = inodes.get_alt(&target_key).cloned()
                     {
-                        let _ = inode::remove_alias_locked(&mut inodes, &target, &new_alias);
                         inode::register_alias_locked(&mut inodes, &target, old_alias);
+                        let _ = inode::remove_alias_locked(&mut inodes, &target, &new_alias);
                     }
                     if let Some(fd) = fd {
                         unsafe { libc::close(fd) };
                     }
                 }
+
+                if pinned_olddir {
+                    inode::unpin_anchor_parent_locked(&mut inodes, olddir);
+                }
+                if pinned_newdir {
+                    inode::unpin_anchor_parent_locked(&mut inodes, newdir);
+                }
             } else {
+                // POSIX: renaming one link of an inode onto another link of the
+                // same inode does nothing at all — both names survive — so the
+                // alias set must stay as it was.
+                if let Some((fd, target_key)) = target_probe.as_ref()
+                    && *target_key == source_key
+                {
+                    if let Some(fd) = fd {
+                        unsafe { libc::close(*fd) };
+                    }
+                    return Ok(());
+                }
+
                 if let Some(source) = source_data.as_ref() {
-                    let _ = inode::remove_alias_locked(&mut inodes, source, &old_alias);
                     inode::register_alias_locked(&mut inodes, source, new_alias.clone());
+                    let _ = inode::remove_alias_locked(&mut inodes, source, &old_alias);
                 }
                 if let Some((fd, target_key)) = target_probe {
                     let source_inode = source_data.as_ref().map(|data| data.inode);

--- a/crates/filesystem/lib/backends/passthroughfs/unix/remove_ops.rs
+++ b/crates/filesystem/lib/backends/passthroughfs/unix/remove_ops.rs
@@ -7,11 +7,9 @@
 use std::{ffi::CStr, io};
 
 use super::{PassthroughFs, inode};
-#[cfg(target_os = "linux")]
-use crate::backends::shared::inode_table::NamespaceAlias;
 use crate::{
     Context,
-    backends::shared::{name_validation, platform},
+    backends::shared::{inode_table::NamespaceAlias, name_validation, platform},
 };
 
 //--------------------------------------------------------------------------------------------------
@@ -19,7 +17,6 @@ use crate::{
 //--------------------------------------------------------------------------------------------------
 
 /// Linux `RENAME_EXCHANGE` flag: atomically swap source and destination.
-#[cfg(target_os = "linux")]
 const RENAME_EXCHANGE: u32 = 2;
 
 /// Remove a file.
@@ -115,25 +112,36 @@ pub(crate) fn do_unlink(
         }
     }
 
-    // Store the fd in InodeData so open_inode_fd can use it.
+    // Store the fd in InodeData so open_inode_fd can use it. In anchor mode
+    // also drop the alias so no reopen tries the removed name.
     #[cfg(target_os = "macos")]
     if let Some(fd) = pre_unlink_fd {
-        // Look up the inode by stat identity from the pre-unlink fd.
-        let st = platform::fstat(fd);
-        if let Ok(st) = st {
-            let alt_key = crate::backends::shared::inode_table::InodeAltKey::new(
-                st.st_ino,
-                platform::stat_dev(&st),
-            );
-            let inodes = fs.inodes.read().unwrap();
-            if let Some(data) = inodes.get_alt(&alt_key) {
-                inode::store_unlinked_fd(data, fd);
-            } else {
-                // No tracked inode — close the fd.
-                unsafe { libc::close(fd) };
+        match platform::fstat(fd) {
+            Ok(st) => {
+                let alt_key = crate::backends::shared::inode_table::InodeAltKey::new(
+                    st.st_ino,
+                    platform::stat_dev(&st),
+                );
+                let mut inodes = fs.inodes.write().unwrap();
+                match inodes.get_alt(&alt_key).cloned() {
+                    Some(data) if fs.anchor_mode() => {
+                        let alias = NamespaceAlias::new(parent, name.to_bytes());
+                        let detached = inode::remove_alias_locked(&mut inodes, &data, &alias);
+                        if detached {
+                            inode::store_unlinked_fd(&data, fd);
+                        } else {
+                            unsafe { libc::close(fd) };
+                        }
+                    }
+                    Some(data) => inode::store_unlinked_fd(&data, fd),
+                    None => unsafe {
+                        libc::close(fd);
+                    },
+                }
             }
-        } else {
-            unsafe { libc::close(fd) };
+            Err(_) => unsafe {
+                libc::close(fd);
+            },
         }
     }
 
@@ -157,6 +165,20 @@ pub(crate) fn do_rmdir(
     }
 
     let parent_fd = inode::get_inode_fd(fs, parent)?;
+
+    #[cfg(target_os = "macos")]
+    let pre_rmdir_key = if fs.anchor_mode() {
+        platform::fstatat_nofollow(parent_fd.raw(), name)
+            .ok()
+            .map(|st| {
+                crate::backends::shared::inode_table::InodeAltKey::new(
+                    platform::stat_ino(&st),
+                    platform::stat_dev(&st),
+                )
+            })
+    } else {
+        None
+    };
 
     #[cfg(target_os = "linux")]
     let pre_rmdir_fd = {
@@ -210,6 +232,16 @@ pub(crate) fn do_rmdir(
             unsafe { libc::close(fd) };
         }
     }
+
+    #[cfg(target_os = "macos")]
+    if let Some(alt_key) = pre_rmdir_key {
+        let alias = NamespaceAlias::new(parent, name.to_bytes());
+        let mut inodes = fs.inodes.write().unwrap();
+        if let Some(data) = inodes.get_alt(&alt_key).cloned() {
+            let _ = inode::remove_alias_locked(&mut inodes, &data, &alias);
+        }
+    }
+
     Ok(())
 }
 
@@ -352,6 +384,42 @@ pub(crate) fn do_rename(
 
     #[cfg(target_os = "macos")]
     {
+        let anchor_mode = fs.anchor_mode();
+        let source_key = if anchor_mode {
+            let st = platform::fstatat_nofollow(old_fd.raw(), oldname)?;
+            Some(crate::backends::shared::inode_table::InodeAltKey::new(
+                platform::stat_ino(&st),
+                platform::stat_dev(&st),
+            ))
+        } else {
+            None
+        };
+        // Keep the replaced target readable through open handles, as unlink does.
+        // O_NONBLOCK guards against a target that is a FIFO: without it, an
+        // open on a FIFO with no writer would block the FUSE worker.
+        let target_probe = if anchor_mode {
+            match platform::fstatat_nofollow(new_fd.raw(), newname) {
+                Ok(st) => {
+                    let key = crate::backends::shared::inode_table::InodeAltKey::new(
+                        platform::stat_ino(&st),
+                        platform::stat_dev(&st),
+                    );
+                    let fd = unsafe {
+                        libc::openat(
+                            new_fd.raw(),
+                            newname.as_ptr(),
+                            libc::O_RDONLY | libc::O_CLOEXEC | libc::O_NOFOLLOW | libc::O_NONBLOCK,
+                        )
+                    };
+                    Some((if fd >= 0 { Some(fd) } else { None }, key))
+                }
+                Err(err) if err.raw_os_error() == Some(libc::ENOENT) => None,
+                Err(err) => return Err(err),
+            }
+        } else {
+            None
+        };
+
         if flags == 0 {
             let ret = unsafe {
                 libc::renameat(
@@ -362,6 +430,9 @@ pub(crate) fn do_rename(
                 )
             };
             if ret < 0 {
+                if let Some((Some(fd), _)) = target_probe.as_ref() {
+                    unsafe { libc::close(*fd) };
+                }
                 return Err(platform::linux_error(io::Error::last_os_error()));
             }
         } else {
@@ -388,7 +459,65 @@ pub(crate) fn do_rename(
                 )
             };
             if ret < 0 {
+                if let Some((Some(fd), _)) = target_probe.as_ref() {
+                    unsafe { libc::close(*fd) };
+                }
                 return Err(platform::linux_error(io::Error::last_os_error()));
+            }
+        }
+
+        if let Some(source_key) = source_key {
+            let old_alias = NamespaceAlias::new(olddir, oldname.to_bytes());
+            let new_alias = NamespaceAlias::new(newdir, newname.to_bytes());
+            let mut inodes = fs.inodes.write().unwrap();
+            let source_data = inodes.get_alt(&source_key).cloned();
+
+            if flags & RENAME_EXCHANGE != 0 {
+                if let Some((fd, target_key)) = target_probe.as_ref()
+                    && *target_key == source_key
+                {
+                    if let Some(fd) = fd {
+                        unsafe { libc::close(*fd) };
+                    }
+                    return Ok(());
+                }
+
+                if let Some(source) = source_data.as_ref() {
+                    let _ = inode::remove_alias_locked(&mut inodes, source, &old_alias);
+                    inode::register_alias_locked(&mut inodes, source, new_alias.clone());
+                }
+                if let Some((fd, target_key)) = target_probe {
+                    if target_key != source_key
+                        && let Some(target) = inodes.get_alt(&target_key).cloned()
+                    {
+                        let _ = inode::remove_alias_locked(&mut inodes, &target, &new_alias);
+                        inode::register_alias_locked(&mut inodes, &target, old_alias);
+                    }
+                    if let Some(fd) = fd {
+                        unsafe { libc::close(fd) };
+                    }
+                }
+            } else {
+                if let Some(source) = source_data.as_ref() {
+                    let _ = inode::remove_alias_locked(&mut inodes, source, &old_alias);
+                    inode::register_alias_locked(&mut inodes, source, new_alias.clone());
+                }
+                if let Some((fd, target_key)) = target_probe {
+                    let source_inode = source_data.as_ref().map(|data| data.inode);
+                    let mut keep_fd = false;
+                    if let Some(target) = inodes.get_alt(&target_key).cloned()
+                        && Some(target.inode) != source_inode
+                    {
+                        let detached = inode::remove_alias_locked(&mut inodes, &target, &new_alias);
+                        if detached && let Some(fd) = fd {
+                            inode::store_unlinked_fd(&target, fd);
+                            keep_fd = true;
+                        }
+                    }
+                    if !keep_fd && let Some(fd) = fd {
+                        unsafe { libc::close(fd) };
+                    }
+                }
             }
         }
     }

--- a/crates/filesystem/lib/backends/passthroughfs/unix/tests/mod.rs
+++ b/crates/filesystem/lib/backends/passthroughfs/unix/tests/mod.rs
@@ -1,3 +1,4 @@
+mod test_anchor_mode;
 mod test_bootstrap;
 mod test_concurrency;
 mod test_config;
@@ -131,6 +132,17 @@ impl TestSandbox {
             _tmp: tmp,
             root,
         }
+    }
+
+    /// Create a sandbox forced into anchor mode, as if the host root had no
+    /// volfs support. Only meaningful on macOS.
+    #[cfg(target_os = "macos")]
+    fn with_anchor_mode() -> Self {
+        let sb = Self::new();
+        sb.fs
+            .volfs_supported
+            .store(false, std::sync::atomic::Ordering::Release);
+        sb
     }
 
     /// Get a default Context (uid=0, gid=0 — root user).

--- a/crates/filesystem/lib/backends/passthroughfs/unix/tests/mod.rs
+++ b/crates/filesystem/lib/backends/passthroughfs/unix/tests/mod.rs
@@ -5,6 +5,7 @@ mod test_config;
 mod test_corrupt_xattr;
 mod test_create_ops;
 mod test_dir_ops;
+mod test_exfat_fixture;
 mod test_file_ops;
 mod test_flag_translation;
 mod test_host_permissions;
@@ -45,6 +46,8 @@ const LINUX_EPERM: i32 = 1;
 const LINUX_ENOENT: i32 = 2;
 #[allow(dead_code)]
 const LINUX_EIO: i32 = 5;
+#[cfg(target_os = "macos")]
+const LINUX_ENXIO: i32 = 6;
 const LINUX_EBADF: i32 = 9;
 const LINUX_EACCES: i32 = 13;
 const LINUX_EEXIST: i32 = 17;
@@ -63,6 +66,8 @@ const LINUX_EOPNOTSUPP: i32 = 95;
 /// Linux open flags (FUSE always passes Linux values, even on macOS).
 const LINUX_O_RDWR: u32 = 2;
 const LINUX_O_TRUNC: u32 = 0x200;
+#[cfg(target_os = "macos")]
+const LINUX_O_NONBLOCK: u32 = 0x800;
 
 /// Root inode number (FUSE convention).
 const ROOT_INODE: u64 = 1;

--- a/crates/filesystem/lib/backends/passthroughfs/unix/tests/test_anchor_mode.rs
+++ b/crates/filesystem/lib/backends/passthroughfs/unix/tests/test_anchor_mode.rs
@@ -71,3 +71,217 @@ fn test_lookup_records_no_alias_in_volfs_mode() {
     );
     assert!(data.aliases.read().unwrap().is_empty());
 }
+
+//--------------------------------------------------------------------------------------------------
+// Tests: reopen by anchor
+//--------------------------------------------------------------------------------------------------
+
+/// Read a nested file entirely through anchor resolution.
+#[test]
+fn test_anchor_read_nested_file() {
+    let sb = TestSandbox::with_anchor_mode();
+    sb.host_create_dir("a/b/c");
+    sb.host_create_file("a/b/c/deep.txt", b"deep");
+    let a = sb.lookup_root("a").unwrap();
+    let b = sb.lookup(a.inode, "b").unwrap();
+    let c = sb.lookup(b.inode, "c").unwrap();
+    let f = sb.lookup(c.inode, "deep.txt").unwrap();
+    let h = sb.fuse_open(f.inode, libc::O_RDONLY as u32).unwrap();
+    assert_eq!(&sb.fuse_read(f.inode, h, 64, 0).unwrap()[..], b"deep");
+}
+
+/// getattr on a tracked inode reopens through the anchor walk.
+#[test]
+fn test_anchor_getattr_after_lookup() {
+    let sb = TestSandbox::with_anchor_mode();
+    sb.host_create_file("g.txt", b"12345");
+    let g = sb.lookup_root("g.txt").unwrap();
+    let (st, _) = sb.fs.getattr(sb.ctx(), g.inode, None).unwrap();
+    assert_eq!(st.st_size, 5);
+}
+
+/// opendir + readdir on a nested directory through anchor resolution.
+#[test]
+fn test_anchor_readdir_nested() {
+    let sb = TestSandbox::with_anchor_mode();
+    sb.host_create_dir("d");
+    sb.host_create_file("d/one", b"1");
+    sb.host_create_file("d/two", b"2");
+    let d = sb.lookup_root("d").unwrap();
+    let h = sb.fuse_opendir(d.inode).unwrap();
+    let entries = sb.fs.readdir(sb.ctx(), d.inode, h, 4096, 0).unwrap();
+    let mut names: Vec<Vec<u8>> = entries.iter().map(|e| e.name.to_vec()).collect();
+    names.sort();
+    assert!(names.contains(&b"one".to_vec()));
+    assert!(names.contains(&b"two".to_vec()));
+}
+
+/// A twelve-level path resolves; this is the deepest layout seen in a real
+/// forensic case tree.
+#[test]
+fn test_anchor_twelve_levels() {
+    let sb = TestSandbox::with_anchor_mode();
+    let path = "l1/l2/l3/l4/l5/l6/l7/l8/l9/l10/l11";
+    sb.host_create_dir(path);
+    sb.host_create_file(&format!("{path}/leaf"), b"leaf");
+    let mut parent = ROOT_INODE;
+    for comp in path.split('/') {
+        parent = sb.lookup(parent, comp).unwrap().inode;
+    }
+    let leaf = sb.lookup(parent, "leaf").unwrap();
+    let h = sb.fuse_open(leaf.inode, libc::O_RDONLY as u32).unwrap();
+    assert_eq!(&sb.fuse_read(leaf.inode, h, 16, 0).unwrap()[..], b"leaf");
+}
+
+/// If the host swaps a different file into the anchored name after lookup, the
+/// reopen must fail closed (ENOENT) rather than serve the impostor.
+#[test]
+fn test_anchor_identity_mismatch_fails_closed() {
+    let sb = TestSandbox::with_anchor_mode();
+    sb.host_create_file("victim.txt", b"secret");
+    let v = sb.lookup_root("victim.txt").unwrap();
+    // Move the original aside instead of deleting it, so its inode number
+    // stays live and APFS cannot coincidentally reuse it for the
+    // replacement (which would mask the identity check succeeding for the
+    // wrong reason).
+    std::fs::rename(sb.root.join("victim.txt"), sb.root.join("victim.orig")).unwrap();
+    sb.host_create_file("victim.txt", b"impostor");
+
+    let result = sb.fuse_open(v.inode, libc::O_RDONLY as u32);
+    TestSandbox::assert_errno(result, LINUX_ENOENT);
+
+    // Only the stale inode handle is refused; a fresh lookup of the name
+    // sees the impostor normally.
+    let fresh = sb.lookup_root("victim.txt").unwrap();
+    let h = sb.fuse_open(fresh.inode, libc::O_RDONLY as u32).unwrap();
+    assert_eq!(
+        &sb.fuse_read(fresh.inode, h, 64, 0).unwrap()[..],
+        b"impostor"
+    );
+}
+
+/// A destructive reopen (`O_TRUNC`) must not touch the impostor before the
+/// identity check rejects the stale inode: truncation happens only after
+/// `validate_identity_macos` passes, never as a side effect of the walk's
+/// final `openat`.
+#[test]
+fn test_anchor_reopen_truncate_does_not_touch_impostor() {
+    const LINUX_O_WRONLY: u32 = 1;
+
+    let sb = TestSandbox::with_anchor_mode();
+    sb.host_create_file("victim.txt", b"secret");
+    let v = sb.lookup_root("victim.txt").unwrap();
+    std::fs::rename(sb.root.join("victim.txt"), sb.root.join("victim.moved")).unwrap();
+    sb.host_create_file("victim.txt", b"impostor");
+
+    let result = sb.fuse_open(v.inode, LINUX_O_WRONLY | LINUX_O_TRUNC);
+    TestSandbox::assert_errno(result, LINUX_ENOENT);
+
+    let contents = std::fs::read(sb.root.join("victim.txt")).unwrap();
+    assert_eq!(contents, b"impostor");
+}
+
+/// A host-side symlink component in the anchor path is refused.
+#[test]
+fn test_anchor_refuses_symlink_component() {
+    let sb = TestSandbox::with_anchor_mode();
+    sb.host_create_dir("real");
+    sb.host_create_file("real/f", b"f");
+    let real = sb.lookup_root("real").unwrap();
+    let f = sb.lookup(real.inode, "f").unwrap();
+    // Swap the directory for a symlink to itself-under-another-name.
+    std::fs::rename(sb.root.join("real"), sb.root.join("moved")).unwrap();
+    std::os::unix::fs::symlink(sb.root.join("moved"), sb.root.join("real")).unwrap();
+    let result = sb.fuse_open(f.inode, libc::O_RDONLY as u32);
+    TestSandbox::assert_errno(result, LINUX_ENOENT);
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests: root inode
+//--------------------------------------------------------------------------------------------------
+
+/// The root inode has no anchor alias (it is inode 1 by FUSE convention, not
+/// a recorded (parent, name) pair), so `getattr` on it must resolve via the
+/// root-inode shortcut in `open_anchor_fd_macos` rather than the (empty)
+/// alias loop.
+#[test]
+fn test_anchor_root_getattr() {
+    let sb = TestSandbox::with_anchor_mode();
+    let (st, _) = sb.fs.getattr(sb.ctx(), ROOT_INODE, None).unwrap();
+    assert_eq!(
+        st.st_mode as u32 & libc::S_IFMT as u32,
+        libc::S_IFDIR as u32
+    );
+}
+
+/// `opendir` + `readdir` on the root inode must also resolve via the
+/// root-inode shortcut.
+#[test]
+fn test_anchor_root_readdir() {
+    let sb = TestSandbox::with_anchor_mode();
+    sb.host_create_file("marker.txt", b"x");
+    let h = sb.fuse_opendir(ROOT_INODE).unwrap();
+    let entries = sb.fs.readdir(sb.ctx(), ROOT_INODE, h, 4096, 0).unwrap();
+    let names: Vec<Vec<u8>> = entries.iter().map(|e| e.name.to_vec()).collect();
+    assert!(names.contains(&b"marker.txt".to_vec()));
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests: symlinks
+//--------------------------------------------------------------------------------------------------
+
+/// A tracked symlink inode can still be stat'ed in anchor mode: the final
+/// component's `ELOOP` from `O_NOFOLLOW` triggers the `O_SYMLINK` retry
+/// instead of being classified as a stale alias.
+#[test]
+fn test_anchor_getattr_symlink() {
+    let sb = TestSandbox::with_anchor_mode();
+    sb.host_create_file("target.txt", b"x");
+    std::os::unix::fs::symlink(sb.root.join("target.txt"), sb.root.join("link")).unwrap();
+    let link = sb.lookup_root("link").unwrap();
+    let (st, _) = sb.fs.getattr(sb.ctx(), link.inode, None).unwrap();
+    assert_eq!(
+        st.st_mode as u32 & libc::S_IFMT as u32,
+        libc::S_IFLNK as u32
+    );
+}
+
+/// Opening a tracked symlink inode for I/O must still fail closed with
+/// `ELOOP`, exactly as a real symlink would on Linux — the anchor walk must
+/// not follow it just because reopening it for stat succeeds.
+#[test]
+fn test_anchor_open_symlink_for_io_is_eloop() {
+    let sb = TestSandbox::with_anchor_mode();
+    sb.host_create_file("target.txt", b"x");
+    std::os::unix::fs::symlink(sb.root.join("target.txt"), sb.root.join("link")).unwrap();
+    let link = sb.lookup_root("link").unwrap();
+    let result = sb.fuse_open(link.inode, libc::O_RDONLY as u32);
+    TestSandbox::assert_errno(result, LINUX_ELOOP);
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests: exclusive create
+//--------------------------------------------------------------------------------------------------
+
+/// `do_create`'s reopen of a just-created file keeps `O_EXCL` set (it strips
+/// only `O_CREAT`), so `open_inode_fd`'s anchor branch must let `O_EXCL`
+/// through the walk rather than rejecting it: `O_CREAT|O_EXCL` creates must
+/// still succeed in anchor mode, and a second exclusive create of the same
+/// name must still fail `EEXIST`.
+#[test]
+fn test_anchor_exclusive_create() {
+    const LINUX_O_WRONLY: u32 = 1;
+    const LINUX_O_CREAT: u32 = 0x40;
+    const LINUX_O_EXCL: u32 = 0x80;
+
+    let sb = TestSandbox::with_anchor_mode();
+    let flags = LINUX_O_WRONLY | LINUX_O_CREAT | LINUX_O_EXCL;
+    let (entry, handle) = sb
+        .fuse_create_flags(ROOT_INODE, "excl.txt", 0o644, false, flags)
+        .unwrap();
+    sb.fuse_write(entry.inode, handle, b"hello", 0).unwrap();
+    assert_eq!(std::fs::read(sb.root.join("excl.txt")).unwrap(), b"hello");
+
+    let second = sb.fuse_create_flags(ROOT_INODE, "excl.txt", 0o644, false, flags);
+    TestSandbox::assert_errno(second, LINUX_EEXIST);
+}

--- a/crates/filesystem/lib/backends/passthroughfs/unix/tests/test_anchor_mode.rs
+++ b/crates/filesystem/lib/backends/passthroughfs/unix/tests/test_anchor_mode.rs
@@ -479,6 +479,64 @@ fn test_anchor_exchange_same_inode_keeps_both_aliases() {
     );
 }
 
+/// A cross-directory exchange must not collect a parent between the two
+/// anchor transfers. `p` (or `q`) is forgotten and survives only through the
+/// child anchored to it; moving that child away first would drop the
+/// directory before the other child is re-anchored to it, and the other child
+/// would then be unresolvable even though the exchange succeeded.
+#[test]
+fn test_anchor_exchange_cross_dir_after_parent_forgotten() {
+    for forget_source_parent in [true, false] {
+        let sb = TestSandbox::with_anchor_mode();
+        sb.host_create_dir("p");
+        sb.host_create_dir("q");
+        sb.host_create_file("p/a", b"aaa");
+        sb.host_create_file("q/b", b"bbb");
+        let p = sb.lookup_root("p").unwrap();
+        let q = sb.lookup_root("q").unwrap();
+        let a = sb.lookup(p.inode, "a").unwrap();
+        let b = sb.lookup(q.inode, "b").unwrap();
+        assert_ne!(a.inode, b.inode);
+
+        if forget_source_parent {
+            sb.fs.forget(sb.ctx(), p.inode, 1);
+        } else {
+            sb.fs.forget(sb.ctx(), q.inode, 1);
+        }
+
+        sb.fs
+            .rename(
+                sb.ctx(),
+                p.inode,
+                &TestSandbox::cstr("a"),
+                q.inode,
+                &TestSandbox::cstr("b"),
+                2, // RENAME_EXCHANGE
+            )
+            .unwrap();
+
+        {
+            let inodes = sb.fs.inodes.read().unwrap();
+            assert!(
+                inodes.get(&p.inode).is_some(),
+                "p was collected during the exchange"
+            );
+            assert!(
+                inodes.get(&q.inode).is_some(),
+                "q was collected during the exchange"
+            );
+        }
+
+        // `a` now lives at q/b and `b` at p/a; both must still reopen.
+        let ha = sb.fuse_open(a.inode, libc::O_RDONLY as u32).unwrap();
+        assert_eq!(&sb.fuse_read(a.inode, ha, 8, 0).unwrap()[..], b"aaa");
+        let hb = sb.fuse_open(b.inode, libc::O_RDONLY as u32).unwrap();
+        assert_eq!(&sb.fuse_read(b.inode, hb, 8, 0).unwrap()[..], b"bbb");
+        assert_eq!(std::fs::read(sb.root.join("q/b")).unwrap(), b"aaa");
+        assert_eq!(std::fs::read(sb.root.join("p/a")).unwrap(), b"bbb");
+    }
+}
+
 //--------------------------------------------------------------------------------------------------
 // Tests: link, readlink, symlink metadata
 //--------------------------------------------------------------------------------------------------
@@ -558,4 +616,867 @@ fn test_anchor_symlink_fd_identity_mismatch() {
         .fs
         .setattr(sb.ctx(), l.inode, attr, None, SetattrValid::MODE);
     TestSandbox::assert_errno(result, LINUX_ENOENT);
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests: root reopen is a fresh file description
+//--------------------------------------------------------------------------------------------------
+
+/// Two root directory handles must not share one file description. A dup of
+/// the retained root fd would share its seek offset, so draining one listing
+/// would truncate the other.
+#[test]
+fn test_anchor_root_opendir_twice_independent() {
+    let sb = TestSandbox::with_anchor_mode();
+    for i in 0..8 {
+        sb.host_create_file(&format!("entry{i}"), b"x");
+    }
+
+    let first = sb.fuse_opendir(ROOT_INODE).unwrap();
+    let second = sb.fuse_opendir(ROOT_INODE).unwrap();
+
+    // Distinct file descriptions: moving one handle's offset must not move
+    // the other's.
+    let (fd_first, fd_second) = {
+        let handles = sb.fs.dir_handles.read().unwrap();
+        let a = handles
+            .get(&first)
+            .unwrap()
+            .file
+            .read()
+            .unwrap()
+            .as_raw_fd();
+        let b = handles
+            .get(&second)
+            .unwrap()
+            .file
+            .read()
+            .unwrap()
+            .as_raw_fd();
+        (a, b)
+    };
+    assert_ne!(fd_first, fd_second);
+    let moved = unsafe { libc::lseek(fd_first, 0, libc::SEEK_END) };
+    assert!(moved > 0);
+    assert_eq!(unsafe { libc::lseek(fd_second, 0, libc::SEEK_CUR) }, 0);
+
+    // Drain the first listing, then list the second from offset 0.
+    let drained = sb.fs.readdir(sb.ctx(), ROOT_INODE, first, 4096, 0).unwrap();
+    assert!(!drained.is_empty());
+    assert!(
+        sb.fs
+            .readdir(sb.ctx(), ROOT_INODE, first, 4096, drained.len() as u64)
+            .unwrap()
+            .is_empty()
+    );
+
+    let names: Vec<Vec<u8>> = sb
+        .fs
+        .readdir(sb.ctx(), ROOT_INODE, second, 4096, 0)
+        .unwrap()
+        .iter()
+        .map(|e| e.name.to_vec())
+        .collect();
+    for i in 0..8 {
+        assert!(names.contains(&format!("entry{i}").into_bytes()));
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests: entries that cannot be opened
+//--------------------------------------------------------------------------------------------------
+
+/// A Unix socket cannot be opened, but it must still look up: the anchor-mode
+/// lookup falls back to `fstatat` for any open failure, not just a denied
+/// permission.
+#[test]
+fn test_anchor_lookup_socket_entry() {
+    let sb = TestSandbox::with_anchor_mode();
+    let _listener = std::os::unix::net::UnixListener::bind(sb.root.join("sock")).unwrap();
+    let entry = sb.lookup_root("sock").unwrap();
+    assert_eq!(
+        entry.attr.st_mode as u32 & libc::S_IFMT as u32,
+        libc::S_IFSOCK as u32
+    );
+}
+
+/// A FIFO with no writer must not park the worker: every pre-verification
+/// open in anchor mode carries `O_NONBLOCK`.
+#[test]
+fn test_anchor_getattr_fifo_does_not_block() {
+    let sb = TestSandbox::with_anchor_mode();
+    let path = TestSandbox::cstr(sb.root.join("pipe").to_str().unwrap());
+    assert_eq!(unsafe { libc::mkfifo(path.as_ptr(), 0o644) }, 0);
+
+    let entry = sb.lookup_root("pipe").unwrap();
+    assert_eq!(
+        entry.attr.st_mode as u32 & libc::S_IFMT as u32,
+        libc::S_IFIFO as u32
+    );
+    let (st, _) = sb.fs.getattr(sb.ctx(), entry.inode, None).unwrap();
+    assert_eq!(
+        st.st_mode as u32 & libc::S_IFMT as u32,
+        libc::S_IFIFO as u32
+    );
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests: FIFO reopen helpers
+//--------------------------------------------------------------------------------------------------
+
+/// How long a FIFO test may run before the binary is considered wedged.
+const FIFO_TEST_DEADLINE: std::time::Duration = std::time::Duration::from_secs(30);
+
+/// How long a FIFO test waits for one expected step.
+const FIFO_STEP_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+
+/// Aborts the test binary if a FIFO test wedges.
+///
+/// These tests park real threads on real FIFO opens. A regression that never
+/// releases one would otherwise hang `cargo test` forever with no output, so
+/// the deadline turns it into a loud, bounded failure. Cancellation travels
+/// over a channel: the watchdog treats both a message and a disconnected
+/// sender as "the test is done", so dropping this value — on a normal return
+/// or while unwinding — disarms it, and a thread that oversleeps past the
+/// deadline still sees the cancellation instead of aborting a passed test.
+struct FifoWatchdog {
+    _cancel: std::sync::mpsc::Sender<()>,
+}
+
+impl FifoWatchdog {
+    fn new(name: &'static str) -> Self {
+        let (cancel, rx) = std::sync::mpsc::channel();
+        std::thread::spawn(move || {
+            // A message and a disconnected sender both mean "cancelled"; only
+            // the timeout is a wedged test.
+            if let Err(std::sync::mpsc::RecvTimeoutError::Timeout) =
+                rx.recv_timeout(FIFO_TEST_DEADLINE)
+            {
+                eprintln!("fifo watchdog: {name} did not finish within 30s; aborting");
+                std::process::abort();
+            }
+        });
+        Self { _cancel: cancel }
+    }
+}
+
+/// Sets a flag when it is dropped, however the drop comes about.
+struct FlagOnDrop(std::sync::Arc<std::sync::atomic::AtomicBool>);
+
+impl Drop for FlagOnDrop {
+    fn drop(&mut self) {
+        self.0.store(true, std::sync::atomic::Ordering::Release);
+    }
+}
+
+/// One worker thread running a call that may park on a FIFO open.
+///
+/// The worker owns its thread. Completion is published from a guard inside the
+/// worker closure, so a panic reports completion too, and `Drop` releases the
+/// worker — by opening the side of the FIFO the blocked party is waiting for —
+/// and then joins it, on every exit path. A worker panic is re-raised on the
+/// main thread unless it is already unwinding.
+struct FifoWorker<T> {
+    results: std::sync::mpsc::Receiver<io::Result<T>>,
+    finished: std::sync::Arc<std::sync::atomic::AtomicBool>,
+    peer: CString,
+    peer_flags: i32,
+    handle: Option<std::thread::JoinHandle<()>>,
+}
+
+impl<T: Send + 'static> FifoWorker<T> {
+    /// Run `call` against the sandbox on its own thread.
+    ///
+    /// `peer_flags` is the side of `peer` that releases this worker: the
+    /// opposite side of the open it may park on.
+    fn spawn(
+        sb: &std::sync::Arc<TestSandbox>,
+        peer: CString,
+        peer_flags: i32,
+        call: impl FnOnce(&TestSandbox) -> io::Result<T> + Send + 'static,
+    ) -> Self {
+        let worker = std::sync::Arc::clone(sb);
+        Self::spawn_raw(peer, peer_flags, move || call(&worker))
+    }
+
+    /// Run `call` on its own thread without a sandbox, for host-side peers.
+    fn spawn_raw(
+        peer: CString,
+        peer_flags: i32,
+        call: impl FnOnce() -> io::Result<T> + Send + 'static,
+    ) -> Self {
+        let finished = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let flag = std::sync::Arc::clone(&finished);
+        let (tx, results) = std::sync::mpsc::channel();
+        let handle = std::thread::spawn(move || {
+            // Declared first so it drops last: completion is published after
+            // the result is sent, and also when the call panics.
+            let _done = FlagOnDrop(flag);
+            let _ = tx.send(call());
+        });
+        Self {
+            results,
+            finished,
+            peer,
+            peer_flags,
+            handle: Some(handle),
+        }
+    }
+
+    /// Whether the call is still running after a short observation window.
+    fn is_pending(&self) -> bool {
+        matches!(
+            self.results
+                .recv_timeout(std::time::Duration::from_millis(300)),
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout)
+        )
+    }
+
+    /// Wait for the call's result, or fail the test.
+    fn wait(&self, what: &str) -> io::Result<T> {
+        match self.results.recv_timeout(FIFO_STEP_TIMEOUT) {
+            Ok(result) => result,
+            Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+                panic!("{what} ended without a result")
+            }
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => panic!("{what} never completed"),
+        }
+    }
+}
+
+impl<T> Drop for FifoWorker<T> {
+    fn drop(&mut self) {
+        let deadline = std::time::Instant::now() + FIFO_STEP_TIMEOUT;
+        while !self.finished.load(std::sync::atomic::Ordering::Acquire) {
+            // Opening the peer side never waits: a read-open of a FIFO returns
+            // at once, and a non-blocking write-open either finds the parked
+            // reader or fails ENXIO. The worker may not have reached its open
+            // yet, so this retries until it reports that it finished.
+            let fd = unsafe { libc::open(self.peer.as_ptr(), self.peer_flags | libc::O_NONBLOCK) };
+            if fd >= 0 {
+                unsafe { libc::close(fd) };
+            }
+            if std::time::Instant::now() >= deadline {
+                eprintln!("fifo worker could not be released; aborting");
+                std::process::abort();
+            }
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
+        if let Some(handle) = self.handle.take()
+            && let Err(payload) = handle.join()
+        {
+            eprintln!("fifo worker panicked");
+            if !std::thread::panicking() {
+                std::panic::resume_unwind(payload);
+            }
+        }
+    }
+}
+
+/// Prove the inode table still takes its write lock, without hanging if it
+/// does not: a lookup registers an inode, so it needs the same lock a parked
+/// open must not be holding.
+fn assert_inode_table_live(sb: &std::sync::Arc<TestSandbox>, name: &'static str) {
+    let probe = std::sync::Arc::clone(sb);
+    let (tx, rx) = std::sync::mpsc::channel();
+    let handle = std::thread::spawn(move || {
+        probe.host_create_file(name, b"x");
+        let _ = tx.send(probe.lookup_root(name).map(|_| ()));
+    });
+    let result = match rx.recv_timeout(FIFO_STEP_TIMEOUT) {
+        Ok(result) => result,
+        // The thread is left to the watchdog: it is stuck on the very lock
+        // this call was meant to prove is free, so joining it here would hang
+        // the test instead of failing it.
+        Err(_) => panic!("the inode table was still locked while a FIFO open waited"),
+    };
+    result.expect("lookup failed while a FIFO open waited");
+    handle.join().expect("the inode-table probe panicked");
+}
+
+/// Spin until `flag` is set, or fail with `what`.
+fn await_flag(flag: &std::sync::atomic::AtomicBool, what: &str) {
+    let deadline = std::time::Instant::now() + FIFO_STEP_TIMEOUT;
+    while !flag.load(std::sync::atomic::Ordering::Acquire) {
+        assert!(std::time::Instant::now() < deadline, "{what}");
+        std::thread::sleep(std::time::Duration::from_millis(5));
+    }
+}
+
+/// Make the FIFO at `name` and return the C path used to reach it.
+fn make_fifo(sb: &TestSandbox, name: &str) -> CString {
+    let path = TestSandbox::cstr(sb.root.join(name).to_str().unwrap());
+    assert_eq!(unsafe { libc::mkfifo(path.as_ptr(), 0o644) }, 0);
+    path
+}
+
+/// Install a hook that parks the reopen at its blocking FIFO open until the
+/// returned release flag is set. Returns (reached, release).
+#[allow(clippy::type_complexity)]
+fn park_at_blocking_fifo_open(
+    sb: &TestSandbox,
+) -> (
+    std::sync::Arc<std::sync::atomic::AtomicBool>,
+    std::sync::Arc<std::sync::atomic::AtomicBool>,
+) {
+    let reached = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let release = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let reached_hook = std::sync::Arc::clone(&reached);
+    let release_hook = std::sync::Arc::clone(&release);
+    *sb.fs.before_blocking_fifo_open.write().unwrap() = Some(std::sync::Arc::new(move || {
+        reached_hook.store(true, std::sync::atomic::Ordering::Release);
+        let deadline = std::time::Instant::now() + FIFO_STEP_TIMEOUT;
+        while !release_hook.load(std::sync::atomic::Ordering::Acquire)
+            && std::time::Instant::now() < deadline
+        {
+            std::thread::sleep(std::time::Duration::from_millis(5));
+        }
+    }));
+    (reached, release)
+}
+
+/// Assert the anchor reopen path opened the FIFO endpoint exactly once.
+///
+/// Opening an endpoint is a rendezvous, so a second open — a probe that is
+/// opened and discarded, wherever in the reopen path it sits — can take a
+/// waiting writer's bytes away with it.
+fn assert_single_endpoint_open(sb: &TestSandbox) {
+    assert_eq!(
+        sb.fs
+            .fifo_endpoint_opens
+            .load(std::sync::atomic::Ordering::Acquire),
+        1,
+        "the reopen path opened the FIFO endpoint more than once"
+    );
+}
+
+/// A tracked regular file replaced on the host by a FIFO with no peer must not
+/// park the reopen: the replacement is refused by identity before anything is
+/// opened.
+#[test]
+fn test_anchor_reopen_replaced_by_fifo_does_not_block() {
+    for flags in [libc::O_RDONLY, libc::O_WRONLY] {
+        let _watchdog = FifoWatchdog::new("test_anchor_reopen_replaced_by_fifo_does_not_block");
+        let sb = std::sync::Arc::new(TestSandbox::with_anchor_mode());
+        sb.host_create_file("swapme", b"original");
+        let file = sb.lookup_root("swapme").unwrap();
+
+        // Keep the tracked file alive under another name so its inode number
+        // cannot be reused, then put a peerless FIFO under the anchored name.
+        std::fs::rename(sb.root.join("swapme"), sb.root.join("swapme.orig")).unwrap();
+        let path = make_fifo(&sb, "swapme");
+
+        let peer_flags = if flags == libc::O_RDONLY {
+            libc::O_WRONLY
+        } else {
+            libc::O_RDONLY
+        };
+        let worker = FifoWorker::spawn(&sb, path, peer_flags, move |sb| {
+            sb.fuse_open(file.inode, flags as u32).map(|_| ())
+        });
+        TestSandbox::assert_errno(worker.wait("reopen of a replacement FIFO"), LINUX_ENOENT);
+    }
+}
+
+/// A guest that asks for `O_NONBLOCK` itself gets the POSIX answer for a
+/// write-open of a FIFO with no reader, and no retry.
+#[test]
+fn test_anchor_open_fifo_nonblocking_write_reports_enxio() {
+    let _watchdog = FifoWatchdog::new("test_anchor_open_fifo_nonblocking_write_reports_enxio");
+    let sb = TestSandbox::with_anchor_mode();
+    make_fifo(&sb, "pipe");
+    let entry = sb.lookup_root("pipe").unwrap();
+    TestSandbox::assert_errno(
+        sb.fuse_open(entry.inode, libc::O_WRONLY as u32 | LINUX_O_NONBLOCK),
+        LINUX_ENXIO,
+    );
+}
+
+/// A blocking read-open of a tracked FIFO must wait for a writer, as POSIX and
+/// the Linux backend do — and it must wait without holding the inode table.
+#[test]
+fn test_anchor_open_fifo_blocking_read_waits_for_writer() {
+    use std::os::fd::FromRawFd;
+
+    let _watchdog = FifoWatchdog::new("test_anchor_open_fifo_blocking_read_waits_for_writer");
+    let sb = std::sync::Arc::new(TestSandbox::with_anchor_mode());
+    let path = make_fifo(&sb, "pipe");
+    let entry = sb.lookup_root("pipe").unwrap();
+    let (reached, release) = park_at_blocking_fifo_open(&sb);
+    release.store(true, std::sync::atomic::Ordering::Release);
+
+    let worker = FifoWorker::spawn(&sb, path.clone(), libc::O_WRONLY, move |sb| {
+        sb.fuse_open(entry.inode, libc::O_RDONLY as u32).map(|_| ())
+    });
+
+    // The worker reaches the blocking open and stays there: a non-blocking fd
+    // handed to the guest here would report EOF on the first read.
+    await_flag(&reached, "the reopen never reached the blocking FIFO open");
+    assert!(
+        worker.is_pending(),
+        "blocking FIFO read-open returned before any writer existed"
+    );
+    assert_inode_table_live(&sb, "other");
+
+    let writer = unsafe { libc::open(path.as_ptr(), libc::O_WRONLY | libc::O_NONBLOCK) };
+    assert!(writer >= 0, "could not open the writing end of the FIFO");
+    let writer = unsafe { std::fs::File::from_raw_fd(writer) };
+    worker
+        .wait("blocking FIFO read-open")
+        .expect("blocking FIFO read-open failed");
+    assert_single_endpoint_open(&sb);
+    drop(writer);
+}
+
+/// The same rendezvous in the other direction: a blocking write-open waits for
+/// a reader, and the wait does not freeze the inode table.
+#[test]
+fn test_anchor_open_fifo_blocking_write_waits_for_reader() {
+    use std::os::fd::FromRawFd;
+
+    let _watchdog = FifoWatchdog::new("test_anchor_open_fifo_blocking_write_waits_for_reader");
+    let sb = std::sync::Arc::new(TestSandbox::with_anchor_mode());
+    let path = make_fifo(&sb, "pipe");
+    let entry = sb.lookup_root("pipe").unwrap();
+    let (reached, release) = park_at_blocking_fifo_open(&sb);
+    release.store(true, std::sync::atomic::Ordering::Release);
+
+    let worker = FifoWorker::spawn(&sb, path.clone(), libc::O_RDONLY, move |sb| {
+        sb.fuse_open(entry.inode, libc::O_WRONLY as u32).map(|_| ())
+    });
+
+    await_flag(&reached, "the reopen never reached the blocking FIFO open");
+    assert!(
+        worker.is_pending(),
+        "blocking FIFO write-open returned before any reader existed"
+    );
+    assert_inode_table_live(&sb, "other");
+
+    let reader = unsafe { libc::open(path.as_ptr(), libc::O_RDONLY | libc::O_NONBLOCK) };
+    assert!(reader >= 0, "could not open the reading end of the FIFO");
+    let reader = unsafe { std::fs::File::from_raw_fd(reader) };
+    worker
+        .wait("blocking FIFO write-open")
+        .expect("blocking FIFO write-open failed");
+    assert_single_endpoint_open(&sb);
+    drop(reader);
+}
+
+/// The guest's descriptor must be the one that meets the writer, and it must
+/// be the only endpoint the reopen ever opens.
+///
+/// While the reopen is parked at its open, a host non-blocking write-open must
+/// fail `ENXIO`: that is the observable proof that no reader endpoint of this
+/// FIFO is open, so the reopen has not opened one "just to look". Releasing it
+/// then lets one writer deliver a payload that the guest must be able to read
+/// — a probe that was opened and discarded would have taken those bytes with
+/// it and left the guest waiting for a writer that had already gone.
+#[test]
+fn test_anchor_open_fifo_short_lived_writer_data_not_lost() {
+    use std::io::{Read, Write};
+
+    let _watchdog = FifoWatchdog::new("test_anchor_open_fifo_short_lived_writer_data_not_lost");
+    let sb = std::sync::Arc::new(TestSandbox::with_anchor_mode());
+    let path = make_fifo(&sb, "pipe");
+    let entry = sb.lookup_root("pipe").unwrap();
+    let (reached, release) = park_at_blocking_fifo_open(&sb);
+
+    let reader = FifoWorker::spawn(&sb, path.clone(), libc::O_WRONLY, move |sb| {
+        sb.fuse_open(entry.inode, libc::O_RDONLY as u32)
+    });
+    await_flag(&reached, "the reopen never reached the blocking FIFO open");
+
+    // No reader endpoint may exist while the reopen waits at the boundary.
+    let probe = unsafe { libc::open(path.as_ptr(), libc::O_WRONLY | libc::O_NONBLOCK) };
+    if probe >= 0 {
+        unsafe { libc::close(probe) };
+        panic!("the reopen had already opened a reader endpoint of the FIFO");
+    }
+    assert_eq!(
+        io::Error::last_os_error().raw_os_error(),
+        Some(libc::ENXIO),
+        "unexpected error from the host write-open probe"
+    );
+    release.store(true, std::sync::atomic::Ordering::Release);
+
+    // One writer, alive only long enough to deliver its payload.
+    let writer_path = sb.root.join("pipe");
+    let writer = FifoWorker::spawn_raw(path.clone(), libc::O_RDONLY, move || {
+        let mut file = std::fs::OpenOptions::new().write(true).open(&writer_path)?;
+        file.write_all(b"payload")
+    });
+
+    let handle = reader
+        .wait("blocking FIFO read-open")
+        .expect("blocking FIFO read-open failed");
+    writer.wait("host writer").expect("host writer failed");
+
+    // The decisive check: a probe opened and discarded anywhere in the reopen
+    // path — including before the hook, where the host ENXIO check above
+    // cannot see it — shows up here as a second endpoint open.
+    assert_single_endpoint_open(&sb);
+
+    // Read through the handle's own descriptor: `pread` is invalid on a FIFO,
+    // so the usual FUSE read helper cannot be used here. The writer has
+    // already finished, so this read cannot wait.
+    let mut file = {
+        let handles = sb.fs.handles.read().unwrap();
+        let data = handles.get(&handle).expect("handle was not registered");
+        let file = data.file.read().unwrap();
+        file.try_clone().unwrap()
+    };
+    let mut buf = [0u8; 16];
+    let n = file
+        .read(&mut buf)
+        .expect("read from the FIFO handle failed");
+    assert_eq!(
+        &buf[..n],
+        b"payload",
+        "the waiting writer's bytes did not reach the guest's descriptor"
+    );
+}
+
+/// The pre-unlink open must not park either, and must not take a FIFO's peer:
+/// an identified FIFO is never opened at all. A tracked file replaced on the
+/// host by a peerless FIFO is still unlinked, and no descriptor is retained.
+#[test]
+fn test_anchor_unlink_of_replacement_fifo_does_not_block() {
+    let _watchdog = FifoWatchdog::new("test_anchor_unlink_of_replacement_fifo_does_not_block");
+    let sb = std::sync::Arc::new(TestSandbox::with_anchor_mode());
+    sb.host_create_file("doomed", b"x");
+    let file = sb.lookup_root("doomed").unwrap();
+
+    std::fs::rename(sb.root.join("doomed"), sb.root.join("doomed.orig")).unwrap();
+    let path = make_fifo(&sb, "doomed");
+
+    let worker = FifoWorker::spawn(&sb, path, libc::O_WRONLY, |sb| {
+        let ctx = sb.ctx();
+        sb.fs.unlink(ctx, ROOT_INODE, &TestSandbox::cstr("doomed"))
+    });
+    worker
+        .wait("unlink of a replacement FIFO")
+        .expect("unlink of the replacement FIFO failed");
+    assert!(!sb.root.join("doomed").exists());
+
+    // The FIFO was never the tracked inode, so nothing was retained for it.
+    let inodes = sb.fs.inodes.read().unwrap();
+    let data = inodes.get(&file.inode).unwrap();
+    assert_eq!(
+        data.unlinked_fd.load(std::sync::atomic::Ordering::Acquire),
+        -1
+    );
+}
+
+/// Unlinking a FIFO keeps no descriptor for it, so once its last name is gone
+/// an operation that has only the inode to work from cannot resolve it any
+/// more. Operations that carry a handle keep working, because the handle owns
+/// its own descriptor. Retaining a reader instead would hold the FIFO open
+/// behind the guest's back and suppress its broken-pipe semantics.
+#[test]
+fn test_anchor_unlink_fifo_inode_only_getattr_enoent() {
+    let _watchdog = FifoWatchdog::new("test_anchor_unlink_fifo_inode_only_getattr_enoent");
+    let sb = TestSandbox::with_anchor_mode();
+    make_fifo(&sb, "pipe");
+    let entry = sb.lookup_root("pipe").unwrap();
+    // A non-blocking read-open of a FIFO returns at once, with no peer needed.
+    let handle = sb
+        .fuse_open(entry.inode, libc::O_RDONLY as u32 | LINUX_O_NONBLOCK)
+        .unwrap();
+
+    sb.fs
+        .unlink(sb.ctx(), ROOT_INODE, &TestSandbox::cstr("pipe"))
+        .unwrap();
+
+    TestSandbox::assert_errno(sb.fs.getattr(sb.ctx(), entry.inode, None), LINUX_ENOENT);
+    let (st, _) = sb
+        .fs
+        .getattr(sb.ctx(), entry.inode, Some(handle))
+        .expect("getattr through the open handle must still work");
+    assert_eq!(
+        st.st_mode as u32 & libc::S_IFMT as u32,
+        libc::S_IFIFO as u32
+    );
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests: walk error reporting
+//--------------------------------------------------------------------------------------------------
+
+/// A host-side error on the walk is reported as itself. A denied parent
+/// directory must surface as `EACCES`, never as a phantom `ENOENT`.
+#[test]
+fn test_anchor_reopen_preserves_host_error() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let sb = TestSandbox::with_anchor_mode();
+    sb.host_create_dir("locked");
+    sb.host_create_file("locked/file", b"x");
+    let dir = sb.lookup_root("locked").unwrap();
+    let file = sb.lookup(dir.inode, "file").unwrap();
+
+    let dir_path = sb.root.join("locked");
+    std::fs::set_permissions(&dir_path, std::fs::Permissions::from_mode(0o000)).unwrap();
+    let result = sb.fuse_open(file.inode, libc::O_RDONLY as u32);
+    // Restore before asserting: a failed assertion must not leave a mode-000
+    // directory behind for the temp-dir cleanup to trip over.
+    std::fs::set_permissions(&dir_path, std::fs::Permissions::from_mode(0o755)).unwrap();
+    TestSandbox::assert_errno(result, LINUX_EACCES);
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests: alias bookkeeping edge cases
+//--------------------------------------------------------------------------------------------------
+
+/// A plain rename of one link onto another link of the same inode changes
+/// nothing on disk, so both aliases must survive.
+#[test]
+fn test_anchor_plain_rename_same_inode_keeps_both_aliases() {
+    let sb = TestSandbox::with_anchor_mode();
+    let a = sb.host_create_file("a", b"linked");
+    std::fs::hard_link(&a, sb.root.join("b")).unwrap();
+    let entry_a = sb.lookup_root("a").unwrap();
+    let entry_b = sb.lookup_root("b").unwrap();
+    assert_eq!(entry_a.inode, entry_b.inode);
+
+    sb.fs
+        .rename(
+            sb.ctx(),
+            ROOT_INODE,
+            &TestSandbox::cstr("a"),
+            ROOT_INODE,
+            &TestSandbox::cstr("b"),
+            0,
+        )
+        .unwrap();
+
+    {
+        let inodes = sb.fs.inodes.read().unwrap();
+        let data = inodes.get(&entry_a.inode).unwrap();
+        assert_eq!(data.aliases.read().unwrap().len(), 2);
+    }
+
+    assert!(sb.root.join("a").exists());
+    assert!(sb.root.join("b").exists());
+    let handle = sb.fuse_open(entry_a.inode, libc::O_RDONLY as u32).unwrap();
+    assert_eq!(
+        &sb.fuse_read(entry_a.inode, handle, 8, 0).unwrap()[..],
+        b"linked"
+    );
+}
+
+/// Renaming inside a directory the guest has already forgotten must not
+/// collect that directory: the new alias is registered before the old one is
+/// removed, so the parent never loses its last dependent.
+#[test]
+fn test_anchor_rename_after_parent_forgotten() {
+    let sb = TestSandbox::with_anchor_mode();
+    sb.host_create_dir("p");
+    sb.host_create_file("p/f", b"body");
+    let parent = sb.lookup_root("p").unwrap();
+    let file = sb.lookup(parent.inode, "f").unwrap();
+    sb.fs.forget(sb.ctx(), parent.inode, 1);
+
+    sb.fs
+        .rename(
+            sb.ctx(),
+            parent.inode,
+            &TestSandbox::cstr("f"),
+            parent.inode,
+            &TestSandbox::cstr("g"),
+            0,
+        )
+        .unwrap();
+
+    assert!(sb.fs.inodes.read().unwrap().get(&parent.inode).is_some());
+    let handle = sb.fuse_open(file.inode, libc::O_RDONLY as u32).unwrap();
+    assert_eq!(
+        &sb.fuse_read(file.inode, handle, 8, 0).unwrap()[..],
+        b"body"
+    );
+}
+
+/// Unlinking a symlink drops its alias even though the pre-unlink open fails
+/// `ELOOP`: the identity comes from the directory entry, not from an fd.
+#[test]
+fn test_anchor_unlink_symlink_drops_alias() {
+    let sb = TestSandbox::with_anchor_mode();
+    std::os::unix::fs::symlink("elsewhere", sb.root.join("sl")).unwrap();
+    let link = sb.lookup_root("sl").unwrap();
+
+    sb.fs
+        .unlink(sb.ctx(), ROOT_INODE, &TestSandbox::cstr("sl"))
+        .unwrap();
+
+    let inodes = sb.fs.inodes.read().unwrap();
+    let data = inodes.get(&link.inode).unwrap();
+    assert!(data.aliases.read().unwrap().is_empty());
+    assert_eq!(
+        data.anchor_parent
+            .load(std::sync::atomic::Ordering::Acquire),
+        0
+    );
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests: teardown
+//--------------------------------------------------------------------------------------------------
+
+/// `destroy` must release the fds retained for unlinked inodes. They are raw
+/// numbers, so only the inode's destructor closes them.
+#[test]
+fn test_anchor_destroy_closes_retained_fds() {
+    let sb = TestSandbox::with_anchor_mode();
+    let (entry, handle) = sb.fuse_create_root("doomed").unwrap();
+    sb.fuse_write(entry.inode, handle, b"bye", 0).unwrap();
+    sb.fs
+        .unlink(sb.ctx(), ROOT_INODE, &TestSandbox::cstr("doomed"))
+        .unwrap();
+
+    let retained = {
+        let inodes = sb.fs.inodes.read().unwrap();
+        inodes
+            .get(&entry.inode)
+            .unwrap()
+            .unlinked_fd
+            .load(std::sync::atomic::Ordering::Acquire)
+    };
+    assert!(retained >= 0);
+    let before = platform::fstat(retained as i32).unwrap();
+
+    sb.fs.destroy();
+
+    // The number is free after the close, and the test binary runs its tests
+    // in threads, so a parallel test may already have reopened it. Either the
+    // number is invalid, or it now names a different file — both prove this
+    // descriptor was released.
+    let probe = unsafe { libc::fcntl(retained as i32, libc::F_GETFD) };
+    if probe == -1 {
+        assert_eq!(io::Error::last_os_error().raw_os_error(), Some(libc::EBADF));
+    } else {
+        let after = platform::fstat(retained as i32).unwrap();
+        assert!(
+            platform::stat_ino(&after) != platform::stat_ino(&before)
+                || platform::stat_dev(&after) != platform::stat_dev(&before),
+            "retained fd {retained} still names the unlinked file after destroy"
+        );
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests: symlink fd identity
+//--------------------------------------------------------------------------------------------------
+
+/// The symlink fd open refuses a replaced name outright, whether the
+/// replacement is a regular file or another symlink: the tracked identity no
+/// longer lives under that name.
+#[test]
+fn test_open_symlink_inode_fd_rejects_replacement() {
+    let sb = TestSandbox::with_anchor_mode();
+    std::os::unix::fs::symlink("elsewhere", sb.root.join("sl")).unwrap();
+    let link = sb.lookup_root("sl").unwrap();
+
+    std::fs::remove_file(sb.root.join("sl")).unwrap();
+    std::fs::write(sb.root.join("sl"), b"not a symlink").unwrap();
+    TestSandbox::assert_errno(
+        super::super::metadata::open_symlink_inode_fd_macos(&sb.fs, link.inode),
+        LINUX_ENOENT,
+    );
+
+    std::fs::remove_file(sb.root.join("sl")).unwrap();
+    std::os::unix::fs::symlink("somewhere-else", sb.root.join("sl")).unwrap();
+    TestSandbox::assert_errno(
+        super::super::metadata::open_symlink_inode_fd_macos(&sb.fs, link.inode),
+        LINUX_ENOENT,
+    );
+}
+
+/// The post-open identity check is what covers a replacement that lands
+/// *after* the parent and name were verified. Resolving the pair first and
+/// swapping the entry in between reproduces that window, which the
+/// replace-before-resolve test above can never reach.
+#[test]
+fn test_open_verified_symlink_fd_rejects_post_open_replacement() {
+    use std::os::unix::fs::MetadataExt;
+
+    let sb = TestSandbox::with_anchor_mode();
+    std::os::unix::fs::symlink("elsewhere", sb.root.join("sl")).unwrap();
+    let link = sb.lookup_root("sl").unwrap();
+    let expected = {
+        let inodes = sb.fs.inodes.read().unwrap();
+        let data = inodes.get(&link.inode).unwrap();
+        crate::backends::shared::inode_table::InodeAltKey::new(data.ino, data.dev)
+    };
+    let (dir, name) =
+        super::super::inode::anchor_parent_and_name_macos(&sb.fs, link.inode).unwrap();
+
+    // Keep the original link alive under another name so its inode number
+    // cannot be reused by the replacement.
+    std::fs::rename(sb.root.join("sl"), sb.root.join("sl.orig")).unwrap();
+    std::os::unix::fs::symlink("somewhere-else", sb.root.join("sl")).unwrap();
+    let before = std::fs::symlink_metadata(sb.root.join("sl")).unwrap();
+
+    TestSandbox::assert_errno(
+        super::super::metadata::open_verified_symlink_fd(dir.raw(), &name, expected),
+        LINUX_ENOENT,
+    );
+
+    // The refusal must leave the replacement untouched.
+    let after = std::fs::symlink_metadata(sb.root.join("sl")).unwrap();
+    assert_eq!(after.ino(), before.ino());
+    assert_eq!(after.mtime(), before.mtime());
+    assert_eq!(after.mtime_nsec(), before.mtime_nsec());
+    assert_eq!(after.mode(), before.mode());
+    assert_eq!(
+        std::fs::read_link(sb.root.join("sl")).unwrap(),
+        std::path::Path::new("somewhere-else")
+    );
+}
+
+/// The fd retained across an unlink must be the file the identity key names.
+///
+/// The key and the fd come from two syscalls, so a host-side replacement can
+/// in principle land between them. That interleaving is not reachable from a
+/// single-threaded test, so this asserts the property from the outside: after
+/// the name is replaced on the host, the FUSE unlink retains no descriptor for
+/// the tracked inode, the tracked inode refuses to resolve through its stale
+/// name, and a handle opened before the replacement still reads the original
+/// bytes.
+#[test]
+fn test_anchor_unlink_replacement_fd_not_retained() {
+    let sb = TestSandbox::with_anchor_mode();
+    sb.host_create_file("f", b"original");
+    let file = sb.lookup_root("f").unwrap();
+    let handle = sb.fuse_open(file.inode, libc::O_RDONLY as u32).unwrap();
+
+    // Move the original aside so its inode stays live, then put a different
+    // file under the tracked name.
+    std::fs::rename(sb.root.join("f"), sb.root.join("f.orig")).unwrap();
+    sb.host_create_file("f", b"replacement");
+
+    sb.fs
+        .unlink(sb.ctx(), ROOT_INODE, &TestSandbox::cstr("f"))
+        .unwrap();
+    assert!(!sb.root.join("f").exists());
+
+    {
+        let inodes = sb.fs.inodes.read().unwrap();
+        let data = inodes.get(&file.inode).unwrap();
+        assert_eq!(
+            data.unlinked_fd.load(std::sync::atomic::Ordering::Acquire),
+            -1,
+            "the replacement's descriptor must not be retained"
+        );
+    }
+
+    // The stale name is gone, so the tracked inode no longer resolves.
+    TestSandbox::assert_errno(
+        sb.fuse_open(file.inode, libc::O_RDONLY as u32),
+        LINUX_ENOENT,
+    );
+
+    assert_eq!(
+        &sb.fuse_read(file.inode, handle, 16, 0).unwrap()[..],
+        b"original"
+    );
+    assert_eq!(std::fs::read(sb.root.join("f.orig")).unwrap(), b"original");
 }

--- a/crates/filesystem/lib/backends/passthroughfs/unix/tests/test_anchor_mode.rs
+++ b/crates/filesystem/lib/backends/passthroughfs/unix/tests/test_anchor_mode.rs
@@ -285,3 +285,277 @@ fn test_anchor_exclusive_create() {
     let second = sb.fuse_create_flags(ROOT_INODE, "excl.txt", 0o644, false, flags);
     TestSandbox::assert_errno(second, LINUX_EEXIST);
 }
+
+//--------------------------------------------------------------------------------------------------
+// Tests: forget keeps anchors alive
+//--------------------------------------------------------------------------------------------------
+
+/// Forgetting a directory that still anchors a child must keep the directory
+/// record so the child can be reopened.
+#[test]
+fn test_anchor_parent_survives_forget_while_child_lives() {
+    let sb = TestSandbox::with_anchor_mode();
+    sb.host_create_dir("p");
+    sb.host_create_file("p/child", b"c");
+    let p = sb.lookup_root("p").unwrap();
+    let child = sb.lookup(p.inode, "child").unwrap();
+
+    sb.fs.forget(sb.ctx(), p.inode, 1);
+    assert!(sb.fs.inodes.read().unwrap().get(&p.inode).is_some());
+
+    let h = sb.fuse_open(child.inode, libc::O_RDONLY as u32).unwrap();
+    assert_eq!(&sb.fuse_read(child.inode, h, 8, 0).unwrap()[..], b"c");
+
+    // Forgetting the child releases the parent too.
+    sb.fs.forget(sb.ctx(), child.inode, 1);
+    assert!(sb.fs.inodes.read().unwrap().get(&child.inode).is_none());
+    assert!(sb.fs.inodes.read().unwrap().get(&p.inode).is_none());
+}
+
+/// In volfs mode forget removes the inode immediately, as before.
+#[test]
+fn test_volfs_forget_removes_immediately() {
+    let sb = TestSandbox::new();
+    sb.host_create_dir("q");
+    sb.host_create_file("q/child", b"c");
+    let q = sb.lookup_root("q").unwrap();
+    let _child = sb.lookup(q.inode, "child").unwrap();
+    sb.fs.forget(sb.ctx(), q.inode, 1);
+    assert!(sb.fs.inodes.read().unwrap().get(&q.inode).is_none());
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests: rename, unlink, rmdir keep aliases correct
+//--------------------------------------------------------------------------------------------------
+
+/// After a guest rename the inode reopens through its new name.
+#[test]
+fn test_anchor_rename_then_read() {
+    let sb = TestSandbox::with_anchor_mode();
+    sb.host_create_file("old.txt", b"same");
+    let f = sb.lookup_root("old.txt").unwrap();
+    sb.fs
+        .rename(
+            sb.ctx(),
+            ROOT_INODE,
+            &TestSandbox::cstr("old.txt"),
+            ROOT_INODE,
+            &TestSandbox::cstr("new.txt"),
+            0,
+        )
+        .unwrap();
+    let h = sb.fuse_open(f.inode, libc::O_RDONLY as u32).unwrap();
+    assert_eq!(&sb.fuse_read(f.inode, h, 8, 0).unwrap()[..], b"same");
+    let inodes = sb.fs.inodes.read().unwrap();
+    let data = inodes.get(&f.inode).unwrap();
+    assert_eq!(&*data.anchor_name.read().unwrap(), b"new.txt");
+}
+
+/// Renaming a directory moves every descendant's resolution path.
+#[test]
+fn test_anchor_rename_directory_moves_children() {
+    let sb = TestSandbox::with_anchor_mode();
+    sb.host_create_dir("dir1");
+    sb.host_create_file("dir1/inner", b"in");
+    let d = sb.lookup_root("dir1").unwrap();
+    let inner = sb.lookup(d.inode, "inner").unwrap();
+    sb.fs
+        .rename(
+            sb.ctx(),
+            ROOT_INODE,
+            &TestSandbox::cstr("dir1"),
+            ROOT_INODE,
+            &TestSandbox::cstr("dir2"),
+            0,
+        )
+        .unwrap();
+    let h = sb.fuse_open(inner.inode, libc::O_RDONLY as u32).unwrap();
+    assert_eq!(&sb.fuse_read(inner.inode, h, 8, 0).unwrap()[..], b"in");
+}
+
+/// Rename over an existing target detaches the target; an open handle on the
+/// old target still reads its data.
+#[test]
+fn test_anchor_rename_replaces_target() {
+    let sb = TestSandbox::with_anchor_mode();
+    sb.host_create_file("src", b"source");
+    sb.host_create_file("dst", b"target");
+    let src = sb.lookup_root("src").unwrap();
+    let dst = sb.lookup_root("dst").unwrap();
+    let dst_h = sb.fuse_open(dst.inode, libc::O_RDONLY as u32).unwrap();
+    sb.fs
+        .rename(
+            sb.ctx(),
+            ROOT_INODE,
+            &TestSandbox::cstr("src"),
+            ROOT_INODE,
+            &TestSandbox::cstr("dst"),
+            0,
+        )
+        .unwrap();
+    assert_eq!(
+        &sb.fuse_read(dst.inode, dst_h, 8, 0).unwrap()[..],
+        b"target"
+    );
+    let src_h = sb.fuse_open(src.inode, libc::O_RDONLY as u32).unwrap();
+    assert_eq!(
+        &sb.fuse_read(src.inode, src_h, 8, 0).unwrap()[..],
+        b"source"
+    );
+}
+
+/// Unlink drops the alias; a pre-existing open handle still reads.
+#[test]
+fn test_anchor_unlink_keeps_open_handle() {
+    let sb = TestSandbox::with_anchor_mode();
+    sb.host_create_file("gone", b"kept");
+    let g = sb.lookup_root("gone").unwrap();
+    let h = sb.fuse_open(g.inode, libc::O_RDONLY as u32).unwrap();
+    sb.fs
+        .unlink(sb.ctx(), ROOT_INODE, &TestSandbox::cstr("gone"))
+        .unwrap();
+    assert_eq!(&sb.fuse_read(g.inode, h, 8, 0).unwrap()[..], b"kept");
+    let inodes = sb.fs.inodes.read().unwrap();
+    let data = inodes.get(&g.inode).unwrap();
+    assert!(data.aliases.read().unwrap().is_empty());
+    assert!(data.unlinked_fd.load(std::sync::atomic::Ordering::Acquire) >= 0);
+}
+
+/// rmdir removes the directory's alias.
+#[test]
+fn test_anchor_rmdir_drops_alias() {
+    let sb = TestSandbox::with_anchor_mode();
+    sb.host_create_dir("empty");
+    let e = sb.lookup_root("empty").unwrap();
+    sb.fs
+        .rmdir(sb.ctx(), ROOT_INODE, &TestSandbox::cstr("empty"))
+        .unwrap();
+    let inodes = sb.fs.inodes.read().unwrap();
+    let data = inodes.get(&e.inode).unwrap();
+    assert!(data.aliases.read().unwrap().is_empty());
+    assert_eq!(
+        data.anchor_parent
+            .load(std::sync::atomic::Ordering::Acquire),
+        0
+    );
+}
+
+/// Exchanging two names that are hard-linked to the same inode must leave
+/// both aliases intact: nothing actually moves on disk.
+#[test]
+fn test_anchor_exchange_same_inode_keeps_both_aliases() {
+    let sb = TestSandbox::with_anchor_mode();
+    let a = sb.host_create_file("a", b"linked");
+    std::fs::hard_link(&a, sb.root.join("b")).unwrap();
+    let entry_a = sb.lookup_root("a").unwrap();
+    let entry_b = sb.lookup_root("b").unwrap();
+    assert_eq!(entry_a.inode, entry_b.inode);
+
+    sb.fs
+        .rename(
+            sb.ctx(),
+            ROOT_INODE,
+            &TestSandbox::cstr("a"),
+            ROOT_INODE,
+            &TestSandbox::cstr("b"),
+            2, // RENAME_EXCHANGE
+        )
+        .unwrap();
+
+    let inodes = sb.fs.inodes.read().unwrap();
+    let data = inodes.get(&entry_a.inode).unwrap();
+    assert_eq!(data.aliases.read().unwrap().len(), 2);
+    drop(inodes);
+
+    let h_a = sb.fuse_open(entry_a.inode, libc::O_RDONLY as u32).unwrap();
+    assert_eq!(
+        &sb.fuse_read(entry_a.inode, h_a, 8, 0).unwrap()[..],
+        b"linked"
+    );
+    let h_b = sb.fuse_open(entry_b.inode, libc::O_RDONLY as u32).unwrap();
+    assert_eq!(
+        &sb.fuse_read(entry_b.inode, h_b, 8, 0).unwrap()[..],
+        b"linked"
+    );
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests: link, readlink, symlink metadata
+//--------------------------------------------------------------------------------------------------
+
+/// Hard link creation resolves the source through its anchor.
+#[test]
+fn test_anchor_hard_link() {
+    let sb = TestSandbox::with_anchor_mode();
+    sb.host_create_dir("lnk");
+    sb.host_create_file("lnk/orig", b"linked");
+    let d = sb.lookup_root("lnk").unwrap();
+    let orig = sb.lookup(d.inode, "orig").unwrap();
+    let copy = sb
+        .fs
+        .link(sb.ctx(), orig.inode, ROOT_INODE, &TestSandbox::cstr("copy"))
+        .unwrap();
+    assert_eq!(copy.inode, orig.inode);
+    let h = sb.fuse_open(copy.inode, libc::O_RDONLY as u32).unwrap();
+    assert_eq!(&sb.fuse_read(copy.inode, h, 8, 0).unwrap()[..], b"linked");
+    assert_eq!(std::fs::read(sb.root.join("copy")).unwrap(), b"linked");
+}
+
+/// readlink on a nested symlink works through the anchor parent.
+#[test]
+fn test_anchor_readlink_nested() {
+    let sb = TestSandbox::with_anchor_mode();
+    sb.host_create_dir("s");
+    std::os::unix::fs::symlink("target-name", sb.root.join("s/link")).unwrap();
+    let s = sb.lookup_root("s").unwrap();
+    let l = sb.lookup(s.inode, "link").unwrap();
+    assert_eq!(sb.fs.readlink(sb.ctx(), l.inode).unwrap(), b"target-name");
+}
+
+/// setattr times on a symlink go through the anchor parent, and both atime
+/// and mtime land on the verified fd via `futimens` rather than a name-based
+/// `utimensat`.
+#[test]
+fn test_anchor_symlink_times() {
+    let sb = TestSandbox::with_anchor_mode();
+    std::os::unix::fs::symlink("elsewhere", sb.root.join("tl")).unwrap();
+    let l = sb.lookup_root("tl").unwrap();
+    let mut attr: stat64 = unsafe { std::mem::zeroed() };
+    attr.st_mtime = 1_000_000_000;
+    attr.st_atime = 2_000_000_000;
+    let (st, _) = sb
+        .fs
+        .setattr(
+            sb.ctx(),
+            l.inode,
+            attr,
+            None,
+            SetattrValid::MTIME | SetattrValid::ATIME,
+        )
+        .unwrap();
+    assert_eq!(st.st_mtime, 1_000_000_000);
+    assert_eq!(st.st_atime, 2_000_000_000);
+}
+
+/// A host-side replacement of a symlink's name with a regular file must not
+/// let a stale fd operate on the replacement: the anchor-mode fd open
+/// verifies (dev, ino) after opening and fails closed as `ENOENT`.
+#[test]
+fn test_anchor_symlink_fd_identity_mismatch() {
+    let sb = TestSandbox::with_anchor_mode();
+    std::os::unix::fs::symlink("elsewhere", sb.root.join("sl")).unwrap();
+    let l = sb.lookup_root("sl").unwrap();
+
+    // Simulate a host-side race: remove the symlink and put a regular file
+    // under the same name, so the tracked inode's anchor now names a
+    // different on-disk identity.
+    std::fs::remove_file(sb.root.join("sl")).unwrap();
+    std::fs::write(sb.root.join("sl"), b"not a symlink").unwrap();
+
+    let mut attr: stat64 = unsafe { std::mem::zeroed() };
+    attr.st_mode = libc::S_IFLNK | 0o777;
+    let result = sb
+        .fs
+        .setattr(sb.ctx(), l.inode, attr, None, SetattrValid::MODE);
+    TestSandbox::assert_errno(result, LINUX_ENOENT);
+}

--- a/crates/filesystem/lib/backends/passthroughfs/unix/tests/test_anchor_mode.rs
+++ b/crates/filesystem/lib/backends/passthroughfs/unix/tests/test_anchor_mode.rs
@@ -1,0 +1,73 @@
+#![cfg(target_os = "macos")]
+
+use super::*;
+
+//--------------------------------------------------------------------------------------------------
+// Tests: volfs probe
+//--------------------------------------------------------------------------------------------------
+
+/// A temp dir on the developer's APFS volume supports volfs, so a default
+/// sandbox must report volfs support and not run in anchor mode.
+#[test]
+fn test_probe_reports_volfs_on_apfs_tempdir() {
+    let sb = TestSandbox::new();
+    assert!(!sb.fs.anchor_mode());
+}
+
+/// The forced helper flips the share into anchor mode.
+#[test]
+fn test_with_anchor_mode_forces_anchor_mode() {
+    let sb = TestSandbox::with_anchor_mode();
+    assert!(sb.fs.anchor_mode());
+}
+
+/// The probe itself: a real root fd probes true; a fabricated identity that
+/// cannot exist on any mounted volume probes false.
+#[test]
+fn test_probe_volfs_support_direct() {
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = std::fs::File::open(tmp.path()).unwrap();
+    assert!(probe_volfs_support(dir.as_raw_fd()));
+    // dev 0 is never a mounted volume: open("/.vol/0/1") must fail.
+    assert!(!probe_volfs_path(0, 1));
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests: alias bookkeeping
+//--------------------------------------------------------------------------------------------------
+
+/// In anchor mode a lookup records the (parent, name) alias on the inode.
+#[test]
+fn test_lookup_registers_alias_in_anchor_mode() {
+    let sb = TestSandbox::with_anchor_mode();
+    sb.host_create_dir("a");
+    sb.host_create_file("a/f.txt", b"x");
+    let a = sb.lookup_root("a").unwrap();
+    let f = sb.lookup(a.inode, "f.txt").unwrap();
+
+    let inodes = sb.fs.inodes.read().unwrap();
+    let data = inodes.get(&f.inode).unwrap();
+    assert_eq!(
+        data.anchor_parent
+            .load(std::sync::atomic::Ordering::Acquire),
+        a.inode
+    );
+    assert_eq!(&*data.anchor_name.read().unwrap(), b"f.txt");
+    assert_eq!(data.aliases.read().unwrap().len(), 1);
+}
+
+/// In volfs mode the alias table stays empty, so APFS behaviour is unchanged.
+#[test]
+fn test_lookup_records_no_alias_in_volfs_mode() {
+    let sb = TestSandbox::new();
+    sb.host_create_file("f.txt", b"x");
+    let f = sb.lookup_root("f.txt").unwrap();
+    let inodes = sb.fs.inodes.read().unwrap();
+    let data = inodes.get(&f.inode).unwrap();
+    assert_eq!(
+        data.anchor_parent
+            .load(std::sync::atomic::Ordering::Acquire),
+        0
+    );
+    assert!(data.aliases.read().unwrap().is_empty());
+}

--- a/crates/filesystem/lib/backends/passthroughfs/unix/tests/test_anchor_mode.rs
+++ b/crates/filesystem/lib/backends/passthroughfs/unix/tests/test_anchor_mode.rs
@@ -559,6 +559,75 @@ fn test_anchor_hard_link() {
     assert_eq!(std::fs::read(sb.root.join("copy")).unwrap(), b"linked");
 }
 
+/// Install a one-shot hook that runs `swap` in the window between an anchor
+/// resolution and the name-bound syscall that follows it.
+fn swap_before_name_bound_syscall(sb: &TestSandbox, swap: impl Fn() + Send + Sync + 'static) {
+    let done = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+    *sb.fs.before_name_bound_syscall.write().unwrap() = Some(std::sync::Arc::new(move || {
+        if !done.swap(true, std::sync::atomic::Ordering::AcqRel) {
+            swap();
+        }
+    }));
+}
+
+/// The hard link source is named again by `linkat`, so a replacement that
+/// lands after the anchor was verified is what gets linked. The guest must be
+/// told ENOENT rather than handed an entry for the replacement.
+///
+/// The entry `linkat` created stays on the host: that is the accepted outcome.
+/// It is what an unchecked `linkat` would have left, and removing it by name
+/// would be a second name-based race against whatever is under that name by
+/// then.
+#[test]
+fn test_anchor_link_rejects_replaced_source() {
+    use std::os::unix::fs::MetadataExt;
+
+    let sb = TestSandbox::with_anchor_mode();
+    sb.host_create_file("a", b"original");
+    let a = sb.lookup_root("a").unwrap();
+
+    // Keep the original alive under another name so its inode number cannot be
+    // reused by the replacement.
+    let root = sb.root.clone();
+    swap_before_name_bound_syscall(&sb, move || {
+        std::fs::rename(root.join("a"), root.join("a.orig")).unwrap();
+        std::fs::write(root.join("a"), b"replacement").unwrap();
+    });
+
+    TestSandbox::assert_errno(
+        sb.fs
+            .link(sb.ctx(), a.inode, ROOT_INODE, &TestSandbox::cstr("copy")),
+        LINUX_ENOENT,
+    );
+    assert_eq!(std::fs::read(sb.root.join("a.orig")).unwrap(), b"original");
+
+    // Accepted outcome: the link exists and names the replacement, not the
+    // tracked file. This request returns no entry, but the surviving link
+    // remains discoverable through lookup and readdir.
+    let linked = std::fs::metadata(sb.root.join("copy")).unwrap();
+    let replacement = std::fs::metadata(sb.root.join("a")).unwrap();
+    let tracked = std::fs::metadata(sb.root.join("a.orig")).unwrap();
+    assert_eq!(linked.ino(), replacement.ino());
+    assert_ne!(linked.ino(), tracked.ino());
+}
+
+/// A destination that already exists keeps the POSIX answer of a plain
+/// `linkat`: EEXIST, with the destination untouched.
+#[test]
+fn test_anchor_link_existing_target_eexist() {
+    let sb = TestSandbox::with_anchor_mode();
+    sb.host_create_file("a", b"source");
+    sb.host_create_file("taken", b"occupied");
+    let a = sb.lookup_root("a").unwrap();
+
+    TestSandbox::assert_errno(
+        sb.fs
+            .link(sb.ctx(), a.inode, ROOT_INODE, &TestSandbox::cstr("taken")),
+        LINUX_EEXIST,
+    );
+    assert_eq!(std::fs::read(sb.root.join("taken")).unwrap(), b"occupied");
+}
+
 /// readlink on a nested symlink works through the anchor parent.
 #[test]
 fn test_anchor_readlink_nested() {

--- a/crates/filesystem/lib/backends/passthroughfs/unix/tests/test_anchor_mode.rs
+++ b/crates/filesystem/lib/backends/passthroughfs/unix/tests/test_anchor_mode.rs
@@ -639,6 +639,26 @@ fn test_anchor_readlink_nested() {
     assert_eq!(sb.fs.readlink(sb.ctx(), l.inode).unwrap(), b"target-name");
 }
 
+/// `readlinkat` names the entry again, so a symlink replaced after the anchor
+/// was verified would otherwise have its target read and returned. The read
+/// must be refused instead.
+#[test]
+fn test_anchor_readlink_rejects_replaced_symlink() {
+    let sb = TestSandbox::with_anchor_mode();
+    std::os::unix::fs::symlink("target-one", sb.root.join("s")).unwrap();
+    let s = sb.lookup_root("s").unwrap();
+
+    // Keep the original link alive under another name so its inode number
+    // cannot be reused by the replacement.
+    let root = sb.root.clone();
+    swap_before_name_bound_syscall(&sb, move || {
+        std::fs::rename(root.join("s"), root.join("s.orig")).unwrap();
+        std::os::unix::fs::symlink("target-two", root.join("s")).unwrap();
+    });
+
+    TestSandbox::assert_errno(sb.fs.readlink(sb.ctx(), s.inode), LINUX_ENOENT);
+}
+
 /// setattr times on a symlink go through the anchor parent, and both atime
 /// and mtime land on the verified fd via `futimens` rather than a name-based
 /// `utimensat`.

--- a/crates/filesystem/lib/backends/passthroughfs/unix/tests/test_exfat_fixture.rs
+++ b/crates/filesystem/lib/backends/passthroughfs/unix/tests/test_exfat_fixture.rs
@@ -1,0 +1,321 @@
+#![cfg(target_os = "macos")]
+
+//! Real FSKit exFAT fixture.
+//!
+//! Creates a small exFAT disk image with `hdiutil`, mounts it, and exercises
+//! the passthrough backend on it. On macOS 15+ the mount is FSKit-backed and
+//! has no volfs, so the share runs in anchor mode; on older hosts exFAT is a
+//! kext with volfs and the share runs in volfs mode. Both must pass. The test
+//! skips itself when `hdiutil` is unavailable or the mount fails (CI runners
+//! without disk-image support).
+
+use std::{
+    ffi::CString,
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+use super::*;
+use crate::{FsOptions, PassthroughConfig};
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+struct ExfatVolume {
+    image: PathBuf,
+    mount: PathBuf,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Methods
+//--------------------------------------------------------------------------------------------------
+
+impl ExfatVolume {
+    fn create(tmp: &Path) -> Option<Self> {
+        let image = tmp.join("exfat-fixture.dmg");
+        let status = Command::new("hdiutil")
+            .args([
+                "create", "-size", "64m", "-fs", "ExFAT", "-volname", "MSBEXFAT", "-quiet",
+            ])
+            .arg(&image)
+            .status()
+            .ok()?;
+        if !status.success() {
+            return None;
+        }
+        let mount = tmp.join("mnt");
+        std::fs::create_dir_all(&mount).ok()?;
+        let status = Command::new("hdiutil")
+            .args(["attach", "-nobrowse", "-quiet", "-mountpoint"])
+            .arg(&mount)
+            .arg(&image)
+            .status()
+            .ok()?;
+        if !status.success() {
+            return None;
+        }
+        Some(Self { image, mount })
+    }
+}
+
+impl Drop for ExfatVolume {
+    fn drop(&mut self) {
+        let _ = Command::new("hdiutil")
+            .args(["detach", "-quiet", "-force"])
+            .arg(&self.mount)
+            .status();
+        let _ = std::fs::remove_file(&self.image);
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests
+//--------------------------------------------------------------------------------------------------
+
+/// Lookup, getattr, read, readdir, and reopen-after-forget on a real exFAT
+/// volume. Inode numbers must stay stable across reopen, which anchor mode
+/// relies on for its identity check.
+#[test]
+fn test_exfat_volume_read_path() {
+    let tmp = tempfile::tempdir().unwrap();
+    let Some(vol) = ExfatVolume::create(tmp.path()) else {
+        eprintln!("skipping: hdiutil exFAT fixture unavailable");
+        return;
+    };
+
+    let root = vol.mount.join("case");
+    std::fs::create_dir_all(root.join("evidence/sub")).unwrap();
+    std::fs::write(root.join("evidence/sub/file.bin"), b"exfat-bytes").unwrap();
+    std::fs::write(root.join("top.txt"), b"top").unwrap();
+
+    let fs = PassthroughFs::new(PassthroughConfig {
+        root_dir: root.clone(),
+        ..Default::default()
+    })
+    .unwrap();
+    fs.init(FsOptions::empty()).unwrap();
+    let ctx = Context {
+        uid: 0,
+        gid: 0,
+        pid: 1,
+    };
+    let c = |s: &str| CString::new(s).unwrap();
+
+    let is_fskit = !probe_volfs_support(fs.root_fd.as_raw_fd());
+    eprintln!(
+        "exfat fixture: anchor_mode={} (fskit={is_fskit})",
+        fs.anchor_mode()
+    );
+    assert_eq!(fs.anchor_mode(), is_fskit);
+
+    let ev = fs.lookup(ctx, ROOT_INODE, &c("evidence")).unwrap();
+    let sub = fs.lookup(ctx, ev.inode, &c("sub")).unwrap();
+    let file = fs.lookup(ctx, sub.inode, &c("file.bin")).unwrap();
+    let (st, _) = fs.getattr(ctx, file.inode, None).unwrap();
+    assert_eq!(st.st_size, 11);
+
+    let (handle, _) = fs.open(ctx, file.inode, false, 0).unwrap();
+    let mut w = MockZeroCopyWriter::new();
+    let n = fs
+        .read(ctx, file.inode, handle.unwrap(), &mut w, 64, 0, None, 0)
+        .unwrap();
+    let mut data = w.into_data();
+    data.truncate(n);
+    assert_eq!(&data[..], b"exfat-bytes");
+
+    let (dh, _) = fs.opendir(ctx, ev.inode, 0).unwrap();
+    let names: Vec<Vec<u8>> = fs
+        .readdir(ctx, ev.inode, dh.unwrap(), 4096, 0)
+        .unwrap()
+        .iter()
+        .map(|e| e.name.to_vec())
+        .collect();
+    assert!(names.contains(&b"sub".to_vec()));
+
+    // Reopen after the intermediate directories are forgotten by the guest.
+    fs.forget(ctx, ev.inode, 1);
+    fs.forget(ctx, sub.inode, 1);
+    let (st2, _) = fs.getattr(ctx, file.inode, None).unwrap();
+    assert_eq!(st2.st_ino, st.st_ino);
+    assert_eq!(st2.st_size, 11);
+}
+
+/// Create, write, rename, unlink, rmdir, and link on a real exFAT volume, all
+/// through FUSE operations. The rename assertions are the load-bearing ones:
+/// anchor mode reopens an inode by name and then checks `(st_dev, st_ino)`, so
+/// exFAT must keep an inode number stable while the name moves.
+#[test]
+fn test_exfat_volume_write_path() {
+    let tmp = tempfile::tempdir().unwrap();
+    let Some(vol) = ExfatVolume::create(tmp.path()) else {
+        eprintln!("skipping: hdiutil exFAT fixture unavailable");
+        return;
+    };
+
+    let root = vol.mount.join("case");
+    std::fs::create_dir_all(root.join("movable")).unwrap();
+    std::fs::write(root.join("movable/inner.txt"), b"inner").unwrap();
+    std::fs::create_dir_all(root.join("emptydir")).unwrap();
+    std::fs::write(root.join("doomed.txt"), b"doomed").unwrap();
+    std::fs::write(root.join("linkme.txt"), b"linkme").unwrap();
+
+    let fs = PassthroughFs::new(PassthroughConfig {
+        root_dir: root.clone(),
+        ..Default::default()
+    })
+    .unwrap();
+    fs.init(FsOptions::empty()).unwrap();
+    let ctx = Context {
+        uid: 0,
+        gid: 0,
+        pid: 1,
+    };
+    let c = |s: &str| CString::new(s).unwrap();
+    eprintln!("exfat write fixture: anchor_mode={}", fs.anchor_mode());
+
+    // Create and write through FUSE.
+    const LINUX_O_RDWR_FLAGS: u32 = 2;
+    let (created, handle, _) = fs
+        .create(
+            ctx,
+            ROOT_INODE,
+            &c("created.txt"),
+            0o644,
+            false,
+            LINUX_O_RDWR_FLAGS,
+            0,
+            Extensions::default(),
+        )
+        .unwrap();
+    let handle = handle.unwrap();
+    let mut reader = MockZeroCopyReader::new(b"written-bytes".to_vec());
+    let written = fs
+        .write(
+            ctx,
+            created.inode,
+            handle,
+            &mut reader,
+            13,
+            0,
+            None,
+            false,
+            false,
+            0,
+        )
+        .unwrap();
+    assert_eq!(written, 13);
+    assert_eq!(
+        std::fs::read(root.join("created.txt")).unwrap(),
+        b"written-bytes"
+    );
+
+    // Rename the file: the host inode number must survive the move, or the
+    // anchor-mode identity check would refuse every later reopen.
+    let (before, _) = fs.getattr(ctx, created.inode, None).unwrap();
+    fs.rename(
+        ctx,
+        ROOT_INODE,
+        &c("created.txt"),
+        ROOT_INODE,
+        &c("renamed.txt"),
+        0,
+    )
+    .unwrap();
+    let (after, _) = fs.getattr(ctx, created.inode, None).unwrap();
+    assert_eq!(after.st_ino, before.st_ino);
+    assert_eq!(after.st_size, 13);
+
+    // Rename a directory and read a file inside it through its old inode.
+    let movable = fs.lookup(ctx, ROOT_INODE, &c("movable")).unwrap();
+    let inner = fs.lookup(ctx, movable.inode, &c("inner.txt")).unwrap();
+    fs.rename(ctx, ROOT_INODE, &c("movable"), ROOT_INODE, &c("moved"), 0)
+        .unwrap();
+    let (inner_handle, _) = fs.open(ctx, inner.inode, false, 0).unwrap();
+    let mut writer = MockZeroCopyWriter::new();
+    let n = fs
+        .read(
+            ctx,
+            inner.inode,
+            inner_handle.unwrap(),
+            &mut writer,
+            32,
+            0,
+            None,
+            0,
+        )
+        .unwrap();
+    let mut data = writer.into_data();
+    data.truncate(n);
+    assert_eq!(&data[..], b"inner");
+
+    // Unlink with a handle open: the retained fd keeps the data readable.
+    let doomed = fs.lookup(ctx, ROOT_INODE, &c("doomed.txt")).unwrap();
+    let (doomed_handle, _) = fs.open(ctx, doomed.inode, false, 0).unwrap();
+    fs.unlink(ctx, ROOT_INODE, &c("doomed.txt")).unwrap();
+    assert!(!root.join("doomed.txt").exists());
+    let mut writer = MockZeroCopyWriter::new();
+    let n = fs
+        .read(
+            ctx,
+            doomed.inode,
+            doomed_handle.unwrap(),
+            &mut writer,
+            32,
+            0,
+            None,
+            0,
+        )
+        .unwrap();
+    let mut data = writer.into_data();
+    data.truncate(n);
+    assert_eq!(&data[..], b"doomed");
+
+    // rmdir an empty directory.
+    let empty = fs.lookup(ctx, ROOT_INODE, &c("emptydir")).unwrap();
+    fs.rmdir(ctx, ROOT_INODE, &c("emptydir")).unwrap();
+    assert!(!root.join("emptydir").exists());
+    let _ = empty;
+
+    // Hard link. exFAT has no hard links, so an unsupported answer is a pass
+    // as long as it is reported honestly instead of creating a wrong entry.
+    let linkme = fs.lookup(ctx, ROOT_INODE, &c("linkme.txt")).unwrap();
+    match fs.link(ctx, linkme.inode, ROOT_INODE, &c("linked.txt")) {
+        Ok(linked) => {
+            assert_eq!(linked.inode, linkme.inode);
+            let (linked_handle, _) = fs.open(ctx, linked.inode, false, 0).unwrap();
+            let mut writer = MockZeroCopyWriter::new();
+            let n = fs
+                .read(
+                    ctx,
+                    linked.inode,
+                    linked_handle.unwrap(),
+                    &mut writer,
+                    32,
+                    0,
+                    None,
+                    0,
+                )
+                .unwrap();
+            let mut data = writer.into_data();
+            data.truncate(n);
+            assert_eq!(&data[..], b"linkme");
+            assert_eq!(std::fs::read(root.join("linked.txt")).unwrap(), b"linkme");
+        }
+        Err(err) => {
+            // Only an honest "this volume cannot do that" is a pass. FSKit
+            // exFAT on macOS 15 answers `linkat` with ENOTSUP (macOS 45),
+            // which translates to Linux EOPNOTSUPP; a kext-backed exFAT can
+            // answer EPERM. Any other code — a missing entry, a bad
+            // descriptor, an I/O error — means the anchor resolution failed
+            // and must not be read as "unsupported".
+            let code = err.raw_os_error();
+            assert!(
+                code == Some(LINUX_EOPNOTSUPP) || code == Some(LINUX_EPERM),
+                "hard link on exfat failed with an unexpected error: {err}"
+            );
+            eprintln!("exfat write fixture: hard link unsupported ({err})");
+            assert!(!root.join("linked.txt").exists());
+        }
+    }
+}

--- a/crates/filesystem/lib/backends/passthroughfs/unix/tests/test_quota.rs
+++ b/crates/filesystem/lib/backends/passthroughfs/unix/tests/test_quota.rs
@@ -76,7 +76,7 @@ fn statfs_reports_baseline_plus_quota() {
         .unwrap();
 
     let st = sb.fs.statfs(sb.ctx(), ROOT_INODE).unwrap();
-    let frsize = st.f_frsize as u64;
+    let frsize = st.f_frsize;
     let total = st.f_blocks as u64 * frsize;
     let avail = st.f_bavail as u64 * frsize;
     // df total = baseline + quota; available = quota - used.

--- a/crates/filesystem/lib/backends/shared/inode_table.rs
+++ b/crates/filesystem/lib/backends/shared/inode_table.rs
@@ -193,6 +193,23 @@ where
 // Trait Implementations
 //--------------------------------------------------------------------------------------------------
 
+/// Close the retained fd when the last reference to the inode goes away.
+///
+/// The fd is a raw number, so nothing else would close it when the inode table
+/// is cleared on `destroy()` or dropped without a FORGET from the guest. Every
+/// other owner hands the fd over: `store_unlinked_fd` closes the value it
+/// replaces, and inode removal now relies on this destructor, so the fd is
+/// closed exactly once.
+#[cfg(target_os = "macos")]
+impl Drop for InodeData {
+    fn drop(&mut self) {
+        let fd = self.unlinked_fd.load(std::sync::atomic::Ordering::Acquire);
+        if fd >= 0 {
+            unsafe { libc::close(fd as i32) };
+        }
+    }
+}
+
 impl InodeAltKey {
     /// Create a new alternate key from stat fields.
     #[cfg(target_os = "linux")]

--- a/crates/filesystem/lib/backends/shared/inode_table.rs
+++ b/crates/filesystem/lib/backends/shared/inode_table.rs
@@ -5,13 +5,13 @@
 
 #[cfg(target_os = "macos")]
 use std::sync::atomic::AtomicI64;
-use std::{borrow::Borrow, collections::BTreeMap, sync::atomic::AtomicU64};
-#[cfg(target_os = "linux")]
 use std::{
-    collections::BTreeSet,
-    fs::File,
-    sync::{Mutex, RwLock},
+    borrow::Borrow,
+    collections::{BTreeMap, BTreeSet},
+    sync::{RwLock, atomic::AtomicU64},
 };
+#[cfg(target_os = "linux")]
+use std::{fs::File, sync::Mutex};
 
 //--------------------------------------------------------------------------------------------------
 // Types
@@ -48,7 +48,6 @@ pub(crate) struct InodeAltKey {
 }
 
 /// One namespace alias for a tracked passthrough inode.
-#[cfg(target_os = "linux")]
 #[derive(Clone, PartialOrd, Ord, PartialEq, Eq, Debug)]
 pub(crate) struct NamespaceAlias {
     pub parent: u64,
@@ -75,19 +74,27 @@ pub(crate) struct InodeData {
     pub mnt_id: u64,
 
     /// Current anchor parent inode for secure reopen-from-root.
-    #[cfg(target_os = "linux")]
+    ///
+    /// Tracked on both platforms; on macOS populated only for shares in
+    /// anchor mode.
     pub anchor_parent: AtomicU64,
 
     /// Current anchor name under `anchor_parent`.
-    #[cfg(target_os = "linux")]
+    ///
+    /// Tracked on both platforms; on macOS populated only for shares in
+    /// anchor mode.
     pub anchor_name: RwLock<Vec<u8>>,
 
     /// All known live aliases for this inode within the exported namespace.
-    #[cfg(target_os = "linux")]
+    ///
+    /// Tracked on both platforms; on macOS populated only for shares in
+    /// anchor mode.
     pub aliases: RwLock<BTreeSet<NamespaceAlias>>,
 
     /// Number of descendant anchors that currently depend on this inode.
-    #[cfg(target_os = "linux")]
+    ///
+    /// Tracked on both platforms; on macOS populated only for shares in
+    /// anchor mode.
     pub anchor_children: AtomicU64,
 
     /// Retained fd for detached objects that lost their last visible alias.
@@ -200,7 +207,6 @@ impl InodeAltKey {
     }
 }
 
-#[cfg(target_os = "linux")]
 impl NamespaceAlias {
     pub fn new(parent: u64, name: &[u8]) -> Self {
         Self {

--- a/crates/filesystem/lib/backends/shared/platform.rs
+++ b/crates/filesystem/lib/backends/shared/platform.rs
@@ -321,6 +321,11 @@ fn linux_errno_raw(errno: i32) -> i32 {
         libc::ENOSTR => LINUX_ENOSTR,
         libc::EPROTO => LINUX_EPROTO,
         libc::ETIME => LINUX_ETIME,
+        // macOS has two distinct codes here: ENOTSUP (45) and EOPNOTSUPP
+        // (102). Linux collapses both into EOPNOTSUPP (95). Without the
+        // first arm, ENOTSUP — which FSKit exFAT returns for `linkat` —
+        // falls through to the catch-all and reaches the guest as EIO.
+        libc::ENOTSUP => LINUX_EOPNOTSUPP,
         libc::EOPNOTSUPP => LINUX_EOPNOTSUPP,
         libc::ENOTRECOVERABLE => LINUX_ENOTRECOVERABLE,
         libc::EOWNERDEAD => LINUX_EOWNERDEAD,


### PR DESCRIPTION
## TL;DR

FSKit-backed filesystems on macOS 15 (exFAT today) do not answer `/.vol/<dev>/<ino>` lookups, so every passthrough share on them failed with ENOENT. This probes volfs once per share and, when it is absent, reopens inodes by an `openat(O_NOFOLLOW)` walk from the retained root fd with a `(dev, ino)` identity check, reusing the anchor bookkeeping the Linux backend already has. Shares where volfs works keep the existing code paths. Fixes #1567.

## Motivation

I have an exFAT external drive. I want to mount a Microsandbox on macOS 15 that can read files from it.

## Description

- Add `PassthroughFs::volfs_supported` (macOS), probed at construction by opening the share root's own `/.vol/<dev>/<ino>`; `anchor_mode()` is its negation. The probe is per share root; a permission-denied probe conservatively selects anchor mode.
- Make `InodeData`'s anchor fields and `NamespaceAlias` available on macOS; the alias helpers in `inode.rs` are no longer Linux-only. The macOS lookup registers `(parent, name)` aliases only in anchor mode, so volfs shares keep the read-lock fast path.
- New `secure_open_path_macos`, `open_anchor_fd_macos`, `anchor_parent_and_name_macos`, `open_child_for_stat_macos`; `get_inode_fd`, `open_inode_fd`, `stat_inode` use them in anchor mode. The walk validates every component, opens every step `O_NOFOLLOW` (intermediates `O_DIRECTORY`), verifies `(st_dev, st_ino)` after open, and applies `O_TRUNC` only after validation (`O_CREAT` is rejected on reopen). Stale aliases (ENOENT/ENOTDIR) fall through to the next alias; any other host error is preserved. Root reopens through `openat(root_fd, ".")` so handles never share the root fd's file description. Symlinks stat through an `O_SYMLINK` retry; symlink metadata binds to an identity-verified `O_SYMLINK` fd and times use `futimens`.
- `unlink`, `rmdir`, `rename` (including exchange, replaced targets, same-inode no-ops) maintain aliases in anchor mode; the replaced target's fd is identity-checked before retention; a cross-directory exchange pins both parents in the table until both anchors are installed, so a forgotten parent is never collected between the two transfers (the Linux block has the original ordering; follow-up). A rename whose retained probe cannot have `O_NONBLOCK` cleared aborts before the syscall; an unlink in that position keeps the descriptor and logs.
- `link`, `readlink` resolve through the anchor parent and name in anchor mode.
- On macOS, `InodeData` now owns its retained `unlinked_fd` via `Drop`, so `destroy()` and filesystem drop no longer leak descriptors (previously leaked in volfs mode too). Linux keeps its `Mutex<Option<File>>` ownership unchanged.
- No reopen opens an entry to find out what it is. The walk identifies the final entry with `fstatat` on the verified parent and opens it once: non-blocking with the flag cleared after the identity check for everything except a FIFO, and blocking for a FIFO with the table guard already released. A host-side replacement by a peerless FIFO therefore cannot freeze the inode table, a guest FIFO open still waits for its peer, and no exploratory open can take a short-lived writer's bytes. A guest that asks for `O_NONBLOCK` keeps it; a peerless non-blocking write reports ENXIO. Unlink and the rename target probe skip FIFO endpoints.
- `linux_errno_raw` now translates macOS `ENOTSUP` (45) to `EOPNOTSUPP`; it previously fell through to `EIO`. FSKit exFAT answers ENOTSUP to `linkat`.
- One-line clippy fix in `test_quota.rs` (a redundant cast rejected by `-D warnings` on macOS aarch64), in its own commit so the crate lint gate is green for every commit in the series.
- `open_anchor_fd_macos` and `anchor_parent_and_name_macos` share their candidate-loop scaffolding by design; a closure-parameterised helper was awkward around the read guard, so the duplication is deliberate.

## Compatibility review

This adds a fallback path. It was proposed in #1567 before implementation; always-anchor on macOS was the alternative and probe-and-fallback was chosen to keep volfs-capable shares byte-identical.

- No public API, wire protocol, CLI, SDK, database, persisted artifact, serialized field, hash, or ordering change. Every new item is `pub(crate)`.
- Error interpretations on volfs-less shares: a stale anchor yields ENOENT (previously every operation failed ENOENT from volfs); `open_inode_fd` returns EINVAL for `O_CREAT` in anchor mode (volfs mode still passes it through, a pre-existing latent bug the new branch does not reproduce); after the last name of an unlinked FIFO is gone, inode-only operations on it (a handle-less `getattr`) return ENOENT because no FIFO endpoint is retained, since a retained reader would suppress the guest's broken-pipe semantics; handle-bearing operations are unaffected.
- Guest-visible errno change on every macOS share: host `ENOTSUP` now reaches the guest as `EOPNOTSUPP` instead of `EIO`. No caller in the repository keyed on the old value.
- Observable differences on volfs-capable shares, the complete set: the root inode is retained on forget (as on Linux); `forget` re-checks the refcount under the write lock before removal (fixes a lookup/forget race); `do_link` resolves the destination parent before the source (lock-order fix; error precedence on a double failure changes); one extra `fstat` + `open`/`close` per share at construction; four anchor fields (about 80 bytes) per tracked inode, all zero in volfs mode, matching what Linux already pays; retained fds are now closed on drop. `do_unlink` keeps its read lock on volfs shares.
- Trade-offs on volfs-less shares, all fail-closed: a host-side rename under a live share can make a tracked inode unresolvable until the guest looks it up again (the Linux backend's existing behaviour); a host-side move of an already-opened intermediate directory is not an ancestry violation the final identity check can detect (also shared with Linux); the hard-link source and readlink are name-bound between verification and the syscall because macOS has no identity-bound `linkat` without volfs.
- Hard link and readlink in anchor mode verify identity after the name-bound syscall, because macOS has no fd-relative `linkat` or `readlink` (`/dev/fd/N` answers EPERM and EINVAL; Linux uses `/proc/self/fd/N` and `readlinkat(fd, "")`, both identity-bound). A source swapped between verification and the syscall is reported as ENOENT instead of returning the replacement. For `link` the entry that `linkat` created is deliberately left in place: it is the same on-disk outcome an unchecked `linkat` would have produced, and removing it by name would be a second name-based race. Permission behaviour is identical to a plain `linkat`. The check assumes `newname` still names the entry `linkat` created; a host that replaces the destination name inside that window is a retained race. For `readlink` a swap-read-restore inside the window is not detected.
- Known and separate: AppleDouble `._*` sidecar files on non-APFS volumes fail lookup in strict stat-virtualization mode because `getxattr` on them returns EPERM, which `stat_override` does not treat as "no xattr". Pre-existing shared code; will be filed as its own issue.

## Test Plan

- `cargo fmt --all -- --check`, `cargo clippy --workspace -- -D warnings`, `cargo test --workspace` (2,898 passed, 0 failed), `cargo build -p microsandbox-cli` on macOS 15.1.1 / Apple Silicon.
- `unix/tests/test_anchor_mode.rs` forces anchor mode on an APFS temp dir (48 tests): nested read, getattr, readdir, 12-level path, identity-mismatch fail-closed, symlink-component refusal, host-error preservation (EACCES), root getattr/readdir and two independent root dir handles, FIFO getattr does not block, a regular file replaced by a FIFO cannot block reopen or unlink, blocking FIFO read and write opens wait for their peer off the table lock, a short-lived writer's payload is not lost, non-blocking peerless write reports ENXIO, socket lookup, forget keeps anchored parents, rename (file, directory, replaced target, same-inode plain and exchange, after the parent was forgotten, cross-directory exchange after a parent was forgotten), unlink keeps open handle and drops symlink aliases, rmdir, hard link, readlink, symlink getattr/times and a direct test of the post-open symlink identity check, exclusive create, retained fds closed on destroy. Every anchor branch returns before any volfs code, so the forced flag cannot silently fall through to volfs on APFS.
- `unix/tests/test_exfat_fixture.rs` creates a 64 MB exFAT image with `hdiutil`, mounts it (FSKit on macOS 15, so `anchor_mode=true`), and runs lookup/getattr/read/readdir/reopen-after-forget plus the write path: create, write, rename with inode-stability assertion, directory rename with read through the old inode, unlink with an open handle, rmdir, hard link (accepting only EOPNOTSUPP or EPERM). Self-skips when hdiutil is unavailable.
- End to end with a release `msb` built from this branch: `msb run --mount-dir <exfat dir>:/case:ro alpine -- ls /case` lists the directory on a FSKit exFAT volume (previously "No such file or directory"). On a 45 GB forensic case directory: sequential 2 GiB read 1.9 GB/s on exFAT vs 2.6 GB/s on APFS with the same binary; a 7,832-entry APFS tree lists in 0.48 s and stats every entry in 0.30 s (volfs mode, unchanged).


<!-- greptile_comment -->

<details><summary><h3>Confidence Score: 2/5</h3></summary>

The PR is not yet safe to merge because nested volfs-incompatible mounts remain inaccessible, readlink can still return data from a transient replacement, and a failed hard-link request can leave an unintended destination behind.

The root-only probe still selects volfs mode for an entire APFS-rooted share, so entries residing on a nested FSKit volume continue to use unsupported volfs paths. cameronk claimed the readlink race was fixed, but the post-call identity check remains insufficient when the replacement symlink is restored before that check, allowing the replacement target to be returned. The hard-link fix also detects source substitution only after creating the destination and deliberately leaves that incorrect link while returning an error. The earlier hard-link thread was manually resolved and is not counted as outstanding.

**Files Needing Attention:** crates/filesystem/lib/backends/passthroughfs/unix/builder.rs, crates/filesystem/lib/backends/passthroughfs/unix/create_ops.rs
</details>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22superradcompany%2Fmicrosandbox%22%20on%20the%20existing%20branch%20%22macos-anchor-mode-volfs-fallback%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22macos-anchor-mode-volfs-fallback%22.%0A%0AGreploop%20superradcompany%2Fmicrosandbox%20PR%20%231568%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AAFTER%20THE%20LOOP%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%20%20%20%20%20%20%20%20%20%20%7C%0A%2B------------------------------------------------------%2B&repo=superradcompany%2Fmicrosandbox&pr=1568&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22superradcompany%2Fmicrosandbox%22%20on%20the%20existing%20branch%20%22macos-anchor-mode-volfs-fallback%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22macos-anchor-mode-volfs-fallback%22.%0A%0A%23%23%23%20Issue%201%0Acrates%2Ffilesystem%2Flib%2Fbackends%2Fpassthroughfs%2Funix%2Fcreate_ops.rs%3A510-519%0A**Failed%20Link%20Leaves%20Destination**%0A%0AIn%20anchor%20mode%2C%20if%20the%20source%20is%20replaced%20after%20verification%2C%20%60linkat%60%20creates%20%60newname%60%20for%20the%20replacement%20inode.%20The%20post-check%20then%20returns%20%60ENOENT%60%20but%20deliberately%20keeps%20that%20link%2C%20and%20%60PassthroughFs%3A%3Alink%60%20propagates%20the%20error%20directly.%20The%20guest%20therefore%20sees%20a%20failed%20operation%20even%20though%20an%20incorrect%20destination%20was%20created%2C%20and%20retrying%20can%20fail%20with%20%60EEXIST%60.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=superradcompany%2Fmicrosandbox&pr=1568&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Acrates%2Ffilesystem%2Flib%2Fbackends%2Fpassthroughfs%2Funix%2Fcreate_ops.rs%3A510-519%0A**Failed%20Link%20Leaves%20Destination**%0A%0AIn%20anchor%20mode%2C%20if%20the%20source%20is%20replaced%20after%20verification%2C%20%60linkat%60%20creates%20%60newname%60%20for%20the%20replacement%20inode.%20The%20post-check%20then%20returns%20%60ENOENT%60%20but%20deliberately%20keeps%20that%20link%2C%20and%20%60PassthroughFs%3A%3Alink%60%20propagates%20the%20error%20directly.%20The%20guest%20therefore%20sees%20a%20failed%20operation%20even%20though%20an%20incorrect%20destination%20was%20created%2C%20and%20retrying%20can%20fail%20with%20%60EEXIST%60.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=superradcompany%2Fmicrosandbox&pr=1568&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
crates/filesystem/lib/backends/passthroughfs/unix/create_ops.rs:510-519
**Failed Link Leaves Destination**

In anchor mode, if the source is replaced after verification, `linkat` creates `newname` for the replacement inode. The post-check then returns `ENOENT` but deliberately keeps that link, and `PassthroughFs::link` propagates the error directly. The guest therefore sees a failed operation even though an incorrect destination was created, and retrying can fail with `EEXIST`.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(filesystem): verify anchor symlink i..."](https://github.com/superradcompany/microsandbox/commit/21fbe2de015192444727be4084aa8d7cfc7f3397) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=63547030)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->